### PR TITLE
Added: ChangeShortcutBankMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -367,7 +367,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x27 => noDecoder(ObjectDetachMessage)
     // 0x28
     case 0x28 => noDecoder(CreateShortcutMessage)
-    case 0x29 => noDecoder(ChangeShortcutBankMessage)
+    case 0x29 => game.ChangeShortcutBankMessage.decode
     case 0x2a => noDecoder(ObjectAttachMessage)
     case 0x2b => noDecoder(UnknownMessage43)
     case 0x2c => noDecoder(PlanetsideAttributeMessage)

--- a/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
@@ -6,21 +6,16 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Switch the reference group of shortcuts on the HUD's hotbar.<br>
+  * Switch the set of shortcuts displayed on the HUD's hotbar.<br>
   * <br>
   * The hotbar contains eight slots for user shortcuts - medkits, implants, and text macros.
   * Next to the first slot are up and down arrow buttons with a number.
   * By progressing through the options available from the arrows, eight sets of eight shortcut slots are revealed.
-  * Which set is visible determines the effect of the activating the respective of eight binding keys for the hotbar.
-  * Each set is called a "bank."<br>
-  * <br>
-  * When shortcuts are manipulated, the bank acts as a reference point to the set and moves that set of eight shortcuts onto the HUD.
-  * Adding a shortcut to the first slot when viewing the second bank is the same as added a shortcut to the ninth slot when viewing the first bank.
-  * Obviously, there is no ninth slot.
-  * The slot value merely wraps back around into the next bank.
-  * The `bank` value can also wrap around through the first set, so requesting bank 8 (`80`) is the equivalent of requesting bank 1 (`00`).
+  * Which set is visible determines the effect of the activating the respective of eight binding keys (the Function keys) for the hotbar.
+  * Each set is called a "bank."
   * @param player_guid the player
-  * @param bank the shortcut bank (zero-indexed)
+  * @param bank the shortcut bank (zero-indexed);
+  *             0-7 are the valid banks
   */
 final case class ChangeShortcutBankMessage(player_guid : PlanetSideGUID,
                                   bank : Int)

--- a/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
@@ -32,7 +32,7 @@ final case class ChangeShortcutBankMessage(player_guid : PlanetSideGUID,
 
 object ChangeShortcutBankMessage extends Marshallable[ChangeShortcutBankMessage] {
   implicit val codec : Codec[ChangeShortcutBankMessage] = (
-    ("unk1" | PlanetSideGUID.codec) ::
+    ("player_guid" | PlanetSideGUID.codec) ::
       ("bank" | uintL(4))
     ).as[ChangeShortcutBankMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Switch the reference group of shortcuts on the HUD's hotbar.<br>
+  * <br>
+  * The hotbar contains eight slots for user shortcuts - medkits, implants, and text macros.
+  * Next to the first slot are up and down arrow buttons with a number.
+  * By progressing through the options available from the arrows, eight sets of eight shortcut slots are revealed.
+  * Which set is visible determines the effect of the activating the respective of eight binding keys for the hotbar.
+  * Each set is called a "bank."<br>
+  * <br>
+  * When shortcuts are manipulated, the bank acts as a reference point to the set and moves that set of eight shortcuts onto the HUD.
+  * Adding a shortcut to the first slot when viewing the second bank is the same as added a shortcut to the ninth slot when viewing the first bank.
+  * Obviously, there is no ninth slot.
+  * The slot value merely wraps back around into the next bank.
+  * The `bank` value can also wrap around through the first set, so requesting bank 8 (`80`) is the equivalent of requesting bank 1 (`00`).
+  * @param player_guid the player
+  * @param bank the shortcut bank (zero-indexed)
+  */
+final case class ChangeShortcutBankMessage(player_guid : PlanetSideGUID,
+                                  bank : Int)
+  extends PlanetSideGamePacket {
+  type Packet = ChangeShortcutBankMessage
+  def opcode = GamePacketOpcode.ChangeShortcutBankMessage
+  def encode = ChangeShortcutBankMessage.encode(this)
+}
+
+object ChangeShortcutBankMessage extends Marshallable[ChangeShortcutBankMessage] {
+  implicit val codec : Codec[ChangeShortcutBankMessage] = (
+    ("unk1" | PlanetSideGUID.codec) ::
+      ("bank" | uintL(4))
+    ).as[ChangeShortcutBankMessage]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -299,6 +299,27 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "ChangeShortcutBankMessage" should {
+      val string = hex"29 4B00 20"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case ChangeShortcutBankMessage(player_guid, bank) =>
+            player_guid mustEqual PlanetSideGUID(75)
+            bank mustEqual 2
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = ChangeShortcutBankMessage(PlanetSideGUID(75), 2)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "DropItemMessage" should {
       val string = hex"37 4C00"
 


### PR DESCRIPTION
This packet is pretty simple and self-explanatory.  As long as you read what a "bank" is.

I noticed that this functionality was not being addressed while working on CreateShortcutMessage.  It wasn't difficult to hammer out.
