### PR TITLE
Added: BindPlayerMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -344,7 +344,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x13 => noDecoder(CharacterNoRecordMessage)
     case 0x14 => game.CharacterInfoMessage.decode
     case 0x15 => noDecoder(UnknownMessage21)
-    case 0x16 => noDecoder(BindPlayerMessage)
+    case 0x16 => game.BindPlayerMessage.decode
     case 0x17 => noDecoder(ObjectCreateMessage_Duplicate)
     // 0x18
     case 0x18 => game.ObjectCreateMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
@@ -2,31 +2,45 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.Vector3
 import scodec.Codec
-import scodec.bits.{ByteVector, HexStringSyntax}
 import scodec.codecs._
 
 /**
   * A mysterious packet that is dispatched from the server to the client during zone transitions.<br>
   * <br>
-  * This packet is sent out after unloading the current zone but before beginning loading in the new zone.
-  * Specifically, it is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.<br>
+  * One common instance of this packet occurs during zone transport.
+  * Specifically, a packet is dispatched after unloading the current zone but before beginning loading in the new zone.
+  * It is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.<br>
   * <br>
-  * Exploration:<br>
+  * Exploration 1:<br>
   * We will not have any clue how this packet truly works until we are at the point where we allow the player to change continents.
-  * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.
+  * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.<br>
+  * <br>
+  * Exploration 2:<br>
+  * Find other bind descriptors.<br>
+  * <br>
+  * Bind Descriptors:<br>
+  * `&#64;ams`<br>
+  * `&#64;tech_plant`
   * @param unk1 na
-  * @param bindDesc a description of the binding point ("@ams")
+  * @param bindDesc a description of the binding point
   * @param unk2 na
   * @param unk3 na
   * @param unk4 na
+  * @param unk5 na
+  * @param unk6 na
+  * @param pos a position associated with the binding unit
   */
-//TODO except for bindDesc, this is all wrong
+//TODO everything in between bindDesc and unk5 is probably wrong
 final case class BindPlayerMessage(unk1 : Int,
                                    bindDesc : String,
-                                   unk2 : Int,
-                                   unk3 : Int,
-                                   unk4 : ByteVector)
+                                   unk2 : Boolean,
+                                   unk3 : Boolean,
+                                   unk4 : Int,
+                                   unk5 : Long,
+                                   unk6 : Long,
+                                   pos : Vector3)
   extends PlanetSideGamePacket {
   type Packet = BindPlayerMessage
   def opcode = GamePacketOpcode.BindPlayerMessage
@@ -35,15 +49,21 @@ final case class BindPlayerMessage(unk1 : Int,
 
 object BindPlayerMessage extends Marshallable[BindPlayerMessage] {
   /**
-    * A common variant of this packet
+    * A common variant of this packet.
+    * `16028004000000000000000000000000000000`
     */
-  val STANDARD = BindPlayerMessage(2, "", 4, 0, hex"00 00 00 00 00 00 00 00 00 00 00 00 00 00")
+  val STANDARD = BindPlayerMessage(2, "", false, false, 2, 0, 0, Vector3(0, 0, 0))
 
   implicit val codec : Codec[BindPlayerMessage] = (
     ("unk1" | uint8L) ::
       ("bindDesc" | PacketHelpers.encodedString) ::
-      ("unk2" | uint8L) ::
-      ("unk3" | uint8L) ::
-      ("unk4" | bytes)
+      ("unk2" | bool) ::
+      ("unk3" | bool) ::
+      ignore(1) :: //remove this and double up the other `ignore`?
+      ("unk4" | uint4L) ::
+      ignore(1) ::
+      ("unk5" | uint32L) ::
+      ("unk6" | uint32L) ::
+      ("pos" | Vector3.codec_pos)
     ).as[BindPlayerMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
@@ -1,30 +1,32 @@
 // Copyright (c) 2016 PSForever.net to present
 package net.psforever.packet.game
 
-import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
 import scodec.Codec
-import scodec.bits.{ByteVector, HexStringSyntax} //It's not unused! shut up, IDEA. :(
+import scodec.bits.{ByteVector, HexStringSyntax}
 import scodec.codecs._
 
 /**
   * A mysterious packet that is dispatched from the server to the client during zone transitions.<br>
   * <br>
   * This packet is sent out after unloading the current zone but before beginning loading in the new zone.
-  * Specifically, it is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.
-  * The server does not attempt to "bind" during initial login.<br>
+  * Specifically, it is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.<br>
   * <br>
   * Exploration:<br>
   * We will not have any clue how this packet truly works until we are at the point where we allow the player to change continents.
   * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.
-  * @param unk1 na; always 2 (`02`)?
-  * @param unk2 na; always 128 (`80`)?
-  * @param unk3 na; always 4 (`04`)?
-  * @param unk4 na; always a stream of fifteen `00` values?
+  * @param unk1 na
+  * @param bindDesc a description of the binding point ("@ams")
+  * @param unk2 na
+  * @param unk3 na
+  * @param unk4 na
   */
+//TODO except for bindDesc, this is all wrong
 final case class BindPlayerMessage(unk1 : Int,
-                                  unk2 : Int,
-                                  unk3 : Int,
-                                  unk4 : ByteVector)
+                                   bindDesc : String,
+                                   unk2 : Int,
+                                   unk3 : Int,
+                                   unk4 : ByteVector)
   extends PlanetSideGamePacket {
   type Packet = BindPlayerMessage
   def opcode = GamePacketOpcode.BindPlayerMessage
@@ -33,12 +35,13 @@ final case class BindPlayerMessage(unk1 : Int,
 
 object BindPlayerMessage extends Marshallable[BindPlayerMessage] {
   /**
-    * The most common (only?) variant of this packet created by the server and sent to the client
+    * A common variant of this packet
     */
-  val STANDARD = BindPlayerMessage(2, 128, 4, hex"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00")
+  val STANDARD = BindPlayerMessage(2, "", 4, 0, hex"00 00 00 00 00 00 00 00 00 00 00 00 00 00")
 
   implicit val codec : Codec[BindPlayerMessage] = (
     ("unk1" | uint8L) ::
+      ("bindDesc" | PacketHelpers.encodedString) ::
       ("unk2" | uint8L) ::
       ("unk3" | uint8L) ::
       ("unk4" | bytes)

--- a/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
@@ -3,7 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
 import scodec.Codec
-import scodec.bits.{ByteVector, HexStringSyntax} //It's not unused! shut up. :(
+import scodec.bits.{ByteVector, HexStringSyntax} //It's not unused! shut up, IDEA. :(
 import scodec.codecs._
 
 /**
@@ -14,7 +14,7 @@ import scodec.codecs._
   * The server does not attempt to "bind" during initial login.<br>
   * <br>
   * Exploration:<br>
-  * We will not have any clue how this packet truly works until we are at the point where we left the player change continents.
+  * We will not have any clue how this packet truly works until we are at the point where we allow the player to change continents.
   * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.
   * @param unk1 na; always 2 (`02`)?
   * @param unk2 na; always 128 (`80`)?

--- a/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.bits.{ByteVector, HexStringSyntax} //It's not unused! shut up. :(
+import scodec.codecs._
+
+/**
+  * A mysterious packet that is dispatched from the server to the client during zone transitions.<br>
+  * <br>
+  * This packet is sent out after unloading the current zone but before beginning loading in the new zone.
+  * Specifically, it is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.
+  * The server does not attempt to "bind" during initial login.<br>
+  * <br>
+  * Exploration:<br>
+  * We will not have any clue how this packet truly works until we are at the point where we left the player change continents.
+  * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.
+  * @param unk1 na; always 2 (`02`)?
+  * @param unk2 na; always 128 (`80`)?
+  * @param unk3 na; always 4 (`04`)?
+  * @param unk4 na; always a stream of fifteen `00` values?
+  */
+final case class BindPlayerMessage(unk1 : Int,
+                                  unk2 : Int,
+                                  unk3 : Int,
+                                  unk4 : ByteVector)
+  extends PlanetSideGamePacket {
+  type Packet = BindPlayerMessage
+  def opcode = GamePacketOpcode.BindPlayerMessage
+  def encode = BindPlayerMessage.encode(this)
+}
+
+object BindPlayerMessage extends Marshallable[BindPlayerMessage] {
+  /**
+    * The most common (only?) variant of this packet created by the server and sent to the client
+    */
+  val STANDARD = BindPlayerMessage(2, 128, 4, hex"00 00 00 00 00 00 00 00 00 00 00 00 00 00 00")
+
+  implicit val codec : Codec[BindPlayerMessage] = (
+    ("unk1" | uint8L) ::
+      ("unk2" | uint8L) ::
+      ("unk3" | uint8L) ::
+      ("unk4" | bytes)
+    ).as[BindPlayerMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BindPlayerMessage.scala
@@ -7,39 +7,59 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * A mysterious packet that is dispatched from the server to the client during zone transitions.<br>
+  * A packet dispatched from the server to the client to maintain a manually-set respawn location.<br>
   * <br>
-  * One common instance of this packet occurs during zone transport.
+  * The packet establish the player's ability to spawn in an arbitrary location that is not within the normal options of local spawns.
+  * This process is called "binding."
+  * In addition to establishing the binding, the packet is updated as respawn locations change in case they would affect the user's options.<br>
+  * <br>
+  * If logging is turned on, packets will display different messages depending on their functionality and, sometimes, on context.
+  * As long as the event is marked to be logged, when the packet is received, a message is displayed in the events window.
+  * If the logged action is applicable, the matrixing sound effect will be played too.
+  * Not displaying events is occasionally warranted for aesthetics.
+  * The game will always note if this is your first time binding somewhere.<br>
+  * <br>
+  * One common occurrence of this packet is during zone transport.
   * Specifically, a packet is dispatched after unloading the current zone but before beginning loading in the new zone.
   * It is preceded by all of the `ObjectDeleteMessage` packets and itself precedes the `LoadMapMessage` packet.<br>
   * <br>
-  * Exploration 1:<br>
-  * We will not have any clue how this packet truly works until we are at the point where we allow the player to change continents.
-  * Before that, however, all evidence seems to indicate "standard" `BindPlayerMessage` data, as indicated below.<br>
+  * Exploration:<br>
+  * Find other bind descriptors.
+  * Throw stuff from the decompiled strings data (start near `C6C9D8`) against the wall and see what sticks.<br>
   * <br>
-  * Exploration 2:<br>
-  * Find other bind descriptors.<br>
+  * Actions:<br>
+  * `1` - bound to respawn point<br>
+  * `2` - general unbound / unbinding from respawn point<br>
+  * `3` - respawn point lost<br>
+  * `4` - bound spawn point became available<br>
+  * `5` - bound spawn point became unavailable (different from 3)<br>
   * <br>
   * Bind Descriptors:<br>
+  * (blank)<br>
+  * `&#64;amp_station`<br>
   * `&#64;ams`<br>
+  * `&#64;comm_station` (interlink facility?)<br>
+  * `&#64;comm_station_dsp` (dropship center?)<br>
+  * `&#64;cryo_facility` (biolab?)<br>
   * `&#64;tech_plant`
-  * @param unk1 na
-  * @param bindDesc a description of the binding point
-  * @param unk2 na
+  * @param action the purpose of the packet
+  * @param bindDesc a description of the respawn binding point
+  * @param unk1 na; usually set `true` if there is more data in the packet ...
+  * @param logging true, to report on bind point change visible in the events window;
+  *                false, to render spawn change silent;
+  *                a first time event notification will always show
+  * @param unk2 na; if a value, it is usually 40 (hex`28`)
   * @param unk3 na
   * @param unk4 na
-  * @param unk5 na
-  * @param unk6 na
-  * @param pos a position associated with the binding unit
+  * @param pos a position associated with the binding
   */
-//TODO everything in between bindDesc and unk5 is probably wrong
-final case class BindPlayerMessage(unk1 : Int,
+final case class BindPlayerMessage(action : Int,
                                    bindDesc : String,
-                                   unk2 : Boolean,
-                                   unk3 : Boolean,
-                                   unk4 : Int,
-                                   unk5 : Long,
-                                   unk6 : Long,
+                                   unk1 : Boolean,
+                                   logging : Boolean,
+                                   unk2 : Int,
+                                   unk3 : Long,
+                                   unk4 : Long,
                                    pos : Vector3)
   extends PlanetSideGamePacket {
   type Packet = BindPlayerMessage
@@ -55,15 +75,15 @@ object BindPlayerMessage extends Marshallable[BindPlayerMessage] {
   val STANDARD = BindPlayerMessage(2, "", false, false, 2, 0, 0, Vector3(0, 0, 0))
 
   implicit val codec : Codec[BindPlayerMessage] = (
-    ("unk1" | uint8L) ::
+    ("action" | uint8L) ::
       ("bindDesc" | PacketHelpers.encodedString) ::
-      ("unk2" | bool) ::
-      ("unk3" | bool) ::
+      ("unk1" | bool) ::
+      ("logging" | bool) ::
       ignore(1) :: //remove this and double up the other `ignore`?
-      ("unk4" | uint4L) ::
+      ("unk2" | uint4L) ::
       ignore(1) ::
-      ("unk5" | uint32L) ::
-      ("unk6" | uint32L) ::
+      ("unk3" | uint32L) ::
+      ("unk4" | uint32L) ::
       ("pos" | Vector3.codec_pos)
     ).as[BindPlayerMessage]
 }

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -223,15 +223,15 @@ class GamePacketTest extends Specification {
 
       "decode (ams)" in {
         PacketCoding.DecodePacket(string_ams).require match {
-          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4, unk5, unk6, pos) =>
-            unk1 mustEqual 5
+          case BindPlayerMessage(action, bindDesc, unk1, logging, unk2, unk3, unk4, pos) =>
+            action mustEqual 5
             bindDesc.length mustEqual 4
             bindDesc mustEqual "@ams"
-            unk2 mustEqual false
-            unk3 mustEqual false
-            unk4 mustEqual 4
-            unk5 mustEqual 40
-            unk6 mustEqual 0
+            unk1 mustEqual false
+            logging mustEqual false
+            unk2 mustEqual 4
+            unk3 mustEqual 40
+            unk4 mustEqual 0
             pos.x mustEqual 0f
             pos.y mustEqual 0f
             pos.z mustEqual 0f
@@ -242,15 +242,15 @@ class GamePacketTest extends Specification {
 
       "decode (tech)" in {
         PacketCoding.DecodePacket(string_tech).require match {
-          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4, unk5, unk6, pos) =>
-            unk1 mustEqual 1
+          case BindPlayerMessage(action, bindDesc, unk1, logging, unk2, unk3, unk4, pos) =>
+            action mustEqual 1
             bindDesc.length mustEqual 11
             bindDesc mustEqual "@tech_plant"
-            unk2 mustEqual true
-            unk3 mustEqual true
-            unk4 mustEqual 10
-            unk5 mustEqual 40
-            unk6 mustEqual 56
+            unk1 mustEqual true
+            logging mustEqual true
+            unk2 mustEqual 10
+            unk3 mustEqual 40
+            unk4 mustEqual 56
             pos.x mustEqual 2060.0f
             pos.y mustEqual 598.0078f
             pos.z mustEqual 274.5f

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -217,6 +217,36 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "BindPlayerMessage" should {
+      val string = hex"16 02 80 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case BindPlayerMessage(unk1, unk2, unk3, unk4) =>
+            unk1 mustEqual 2
+            unk2 mustEqual 128
+            unk3 mustEqual 4
+            unk4.toString mustEqual hex"000000000000000000000000000000".toString
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = BindPlayerMessage(2, 128, 4, hex"000000000000000000000000000000")
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+
+      "standard" in {
+        val msg = BindPlayerMessage.STANDARD
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "ChangeFireModeMessage" should {
       val string = hex"46 4C0020"
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -218,22 +218,24 @@ class GamePacketTest extends Specification {
     }
 
     "BindPlayerMessage" should {
-      val string = hex"16 02 80 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+      val string = hex"16 05 84 40 61 6D 73 08  28 00 00 00 00 00 00 00  00 00 00 00 00 00 00"
 
       "decode" in {
         PacketCoding.DecodePacket(string).require match {
-          case BindPlayerMessage(unk1, unk2, unk3, unk4) =>
-            unk1 mustEqual 2
-            unk2 mustEqual 128
-            unk3 mustEqual 4
-            unk4.toString mustEqual hex"000000000000000000000000000000".toString
+          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4) =>
+            unk1 mustEqual 5
+            bindDesc.length mustEqual 4
+            bindDesc mustEqual "@ams"
+            unk2 mustEqual 8
+            unk3 mustEqual 40
+            unk4.toString mustEqual hex"0000000000000000000000000000".toString
           case default =>
             ko
         }
       }
 
       "encode" in {
-        val msg = BindPlayerMessage(2, 128, 4, hex"000000000000000000000000000000")
+        val msg = BindPlayerMessage(5, "@ams", 8, 40, hex"0000000000000000000000000000")
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual string
@@ -243,7 +245,7 @@ class GamePacketTest extends Specification {
         val msg = BindPlayerMessage.STANDARD
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual string
+        pkt mustEqual hex"16028004000000000000000000000000000000"
       }
     }
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -218,27 +218,59 @@ class GamePacketTest extends Specification {
     }
 
     "BindPlayerMessage" should {
-      val string = hex"16 05 84 40 61 6D 73 08  28 00 00 00 00 00 00 00  00 00 00 00 00 00 00"
+      val string_ams = hex"16 05 8440616D73 08 28000000 00000000 00000 00000 0000"
+      val string_tech = hex"16 01 8b40746563685f706c616e74 d4 28000000 38000000 00064 012b1 a044"
 
-      "decode" in {
-        PacketCoding.DecodePacket(string).require match {
-          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4) =>
+      "decode (ams)" in {
+        PacketCoding.DecodePacket(string_ams).require match {
+          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4, unk5, unk6, pos) =>
             unk1 mustEqual 5
             bindDesc.length mustEqual 4
             bindDesc mustEqual "@ams"
-            unk2 mustEqual 8
-            unk3 mustEqual 40
-            unk4.toString mustEqual hex"0000000000000000000000000000".toString
+            unk2 mustEqual false
+            unk3 mustEqual false
+            unk4 mustEqual 4
+            unk5 mustEqual 40
+            unk6 mustEqual 0
+            pos.x mustEqual 0f
+            pos.y mustEqual 0f
+            pos.z mustEqual 0f
           case default =>
             ko
         }
       }
 
-      "encode" in {
-        val msg = BindPlayerMessage(5, "@ams", 8, 40, hex"0000000000000000000000000000")
+      "decode (tech)" in {
+        PacketCoding.DecodePacket(string_tech).require match {
+          case BindPlayerMessage(unk1, bindDesc, unk2, unk3, unk4, unk5, unk6, pos) =>
+            unk1 mustEqual 1
+            bindDesc.length mustEqual 11
+            bindDesc mustEqual "@tech_plant"
+            unk2 mustEqual true
+            unk3 mustEqual true
+            unk4 mustEqual 10
+            unk5 mustEqual 40
+            unk6 mustEqual 56
+            pos.x mustEqual 2060.0f
+            pos.y mustEqual 598.0078f
+            pos.z mustEqual 274.5f
+          case default =>
+            ko
+        }
+      }
+
+      "encode (ams)" in {
+        val msg = BindPlayerMessage(5, "@ams", false, false, 4, 40, 0, Vector3(0, 0, 0))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual string
+        pkt mustEqual string_ams
+      }
+
+      "encode (tech)" in {
+        val msg = BindPlayerMessage(1, "@tech_plant", true, true, 10, 40, 56, Vector3(2060.0f, 598.0078f, 274.5f))
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string_tech
       }
 
       "standard" in {


### PR DESCRIPTION
This is not necessarily a normal packet submission.  I'm actually looking for additional information.

I have numerous personal packet captures of the process of tranferring between different zones.  This packet serves some part of that system.  In every capture, however, the data always takes the same form:
`16 02 80 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00`
... regardless of origin, destination, or character.  For me, all entries always contain the same eighteen byte sequence of data after the opcode.

Does this match other people's captures?

Update:
PR re-opened.  See comments below.
