### PR TITLE
Added: ArmorChangedPacket

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -391,7 +391,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x3b => noDecoder(UnknownMessage59)
     case 0x3c => noDecoder(GenericCollisionMsg)
     case 0x3d => game.QuantityUpdateMessage.decode
-    case 0x3e => noDecoder(ArmorChangedMessage)
+    case 0x3e => game.ArmorChangedMessage.decode
     case 0x3f => noDecoder(ProjectileStateMessage)
 
     // OPCODES 0x40-4f

--- a/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Force a player to change their exo-suit.
+  * This one command sets personal armor value, weapon slots, GUI elements, and other such things, related to the exo-suit being worn.<br>
+  * <br>
+  * Due to the way MAXes are handled internally, a player of one faction may not spawn in the MAX suit of another faction.
+  * MAXes do not get their weapon by default.
+  * It is created by subsequent ObjectCreatedMessage and an ObjectHeldMessage pairs (two for TR?).
+  * Consequentially, the three MAX values all produce the same mechanized exo-suit body visually.<br>
+  * <br>
+  * `
+  * - Standard:     hex 00, dec  0<br>
+  * - Agile:        hex 00, dex  0<br>
+  * - Reinforced:   hex 00, dex  0<br>
+  * - MAX AI:       hex 44, dec 68<br>
+  * - MAX AV:       hex 48, dec 72<br>
+  * - MAX AA:       hex 4C, dec 76<br>
+  * - Infiltration: hex 60, dec 96<br>
+  * `
+  *
+  * @param player_guid the player
+  * @param armor the type of armor to change into (if a MAX, you will not have your weapons)
+  */
+//sendResponse(PacketCoding.CreateGamePacket(0, ArmorChangedMessage(PlanetSideGUID(guid),68)))
+final case class ArmorChangedMessage(player_guid : PlanetSideGUID,
+                                    armor : Int)
+  extends PlanetSideGamePacket {
+  type Packet = ArmorChangedMessage
+  def opcode = GamePacketOpcode.ArmorChangedMessage
+  def encode = ArmorChangedMessage.encode(this)
+}
+
+object ArmorChangedMessage extends Marshallable[ArmorChangedMessage] {
+  implicit val codec : Codec[ArmorChangedMessage] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("time" | uint8L)
+    ).as[ArmorChangedMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
@@ -13,26 +13,24 @@ import scodec.codecs._
   * Due to the way armor is handled internally, a player of one faction may not spawn in the exo-suit of another faction.
   * That style of exo-suit is never available through this packet.
   * As MAX units do not get their weapon by default, all the MAX values produce the same faction-appropriate mechanized exo-suit body visually.
-  * (The MAX weapons are supplied in subsequent packets.)<br>
-  * <br>
-  * All values in between the ones indicated (below) dress the player in the lesser suit, e.g., 1F is Agile, 21 is Reinforced.
-  * 44, 48, and 4C are distinguished in that those are the prescribed values for terminal-swapped MAX exo-suits.<br>
-  * <br>
+  * (The MAX weapons are supplied in subsequent packets.)
   * `
-  * 00 - Agile (0)<br>
-  * 20 - Reinforced (32)<br>
-  * 40 - MAX (64)<br>
-  * 44 - AI MAX (68)<br>
-  * 48 - AV MAX (72)<br>
-  * 4C - AA MAX (76)<br>
-  * 60 - Infiltration (96)<br>
-  * 80 - Standard (128)
+  * 0, 0 - Agile<br>
+  * 1, 0 - Reinforced<br>
+  * 2, 0 - MAX<br>
+  * 2, 1 - AI MAX<br>
+  * 2, 2 - AV MAX<br>
+  * 2, 3 - AA MAX<br>
+  * 3, 0 - Infiltration<br>
+  * 4, 0 - Standard
   * `
   * @param player_guid the player
   * @param armor the type of exo-suit
+  * @param subtype the exo-suit subtype, if any
   */
 final case class ArmorChangedMessage(player_guid : PlanetSideGUID,
-                                    armor : Int)
+                                    armor : Int,
+                                    subtype : Int)
   extends PlanetSideGamePacket {
   type Packet = ArmorChangedMessage
   def opcode = GamePacketOpcode.ArmorChangedMessage
@@ -42,6 +40,7 @@ final case class ArmorChangedMessage(player_guid : PlanetSideGUID,
 object ArmorChangedMessage extends Marshallable[ArmorChangedMessage] {
   implicit val codec : Codec[ArmorChangedMessage] = (
     ("player_guid" | PlanetSideGUID.codec) ::
-      ("armor" | uint8L)
+      ("armor" | uintL(3)) ::
+      ("subtype" | uintL(3))
     ).as[ArmorChangedMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
@@ -6,28 +6,31 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Force a player to change their exo-suit.
-  * This one command sets personal armor value, weapon slots, GUI elements, and other such things, related to the exo-suit being worn.<br>
+  * Force a player model to change its exo-suit.
+  * Set all GUI elements and functional elements to be associated with that type of exo-suit.
+  * Inventory and holster contents are discarded.<br>
   * <br>
-  * Due to the way MAXes are handled internally, a player of one faction may not spawn in the MAX suit of another faction.
-  * MAXes do not get their weapon by default.
-  * It is created by subsequent ObjectCreatedMessage and an ObjectHeldMessage pairs (two for TR?).
-  * Consequentially, the three MAX values all produce the same mechanized exo-suit body visually.<br>
+  * Due to the way armor is handled internally, a player of one faction may not spawn in the exo-suit of another faction.
+  * That style of exo-suit is never available through this packet.
+  * As MAX units do not get their weapon by default, all the MAX values produce the same faction-appropriate mechanized exo-suit body visually.
+  * (The MAX weapons are supplied in subsequent packets.)<br>
+  * <br>
+  * All values in between the ones indicated (below) dress the player in the lesser suit, e.g., 1F is Agile, 21 is Reinforced.
+  * 44, 48, and 4C are distinguished in that those are the prescribed values for terminal-swapped MAX exo-suits.<br>
   * <br>
   * `
-  * - Standard:     hex 00, dec  0<br>
-  * - Agile:        hex 00, dex  0<br>
-  * - Reinforced:   hex 00, dex  0<br>
-  * - MAX AI:       hex 44, dec 68<br>
-  * - MAX AV:       hex 48, dec 72<br>
-  * - MAX AA:       hex 4C, dec 76<br>
-  * - Infiltration: hex 60, dec 96<br>
+  * 00 - Agile (0)<br>
+  * 20 - Reinforced (32)<br>
+  * 40 - MAX (64)<br>
+  * 44 - AI MAX (68)<br>
+  * 48 - AV MAX (72)<br>
+  * 4C - AA MAX (76)<br>
+  * 60 - Infiltration (96)<br>
+  * 80 - Standard (128)
   * `
-  *
   * @param player_guid the player
-  * @param armor the type of armor to change into (if a MAX, you will not have your weapons)
+  * @param armor the type of exo-suit
   */
-//sendResponse(PacketCoding.CreateGamePacket(0, ArmorChangedMessage(PlanetSideGUID(guid),68)))
 final case class ArmorChangedMessage(player_guid : PlanetSideGUID,
                                     armor : Int)
   extends PlanetSideGamePacket {
@@ -39,6 +42,6 @@ final case class ArmorChangedMessage(player_guid : PlanetSideGUID,
 object ArmorChangedMessage extends Marshallable[ArmorChangedMessage] {
   implicit val codec : Codec[ArmorChangedMessage] = (
     ("player_guid" | PlanetSideGUID.codec) ::
-      ("time" | uint8L)
+      ("armor" | uint8L)
     ).as[ArmorChangedMessage]
 }

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -982,20 +982,21 @@ class GamePacketTest extends Specification {
     }
 
     "ArmorChangedMessage" should {
-      val string = hex"3E 11 01 80"
+      val string = hex"3E 11 01 4C"
 
       "decode" in {
         PacketCoding.DecodePacket(string).require match {
-          case ArmorChangedMessage(player_guid, armor) =>
+          case ArmorChangedMessage(player_guid, armor, subtype) =>
             player_guid mustEqual PlanetSideGUID(273)
-            armor mustEqual 128
+            armor mustEqual 2
+            subtype mustEqual 3
           case default =>
             ko
         }
       }
 
       "encode" in {
-        val msg = ArmorChangedMessage(PlanetSideGUID(273), 128)
+        val msg = ArmorChangedMessage(PlanetSideGUID(273), 2, 3)
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual string

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -981,6 +981,27 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "ArmorChangedMessage" should {
+      val string = hex"3E 11 01 80"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case ArmorChangedMessage(player_guid, armor) =>
+            player_guid mustEqual PlanetSideGUID(273)
+            armor mustEqual 128
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = ArmorChangedMessage(PlanetSideGUID(273), 128)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "QuantityDeltaUpdateMessage" should {
       val string = hex"C4 5300 FBFFFFFF"
 


### PR DESCRIPTION
All 128 neatly folded changes of standard exo-suit.  It's like a cartoon where the character opens their wardrobe and has hangers and hangers of a single outfit.

ArmorChangedMessage is a simple four byte - opcode plus three in the data section - packet sent from the server to the client.