### PR TITLE
Packet ContinentalLockUpdateMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -519,7 +519,7 @@ object GamePacketOpcode extends Enumeration {
       case WarpgateResponse => noDecoder(opcode)
       case DamageWithPositionMessage => noDecoder(opcode)
       case GenericActionMessage => noDecoder(opcode)
-      case ContinentalLockUpdateMessage => noDecoder(opcode)
+      case ContinentalLockUpdateMessage => game.ContinentalLockUpdateMessage.decode
       case AvatarGrenadeStateMessage => noDecoder(opcode)
 
       // OPCODE 170

--- a/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
@@ -6,9 +6,9 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Create a dispatched game packet that instructs the client to update the user about continents being conquered.
+  * Create a dispatched game packet that instructs the client to update the user about continents that are conquered.
   *
-  * This generates the event message "The [empire] have captured [continent_guid]."
+  * This generates the event message "The [empire] have captured [continent]."
   * If the continent_guid is not a valid zone, no message is displayed.
   * If empire is not a valid empire, no message is displayed.
   *

--- a/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
@@ -13,11 +13,10 @@ import scodec.codecs._
   * If empire is not a valid empire, no message is displayed.
   *
   * @param continent_guid identifies the zone (continent)
-  * @param empire identifies the empire;
-  *               this value is matchable against PlanetSideEmpire, except for hex `C0` (open)
+  * @param empire identifies the empire; this value is matchable against PlanetSideEmpire
   */
 final case class ContinentalLockUpdateMessage(continent_guid : PlanetSideGUID,
-                                              empire : Int) // 00 for TR, 40 for NC, 80 for VS; C0 is used, but it generates no message
+                                              empire : PlanetSideEmpire.Value) // 00 for TR, 40 for NC, 80 for VS; C0 generates no message
   extends PlanetSideGamePacket {
   type Packet = ContinentalLockUpdateMessage
   def opcode = GamePacketOpcode.ContinentalLockUpdateMessage
@@ -27,6 +26,6 @@ final case class ContinentalLockUpdateMessage(continent_guid : PlanetSideGUID,
 object ContinentalLockUpdateMessage extends Marshallable[ContinentalLockUpdateMessage] {
   implicit val codec : Codec[ContinentalLockUpdateMessage] = (
     ("continent_guid" | PlanetSideGUID.codec) ::
-      ("empire" | uint8L)
+      ("empire" | PlanetSideEmpire.codec)
     ).as[ContinentalLockUpdateMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Create a dispatched game packet that instructs the client to update the user about continents being conquered.
+  *
+  * This generates the event message "The [empire] have captured [continent_guid]."
+  * If the continent_guid is not a valid zone, no message is displayed.
+  * If empire is not a valid empire, no message is displayed.
+  *
+  * @param continent_guid identifies the zone (continent)
+  * @param empire identifies the empire;
+  *               this value is matchable against PlanetSideEmpire, except for hex `C0` (open)
+  */
+final case class ContinentalLockUpdateMessage(continent_guid : PlanetSideGUID,
+                                              empire : Int) // 00 for TR, 40 for NC, 80 for VS; C0 is used, but it generates no message
+  extends PlanetSideGamePacket {
+  type Packet = ContinentalLockUpdateMessage
+  def opcode = GamePacketOpcode.ContinentalLockUpdateMessage
+  def encode = ContinentalLockUpdateMessage.encode(this)
+}
+
+object ContinentalLockUpdateMessage extends Marshallable[ContinentalLockUpdateMessage] {
+  implicit val codec : Codec[ContinentalLockUpdateMessage] = (
+    ("continent_guid" | PlanetSideGUID.codec) ::
+      ("empire" | uint8L)
+    ).as[ContinentalLockUpdateMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/VNLWorldStatusMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VNLWorldStatusMessage.scala
@@ -24,7 +24,7 @@ object ServerType extends Enumeration(1) {
 
 object PlanetSideEmpire extends Enumeration {
   type Type = Value
-  val TR, NC, VS = Value
+  val TR, NC, VS, NEUTRAL = Value
 
   implicit val codec = PacketHelpers.createEnumerationCodec(this, uint2L)
 }

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -629,14 +629,14 @@ class GamePacketTest extends Specification {
         PacketCoding.DecodePacket(string).require match {
           case ContinentalLockUpdateMessage(continent_guid, empire) =>
             continent_guid mustEqual PlanetSideGUID(22)
-            empire mustEqual 64
+            empire mustEqual PlanetSideEmpire.NC
           case default =>
             ko
         }
       }
 
       "encode" in {
-        val msg = ContinentalLockUpdateMessage(PlanetSideGUID(22), 64)
+        val msg = ContinentalLockUpdateMessage(PlanetSideGUID(22), PlanetSideEmpire.NC)
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual string

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -622,6 +622,27 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "ContinentalLockUpdateMessage" should {
+      val string = hex"A8 16 00 40"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case ContinentalLockUpdateMessage(continent_guid, empire) =>
+            continent_guid mustEqual PlanetSideGUID(22)
+            empire mustEqual 64
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = ContinentalLockUpdateMessage(PlanetSideGUID(22), 64)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "WeaponFireMessage" should {
       val string = hex"34 44130029272F0B5DFD4D4EC5C00009BEF78172003FC0"
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -126,6 +126,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
               // XXX: hardcoded shit
               sendRawResponse(hex"31 85 6D 61 70 31 33 85  68 6F 6D 65 33 A4 9C 19 00 00 00 AE 30 5E 70 00  ")
               sendRawResponse(objectHex)
+
+              sendResponse(PacketCoding.CreateGamePacket(0, ContinentalLockUpdateMessage(PlanetSideGUID(13),128))) // "The VS have captured the VS Sanctuary."
+
               sendResponse(PacketCoding.CreateGamePacket(0, SetCurrentAvatarMessage(PlanetSideGUID(guid),0,0)))
 
               import scala.concurrent.duration._

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -127,7 +127,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               sendRawResponse(hex"31 85 6D 61 70 31 33 85  68 6F 6D 65 33 A4 9C 19 00 00 00 AE 30 5E 70 00  ")
               sendRawResponse(objectHex)
 
-              sendResponse(PacketCoding.CreateGamePacket(0, ContinentalLockUpdateMessage(PlanetSideGUID(13),128))) // "The VS have captured the VS Sanctuary."
+              sendResponse(PacketCoding.CreateGamePacket(0, ContinentalLockUpdateMessage(PlanetSideGUID(13), PlanetSideEmpire.VS))) // "The VS have captured the VS Sanctuary."
 
               sendResponse(PacketCoding.CreateGamePacket(0, SetCurrentAvatarMessage(PlanetSideGUID(guid),0,0)))
 


### PR DESCRIPTION
This packet is sent by the server, upon login (usually), to instruct clients to generate event messages about which faction owns which continent.