### PR TITLE
Added: BattleExperienceMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -532,7 +532,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xb1 => noDecoder(VoiceHostKill)
     case 0xb2 => noDecoder(VoiceHostInfo)
     case 0xb3 => noDecoder(BattleplanMessage)
-    case 0xb4 => noDecoder(BattleExperienceMessage)
+    case 0xb4 => game.BattleExperienceMessage.decode
     case 0xb5 => noDecoder(TargetingImplantRequest)
     case 0xb6 => game.ZonePopulationUpdateMessage.decode
     case 0xb7 => noDecoder(DisconnectMessage)

--- a/common/src/main/scala/net/psforever/packet/game/BattleExperienceMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BattleExperienceMessage.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Inform the client how many battle experience points (BEP) the player currently has earned.<br>
+  * <br>
+  * The amount of `experience` earned is an accumulating value.
+  * Whenever the server sends this packet, the value of this field is equal to the player's current total BEP.
+  * Each packet updates to a higher BEP score and the client occasionally reports of the difference as an event message.
+  * "You have been awarded `x` battle experience points."
+  * Milestone notifications that occur due to BEP gain, e.g., rank progression, will trigger naturally as the client is updated.<br>
+  * <br>
+  * It is possible to award more battle experience than is necessary to progress one's character to the highest battle rank.
+  * (This must be accomplished in a single event packet.)
+  * Only the most significant notification will be displayed.
+  * @param player_guid the player
+  * @param experience the current total experience
+  * @param unk na; always zero?
+  */
+final case class BattleExperienceMessage(player_guid : PlanetSideGUID,
+                                         experience : Long,
+                                         unk : Int)
+  extends PlanetSideGamePacket {
+  type Packet = BattleExperienceMessage
+  def opcode = GamePacketOpcode.BattleExperienceMessage
+  def encode = BattleExperienceMessage.encode(this)
+}
+
+object BattleExperienceMessage extends Marshallable[BattleExperienceMessage] {
+  implicit val codec : Codec[BattleExperienceMessage] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("experience" | ulongL(32)) ::
+      ("unk" | uint8L)
+    ).as[BattleExperienceMessage]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -703,6 +703,28 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "BattleExperienceMessage" should {
+      val string = hex"B4 8A0A E7030000 00"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case BattleExperienceMessage(player_guid, experience, unk) =>
+            player_guid mustEqual PlanetSideGUID(2698)
+            experience mustEqual 999
+            unk mustEqual 0
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = BattleExperienceMessage(PlanetSideGUID(2698), 999, 0)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "ZonePopulationUpdateMessage" should {
       val string = hex"B6 0400 9E010000 8A000000 25000000 8A000000 25000000 8A000000 25000000 8A000000 25000000"
 


### PR DESCRIPTION
A pretty straightforward packet, I only had to determine how many bytes were involved in the experience field and why the numbers in my test code were always so large.  The rest wrote itself.

There's a bit of a bug in live but I don't know whether it's an issue with our login test character or the client itself.  The client won't tell the user of the first 100 BEP he earned.  For example, if the first thing the player does is earn 200 BEP, the packet will reach the client, and the client will properly record that 200 BEP was earned; but, the events window will only display "You have been awarded **100** battle experience."  This only happens the first time as far as I can tell.
