### PR TITLE
Added: MountVehicleMsg Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -334,7 +334,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x0b => noDecoder(DamageMessage)
     case 0x0c => noDecoder(DestroyMessage)
     case 0x0d => game.ReloadMessage.decode
-    case 0x0e => noDecoder(MountVehicleMsg)
+    case 0x0e => game.MountVehicleMsg.decode
     case 0x0f => noDecoder(DismountVehicleMsg)
 
     // OPCODES 0x10-1f

--- a/common/src/main/scala/net/psforever/packet/game/MountVehicleMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/MountVehicleMsg.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Alert that the player wishes to board a vehicle into a specific seat.<br>
+  * <br>
+  * The client will only dispatch this packet when it feels confident that the player can get into the specific seat on a vehicle.
+  * It makes its own check whether or not to display that "enter vehicle here" icon on the ground.
+  * Even without that condition, the player is not allowed to do anything until the server responds in affirmation.<br>
+  * <br>
+  * Base turrets and implant terminals count as "vehicles" for the purpose of mounting.
+  * @param player_guid the player
+  * @param vehicle_guid the vehicle
+  * @param seat the vehicle-specific seat index
+  */
+final case class MountVehicleMsg(player_guid : PlanetSideGUID,
+                                 vehicle_guid : PlanetSideGUID,
+                                 seat : Int)
+  extends PlanetSideGamePacket {
+  type Packet = MountVehicleMsg
+  def opcode = GamePacketOpcode.MountVehicleMsg
+  def encode = MountVehicleMsg.encode(this)
+}
+
+object MountVehicleMsg extends Marshallable[MountVehicleMsg] {
+  implicit val codec : Codec[MountVehicleMsg] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("vehicle_guid" | PlanetSideGUID.codec) ::
+      ("seat" | uint8L)
+    ).as[MountVehicleMsg]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -341,6 +341,28 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "MountVehicleMsg" should {
+      val string = hex"0E E104 6704 06"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case MountVehicleMsg(player_guid, vehicle_guid, seat) =>
+            player_guid mustEqual PlanetSideGUID(1249)
+            vehicle_guid mustEqual PlanetSideGUID(1127)
+            seat mustEqual 6
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = MountVehicleMsg(PlanetSideGUID(1249), PlanetSideGUID(1127), 6)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "ObjectHeldMessage" should {
       val string = hex"33 4B00 02 00"
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -274,6 +274,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ AvatarFirstTimeEventMessage(avatar_guid, object_guid, unk1, event_name) =>
       log.info("AvatarFirstTimeEvent: " + msg)
 
+    case msg @ MountVehicleMsg(player_guid, vehicle_guid, unk) =>
+      log.info("MounVehicleMsg: "+msg)
+
     case default => log.debug(s"Unhandled GamePacket ${pkt}")
   }
 


### PR DESCRIPTION
So, while playing with BattleExperienceMessage packets (pull request #76), I realized that getting enough experience automatically gave me an equivalent battle rank as far as the client was concerned.  Following from that, I found that also made available the implant terminal in the HART building like normal after BR6.  I attempted to use the implant terminals and that's how I discovered this packet.

I used packet captures from other vehicles to confirm the seating byte, though we don't have anything in the game with more seats than 12 as far as I know.

The HART shuttle, however, produced an interesting packet capture as it reported I had tried to board into the "6" seat by myself.  I don't quite get why that is.  Perhaps it had to do with the specific door in the HART building I used for that capture.
