### PR TITLE
Added: ProximityTerminalUseMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -550,7 +550,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xc0 => noDecoder(CaptureFlagUpdateMessage)
     case 0xc1 => noDecoder(VanuModuleUpdateMessage)
     case 0xc2 => noDecoder(FacilityBenefitShieldChargeRequestMessage)
-    case 0xc3 => noDecoder(ProximityTerminalUseMessage)
+    case 0xc3 => game.ProximityTerminalUseMessage.decode
     case 0xc4 => game.QuantityDeltaUpdateMessage.decode
     case 0xc5 => noDecoder(ChainLashMessage)
     case 0xc6 => game.ZoneInfoMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/ProximityTerminalUseMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ProximityTerminalUseMessage.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * The player's avatar has moved in relation to a set piece that reacts with the player due to his proximity.<br>
+  * <br>
+  * Elements that exhibit this behavior include Repair/Rearm Silos in facility courtyards and various cavern crystals.
+  * The packets are only dispatched when it is appropriate for the player to be affected.<br>
+  * <br>
+  * Exploration:<br>
+  * Packets where the bytes for the player's GUID are blank exist.
+  * @param player_guid the player
+  * @param object_guid the object whose functionality is triggered
+  * @param unk na
+  */
+final case class ProximityTerminalUseMessage(player_guid : PlanetSideGUID,
+                                             object_guid : PlanetSideGUID,
+                                             unk : Boolean)
+  extends PlanetSideGamePacket {
+  type Packet = ProximityTerminalUseMessage
+  def opcode = GamePacketOpcode.ProximityTerminalUseMessage
+  def encode = ProximityTerminalUseMessage.encode(this)
+}
+
+object ProximityTerminalUseMessage extends Marshallable[ProximityTerminalUseMessage] {
+  implicit val codec : Codec[ProximityTerminalUseMessage] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("object_guid" | PlanetSideGUID.codec) ::
+      ("unk" | bool)
+    ).as[ProximityTerminalUseMessage]
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -1212,6 +1212,25 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "ProximityTerminalUseMessage" should {
+      val string = hex"C3 4B00 A700 80"
+      "decode" in {
+        PacketCoding.DecodePacket(string).require match {
+          case ProximityTerminalUseMessage(player_guid, object_guid, unk) =>
+            player_guid mustEqual PlanetSideGUID(75)
+            object_guid mustEqual PlanetSideGUID(167)
+            unk mustEqual true
+          case _ =>
+            ko
+        }
+      }
+      "encode" in {
+        val msg = ProximityTerminalUseMessage(PlanetSideGUID(75), PlanetSideGUID(167), true)
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+        pkt mustEqual string
+      }
+    }
+
     "UseItemMessage" should {
       val string = hex"10 4B00 0000 7401 FFFFFFFF 4001000000000000000000000000058C803600800000"
 


### PR DESCRIPTION
Caution: purple crystals ahead.

This is actually the old `proximity-terminal` branch with the old `ProximityTerminalMessage` code.  It's the first time I successfully rebased a stale branch forward to `origin master`.