### PR TITLE
Added: GenericActionMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -516,7 +516,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xa4 => noDecoder(WarpgateRequest)
     case 0xa5 => noDecoder(WarpgateResponse)
     case 0xa6 => noDecoder(DamageWithPositionMessage)
-    case 0xa7 => noDecoder(GenericActionMessage)
+    case 0xa7 => game.GenericActionMessage.decode
     // 0xa8
     case 0xa8 => game.ContinentalLockUpdateMessage.decode
     case 0xa9 => noDecoder(AvatarGrenadeStateMessage)

--- a/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
@@ -8,16 +8,36 @@ import scodec.codecs._
 /**
   * Reports that something has happened.<br>
   * <br>
-  * There are twenty-seven individual actions whose activities are changed by the client that are communicated by this packet.
-  * They are not numbered sequentially and some numbers are not associated with an action.
-  * The maximum known action is 45, or `0xB4`, and the lowest is 0, `0x0`.<br>
+  * When sent from the server to a client, there are twenty-seven individual actions caused by this packet.
+  * They are only vaguely organized by behavior and some numbers may not be associated with an action.
+  * When sent by the client to the server, an unknown number of actions are available (update as discovered).
+  * The maximum known action is a server-sent 45, or `0xB4`.<br>
   *<br>
-  * Actions:<br>
-  * `0x90` - 36 - turn on "Looking for Squad"<br>
-  * `0x94` - 37 - turn off "Looking for Squad"<br>
+  * Actions (when sent from server):<br>
+  * 03 - `0x0C` - symbol: show Mosquito radar<br>
+  * 04 - `0x10` - symbol: hide Mosquito radar<br>
+  * 07 - `0x1C` - warning: missile lock<br>
+  * 08 - `0x20` - warning: Wasp missile lock<br>
+  * 09 - `0x24` - warning: T-REK lock<br>
+  * 12 - `0x30` - sound: base captured fanfare<br>
+  * 14 - `0x38` - prompt: new character basic training<br>
+  * 22 - `0x58` - message: awarded a cavern capture (updates cavern capture status)<br>
+  * 23 - `0x5C` - award a cavern kill<br>
+  * 24 - `0x60` - message: you have been imprinted (updates imprinted status; does it?)<br>
+  * 25 - `0x64` - message: you are no longer imprinted (updates imprinted status; does it?)<br>
+  * 27 - `0x6C` - event: purchase timers reset (does it?)<br>
+  * 31 - `0x7C` - switch to first person view, attempt to deconstruct but fail;
+  *               event: fail to deconstruct due to having a "parent vehicle"<br>
+  * 32 - `0x80` - switch to first person view<br>
+  * 33 - `0x84` - event: fail to deconstruct<br>
+  * 43 - `0xAC` - prompt: friendly fire in virtual reality zone<br>
+  * <br>
+  * Actions (when sent from client):<br>
+  * 36 - `0x90` - turn on "Looking for Squad"<br>
+  * 37 - `0x94` - turn off "Looking for Squad"<br>
   * <br>
   * Exploration:<br>
-  * It could take a long time to manually track down what each of these values does.
+  * Well, get to it. :P
   * @param action what this packet is about
   */
 final case class GenericActionMessage(action : Int)

--- a/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Reports that something has happened.<br>
+  * <br>
+  * There are twenty-seven individual actions whose activities are changed by the client that are communicated by this packet.
+  * They are not numbered sequentially and some numbers are not associated with an action.
+  * The maximum known action is 45, or `0xB4`, and the lowest is 0, `0x0`.<br>
+  *<br>
+  * Actions:<br>
+  * `0x90` - 36 - turn on "Looking for Squad"<br>
+  * `0x94` - 37 - turn off "Looking for Squad"<br>
+  * <br>
+  * Exploration:<br>
+  * It could take a long time to manually track down what each of these values does.
+  * @param action what this packet is about
+  */
+final case class GenericActionMessage(action : Int)
+  extends PlanetSideGamePacket {
+  type Packet = GenericActionMessage
+  def opcode = GamePacketOpcode.GenericActionMessage
+  def encode = GenericActionMessage.encode(this)
+}
+
+object GenericActionMessage extends Marshallable[GenericActionMessage] {
+  implicit val codec : Codec[GenericActionMessage] = (
+    "action" | uint(6)
+    ).as[GenericActionMessage]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -989,6 +989,26 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "GenericActionMessage" should {
+      val string = hex"A7 94"
+
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case GenericActionMessage(action) =>
+            action mustEqual 37
+          case default =>
+            ko
+        }
+      }
+
+      "encode" in {
+        val msg = GenericActionMessage(37)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual string
+      }
+    }
+
     "QuantityUpdateMessage" should {
       val string = hex"3D 5300 7B000000"
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -274,6 +274,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ AvatarFirstTimeEventMessage(avatar_guid, object_guid, unk1, event_name) =>
       log.info("AvatarFirstTimeEvent: " + msg)
 
+    case msg @ GenericActionMessage(bytes) =>
+      log.info("GenericActionMessage: " + msg)
+
     case default => log.debug(s"Unhandled GamePacket ${pkt}")
   }
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -274,7 +274,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ AvatarFirstTimeEventMessage(avatar_guid, object_guid, unk1, event_name) =>
       log.info("AvatarFirstTimeEvent: " + msg)
 
-    case msg @ GenericActionMessage(bytes) =>
+    case msg @ GenericActionMessage(action) =>
       log.info("GenericActionMessage: " + msg)
 
     case default => log.debug(s"Unhandled GamePacket ${pkt}")


### PR DESCRIPTION
I want to say that this is the smallest packet that I have worked on but the truth is that I already worked on the smallest packet.  That's AvatarJumpMessage at 9 bits (8 opcode + 1 data).

~~The only thing this packet has going for it is its mysterious nature.  It handles about twenty-seven actions, some of which may be on-off states of a specific thing, but it's going to be hard to track them all down.  To help with that, I've left the message logged in the window when for it comes across the pipe.~~

~~I'll experiment and update the commentary if I discover anything besides LFS.~~
