### PR TITLE
Added: FriendsResponse Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -455,7 +455,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x70 => noDecoder(SquadMemberEvent)
     case 0x71 => noDecoder(PlatoonEvent)
     case 0x72 => noDecoder(FriendsRequest)
-    case 0x73 => game.FriendsReponse.decode
+    case 0x73 => game.FriendsResponse.decode
     case 0x74 => noDecoder(TriggerEnvironmentalDamageMessage)
     case 0x75 => noDecoder(TrainingZoneMessage)
     case 0x76 => noDecoder(DeployableObjectsInfoMessage)

--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -455,7 +455,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x70 => noDecoder(SquadMemberEvent)
     case 0x71 => noDecoder(PlatoonEvent)
     case 0x72 => noDecoder(FriendsRequest)
-    case 0x73 => noDecoder(FriendsResponse)
+    case 0x73 => game.FriendsReponse.decode
     case 0x74 => noDecoder(TriggerEnvironmentalDamageMessage)
     case 0x75 => noDecoder(TrainingZoneMessage)
     case 0x76 => noDecoder(DeployableObjectsInfoMessage)

--- a/common/src/main/scala/net/psforever/packet/PSPacket.scala
+++ b/common/src/main/scala/net/psforever/packet/PSPacket.scala
@@ -3,7 +3,7 @@ package net.psforever.packet
 
 import java.nio.charset.Charset
 
-import scodec.{Attempt, Codec, DecodeResult, Err}
+import scodec.{DecodeResult, Err, Codec, Attempt}
 import scodec.bits._
 import scodec.codecs._
 import scodec._

--- a/common/src/main/scala/net/psforever/packet/PSPacket.scala
+++ b/common/src/main/scala/net/psforever/packet/PSPacket.scala
@@ -3,7 +3,6 @@ package net.psforever.packet
 
 import java.nio.charset.Charset
 
-import scodec.Attempt.Successful
 import scodec.{Attempt, Codec, DecodeResult, Err}
 import scodec.bits._
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/PSPacket.scala
+++ b/common/src/main/scala/net/psforever/packet/PSPacket.scala
@@ -209,8 +209,8 @@ object PacketHelpers {
     * Codec that encodes/decodes a list of `n` elements, where `n` is known at compile time.<br>
     * <br>
     * This function is copied almost verbatim from its source, with exception of swapping the parameter that is normally a `Nat` `literal`.
-    * The modified function takes a normal unsigned `Integer` and assures that the parameter is a non-negative before further processing.
-    * @param size  the fixed size of the `List`
+    * The modified function takes a normal unsigned `Integer` and assures that the parameter is non-negative before further processing.
+    * @param size the known size of the `List`
     * @param codec a codec that describes each of the contents of the `List`
     * @tparam A the type of the `List` contents
     * @see codec\package.scala, sizedList

--- a/common/src/main/scala/net/psforever/packet/PSPacket.scala
+++ b/common/src/main/scala/net/psforever/packet/PSPacket.scala
@@ -203,4 +203,17 @@ object PacketHelpers {
 
   def encodedStringWithLimit(limit : Int) : Codec[String] = variableSizeBytes(encodedStringSizeWithLimit(limit), ascii)
   */
+
+  /**
+    * Construct a `Codec` for reading `wchar_t` (wide character) `Strings` whose length field are constrained to specific bit size proportions.
+    * Padding may also exist between the length field and the beginning of the contents.
+    * @param lenSize a codec that defines the bit size that encodes the length
+    * @param adjustment the optional alignment for padding; defaults to 0
+    * @return the `String` `Codec`
+    */
+  def specSizeWideStringAligned(lenSize : Codec[Int], adjustment : Int = 0) : Codec[String] =
+    variableSizeBytes((lenSize <~ ignore(adjustment)).xmap(
+      insize => insize*2, // number of symbols -> number of bytes (decode)
+      outSize => outSize/2 // number of bytes -> number of symbols (encode)
+    ), utf16)
 }

--- a/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -13,7 +13,7 @@ import scodec.codecs._
   */
 final case class FriendsResponse(player_guid : PlanetSideGUID,
                                  friend : String,
-                                 unk : Int)
+                                 unk : Boolean)
   extends PlanetSideGamePacket {
   type Packet = FriendsResponse
   def opcode = GamePacketOpcode.FriendsResponse
@@ -24,6 +24,6 @@ object FriendsReponse extends Marshallable[FriendsResponse] {
   implicit val codec : Codec[FriendsResponse] = (
     ("player_guid" | PlanetSideGUID.codec) ::
       ("friend" | PacketHelpers.specSizeWideStringAligned(uint(5), 3)) ::
-      ("unk" | uint8L)
+      ("unk" | bool)
     ).as[FriendsResponse]
 }

--- a/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * na
+  * @param player_guid the player
+  * @param friend the name of the friend
+  * @param unk na
+  */
+final case class FriendsResponse(player_guid : PlanetSideGUID,
+                                 friend : String,
+                                 unk : Int)
+  extends PlanetSideGamePacket {
+  type Packet = FriendsResponse
+  def opcode = GamePacketOpcode.FriendsResponse
+  def encode = FriendsReponse.encode(this)
+}
+
+object FriendsReponse extends Marshallable[FriendsResponse] {
+  implicit val codec : Codec[FriendsResponse] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("friend" | PacketHelpers.specSizeWideStringAligned(uint(5), 3)) ::
+      ("unk" | uint8L)
+    ).as[FriendsResponse]
+}

--- a/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -5,25 +5,43 @@ import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, Plan
 import scodec.Codec
 import scodec.codecs._
 
-/**
-  * na
-  * @param player_guid the player
-  * @param friend the name of the friend
-  * @param unk na
-  */
-final case class FriendsResponse(player_guid : PlanetSideGUID,
-                                 friend : String,
-                                 unk : Boolean)
+final case class Friend(name : String = "",
+                        online : Boolean = false)
+
+final case class FriendsResponse(unk1 : Int,
+                                 unk2 : Int,
+                                 unk3 : Boolean,
+                                 unk4 : Boolean,
+                                 number_of_friends : Int,
+                                 friend : Friend,
+                                 friends : List[Friend] = Nil)
   extends PlanetSideGamePacket {
   type Packet = FriendsResponse
   def opcode = GamePacketOpcode.FriendsResponse
   def encode = FriendsReponse.encode(this)
 }
 
+object Friend extends Marshallable[Friend] {
+  implicit val codec : Codec[Friend] = (
+    ("name" | PacketHelpers.encodedWideStringAligned(3)) ::
+      ("online" | bool)
+    ).as[Friend]
+
+  implicit val codec_list : Codec[Friend] = (
+    ("name" | PacketHelpers.encodedWideStringAligned(7)) ::
+      ("online" | bool)
+    ).as[Friend]
+}
+
 object FriendsReponse extends Marshallable[FriendsResponse] {
   implicit val codec : Codec[FriendsResponse] = (
-    ("player_guid" | PlanetSideGUID.codec) ::
-      ("friend" | PacketHelpers.specSizeWideStringAligned(uint(5), 3)) ::
-      ("unk" | bool)
+    ("unk1" | uintL(3)) ::
+      ("unk2" | uintL(4)) ::
+      ("unk3" | bool) ::
+      ("unk4" | bool) ::
+      (("number_of_friends" | uintL(4)) >>:~ { len =>
+        ("friend" | Friend.codec) ::
+        ("friends" | PacketHelpers.sizedList(len-1, Friend.codec_list))
+      })
     ).as[FriendsResponse]
 }

--- a/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -48,7 +48,7 @@ final case class FriendsResponse(action : Int,
   extends PlanetSideGamePacket {
   type Packet = FriendsResponse
   def opcode = GamePacketOpcode.FriendsResponse
-  def encode = FriendsReponse.encode(this)
+  def encode = FriendsResponse.encode(this)
 }
 
 object Friend extends Marshallable[Friend] {
@@ -67,7 +67,7 @@ object Friend extends Marshallable[Friend] {
     ).as[Friend]
 }
 
-object FriendsReponse extends Marshallable[FriendsResponse] {
+object FriendsResponse extends Marshallable[FriendsResponse] {
   implicit val codec : Codec[FriendsResponse] = (
     ("action" | uintL(3)) ::
       ("unk1" | uint4L) ::

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -839,14 +839,14 @@ class GamePacketTest extends Specification {
             player_guid mustEqual PlanetSideGUID(35937)
             friend.length mustEqual 12
             friend mustEqual "KurtHectic-G"
-            unk mustEqual 0
+            unk mustEqual false
           case default =>
             ko
         }
       }
 
       "encode" in {
-        val msg = FriendsResponse(PlanetSideGUID(35937), "KurtHectic-G", 0)
+        val msg = FriendsResponse(PlanetSideGUID(35937), "KurtHectic-G", false)
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual string

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -833,6 +833,7 @@ class GamePacketTest extends Specification {
     "FriendsResponse" should {
       val stringOneFriend = hex"73 61 8C 60 4B007500720074004800650063007400690063002D004700 00"
       val stringManyFriends = hex"73 01 AC 48 4100 6E00 6700 6500 6C00 6C00 6F00 2D00 5700 47 00 7400 6800 6500 7000 6800 6100 7400 7400 7000 6800 7200 6F00 6700 6700 46 80 4B00 6900 6D00 7000 6F00 7300 7300 6900 6200 6C00 6500 3100 3200 45 00 5A00 6500 6100 7200 7400 6800 6C00 6900 6E00 6700 46 00 4B00 7500 7200 7400 4800 6500 6300 7400 6900 6300 2D00 4700 00"
+      val stringShort = hex"73 81 80"
 
       "decode (one friend)" in {
         PacketCoding.DecodePacket(stringOneFriend).require match {
@@ -842,8 +843,9 @@ class GamePacketTest extends Specification {
             unk3 mustEqual true
             unk4 mustEqual true
             number_of_friends mustEqual 1
-            friend.name mustEqual "KurtHectic-G"
-            friend.online mustEqual false
+            friend.isDefined mustEqual true
+            friend.get.name mustEqual "KurtHectic-G"
+            friend.get.online mustEqual false
             list.size mustEqual 0
           case default =>
             ko
@@ -858,8 +860,9 @@ class GamePacketTest extends Specification {
             unk3 mustEqual true
             unk4 mustEqual true
             number_of_friends mustEqual 5
-            friend.name mustEqual "Angello-W"
-            friend.online mustEqual false
+            friend.isDefined mustEqual true
+            friend.get.name mustEqual "Angello-W"
+            friend.get.online mustEqual false
             list.size mustEqual 4
             list.head.name mustEqual "thephattphrogg"
             list.head.online mustEqual false
@@ -874,21 +877,43 @@ class GamePacketTest extends Specification {
         }
       }
 
+      "decode (short)" in {
+        PacketCoding.DecodePacket(stringShort).require match {
+          case FriendsResponse(unk1, unk2, unk3, unk4, number_of_friends, friend, list) =>
+            unk1 mustEqual 4
+            unk2 mustEqual 0
+            unk3 mustEqual true
+            unk4 mustEqual true
+            number_of_friends mustEqual 0
+            friend.isDefined mustEqual false
+            list.size mustEqual 0
+          case default =>
+            ko
+        }
+      }
+
       "encode (one friend)" in {
-        val msg = FriendsResponse(3, 0, true, true, 1, Friend("KurtHectic-G", false))
+        val msg = FriendsResponse(3, 0, true, true, 1, Option(Friend("KurtHectic-G", false)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringOneFriend
       }
 
       "encode (multiple friends)" in {
-        val msg = FriendsResponse(0, 0, true, true, 5, Friend("Angello-W", false), Friend("thephattphrogg", false) ::
-                                                                                     Friend("Kimpossible12", false) ::
-                                                                                     Friend("Zearthling", false) ::
-                                                                                     Friend("KurtHectic-G", false) :: Nil)
+        val msg = FriendsResponse(0, 0, true, true, 5, Option(Friend("Angello-W", false)), Friend("thephattphrogg", false) ::
+                                                                                            Friend("Kimpossible12", false) ::
+                                                                                            Friend("Zearthling", false) ::
+                                                                                            Friend("KurtHectic-G", false) :: Nil)
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringManyFriends
+      }
+
+      "encode (short)" in {
+        val msg = FriendsResponse(4, 0, true, true, 0)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringShort
       }
     }
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -830,6 +830,29 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "FriendsResponse" should {
+      val string = hex"73 618C 60 4B007500720074004800650063007400690063002D004700 00"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case FriendsResponse(player_guid, friend, unk) =>
+            player_guid mustEqual PlanetSideGUID(35937)
+            friend.length mustEqual 12
+            friend mustEqual "KurtHectic-G"
+            unk mustEqual 0
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = FriendsResponse(PlanetSideGUID(35937), "KurtHectic-G", 0)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "WeaponDryFireMessage" should {
       val string = hex"52 4C00"
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -831,25 +831,64 @@ class GamePacketTest extends Specification {
     }
 
     "FriendsResponse" should {
-      val string = hex"73 618C 60 4B007500720074004800650063007400690063002D004700 00"
+      val stringOneFriend = hex"73 61 8C 60 4B007500720074004800650063007400690063002D004700 00"
+      val stringManyFriends = hex"73 01 AC 48 4100 6E00 6700 6500 6C00 6C00 6F00 2D00 5700 47 00 7400 6800 6500 7000 6800 6100 7400 7400 7000 6800 7200 6F00 6700 6700 46 80 4B00 6900 6D00 7000 6F00 7300 7300 6900 6200 6C00 6500 3100 3200 45 00 5A00 6500 6100 7200 7400 6800 6C00 6900 6E00 6700 46 00 4B00 7500 7200 7400 4800 6500 6300 7400 6900 6300 2D00 4700 00"
 
-      "decode" in {
-        PacketCoding.DecodePacket(string).require match {
-          case FriendsResponse(player_guid, friend, unk) =>
-            player_guid mustEqual PlanetSideGUID(35937)
-            friend.length mustEqual 12
-            friend mustEqual "KurtHectic-G"
-            unk mustEqual false
+      "decode (one friend)" in {
+        PacketCoding.DecodePacket(stringOneFriend).require match {
+          case FriendsResponse(unk1, unk2, unk3, unk4, number_of_friends, friend, list) =>
+            unk1 mustEqual 3
+            unk2 mustEqual 0
+            unk3 mustEqual true
+            unk4 mustEqual true
+            number_of_friends mustEqual 1
+            friend.name mustEqual "KurtHectic-G"
+            friend.online mustEqual false
+            list.size mustEqual 0
           case default =>
             ko
         }
       }
 
-      "encode" in {
-        val msg = FriendsResponse(PlanetSideGUID(35937), "KurtHectic-G", false)
+      "decode (multiple friends)" in {
+        PacketCoding.DecodePacket(stringManyFriends).require match {
+          case FriendsResponse(unk1, unk2, unk3, unk4, number_of_friends, friend, list) =>
+            unk1 mustEqual 0
+            unk2 mustEqual 0
+            unk3 mustEqual true
+            unk4 mustEqual true
+            number_of_friends mustEqual 5
+            friend.name mustEqual "Angello-W"
+            friend.online mustEqual false
+            list.size mustEqual 4
+            list.head.name mustEqual "thephattphrogg"
+            list.head.online mustEqual false
+            list(1).name mustEqual "Kimpossible12"
+            list(1).online mustEqual false
+            list(2).name mustEqual "Zearthling"
+            list(2).online mustEqual false
+            list(3).name mustEqual "KurtHectic-G"
+            list(3).online mustEqual false
+          case default =>
+            ko
+        }
+      }
+
+      "encode (one friend)" in {
+        val msg = FriendsResponse(3, 0, true, true, 1, Friend("KurtHectic-G", false))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual string
+        pkt mustEqual stringOneFriend
+      }
+
+      "encode (multiple friends)" in {
+        val msg = FriendsResponse(0, 0, true, true, 5, Friend("Angello-W", false), Friend("thephattphrogg", false) ::
+                                                                                     Friend("Kimpossible12", false) ::
+                                                                                     Friend("Zearthling", false) ::
+                                                                                     Friend("KurtHectic-G", false) :: Nil)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringManyFriends
       }
     }
 


### PR DESCRIPTION
The story behind this packet is stupid.

I found two samples of the packet and, following my usual methodology, compared the bits against the sessions' `PlayerStateMessageUpstream`s to see if the player GUID was represented.  Sure enough, in both early samples, I had found the random sequence of bits that composed the first two bytes in the packet _conveniently_ matching the player's GUID perfectly.  This resulted in my going about trying to parse this packet in the complete wrong way.  I wrote about this "wrong way" in issue #67; and, I even completed a working form of the weird-length-encoding.  (It's not included.)  I eventually corrected my misunderstanding when attempts to create packets manually were failing, a dive into the decompiled code lead to a strange impression of the data, the discovery of a third sample amongst our many packet captures invited reinterpretation, and I still had to forcibly forget my own preconception of the GUID.  That just revealed the horrifying reality of the packet's `List` encoding.

Please note the awkward format of the provided `Friend` entries, split between a singular `Option` entry and a list of up to fourteen entries.  The reason for this format is because the encoding for what-would-be the first entry in the list is different than the subsequent entries for reasons of intial byte alignment and trailing padding.  The first entry is properly aligned in this way but all other entries are **not**.  The first entry is padded in one way but all other entries are padded differently than it.

I hope to write a codec that encodes a `List` that handles the first entry different from the rest of its entries so that these tricks are no longer necessary.  If I can not do that, I will create a secondary constructor that only accepts  a list of `Friends` and then shifts the first `Friend` for the `Option[Friend]` parameter.
