### PR TITLE
Packet: DismountBuildingMsg

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -465,7 +465,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x79 => noDecoder(TradeMessage)
     case 0x7a => noDecoder(UnknownMessage122)
     case 0x7b => noDecoder(DamageFeedbackMessage)
-    case 0x7c => noDecoder(DismountBuildingMsg)
+    case 0x7c => game.DismountBuildingMsg.decode
     case 0x7d => noDecoder(UnknownMessage125)
     case 0x7e => noDecoder(UnknownMessage126)
     case 0x7f => noDecoder(AvatarStatisticsMessage)

--- a/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
@@ -10,7 +10,7 @@ import scodec.codecs._
   * <br>
   * Paragraph in which "'dismounting' a building" is explained.
   * @param player_guid the player
-  * @param building_guid the building being "dismounted"
+  * @param building_guid the building
   */
 final case class DismountBuildingMsg(player_guid : PlanetSideGUID,
                                      building_guid : PlanetSideGUID)

--- a/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Alert that the player is "dismounting" a building.<br>
+  * <br>
+  * Paragraph in which "'dismounting' a building" is explained.
+  * @param player_guid the player
+  * @param building_guid the building being "dismounted"
+  */
+final case class DismountBuildingMsg(player_guid : PlanetSideGUID,
+                                     building_guid : PlanetSideGUID)
+  extends PlanetSideGamePacket {
+  type Packet = DismountBuildingMsg
+  def opcode = GamePacketOpcode.DismountBuildingMsg
+  def encode = DismountBuildingMsg.encode(this)
+}
+
+object DismountBuildingMsg extends Marshallable[DismountBuildingMsg] {
+  implicit val codec : Codec[DismountBuildingMsg] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("building_guid" | PlanetSideGUID.codec)
+    ).as[DismountBuildingMsg]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -1,1 +1,2 @@
 // Copyright (c) 2016 PSForever.net to present
+

--- a/common/src/test/scala/game/DismountBuildingMsgTest.scala
+++ b/common/src/test/scala/game/DismountBuildingMsgTest.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016 PSForever.net to present
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class DismountBuildingMsgTest extends Specification {
+  val string = hex"7C 4B00 2E00"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case DismountBuildingMsg(player_guid, building_guid) =>
+        player_guid mustEqual PlanetSideGUID(75)
+        building_guid mustEqual PlanetSideGUID(46)
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = DismountBuildingMsg(PlanetSideGUID(75), PlanetSideGUID(46))
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
To trigger this packet in sanctuary, go to the training area entrance doors, run through them until the prompt is encountered, and then select "Exit Virtual Reality."  The building GUID called out in the packet is that same spawn building's GUID (tested using login packets to verify).

I really don't know how to explain "dismounting" a building, especially since you don't go anywhere in the known test case, even if everything were rigged correctly.
