### PR TITLE
Added: AvatarGrenadeStateMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -519,7 +519,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xa7 => noDecoder(GenericActionMessage)
     // 0xa8
     case 0xa8 => game.ContinentalLockUpdateMessage.decode
-    case 0xa9 => noDecoder(AvatarGrenadeStateMessage)
+    case 0xa9 => game.AvatarGrenadeStateMessage.decode
     case 0xaa => noDecoder(UnknownMessage170)
     case 0xab => noDecoder(UnknownMessage171)
     case 0xac => noDecoder(ReleaseAvatarRequestMessage)

--- a/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
@@ -1,30 +1,24 @@
 // Copyright (c) 2016 PSForever.net to present
 package net.psforever.packet.game
 
-import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
 import scodec.Codec
 import scodec.codecs._
 
-object GrenadeState extends Enumeration {
-  type Type = Value
-  val unk0,
-  PRIMED,
-  THROWN,
-  unk3
-  = Value
-
-  implicit val codec = PacketHelpers.createEnumerationCodec(this, uintL(1))
-}
-
 /**
-  * na
+  * Report the state of the "grenade throw" animation for this player.<br>
+  * <br>
+  * States:<br>
+  * 1 - prepare for throwing (grenade held back over shoulder)<br>
+  * 2 - throwing (grenade released overhand)<br>
+  * <br>
+  * Exploration:<br>
+  * How many grenade states are possible?
   * @param player_guid the player
-  * @param count the state
+  * @param state the animation state
   */
-//case msg @ AvatarGrenadeStateMessage(player_guid, state) =>
-//log.info("AvatarGrenadeStateMessage: " + msg)
 final case class AvatarGrenadeStateMessage(player_guid : PlanetSideGUID,
-                                           count : GrenadeState.Value)
+                                           state : Int)
   extends PlanetSideGamePacket {
   type Packet = AvatarGrenadeStateMessage
   def opcode = GamePacketOpcode.AvatarGrenadeStateMessage
@@ -34,7 +28,6 @@ final case class AvatarGrenadeStateMessage(player_guid : PlanetSideGUID,
 object AvatarGrenadeStateMessage extends Marshallable[AvatarGrenadeStateMessage] {
   implicit val codec : Codec[AvatarGrenadeStateMessage] = (
     ("player_guid" | PlanetSideGUID.codec) ::
-      ("state" | GrenadeState.codec)
+      ("state" | uint8L)
     ).as[AvatarGrenadeStateMessage]
 }
-

--- a/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+object GrenadeState extends Enumeration {
+  type Type = Value
+  val unk0,
+  PRIMED,
+  THROWN,
+  unk3
+  = Value
+
+  implicit val codec = PacketHelpers.createEnumerationCodec(this, uintL(1))
+}
+
+/**
+  * na
+  * @param player_guid the player
+  * @param count the state
+  */
+//case msg @ AvatarGrenadeStateMessage(player_guid, state) =>
+//log.info("AvatarGrenadeStateMessage: " + msg)
+final case class AvatarGrenadeStateMessage(player_guid : PlanetSideGUID,
+                                           count : GrenadeState.Value)
+  extends PlanetSideGamePacket {
+  type Packet = AvatarGrenadeStateMessage
+  def opcode = GamePacketOpcode.AvatarGrenadeStateMessage
+  def encode = AvatarGrenadeStateMessage.encode(this)
+}
+
+object AvatarGrenadeStateMessage extends Marshallable[AvatarGrenadeStateMessage] {
+  implicit val codec : Codec[AvatarGrenadeStateMessage] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("state" | GrenadeState.codec)
+    ).as[AvatarGrenadeStateMessage]
+}
+

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -681,6 +681,27 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "AvatarGrenadeStateMessage" should {
+      val string = hex"A9 DA11 01"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case AvatarGrenadeStateMessage(player_guid, state) =>
+            player_guid mustEqual PlanetSideGUID(4570)
+            state mustEqual 1
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = AvatarGrenadeStateMessage(PlanetSideGUID(4570), 1)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "BroadcastWarpgateUpdateMessage" should {
       val string = hex"D9 0D 00 01 00 20"
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -274,6 +274,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ AvatarFirstTimeEventMessage(avatar_guid, object_guid, unk1, event_name) =>
       log.info("AvatarFirstTimeEvent: " + msg)
 
+    case msg @ AvatarGrenadeStateMessage(player_guid, state) =>
+      log.info("AvatarGrenadeStateMessage: " + msg)
+
     case default => log.debug(s"Unhandled GamePacket ${pkt}")
   }
 


### PR DESCRIPTION
I was working on inventory related things in another branch and I dumped a bunch of plasma grenades and jammer grenades into my pistol slots.  That lead to the realization of this packet.  While the packet itself is simple, it was letting the client do its own thing that was necessary to figure out what the extra field does.  I don't know why it passes a byte and that's why I'm hesitant to declare grenade animation only having two states.

Incidentally, after you throw the last grenade in a three set, the client strands you with an "0/n" grenade icon in your slot.  You don't automatically switch to the next set of grenades or technically put away your grenade hand until the server says so.  If you still have grenades in reserve, you can hold (but never throw) an imaginary grenade if you play around with the slot binds.
