### PR TITLE
Added: ReplicationStreamMessage Packet

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -591,7 +591,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xe3 => noDecoder(ZoneForcedCavernConnectionsMessage)
     case 0xe4 => noDecoder(MissionActionMessage)
     case 0xe5 => noDecoder(MissionKillTriggerMessage)
-    case 0xe6 => noDecoder(ReplicationStreamMessage)
+    case 0xe6 => game.ReplicationStreamMessage.decode
     case 0xe7 => noDecoder(SquadDefinitionActionMessage)
     // 0xe8
     case 0xe8 => noDecoder(SquadDetailDefinitionUpdateMessage)

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+final case class SquadHeader(leader : String,
+                             name : String,
+                             continent_guid : PlanetSideGUID,
+                             unk : Int,
+                             size : Int,
+                             capacity : Int = 10)
+
+final case class SquadListing(index : Int = 255,
+                              listing : Option[SquadHeader] = None)
+
+final case class ReplicationStreamMessage(unk : Int,
+                                          entries : Vector[SquadListing])
+  extends PlanetSideGamePacket {
+  type Packet = ReplicationStreamMessage
+  def opcode = GamePacketOpcode.ReplicationStreamMessage
+  def encode = ReplicationStreamMessage.encode(this)
+}
+
+object SquadHeader extends Marshallable[SquadHeader] {
+  implicit val codec : Codec[SquadHeader] = (
+    ("leader" | PacketHelpers.encodedWideString) ::
+      ("name" | PacketHelpers.encodedWideString) ::
+      ("continent_guid" | PlanetSideGUID.codec) ::
+      ("unk" | uint16L) ::
+      ("size" | uint4L) ::
+      ("capacity" | uint4L)
+    ).as[SquadHeader]
+}
+
+object SquadListing extends Marshallable[SquadListing] {
+  implicit val codec : Codec[SquadListing] = (
+    ("index" | uint8L) >>:~ { index =>
+      conditional(index < 255, "listing" | SquadHeader.codec) :: ignore(0)
+    }).as[SquadListing]
+}
+
+object ReplicationStreamMessage extends Marshallable[ReplicationStreamMessage] {
+  implicit val codec : Codec[ReplicationStreamMessage] = (
+    ("unk" | uintL(7)) ::
+      ("entries" | vector(SquadListing.codec))
+    ).as[ReplicationStreamMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -306,17 +306,21 @@ object SquadHeader extends Marshallable[SquadHeader] {
 
   implicit val init_codec : Codec[SquadHeader] = (
     ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) ::
-        conditional(action != 131, "action2" | uintL(3)) ::
-        initCodec
+      ("unk" | bool) >>:~ { unk =>
+        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
+          selectCodec(action, unk, action2, initCodec)
+        }
+      }
     }
     ).as[SquadHeader]
 
   implicit val alt_init_codec : Codec[SquadHeader] = (
     ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) ::
-        conditional(action != 131, "action2" | uintL(3)) ::
-        alt_initCodec
+      ("unk" | bool) >>:~ { unk =>
+        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
+          selectCodec(action, unk, action2, alt_initCodec)
+        }
+      }
     }
     ).as[SquadHeader]
 

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -289,18 +289,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
       uint16L ::
       ("size" | uint4L) ::
       ("capacity" | uint4L)
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
-        Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+        Attempt.successful(Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for adding [A] a squad entry")
+        Attempt.failure(Err("failed to decode squad data for adding [A] a squad entry"))
     },
     {
       case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
-        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
+        Attempt.successful(sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for adding [A] a squad entry")
+        Attempt.failure(Err("failed to encode squad data for adding [A] a squad entry"))
     }
   )
 
@@ -315,18 +315,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
       uint16L ::
       ("size" | uint4L) ::
       ("capacity" | uint4L)
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
-        Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+        Attempt.successful(Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for adding [B] a squad entry")
+        Attempt.failure(Err("failed to decode squad data for adding [B] a squad entry"))
     },
     {
       case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
-        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
+        Attempt.successful(sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for adding [B] a squad entry")
+        Attempt.failure(Err("failed to encode squad data for adding [B] a squad entry"))
     }
   )
 
@@ -341,18 +341,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
       uint16L ::
       ("size" | uint4L) ::
       ("capacity" | uint4L)
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
-        Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+        Attempt.successful(Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for updating a squad entry")
+        Attempt.failure(Err("failed to decode squad data for updating a squad entry"))
     },
     {
       case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
-        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
+        Attempt.successful(sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for updating a squad entry")
+        Attempt.failure(Err("failed to encode squad data for updating a squad entry"))
     }
   )
 
@@ -362,18 +362,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
   private val leaderCodec : Codec[squadPattern] = (
     bool ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7))
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case true :: lead :: HNil =>
-        Some(SquadInfo(lead, None)) :: HNil
+        Attempt.successful(Some(SquadInfo(lead, None)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for a leader name")
+        Attempt.failure(Err("failed to decode squad data for a leader name"))
     },
     {
       case Some(SquadInfo(Some(lead), _, _, _, _, _)) :: HNil =>
-        true :: lead :: HNil
+        Attempt.successful(true :: lead :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for a leader name")
+        Attempt.failure(Err("failed to encode squad data for a leader name"))
     }
   )
 
@@ -386,26 +386,26 @@ object SquadHeader extends Marshallable[SquadHeader] {
         conditional(path, uint16L) ::
         conditional(!path, "task" | PacketHelpers.encodedWideStringAligned(7))
     }
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case true :: Some(cguid) :: Some(0) :: _ :: HNil =>
-        Some(SquadInfo(cguid)) :: HNil
+        Attempt.successful(Some(SquadInfo(cguid)) :: HNil)
       case true :: Some(cguid) :: Some(_) :: _ :: HNil =>
-        throw new RuntimeException("failed to decode squad data for a continent - malformed GUID")
+        Attempt.failure(Err("failed to decode squad data for a continent - malformed GUID"))
       case false :: _ :: _ :: Some(tsk) :: HNil =>
-        Some(SquadInfo(None, tsk)) :: HNil
+        Attempt.successful(Some(SquadInfo(None, tsk)) :: HNil)
       case false :: _ :: _ :: None :: HNil =>
-        throw new RuntimeException("failed to decode squad data for a task - no task")
+        Attempt.failure(Err("failed to decode squad data for a task - no task"))
     },
     {
       case Some(SquadInfo(_, None, Some(cguid), _, _, _)) :: HNil =>
-        true :: Some(cguid) :: Some(0) :: None :: HNil
+        Attempt.successful(true :: Some(cguid) :: Some(0) :: None :: HNil)
       case Some(SquadInfo(_, Some(tsk), None, _, _, _)) :: HNil =>
-        false :: None :: None :: Some(tsk) :: HNil
+        Attempt.successful(false :: None :: None :: Some(tsk) :: HNil)
       case Some(SquadInfo(_, Some(tsk), Some(cguid), _, _, _)) :: HNil =>
-        throw new RuntimeException("failed to encode squad data for either a task or a continent - multiple encodings reachable")
+        Attempt.failure(Err("failed to encode squad data for either a task or a continent - multiple encodings reachable"))
       case _ =>
-        throw new RuntimeException("failed to encode squad data for either a task or a continent")
+        Attempt.failure(Err("failed to encode squad data for either a task or a continent"))
     }
   )
 
@@ -415,18 +415,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
   private val sizeCodec : Codec[squadPattern] = (
     bool ::
       ("size" | uint4L)
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case false :: sz :: HNil =>
-        Some(SquadInfo(sz, None)) :: HNil
+        Attempt.successful(Some(SquadInfo(sz, None)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for a size")
+        Attempt.failure(Err("failed to decode squad data for a size"))
     },
     {
       case Some(SquadInfo(_, _, _, Some(sz), _, _)) :: HNil =>
-        false :: sz :: HNil
+        Attempt.successful(false :: sz :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for a size")
+        Attempt.failure(Err("failed to encode squad data for a size"))
     }
   )
 
@@ -438,18 +438,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
       ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
       uint4L ::
       ("size" | uint4L)
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case true :: lead :: 4 :: sz :: HNil =>
-        Some(SquadInfo(lead, sz)) :: HNil
+        Attempt.successful(Some(SquadInfo(lead, sz)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for a leader and a size")
+        Attempt.failure(Err("failed to decode squad data for a leader and a size"))
     },
     {
       case Some(SquadInfo(Some(lead), _, _, Some(sz), _, _)) :: HNil =>
-        true :: lead :: 4 :: sz :: HNil
+        Attempt.successful(true :: lead :: 4 :: sz :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for a leader and a size")
+        Attempt.failure(Err("failed to encode squad data for a leader and a size"))
     }
   )
 
@@ -463,18 +463,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
       bool ::
       ("continent_guid" | PlanetSideGUID.codec) ::
       uint16L
-    ).xmap[squadPattern] (
+    ).exmap[squadPattern] (
     {
       case false :: tsk :: 1 :: true :: cguid :: 0 :: HNil =>
-        Some(SquadInfo(tsk, cguid)) :: HNil
+        Attempt.successful(Some(SquadInfo(tsk, cguid)) :: HNil)
       case _ =>
-        throw new RuntimeException("failed to decode squad data for a task and a continent")
+        Attempt.failure(Err("failed to decode squad data for a task and a continent"))
     },
     {
       case Some(SquadInfo(_, Some(tsk), Some(cguid), _, _, _)) :: HNil =>
-        false :: tsk :: 1 :: true :: cguid :: 0 :: HNil
+        Attempt.successful(false :: tsk :: 1 :: true :: cguid :: 0 :: HNil)
       case _ =>
-        throw new RuntimeException("failed to encode squad data for a task and a continent")
+        Attempt.failure(Err("failed to encode squad data for a task and a continent"))
     }
   )
 
@@ -499,14 +499,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     * This codec is an invalid codec that does not read any bit data.
     * The `conditional` will always return `None` because its determining boolean is explicitly `false`.
     */
-  val failureCodec : Codec[squadPattern] = conditional(false, bool).xmap[squadPattern] (
+  val failureCodec : Codec[squadPattern] = conditional(false, bool).exmap[squadPattern] (
     {
       case None | _ =>
-        throw new RuntimeException("decoding with unhandled codec")
+        Attempt.failure(Err("decoding with unhandled codec"))
     },
     {
       case None :: HNil | _ =>
-        throw new RuntimeException("encoding with unhandled codec")
+        Attempt.failure(Err("encoding with unhandled codec"))
     }
   )
 

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -3,7 +3,6 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import scodec.Attempt.Successful
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -3,30 +3,34 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import scodec.Codec
+import scodec.bits.BitVector
+import scodec.{Codec, Err}
 import scodec.codecs._
+import shapeless._
 
 //this packet is limited mainly by byte-size
 
 //continents are stored in this packet as 32-bit numbers instead of 16-bit; after the normal 16 bits, two bytes can be ignored
 
-final case class SquadInfo(leader : String,
-                           task : String,
-                           continent_guid : PlanetSideGUID,
-                           size : Int,
-                           capacity : Int)
+final case class SquadInfo(leader : Option[String],
+                           task : Option[String],
+                           continent_guid : Option[PlanetSideGUID],
+                           size : Option[Int],
+                           capacity : Option[Int],
+                           squad_guid : Option[PlanetSideGUID] = None)
 
-final case class SquadHeader(unk1 : Int,
-                             unk2 : Boolean,
-                             squad_guid : PlanetSideGUID,
+final case class SquadHeader(action : Int,
+                             unk : Boolean,
+                             action2 : Option[Int],
                              info : SquadInfo)
 
 final case class SquadListing(index : Int = 255,
                               listing : Option[SquadHeader] = None,
-                              na : Option[Unit] = None)
+                              na : Option[BitVector] = None)
 
-final case class ReplicationStreamMessage(action : Int,
-                                          unk : Int,
+final case class ReplicationStreamMessage(behavior : Int,
+                                          init : Option[ReplicationStreamMessage],
+                                          unk : Option[Boolean] = None,
                                           entries : Vector[SquadListing] = Vector.empty)
   extends PlanetSideGamePacket {
   type Packet = ReplicationStreamMessage
@@ -34,40 +38,236 @@ final case class ReplicationStreamMessage(action : Int,
   def encode = ReplicationStreamMessage.encode(this)
 }
 
-object SquadInfo extends Marshallable[SquadInfo] {
-  implicit val codec : Codec[SquadInfo] = (
-    ("leader" | PacketHelpers.encodedWideString) ::
-      ("task" | PacketHelpers.encodedWideString) ::
-      ("continent_guid" | PlanetSideGUID.codec) ::
-      ignore(16) ::
-      ("size" | uint4L) ::
-      ("capacity" | uint4L)
-    ).as[SquadInfo]
+object SquadInfo {
+  //use: SquadInfo(leader, task, continent_guid, size, capacity)
+  def apply(leader : String, task : String, continent_guid : PlanetSideGUID, size : Int, capacity : Int) : SquadInfo = {
+    SquadInfo(Some(leader), Some(task), Some(continent_guid), Some(size), Some(capacity))
+  }
 
-  implicit val alt_codec : Codec[SquadInfo] = (
-    ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
-      ("task" | PacketHelpers.encodedWideString) ::
-      ("continent_guid" | PlanetSideGUID.codec) ::
-      ignore(16) ::
-      ("size" | uint4L) ::
-      ("capacity" | uint4L)
-    ).as[SquadInfo]
+  //use: SquadInfo(leader, task, continent_guid, size, capacity, sguid)
+  def apply(leader : String, task : String, continent_guid : PlanetSideGUID, size : Int, capacity : Int, sguid : PlanetSideGUID) : SquadInfo = {
+    SquadInfo(Some(leader), Some(task), Some(continent_guid), Some(size), Some(capacity), Some(sguid))
+  }
+
+  //use: SquadInfo(leader, None)
+  def apply(leader : Option[String], task : String) : SquadInfo = {
+    SquadInfo(leader, Some(task), None, None, None)
+  }
+
+  //use: SquadInfo(None, task)
+  def apply(leader : String, task : Option[String]) : SquadInfo = {
+    SquadInfo(Some(leader), task, None, None, None)
+  }
+
+  //use: SquadInfo(continent_guid)
+  def apply(continent_guid : PlanetSideGUID) : SquadInfo = {
+    SquadInfo(None, None, Some(continent_guid), None, None)
+  }
+
+  //use: SquadInfo(size, None)
+  //we currently do not know the action codes that adjust squad capacity
+  def apply(size : Int, capacity : Option[Int]) : SquadInfo = {
+    SquadInfo(None, None, None, Some(size), None)
+  }
+
+  //use: SquadInfo(None, capacity)
+  //we currently do not know the action codes that adjust squad capacity
+  def apply(size : Option[Int], capacity : Int) : SquadInfo = {
+    SquadInfo(None, None, None, size, Some(capacity))
+  }
+
+  //use: SquadInfo(leader, size)
+  def apply(leader : String, size : Int) : SquadInfo = {
+    SquadInfo(Some(leader), None, None, Some(size), None)
+  }
+
+  //use: SquadInfo(task, continent_guid)
+  def apply(task : String, continent_guid : PlanetSideGUID) : SquadInfo = {
+    SquadInfo(None, Some(task), Some(continent_guid), None, None, None)
+  }
 }
 
 object SquadHeader extends Marshallable[SquadHeader] {
+  type squadPattern = SquadInfo :: HNil
+  val initCodec : Codec[squadPattern] = (
+    ("squad_guid" | PlanetSideGUID.codec) ::
+      ("leader" | PacketHelpers.encodedWideString) ::
+      ("task" | PacketHelpers.encodedWideString) ::
+      ("continent_guid" | PlanetSideGUID.codec) ::
+      uint16L ::
+      ("size" | uint4L) ::
+      ("capacity" | uint4L)
+    ).xmap[squadPattern] (
+    {
+      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+        SquadInfo(lead, tsk, cguid, sz, cap, sguid) :: HNil
+    },
+    {
+      case SquadInfo(lead, tsk, cguid, sz, cap, sguid) :: HNil =>
+        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+    }
+  )
+  val alt_initCodec : Codec[squadPattern] = (
+    ("squad_guid" | PlanetSideGUID.codec) ::
+      ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
+      ("task" | PacketHelpers.encodedWideString) ::
+      ("continent_guid" | PlanetSideGUID.codec) ::
+      uint16L ::
+      ("size" | uint4L) ::
+      ("capacity" | uint4L)
+    ).xmap[squadPattern] (
+    {
+      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+        SquadInfo(lead, tsk, cguid, sz, cap, sguid) :: HNil
+    },
+    {
+      case SquadInfo(lead, tsk, cguid, sz, cap, sguid) :: HNil =>
+        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+    }
+  )
+
+  val leaderCodec : Codec[squadPattern] = (
+    bool ::
+      ("leader" | PacketHelpers.encodedWideStringAligned(7))
+    ).xmap[squadPattern] (
+    {
+      case x :: lead :: HNil =>
+        SquadInfo(lead, None) :: HNil
+    },
+    {
+      case SquadInfo(lead, None, None, None, None, None) :: HNil =>
+        true :: lead.get :: HNil
+    }
+  )
+
+  val taskOrContinentCodec : Codec[squadPattern] = (
+    bool >>:~ { path =>
+      conditional(path, "continent_guid" | PlanetSideGUID.codec) ::
+        conditional(path, uint16L) ::
+        conditional(!path, "task" | PacketHelpers.encodedWideStringAligned(7))
+    }
+    ).xmap[squadPattern] (
+    {
+      case true :: cguid :: Some(0) :: None :: HNil =>
+        SquadInfo(cguid.get) :: HNil
+      case false :: None :: None :: tsk :: HNil =>
+        SquadInfo(None, tsk.get) :: HNil
+    },
+    {
+      case SquadInfo(None, None, cguid, None, None, None) :: HNil =>
+        true :: Some(cguid.get) :: Some(0) :: None :: HNil
+      case SquadInfo(None, tsk, None, None, None, None) :: HNil =>
+        false :: None :: None :: tsk :: HNil
+    }
+  )
+
+  val sizeCodec : Codec[squadPattern] = (
+    bool ::
+      ("size" | uint4L)
+    ).xmap[squadPattern] (
+    {
+      case false :: sz :: HNil =>
+        SquadInfo(sz, None) :: HNil
+    },
+    {
+      case SquadInfo(None, None, None, sz, None, None) :: HNil =>
+        false :: sz.get :: HNil
+    }
+  )
+
+  val leaderSizeCodec : Codec[squadPattern] = (
+    bool ::
+      ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
+      uint4L ::
+      ("size" | uint4L)
+    ).xmap[squadPattern] (
+    {
+      case true :: lead :: 4 :: sz :: HNil =>
+        SquadInfo(lead, sz) :: HNil
+    },
+    {
+      case SquadInfo(lead, None, None, sz, None, None) ::HNil =>
+        true :: lead.get :: 4 :: sz.get :: HNil
+    }
+  )
+
+  val taskAndContinentCodec : Codec[squadPattern] = (
+    bool ::
+      ("task" | PacketHelpers.encodedWideStringAligned(7)) ::
+      uintL(3) ::
+      bool ::
+      ("continent_guid" | PlanetSideGUID.codec) ::
+      uint16L
+    ).xmap[squadPattern] (
+    {
+      case false :: tsk :: 0 :: true :: cguid :: 0 :: HNil =>
+        SquadInfo(tsk, cguid) :: HNil
+    },
+    {
+      case SquadInfo(None, tsk, cguid, None, None, None) :: HNil =>
+        false :: tsk.get :: 0 :: true :: cguid.get :: 0 :: HNil
+    }
+  )
+
+  //TODO justify this mess
+  val failureCodec : Codec[squadPattern] = peek(bool).xmap[squadPattern] (
+    {
+      case false => SquadInfo(None, None, None, None, None, None) :: HNil
+      case _ => SquadInfo(None, None, None, None, None, None) :: HNil
+    },
+    {
+      case SquadInfo(None, None, None, None, None, None) :: HNil => false
+      case _ => false
+    }
+  )
+
   implicit val codec : Codec[SquadHeader] = (
-    ("unk1" | uint8L) ::
-      ("unk2" | bool) ::
-      ("squad_guid" | PlanetSideGUID.codec) ::
-      ("info" | SquadInfo.codec)
+    ("action" | uint8L) >>:~ { action =>
+      ("unk" | bool) >>:~ { unk =>
+        conditional(action != 131 && !unk, "action2" | uintL(3)) >>:~ { action2 =>
+          selectCodec(action, unk, action2)
+        }
+      }
+    }
     ).as[SquadHeader]
 
   implicit val alt_codec : Codec[SquadHeader] = (
-    ("unk1" | uint8L) ::
-      ("unk2" | bool) ::
-      ("squad_guid" | PlanetSideGUID.codec) ::
-      ("info" | SquadInfo.alt_codec)
+    ("action" | uint8L) >>:~ { action =>
+      ("unk" | bool) >>:~ { unk =>
+        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
+          selectCodec(action, unk, action2, alt_initCodec)
+        }
+      }
+    }
     ).as[SquadHeader]
+
+  def selectCodec(action : Int, unk : Boolean, action2 : Option[Int], init : Codec[squadPattern] = initCodec) : Codec[squadPattern] = {
+    if(action2.isDefined) {
+      val action2Val = action2.get
+      if(action == 128 && unk) {
+        if(action2Val == 0)
+          return leaderCodec
+        else if(action2Val == 1)
+          return taskOrContinentCodec
+        else if(action2Val == 2)
+          return sizeCodec
+      }
+      else if(action == 129 && !unk) {
+        if(action2Val == 0)
+          return leaderSizeCodec
+        else if(action2Val == 1)
+          return taskAndContinentCodec
+      }
+    }
+    else {
+      if(action == 131 && !unk)
+        return init
+    }
+
+    //TODO better error handling here?
+    Err("requesting an unknown codec")
+    failureCodec
+  }
 }
 
 object SquadListing extends Marshallable[SquadListing] {
@@ -77,16 +277,17 @@ object SquadListing extends Marshallable[SquadListing] {
         newcodecs.binary_choice(index == 0,
           "listing" | SquadHeader.codec,
           "listing" | SquadHeader.alt_codec)
-      ) >>:~ { listing =>
-        conditional(listing.isEmpty, choice(ignore(1), ignore(0))).hlist
-      }
+      ) ::
+        conditional(index == 255, bits).hlist //consume n < 8 bits padding the tail entry, else vector will try to operate on invalid data
     }).as[SquadListing]
 }
 
 object ReplicationStreamMessage extends Marshallable[ReplicationStreamMessage] {
   implicit val codec : Codec[ReplicationStreamMessage] = (
-    ("action" | uintL(3)) ::
-      ("unk" | uint4L) ::
+    (("behavior" | uintL(3)) >>:~ { behavior =>
+      conditional(behavior == 5, "init" | codec) :: //note: uses self
+        conditional(behavior != 5 && behavior != 2, "unk" | bool)
+    }) :+
       ("entries" | vector(SquadListing.codec))
     ).as[ReplicationStreamMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -9,7 +9,7 @@ import scodec.codecs._
 final case class SquadHeader(unk1 : Int,
                              unk2 : Int,
                              squad_guid : Int,
-                             unk3 : Int,
+                             unk3 : Boolean,
                              unk4 : Boolean,
                              leader : String,
                              name : String,
@@ -34,8 +34,8 @@ object SquadHeader extends Marshallable[SquadHeader] {
   implicit val codec : Codec[SquadHeader] = (
     ("unk1" | uint8L) ::
       ("unk2" | uintL(3)) ::
-      ("squad_guid" | uint8L) ::
-      ("unk3" | uintL(5)) ::
+      ("squad_guid" | uintL(12)) ::
+      ("unk3" | bool) ::
       ("unk4" | bool) ::
       ("leader" | PacketHelpers.encodedWideString) ::
       ("name" | PacketHelpers.encodedWideString) ::
@@ -48,8 +48,8 @@ object SquadHeader extends Marshallable[SquadHeader] {
   implicit val alt_codec : Codec[SquadHeader] = (
     ("unk1" | uint8L) ::
       ("unk2" | uintL(3)) ::
-      ("squad_guid" | uint8L) ::
-      ("unk3" | uintL(5)) ::
+      ("squad_guid" | uintL(12)) ::
+      ("unk3" | bool) ::
       ("unk4" | bool) ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
       ("name" | PacketHelpers.encodedWideString) ::

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -8,10 +8,22 @@ import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless._
 
-//this packet is limited mainly by byte-size
-
-//continents are stored in this packet as 32-bit numbers instead of 16-bit; after the normal 16 bits, two bytes can be ignored
-
+/**
+  * Maintains squad information changes performed by this listing.
+  * Only certain information will be transmitted depending on the purpose of the packet.
+  * @param leader the name of the squad leader as a wide character string, or `None` if not applicable
+  * @param task the task the squad is trying to perform as a wide character string, or `None` if not applicable
+  * @param continent_guid the continent on which the squad is acting, or `None` if not applicable;
+  *                       this GUID is transmitted as a 32-bit number;
+  *                       the internal GUID is 16-bit, so the last 16 bits of this field can be ignored
+  * @param size the current size of the squad, or `None` if not applicable;
+  *             "can" be greater than `capacity`, though with issues
+  * @param capacity the maximum number of members that the squad can tolerate, or `None` if not applicable;
+  *                 normally is 10;
+  *                 maximum is 15
+  * @param squad_guid a GUID associated with the squad, used to recover the squad definition, or `None` if not applicable;
+  *                   sometimes it is defined but is still not applicable
+  */
 final case class SquadInfo(leader : Option[String],
                            task : Option[String],
                            continent_guid : Option[PlanetSideGUID],
@@ -19,15 +31,97 @@ final case class SquadInfo(leader : Option[String],
                            capacity : Option[Int],
                            squad_guid : Option[PlanetSideGUID] = None)
 
-final case class SquadHeader(action : Int,
-                             unk : Boolean,
-                             action2 : Option[Int],
+/**
+  * Define three fields determining the purpose of data in this listing.<br>
+  * <br>
+  * The third field `unk3` is not always be defined and will be supplanted by the squad (definition) GUID during initialization and a full update.<br>
+  * <br>
+  * Actions:<br>
+  * (`unk1`, `unk2`, `unk3`)<br>
+  * - `0, true, 4 -- 0x00C -- `Remove a squad from listing<br>
+  * - `128, true, 0 -- 0x808 -- `Update a squad's leader<br>
+  * - `128, true, 1 -- 0x809 -- `Update a squad's task or continent<br>
+  * - `128, true, 2 -- 0x80A -- `Update a squad's size<br>
+  * - `129, false, 0 -- 0x810 -- `Update a squad's leader or size<br>
+  * - `129, false, 1 -- 0x811 -- `Update a squad's task and continent<br>
+  * - `131, false, X -- 0x830 -- `Add all squads during initialization / update all information pertaining to this squad
+  * @param unk1 na
+  * @param unk2 na
+  * @param unk3 na; not always defined
+  * @param info information pertaining to this squad listing
+  */
+//TODO when these unk# values are better understood, transform SquadHeader to streamline the actions to be performed
+final case class SquadHeader(unk1 : Int,
+                             unk2 : Boolean,
+                             unk3 : Option[Int],
                              info : Option[SquadInfo] = None)
 
+/**
+  * An entry in the listing of squads.
+  * The entries are loaded into a `Vector` externally.<br>
+  * <br>
+  * Squad listing indicies are not an arbitrary order.
+  * The server communicates changes to the client by referencing a squad's listing index, defined at the time of list initialization.
+  * Once initialized, each client may organize their squads however they wish, e.g., by leader, by task, etc., without compromising this index.
+  * During the list initialization process, the entries must always follow numerical order, increasing from `0`.
+  * During any other operation, the entries may be prefixed with whichever index is necessary to indicate the squad listing in question.<br>
+  * <br>
+  * Index 255 (`0xFF` or `0x11111111`) is a special entry that signifies the end of the stream.
+  * There are no more listings after this entry and nothing can happen in that entry.
+  * @param index the index of this listing
+  * @param listing the data for this entry, defining both the actions and the pertinent squad information
+  * @param na collects runoff bits that pad the end of the stream that may disrupt the decoding process;
+  *           can (and should) be ignored by the user
+  */
 final case class SquadListing(index : Int = 255,
                               listing : Option[SquadHeader] = None,
                               na : Option[BitVector] = None)
 
+/**
+  * Modify the list of squads visible to a given player.
+  * The squad list updates in real time rather than just whenever a player opens the squad information window.<br>
+  * <br>
+  * The four main operations are: initializing the list, clearing the list, updating entries in the list, and removing entries from the list.
+  * The process of initializing the list and clearing the list actually are performed by the same behavior.
+  * Squads would just not added after the behavior clears the list.
+  * Moreover, removing entries from the list overrides the behavior to update entries in the list.
+  * The two-three per-entry codes (see SquadHeader) are more important for determining the effect of a specific entry than these behaviors.
+  * As of the moment, the important details of the behaviors is that they modify how the packet is encoded and padded.<br>
+  * <br>
+  * Entries are identified by their index in the squad list.
+  * This is followed by a coded section that indicates what action the entry will execute on that squad listing.
+  * After the "coded acton" section is the "codec information" section where the data for the change for the given squad listing is specified.
+  * In this manner, all the entries will have a knowable length.<br>
+  * <br>
+  * The total number of entries in a packet is not known until they have all been parsed.
+  * During the list initialization process, the entries must be in ascending order of index.
+  * Otherwise, the specific index of the squad listing is referenced.
+  * The minimum number of entries is "no entries."
+  * The maximum number of entries is supposedly 254, but is at least a number below 32.
+  * The last item in the stream is the number 255 and this is interpretted as a concluding 255th entry that does nothing.<br>
+  * <br>
+  * Packet length may/will limit the number of squads that can be loaded in a single session.
+  * If the packet is too long in the sense of byte-length, no updates will be made to an existing squad list nor will a new squad list be initialized.
+  * That packet will be discarded by the client.
+  * The presence of and length of string data is the primary variability when it comes to packet length.<br>
+  * <br>
+  * Behaviors:<br>
+  * (`behavior`, `behavior2`, `unk`)<br>
+  * - `1, X, X     -- 0x20 -- `Update where initial entry removes a squad from the list<br>
+  * - `5, 6, false -- 0xB8 -- `Clear squad list and initialize new squad list<br>
+  * - `5, 6, false -- 0xB9 -- `Clear squad list (actually is a `0xB8` that transitions directly into 255-entry)<br>
+  * - `6, X, false -- 0xC0 -- `Update a squad in the list<br>
+  * <br>
+  * Exploration:<br>
+  * This logic contains a lot of holes.
+  * It is consistent for known packets, however.
+  * @param behavior a code that suggests the primary purpose of the data in this packet
+  * @param behavior2 during initialization, this code is read;
+  *                  it supplements the normal `behavior` and is typically is an "update" code
+  * @param unk a spacer byte between the `behavior` code(s) and the start of the first entry;
+  *            should be set to `false` when it exists
+  * @param entries a vector of the squad listings
+  */
 final case class ReplicationStreamMessage(behavior : Int,
                                           behavior2 : Option[Int],
                                           unk : Option[Boolean],
@@ -39,57 +133,155 @@ final case class ReplicationStreamMessage(behavior : Int,
 }
 
 object SquadInfo {
-  //use: SquadInfo(leader, task, continent_guid, size, capacity)
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the fields.<br>
+    * <br>
+    * This constructor is not actually used at the moment.
+    * @param leader the name of the squad leader
+    * @param task the task the squad is trying to perform
+    * @param continent_guid the continent on which the squad is acting
+    * @param size the current size of the squad
+    * @param capacity the maximum number of members that the squad can tolerate
+    * @return a SquadInfo object
+    */
   def apply(leader : String, task : String, continent_guid : PlanetSideGUID, size : Int, capacity : Int) : SquadInfo = {
     SquadInfo(Some(leader), Some(task), Some(continent_guid), Some(size), Some(capacity))
   }
 
-  //use: SquadInfo(leader, task, continent_guid, size, capacity, sguid)
-  def apply(leader : String, task : String, continent_guid : PlanetSideGUID, size : Int, capacity : Int, sguid : PlanetSideGUID) : SquadInfo = {
-    SquadInfo(Some(leader), Some(task), Some(continent_guid), Some(size), Some(capacity), Some(sguid))
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the fields.<br>
+    * <br>
+    * This constructor is used by the `initCodec`, `alt_initCodec`, and `allCodec`.
+    * @param leader the name of the squad leader
+    * @param task the task the squad is trying to perform
+    * @param continent_guid the continent on which the squad is acting
+    * @param size the current size of the squad
+    * @param capacity the maximum number of members that the squad can tolerate
+    * @param squad_guid a GUID associated with the squad, used to recover the squad definition
+    * @return a SquadInfo object
+    */
+  def apply(leader : String, task : String, continent_guid : PlanetSideGUID, size : Int, capacity : Int, squad_guid : PlanetSideGUID) : SquadInfo = {
+    SquadInfo(Some(leader), Some(task), Some(continent_guid), Some(size), Some(capacity), Some(squad_guid))
   }
 
-  //use: SquadInfo(leader, None)
-  def apply(leader : Option[String], task : String) : SquadInfo = {
-    SquadInfo(leader, Some(task), None, None, None)
-  }
-
-  //use: SquadInfo(None, task)
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the important field.<br>
+    * <br>
+    * This constructor is used by `leaderCodec`.
+    * Two of the fields normally are `Option[String]`s.
+    * Only the `leader` field in this packet is a `String`, giving the method a distinct signature.
+    * The other field - an `Option[String]` for `task` - can still be set if passed.<br>
+    * <br>
+    * Recommended use: `SquadInfo(leader, None)`
+    * @param leader the name of the squad leader
+    * @param task the task the squad is trying to perform, if not `None`
+    * @return a SquadInfo object
+    */
   def apply(leader : String, task : Option[String]) : SquadInfo = {
     SquadInfo(Some(leader), task, None, None, None)
   }
 
-  //use: SquadInfo(continent_guid)
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the important field.<br>
+    * <br>
+    * This constructor is used by `taskOrContinentCodec`.
+    * Two of the fields normally are `Option[String]`s.
+    * Only the `task` field in this packet is a `String`, giving the method a distinct signature.
+    * The other field - an `Option[String]` for `leader` - can still be set if passed.<br>
+    * <br>
+    * Recommended use: `SquadInfo(None, task)`
+    * @param leader the name of the squad leader, if not `None`
+    * @param task the task the squad is trying to perform
+    * @return a SquadInfo object
+    */
+  def apply(leader : Option[String], task : String) : SquadInfo = {
+    SquadInfo(leader, Some(task), None, None, None)
+  }
+
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the field.<br>
+    * <br>
+    * This constructor is used by `taskOrContinentCodec`.
+    * @param continent_guid the continent on which the squad is acting
+    * @return a SquadInfo object
+    */
   def apply(continent_guid : PlanetSideGUID) : SquadInfo = {
     SquadInfo(None, None, Some(continent_guid), None, None)
   }
 
-  //use: SquadInfo(size, None)
-  //we currently do not know the action codes that adjust squad capacity
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the important field.<br>
+    * <br>
+    * This constructor is used by `sizeCodec`.
+    * Two of the fields normally are `Option[Int]`s.
+    * Only the `size` field in this packet is an `Int`, giving the method a distinct signature.<br>
+    * <br>
+    * Recommended use: `SquadInfo(size, None)`<br>
+    * <br>
+    * Exploration:<br>
+    * We do not currently know any `SquadHeader` action codes for adjusting `capacity`.
+    * @param size the current size of the squad
+    * @param capacity the maximum number of members that the squad can tolerate, if not `None`
+    * @return a SquadInfo object
+    */
   def apply(size : Int, capacity : Option[Int]) : SquadInfo = {
     SquadInfo(None, None, None, Some(size), None)
   }
 
-  //use: SquadInfo(None, capacity)
-  //we currently do not know the action codes that adjust squad capacity
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the important field.<br>
+    * <br>
+    * This constructor is not actually used at the moment.
+    * Two of the fields normally are `Option[Int]`s.
+    * Only the `capacity` field in this packet is an `Int`, giving the method a distinct signature.<br>
+    * <br>
+    * Recommended use: `SquadInfo(None, capacity)`<br>
+    * <br>
+    * Exploration:<br>
+    * We do not currently know any `SquadHeader` action codes for adjusting `capacity`.
+    * @param size the current size of the squad
+    * @param capacity the maximum number of members that the squad can tolerate, if not `None`
+    * @return a SquadInfo object
+    */
   def apply(size : Option[Int], capacity : Int) : SquadInfo = {
-    SquadInfo(None, None, None, size, Some(capacity))
+    SquadInfo(None, None, None, None, Some(capacity))
   }
 
-  //use: SquadInfo(leader, size)
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the fields.<br>
+    * <br>
+    * This constructor is used by `leaderSizeCodec`.
+    * @param leader the name of the squad leader
+    * @param size the current size of the squad
+    * @return a SquadInfo object
+    */
   def apply(leader : String, size : Int) : SquadInfo = {
     SquadInfo(Some(leader), None, None, Some(size), None)
   }
 
-  //use: SquadInfo(task, continent_guid)
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the fields.<br>
+    * <br>
+    * This constructor is used by `taskAndContinentCodec`.
+    * @param task the task the squad is trying to perform
+    * @param continent_guid the continent on which the squad is acting
+    * @return a SquadInfo object
+    */
   def apply(task : String, continent_guid : PlanetSideGUID) : SquadInfo = {
     SquadInfo(None, Some(task), Some(continent_guid), None, None, None)
   }
 }
 
 object SquadHeader extends Marshallable[SquadHeader] {
-  type squadPattern = Option[SquadInfo] :: HNil
-  val initCodec : Codec[squadPattern] = (
+  /**
+    * `squadPattern` completes the fields for the `SquadHeader` class.
+    * It translates an indeterminate number of bit regions into something that can be processed as an `Option[SquadInfo]`.
+    */
+  private type squadPattern = Option[SquadInfo] :: HNil
+  /**
+    * Codec for reading `SquadInfo` data from the first entry from a packet with squad list initialization entries.
+    */
+  private val initCodec : Codec[squadPattern] = (
     ("squad_guid" | PlanetSideGUID.codec) ::
       ("leader" | PacketHelpers.encodedWideString) ::
       ("task" | PacketHelpers.encodedWideString) ::
@@ -99,19 +291,23 @@ object SquadHeader extends Marshallable[SquadHeader] {
       ("capacity" | uint4L)
     ).xmap[squadPattern] (
     {
-      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+      case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
         Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
       case _ =>
-        null
+        throw new RuntimeException("failed to decode squad data for adding [A] a squad entry")
     },
     {
-      case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
-        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
+        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
       case _ =>
-        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for adding [A] a squad entry")
     }
   )
-  val alt_initCodec : Codec[squadPattern] = (
+
+  /**
+    * Codec for reading `SquadInfo` data from all entries other than the first from a packet with squad list initialization entries.
+    */
+  private val alt_initCodec : Codec[squadPattern] = (
     ("squad_guid" | PlanetSideGUID.codec) ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
       ("task" | PacketHelpers.encodedWideString) ::
@@ -121,20 +317,23 @@ object SquadHeader extends Marshallable[SquadHeader] {
       ("capacity" | uint4L)
     ).xmap[squadPattern] (
     {
-      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+      case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
         Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
       case _ =>
-        null
+        throw new RuntimeException("failed to decode squad data for adding [B] a squad entry")
     },
     {
-      case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
-        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
+        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
       case _ =>
-        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for adding [B] a squad entry")
     }
   )
 
-  val allCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update all squad data" entry.
+    */
+  private val allCodec : Codec[squadPattern] = (
     ("squad_guid" | PlanetSideGUID.codec) ::
       ("leader" | PacketHelpers.encodedWideStringAligned(3)) ::
       ("task" | PacketHelpers.encodedWideString) ::
@@ -144,38 +343,44 @@ object SquadHeader extends Marshallable[SquadHeader] {
       ("capacity" | uint4L)
     ).xmap[squadPattern] (
     {
-      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+      case sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil =>
         Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
       case _ =>
-        null
+        throw new RuntimeException("failed to decode squad data for updating a squad entry")
     },
     {
-      case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
-        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case Some(SquadInfo(Some(lead), Some(tsk), Some(cguid), Some(sz), Some(cap), Some(sguid))) :: HNil =>
+        sguid :: lead :: tsk :: cguid :: 0 :: sz :: cap :: HNil
       case _ =>
-        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for updating a squad entry")
     }
   )
 
-  val leaderCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update squad leader" entry.
+    */
+  private val leaderCodec : Codec[squadPattern] = (
     bool ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7))
     ).xmap[squadPattern] (
     {
-      case x :: lead :: HNil =>
+      case true :: lead :: HNil =>
         Some(SquadInfo(lead, None)) :: HNil
       case _ =>
-        null :: HNil
+        throw new RuntimeException("failed to decode squad data for a leader name")
     },
     {
-      case Some(SquadInfo(lead, _, _, _, _, _)) :: HNil =>
-        true :: lead.get :: HNil
+      case Some(SquadInfo(Some(lead), _, _, _, _, _)) :: HNil =>
+        true :: lead :: HNil
       case _ =>
-        true :: "" :: HNil
+        throw new RuntimeException("failed to encode squad data for a leader name")
     }
   )
 
-  val taskOrContinentCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update squad task or continent" entry.
+    */
+  private val taskOrContinentCodec : Codec[squadPattern] = (
     bool >>:~ { path =>
       conditional(path, "continent_guid" | PlanetSideGUID.codec) ::
         conditional(path, uint16L) ::
@@ -183,24 +388,31 @@ object SquadHeader extends Marshallable[SquadHeader] {
     }
     ).xmap[squadPattern] (
     {
-      case true :: cguid :: Some(0) :: None :: HNil =>
-        Some(SquadInfo(cguid.get)) :: HNil
-      case false :: None :: None :: tsk :: HNil =>
-        Some(SquadInfo(None, tsk.get)) :: HNil
-      case _ =>
-        null :: HNil
+      case true :: Some(cguid) :: Some(0) :: _ :: HNil =>
+        Some(SquadInfo(cguid)) :: HNil
+      case true :: Some(cguid) :: Some(_) :: _ :: HNil =>
+        throw new RuntimeException("failed to decode squad data for a continent - malformed GUID")
+      case false :: _ :: _ :: Some(tsk) :: HNil =>
+        Some(SquadInfo(None, tsk)) :: HNil
+      case false :: _ :: _ :: None :: HNil =>
+        throw new RuntimeException("failed to decode squad data for a task - no task")
     },
     {
-      case Some(SquadInfo(_, None, cguid, _, _, _)) :: HNil =>
-        true :: cguid :: Some(0) :: None :: HNil
-      case Some(SquadInfo(_, tsk, None, _, _, _)) :: HNil =>
-        false :: None :: None :: tsk :: HNil
+      case Some(SquadInfo(_, None, Some(cguid), _, _, _)) :: HNil =>
+        true :: Some(cguid) :: Some(0) :: None :: HNil
+      case Some(SquadInfo(_, Some(tsk), None, _, _, _)) :: HNil =>
+        false :: None :: None :: Some(tsk) :: HNil
+      case Some(SquadInfo(_, Some(tsk), Some(cguid), _, _, _)) :: HNil =>
+        throw new RuntimeException("failed to encode squad data for either a task or a continent - multiple encodings reachable")
       case _ =>
-        false :: None :: None :: None :: HNil
+        throw new RuntimeException("failed to encode squad data for either a task or a continent")
     }
   )
 
-  val sizeCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update squad size" entry.
+    */
+  private val sizeCodec : Codec[squadPattern] = (
     bool ::
       ("size" | uint4L)
     ).xmap[squadPattern] (
@@ -208,17 +420,20 @@ object SquadHeader extends Marshallable[SquadHeader] {
       case false :: sz :: HNil =>
         Some(SquadInfo(sz, None)) :: HNil
       case _ =>
-        null :: HNil
+        throw new RuntimeException("failed to decode squad data for a size")
     },
     {
-      case Some(SquadInfo(_, _, _, sz, _, _)) :: HNil =>
-        false :: sz.get :: HNil
+      case Some(SquadInfo(_, _, _, Some(sz), _, _)) :: HNil =>
+        false :: sz :: HNil
       case _ =>
-        false :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for a size")
     }
   )
 
-  val leaderSizeCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update squad leader and size" entry.
+    */
+  private val leaderSizeCodec : Codec[squadPattern] = (
     bool ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
       uint4L ::
@@ -228,17 +443,20 @@ object SquadHeader extends Marshallable[SquadHeader] {
       case true :: lead :: 4 :: sz :: HNil =>
         Some(SquadInfo(lead, sz)) :: HNil
       case _ =>
-        null :: HNil
+        throw new RuntimeException("failed to decode squad data for a leader and a size")
     },
     {
-      case Some(SquadInfo(lead, _, _, sz, _, _)) ::HNil =>
-        true :: lead.get :: 4 :: sz.get :: HNil
+      case Some(SquadInfo(Some(lead), _, _, Some(sz), _, _)) :: HNil =>
+        true :: lead :: 4 :: sz :: HNil
       case _ =>
-        true :: "" :: 4 :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for a leader and a size")
     }
   )
 
-  val taskAndContinentCodec : Codec[squadPattern] = (
+  /**
+    * Codec for reading the `SquadInfo` data in an "update squad task and continent" entry.
+    */
+  private val taskAndContinentCodec : Codec[squadPattern] = (
     bool ::
       ("task" | PacketHelpers.encodedWideStringAligned(7)) ::
       uintL(3) ::
@@ -250,104 +468,123 @@ object SquadHeader extends Marshallable[SquadHeader] {
       case false :: tsk :: 1 :: true :: cguid :: 0 :: HNil =>
         Some(SquadInfo(tsk, cguid)) :: HNil
       case _ =>
-        null :: HNil
+        throw new RuntimeException("failed to decode squad data for a task and a continent")
     },
     {
-      case Some(SquadInfo(_, tsk, cguid, _, _, _)) :: HNil =>
-        false :: tsk.get :: 1 :: true :: cguid.get :: 0 :: HNil
+      case Some(SquadInfo(_, Some(tsk), Some(cguid), _, _, _)) :: HNil =>
+        false :: tsk :: 1 :: true :: cguid :: 0 :: HNil
       case _ =>
-        false :: "" :: 1 :: true :: PlanetSideGUID(0) :: 0 :: HNil
+        throw new RuntimeException("failed to encode squad data for a task and a continent")
     }
   )
 
-  val removeCodec : Codec[squadPattern] = conditional(false, bool).xmap[squadPattern] (
+  /**
+    * Codec for reading the `SquadInfo` data in a "remove squad from list" entry.
+    * This codec is unique because it is considered a valid codec that does not read any bit data.
+    * The `conditional` will always return `None` because its determining boolean is explicitly `false`.
+    */
+  private val removeCodec : Codec[squadPattern] = conditional(false, bool).xmap[squadPattern] (
     {
-      case None =>
+      case None | _ =>
         None :: HNil
-      case _ =>
-        None :: HNil
     },
     {
-      case None :: HNil =>
-        None
-      case _ =>
+      case None :: HNil | _ =>
         None
     }
   )
 
-  val failureCodec : Codec[squadPattern] = conditional(false, bool).exmap[squadPattern] (
+  /**
+    * Codec for failing to determine a valid codec based on the entry data.
+    * This codec is an invalid codec that does not read any bit data.
+    * The `conditional` will always return `None` because its determining boolean is explicitly `false`.
+    */
+  val failureCodec : Codec[squadPattern] = conditional(false, bool).xmap[squadPattern] (
     {
-      case Some(x) =>
-        Attempt.failure(Err("path that should be unreachable, while decoding with unhandled codec"))
-      case None =>
-        Attempt.failure(Err("decoding with unhandled codec"))
+      case None | _ =>
+        throw new RuntimeException("decoding with unhandled codec")
     },
     {
-      case null =>
-        Attempt.failure(Err("path that should be unreachable, while encoding with unhandled codec"))
-      case _ =>
-        Attempt.failure(Err("encoding with unhandled codec"))
+      case None :: HNil | _ =>
+        throw new RuntimeException("encoding with unhandled codec")
     }
   )
 
-  def apply(action : Int, unk : Boolean, action2 : Option[Int], info : SquadInfo) : SquadHeader = {
-    SquadHeader(action, unk, action2, Some(info))
+  /**
+    * Alternate constructor for SquadInfo that ignores the Option requirement for the `info` field.
+    * @param unk1 na
+    * @param unk2 na
+    * @param unk3 na; not always defined
+    * @param info information pertaining to this squad listing
+    */
+  def apply(unk1 : Int, unk2 : Boolean, unk3 : Option[Int], info : SquadInfo) : SquadHeader = {
+    SquadHeader(unk1, unk2, unk3, Some(info))
   }
 
   implicit val codec : Codec[SquadHeader] = (
-    ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) >>:~ { unk =>
-        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
-          selectCodec(action, unk, action2, allCodec)
+    ("unk1" | uint8L) >>:~ { unk1 =>
+      ("unk2" | bool) >>:~ { unk2 =>
+        conditional(unk1 != 131, "unk3" | uintL(3)) >>:~ { unk3 =>
+          selectCodec(unk1, unk2, unk3, allCodec)
         }
       }
     }
     ).as[SquadHeader]
 
   implicit val init_codec : Codec[SquadHeader] = (
-    ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) >>:~ { unk =>
-        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
-          selectCodec(action, unk, action2, initCodec)
+    ("unk1" | uint8L) >>:~ { unk1 =>
+      ("unk2" | bool) >>:~ { unk2 =>
+        conditional(unk1 != 131, "unk3" | uintL(3)) >>:~ { unk3 =>
+          selectCodec(unk1, unk2, unk3, initCodec)
         }
       }
     }
     ).as[SquadHeader]
 
   implicit val alt_init_codec : Codec[SquadHeader] = (
-    ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) >>:~ { unk =>
-        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
-          selectCodec(action, unk, action2, alt_initCodec)
+    ("unk1" | uint8L) >>:~ { unk1 =>
+      ("unk2" | bool) >>:~ { unk2 =>
+        conditional(unk1 != 131, "unk3" | uintL(3)) >>:~ { unk3 =>
+          selectCodec(unk1, unk2, unk3, alt_initCodec)
         }
       }
     }
     ).as[SquadHeader]
 
-  def selectCodec(action : Int, unk : Boolean, action2 : Option[Int], extra : Codec[squadPattern]) : Codec[squadPattern] = {
-    if(action2.isDefined) {
-      val action2Val = action2.get
-      if(action == 0 && unk)
-        if(action2Val == 4)
+  /**
+    * Select the codec to translate bit data in this packet into an `Option[SquadInfo]` using other fields of the same packet.
+    * Refer to comments for the primary `case class` constructor for `SquadHeader` to explain how the conditions in this function path.
+    * @param a na
+    * @param b na
+    * @param c na; may be `None`
+    * @param optionalCodec a to-be-defined codec that is determined by the suggested mood of the packet and listing of the squad;
+    *                      despite the name, actually a required parameter
+    * @return a codec that corresponds to a `squadPattern` translation
+    */
+  private def selectCodec(a : Int, b : Boolean, c : Option[Int], optionalCodec : Codec[squadPattern]) : Codec[squadPattern] = {
+    if(c.isDefined) {
+      val cVal = c.get
+      if(a == 0 && b)
+        if(cVal == 4)
           return removeCodec
-      if(action == 128 && unk) {
-        if(action2Val == 0)
+      if(a == 128 && b) {
+        if(cVal == 0)
           return leaderCodec
-        else if(action2Val == 1)
+        else if(cVal == 1)
           return taskOrContinentCodec
-        else if(action2Val == 2)
+        else if(cVal == 2)
           return sizeCodec
       }
-      else if(action == 129 && !unk) {
-        if(action2Val == 0)
+      else if(a == 129 && !b) {
+        if(cVal == 0)
           return leaderSizeCodec
-        else if(action2Val == 1)
+        else if(cVal == 1)
           return taskAndContinentCodec
       }
     }
     else {
-      if(action == 131 && !unk)
-        return extra
+      if(a == 131 && !b)
+        return optionalCodec
     }
     //we've not encountered a valid codec
     failureCodec
@@ -373,9 +610,12 @@ object SquadListing extends Marshallable[SquadListing] {
 }
 
 object ReplicationStreamMessage extends Marshallable[ReplicationStreamMessage] {
+  //vector is a greedy unsized codec that will consume data until there is no data left in the stream
+  //vector will attempt to parse the amount of data necessary to translate sequential elements using the supplied codec
+  //an unexpected end of stream while parsing for an element will cause the packet to fail to decode
   implicit val codec : Codec[ReplicationStreamMessage] = (
     ("behavior" | uintL(3)) >>:~ { behavior =>
-      conditional(behavior == 5, "behavior2" | uintL(3)) :: //note: uses self
+      conditional(behavior == 5, "behavior2" | uintL(3)) ::
         conditional(behavior != 1, "unk" | bool) ::
         newcodecs.binary_choice(behavior != 5,
           "entries" | vector(SquadListing.codec),

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -481,23 +481,23 @@ object SquadHeader extends Marshallable[SquadHeader] {
   /**
     * Codec for reading the `SquadInfo` data in a "remove squad from list" entry.
     * This codec is unique because it is considered a valid codec that does not read any bit data.
-    * The `conditional` will always return `None` because its determining boolean is explicitly `false`.
+    * The `conditional` will always return `None` because its determining conditional statement is explicitly `false`.
     */
-  private val removeCodec : Codec[squadPattern] = conditional(false, bool).xmap[squadPattern] (
+  private val removeCodec : Codec[squadPattern] = conditional(false, bool).exmap[squadPattern] (
     {
       case None | _ =>
-        None :: HNil
+        Attempt.successful(None :: HNil)
     },
     {
       case None :: HNil | _ =>
-        None
+        Attempt.successful(None)
     }
   )
 
   /**
     * Codec for failing to determine a valid codec based on the entry data.
     * This codec is an invalid codec that does not read any bit data.
-    * The `conditional` will always return `None` because its determining boolean is explicitly `false`.
+    * The `conditional` will always return `None` because its determining conditional statement is explicitly `false`.
     */
   val failureCodec : Codec[squadPattern] = conditional(false, bool).exmap[squadPattern] (
     {

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -4,7 +4,7 @@ package net.psforever.packet.game
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
 import scodec.bits.BitVector
-import scodec.{Codec, Err}
+import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless._
 
@@ -101,10 +101,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
         Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+      case _ =>
+        null
     },
     {
       case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
         sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case _ =>
+        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
     }
   )
   val alt_initCodec : Codec[squadPattern] = (
@@ -119,10 +123,37 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
         Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+      case _ =>
+        null
     },
     {
       case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
         sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case _ =>
+        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
+    }
+  )
+
+  val allCodec : Codec[squadPattern] = (
+    ("squad_guid" | PlanetSideGUID.codec) ::
+      ("leader" | PacketHelpers.encodedWideStringAligned(3)) ::
+      ("task" | PacketHelpers.encodedWideString) ::
+      ("continent_guid" | PlanetSideGUID.codec) ::
+      uint16L ::
+      ("size" | uint4L) ::
+      ("capacity" | uint4L)
+    ).xmap[squadPattern] (
+    {
+      case sguid :: lead :: tsk :: cguid :: x :: sz :: cap :: HNil =>
+        Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil
+      case _ =>
+        null
+    },
+    {
+      case Some(SquadInfo(lead, tsk, cguid, sz, cap, sguid)) :: HNil =>
+        sguid.get :: lead.get :: tsk.get :: cguid.get :: 0 :: sz.get :: cap.get :: HNil
+      case _ =>
+        PlanetSideGUID(0) :: "" :: "" :: PlanetSideGUID(0) :: 0 :: 0 :: 0 :: HNil
     }
   )
 
@@ -133,10 +164,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case x :: lead :: HNil =>
         Some(SquadInfo(lead, None)) :: HNil
+      case _ =>
+        null :: HNil
     },
     {
       case Some(SquadInfo(lead, _, _, _, _, _)) :: HNil =>
         true :: lead.get :: HNil
+      case _ =>
+        true :: "" :: HNil
     }
   )
 
@@ -152,12 +187,16 @@ object SquadHeader extends Marshallable[SquadHeader] {
         Some(SquadInfo(cguid.get)) :: HNil
       case false :: None :: None :: tsk :: HNil =>
         Some(SquadInfo(None, tsk.get)) :: HNil
+      case _ =>
+        null :: HNil
     },
     {
       case Some(SquadInfo(_, None, cguid, _, _, _)) :: HNil =>
         true :: cguid :: Some(0) :: None :: HNil
       case Some(SquadInfo(_, tsk, None, _, _, _)) :: HNil =>
         false :: None :: None :: tsk :: HNil
+      case _ =>
+        false :: None :: None :: None :: HNil
     }
   )
 
@@ -168,10 +207,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case false :: sz :: HNil =>
         Some(SquadInfo(sz, None)) :: HNil
+      case _ =>
+        null :: HNil
     },
     {
       case Some(SquadInfo(_, _, _, sz, _, _)) :: HNil =>
         false :: sz.get :: HNil
+      case _ =>
+        false :: 0 :: HNil
     }
   )
 
@@ -184,10 +227,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case true :: lead :: 4 :: sz :: HNil =>
         Some(SquadInfo(lead, sz)) :: HNil
+      case _ =>
+        null :: HNil
     },
     {
       case Some(SquadInfo(lead, _, _, sz, _, _)) ::HNil =>
         true :: lead.get :: 4 :: sz.get :: HNil
+      case _ =>
+        true :: "" :: 4 :: 0 :: HNil
     }
   )
 
@@ -202,10 +249,14 @@ object SquadHeader extends Marshallable[SquadHeader] {
     {
       case false :: tsk :: 1 :: true :: cguid :: 0 :: HNil =>
         Some(SquadInfo(tsk, cguid)) :: HNil
+      case _ =>
+        null :: HNil
     },
     {
       case Some(SquadInfo(_, tsk, cguid, _, _, _)) :: HNil =>
         false :: tsk.get :: 1 :: true :: cguid.get :: 0 :: HNil
+      case _ =>
+        false :: "" :: 1 :: true :: PlanetSideGUID(0) :: 0 :: HNil
     }
   )
 
@@ -224,15 +275,18 @@ object SquadHeader extends Marshallable[SquadHeader] {
     }
   )
 
-  //TODO justify this mess
-  val failureCodec : Codec[squadPattern] = peek(bool).xmap[squadPattern] (
+  val failureCodec : Codec[squadPattern] = conditional(false, bool).exmap[squadPattern] (
     {
-      case false => Some(SquadInfo(None, None, None, None, None, None)) :: HNil
-      case true => Some(SquadInfo(None, None, None, None, None, None)) :: HNil
+      case Some(x) =>
+        Attempt.failure(Err("path that should be unreachable, while decoding with unhandled codec"))
+      case None =>
+        Attempt.failure(Err("decoding with unhandled codec"))
     },
     {
-      case Some(x) :: HNil => false
-      case None :: HNil => false
+      case null =>
+        Attempt.failure(Err("path that should be unreachable, while encoding with unhandled codec"))
+      case _ =>
+        Attempt.failure(Err("encoding with unhandled codec"))
     }
   )
 
@@ -244,23 +298,29 @@ object SquadHeader extends Marshallable[SquadHeader] {
     ("action" | uint8L) >>:~ { action =>
       ("unk" | bool) >>:~ { unk =>
         conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
-          selectCodec(action, unk, action2)
+          selectCodec(action, unk, action2, allCodec)
         }
       }
     }
     ).as[SquadHeader]
 
-  implicit val alt_codec : Codec[SquadHeader] = (
+  implicit val init_codec : Codec[SquadHeader] = (
     ("action" | uint8L) >>:~ { action =>
-      ("unk" | bool) >>:~ { unk =>
-        conditional(action != 131, "action2" | uintL(3)) >>:~ { action2 =>
-          selectCodec(action, unk, action2, alt_initCodec)
-        }
-      }
+      ("unk" | bool) ::
+        conditional(action != 131, "action2" | uintL(3)) ::
+        initCodec
     }
     ).as[SquadHeader]
 
-  def selectCodec(action : Int, unk : Boolean, action2 : Option[Int], init : Codec[squadPattern] = initCodec) : Codec[squadPattern] = {
+  implicit val alt_init_codec : Codec[SquadHeader] = (
+    ("action" | uint8L) >>:~ { action =>
+      ("unk" | bool) ::
+        conditional(action != 131, "action2" | uintL(3)) ::
+        alt_initCodec
+    }
+    ).as[SquadHeader]
+
+  def selectCodec(action : Int, unk : Boolean, action2 : Option[Int], extra : Codec[squadPattern]) : Codec[squadPattern] = {
     if(action2.isDefined) {
       val action2Val = action2.get
       if(action == 0 && unk)
@@ -283,11 +343,9 @@ object SquadHeader extends Marshallable[SquadHeader] {
     }
     else {
       if(action == 131 && !unk)
-        return init
+        return extra
     }
-
-    //TODO better error handling here?
-    Err("unhandled codec")
+    //we've not encountered a valid codec
     failureCodec
   }
 }
@@ -295,21 +353,30 @@ object SquadHeader extends Marshallable[SquadHeader] {
 object SquadListing extends Marshallable[SquadListing] {
   implicit val codec : Codec[SquadListing] = (
     ("index" | uint8L) >>:~ { index =>
+      conditional(index < 255, "listing" | SquadHeader.codec) ::
+        conditional(index == 255, bits) //consume n < 8 bits padding the tail entry, else vector will try to operate on invalid data
+    }).as[SquadListing]
+
+  implicit val init_codec : Codec[SquadListing] = (
+    ("index" | uint8L) >>:~ { index =>
       conditional(index < 255,
         newcodecs.binary_choice(index == 0,
-          "listing" | SquadHeader.codec,
-          "listing" | SquadHeader.alt_codec)
+          "listing" | SquadHeader.init_codec,
+          "listing" | SquadHeader.alt_init_codec)
       ) ::
-        conditional(index == 255, bits).hlist //consume n < 8 bits padding the tail entry, else vector will try to operate on invalid data
+        conditional(index == 255, bits) //consume n < 8 bits padding the tail entry, else vector will try to operate on invalid data
     }).as[SquadListing]
 }
 
 object ReplicationStreamMessage extends Marshallable[ReplicationStreamMessage] {
   implicit val codec : Codec[ReplicationStreamMessage] = (
-    (("behavior" | uintL(3)) >>:~ { behavior =>
+    ("behavior" | uintL(3)) >>:~ { behavior =>
       conditional(behavior == 5, "behavior2" | uintL(3)) :: //note: uses self
-        conditional(behavior != 1, "unk" | bool)
-    }) :+
-      ("entries" | vector(SquadListing.codec))
+        conditional(behavior != 1, "unk" | bool) ::
+        newcodecs.binary_choice(behavior != 5,
+          "entries" | vector(SquadListing.codec),
+          "entries" | vector(SquadListing.init_codec)
+        )
+    }
     ).as[ReplicationStreamMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -8,6 +8,7 @@ import scodec.codecs._
 
 final case class SquadHeader(unk1 : Int,
                              unk2 : Int,
+                             squad_guid : Int,
                              unk3 : Int,
                              unk4 : Boolean,
                              leader : String,
@@ -32,8 +33,9 @@ final case class ReplicationStreamMessage(unk : Int,
 object SquadHeader extends Marshallable[SquadHeader] {
   implicit val codec : Codec[SquadHeader] = (
     ("unk1" | uint8L) ::
-      ("unk2" | uint8L) ::
-      ("unk3" | uint8L) ::
+      ("unk2" | uintL(3)) ::
+      ("squad_guid" | uint8L) ::
+      ("unk3" | uintL(5)) ::
       ("unk4" | bool) ::
       ("leader" | PacketHelpers.encodedWideString) ::
       ("name" | PacketHelpers.encodedWideString) ::
@@ -45,8 +47,9 @@ object SquadHeader extends Marshallable[SquadHeader] {
 
   implicit val alt_codec : Codec[SquadHeader] = (
     ("unk1" | uint8L) ::
-      ("unk2" | uint8L) ::
-      ("unk3" | uint8L) ::
+      ("unk2" | uintL(3)) ::
+      ("squad_guid" | uint8L) ::
+      ("unk3" | uintL(5)) ::
       ("unk4" | bool) ::
       ("leader" | PacketHelpers.encodedWideStringAligned(7)) ::
       ("name" | PacketHelpers.encodedWideString) ::

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -707,6 +707,7 @@ class GamePacketTest extends Specification {
       val stringNone = hex"E6 B9 FE"
       val stringOne = hex"E6 B8 01 06 01 00 8B 46007200610067004C0041004E00640049004E004300 84 4600720061006700 0A00 00 00 0A FF"
       val stringTwo = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
+      val stringThree = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 01 80 4600 4E0049004700480054003800380052004100560045004E00 8B 41006C006C002000570065006C0063006F006D006500 0A 00 00 00 4A 02 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
 
       "decode (none)" in {
         PacketCoding.DecodePacket(stringNone).require match {
@@ -777,6 +778,51 @@ class GamePacketTest extends Specification {
         }
       }
 
+      "decode (three)" in {
+        PacketCoding.DecodePacket(stringThree).require match {
+          case ReplicationStreamMessage(unk, entries) =>
+            unk mustEqual 92
+            entries.length mustEqual 4
+            entries.head.index mustEqual 0
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.unk1 mustEqual 131
+            entries.head.listing.get.unk2 mustEqual 3
+            entries.head.listing.get.unk3 mustEqual 0
+            entries.head.listing.get.unk4 mustEqual false
+            entries.head.listing.get.leader mustEqual "GeneralGorgutz"
+            entries.head.listing.get.name mustEqual "FLY,All welcome,cn last night!!!!"
+            entries.head.listing.get.continent_guid mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.unk5 mustEqual 0
+            entries.head.listing.get.size mustEqual 7
+            entries.head.listing.get.capacity mustEqual 10
+            entries(1).index mustEqual 1
+            entries(1).listing.get.unk1 mustEqual 131
+            entries(1).listing.get.unk2 mustEqual 1
+            entries(1).listing.get.unk3 mustEqual 128
+            entries(1).listing.get.unk4 mustEqual false
+            entries(1).listing.get.leader mustEqual "NIGHT88RAVEN"
+            entries(1).listing.get.name mustEqual "All Welcome"
+            entries(1).listing.get.continent_guid mustEqual PlanetSideGUID(10)
+            entries(1).listing.get.unk5 mustEqual 0
+            entries(1).listing.get.size mustEqual 4
+            entries(1).listing.get.capacity mustEqual 10
+            entries(2).index mustEqual 2
+            entries(2).listing.get.unk1 mustEqual 131
+            entries(2).listing.get.unk2 mustEqual 2
+            entries(2).listing.get.unk3 mustEqual 0
+            entries(2).listing.get.unk4 mustEqual false
+            entries(2).listing.get.leader mustEqual "KOKkiasMFCN"
+            entries(2).listing.get.name mustEqual "Squad 2"
+            entries(2).listing.get.continent_guid mustEqual PlanetSideGUID(4)
+            entries(2).listing.get.unk5 mustEqual 0
+            entries(2).listing.get.size mustEqual 6
+            entries(2).listing.get.capacity mustEqual 10
+            entries(3).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
       "encode (none)" in {
         val msg = ReplicationStreamMessage(92, Vector(SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
@@ -801,6 +847,17 @@ class GamePacketTest extends Specification {
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringTwo
+      }
+
+      "encode (three)" in {
+        val msg = ReplicationStreamMessage(92, Vector(
+          SquadListing(0, Option(SquadHeader(131, 3, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
+          SquadListing(1, Option(SquadHeader(131, 1, 128, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
+          SquadListing(2, Option(SquadHeader(131, 2, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+          SquadListing(255)))
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringThree
       }
     }
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -5,6 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
 import net.psforever.types._
+import scodec.Attempt
 import scodec.Attempt.Successful
 import scodec.bits._
 
@@ -716,6 +717,41 @@ class GamePacketTest extends Specification {
       val stringUpdateLeaderSize = hex"E6 C0 58 10 C3 00 4A0069006D006D0079006E00 43 FF"
       val stringUpdateTaskContinent = hex"E6 C0 58 11 40 80 3200 3 04000000 FF0"
       val stringUpdateAll = hex"E6 C0 78 30 58 0430 6D00610064006D0075006A00 80 040000000A FF"
+      //failing conditions
+      val stringCodecFail = hex"E6 20 A1 19 FE"
+      val stringListOneFail = hex"E6 B8 01 06 01 00 8B 46007200610067004C0041004E00640049004E004300 84 4600720061006700 0A00 00 01 0A FF"
+      val stringListTwoFail = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 01 6A FF"
+      val stringUpdateLeaderFail = hex"E6 C0 28 08 44 00 46006100740065004A0048004E004300 FF"
+      val stringUpdateTaskFail = hex"E6 C0 58 09CE00 52004900500020005000530031002C0020007600690073006900740020005000530046006F00720065007600650072002E006E0065007400 FF"
+      val stringUpdateContinentFail = hex"E6 C0 38 09 85000001 7F80"
+      val stringUpdateSizeFail = hex"E6 C0 18 0A B7 F8"
+      val stringUpdateLeaderSizeFail = hex"E6 C0 58 10 43 00 4A0069006D006D0079006E00 43 FF"
+      val stringUpdateTaskContinentFail = hex"E6 C0 58 11 C0 80 3200 3 04000000 FF0"
+      val stringUpdateAllFail = hex"E6 C0 78 30 58 0430 6D00610064006D0075006A00 80 04000001 0A FF"
+
+      "SquadInfo (w/ squad_guid)" in {
+        val o = SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10)
+        o.leader.isDefined mustEqual true
+        o.leader.get mustEqual "FragLANdINC"
+        o.task.isDefined mustEqual true
+        o.task.get mustEqual "Frag"
+        o.continent_guid.isDefined mustEqual true
+        o.continent_guid.get mustEqual PlanetSideGUID(10)
+        o.size.isDefined mustEqual true
+        o.size.get mustEqual 0
+        o.capacity.isDefined mustEqual true
+        o.capacity.get mustEqual 10
+      }
+
+      "SquadInfo (capacity)" in {
+        val o = SquadInfo(None, 7)
+        o.leader.isDefined mustEqual false
+        o.task.isDefined mustEqual false
+        o.continent_guid.isDefined mustEqual false
+        o.size.isDefined mustEqual false
+        o.capacity.isDefined mustEqual true
+        o.capacity.get mustEqual 7
+      }
 
       "decode (clear)" in {
         PacketCoding.DecodePacket(stringListClear).require match {
@@ -742,9 +778,9 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 0
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 131
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.unk1 mustEqual 131
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual false
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.get mustEqual "FragLANdINC"
@@ -773,9 +809,9 @@ class GamePacketTest extends Specification {
             unk.get mustEqual false
             entries.length mustEqual 3
             entries.head.index mustEqual 0
-            entries.head.listing.get.action mustEqual 131
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.unk1 mustEqual 131
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual false
             entries.head.listing.get.info.get.leader.get mustEqual "GeneralGorgutz"
             entries.head.listing.get.info.get.task.get mustEqual "FLY,All welcome,cn last night!!!!"
             entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
@@ -783,9 +819,9 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.info.get.capacity.get mustEqual 10
             entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(6)
             entries(1).index mustEqual 1
-            entries(1).listing.get.action mustEqual 131
-            entries(1).listing.get.unk mustEqual false
-            entries(1).listing.get.action2.isDefined mustEqual false
+            entries(1).listing.get.unk1 mustEqual 131
+            entries(1).listing.get.unk2 mustEqual false
+            entries(1).listing.get.unk3.isDefined mustEqual false
             entries(1).listing.get.info.get.leader.get mustEqual "KOKkiasMFCN"
             entries(1).listing.get.info.get.task.get mustEqual "Squad 2"
             entries(1).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
@@ -807,9 +843,9 @@ class GamePacketTest extends Specification {
             unk.get mustEqual false
             entries.length mustEqual 4
             entries.head.index mustEqual 0
-            entries.head.listing.get.action mustEqual 131
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.unk1 mustEqual 131
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual false
             entries.head.listing.get.info.get.leader.get mustEqual "GeneralGorgutz"
             entries.head.listing.get.info.get.task.get mustEqual "FLY,All welcome,cn last night!!!!"
             entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
@@ -817,9 +853,9 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.info.get.capacity.get mustEqual 10
             entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(6)
             entries(1).index mustEqual 1
-            entries(1).listing.get.action mustEqual 131
-            entries(1).listing.get.unk mustEqual false
-            entries(1).listing.get.action2.isDefined mustEqual false
+            entries(1).listing.get.unk1 mustEqual 131
+            entries(1).listing.get.unk2 mustEqual false
+            entries(1).listing.get.unk3.isDefined mustEqual false
             entries(1).listing.get.info.get.leader.get mustEqual "NIGHT88RAVEN"
             entries(1).listing.get.info.get.task.get mustEqual "All Welcome"
             entries(1).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(10)
@@ -827,9 +863,9 @@ class GamePacketTest extends Specification {
             entries(1).listing.get.info.get.capacity.get mustEqual 10
             entries(1).listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(3)
             entries(2).index mustEqual 2
-            entries(2).listing.get.action mustEqual 131
-            entries(2).listing.get.unk mustEqual false
-            entries(2).listing.get.action2.isDefined mustEqual false
+            entries(2).listing.get.unk1 mustEqual 131
+            entries(2).listing.get.unk2 mustEqual false
+            entries(2).listing.get.unk3.isDefined mustEqual false
             entries(2).listing.get.info.get.leader.get mustEqual "KOKkiasMFCN"
             entries(2).listing.get.info.get.task.get mustEqual "Squad 2"
             entries(2).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
@@ -851,10 +887,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 5
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 0
-            entries.head.listing.get.unk mustEqual true
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 4
+            entries.head.listing.get.unk1 mustEqual 0
+            entries.head.listing.get.unk2 mustEqual true
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 4
             entries.head.listing.get.info.isDefined mustEqual false
             entries(1).index mustEqual 255
           case _ =>
@@ -872,10 +908,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 2
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 128
-            entries.head.listing.get.unk mustEqual true
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 0
+            entries.head.listing.get.unk1 mustEqual 128
+            entries.head.listing.get.unk2 mustEqual true
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 0
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.get mustEqual "FateJHNC"
@@ -900,10 +936,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 5
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 128
-            entries.head.listing.get.unk mustEqual true
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.unk1 mustEqual 128
+            entries.head.listing.get.unk2 mustEqual true
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 1
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual false
             entries.head.listing.get.info.get.task.isDefined mustEqual true
@@ -928,10 +964,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 3
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 128
-            entries.head.listing.get.unk mustEqual true
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.unk1 mustEqual 128
+            entries.head.listing.get.unk2 mustEqual true
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 1
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual false
             entries.head.listing.get.info.get.task.isDefined mustEqual false
@@ -956,10 +992,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 1
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 128
-            entries.head.listing.get.unk mustEqual true
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 2
+            entries.head.listing.get.unk1 mustEqual 128
+            entries.head.listing.get.unk2 mustEqual true
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 2
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual false
             entries.head.listing.get.info.get.task.isDefined mustEqual false
@@ -984,10 +1020,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 5
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 129
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 0
+            entries.head.listing.get.unk1 mustEqual 129
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 0
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.get mustEqual "Jimmyn"
@@ -1013,10 +1049,10 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 5
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 129
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual true
-            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.unk1 mustEqual 129
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual true
+            entries.head.listing.get.unk3.get mustEqual 1
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual false
             entries.head.listing.get.info.get.task.isDefined mustEqual true
@@ -1042,9 +1078,9 @@ class GamePacketTest extends Specification {
             entries.length mustEqual 2
             entries.head.index mustEqual 7
             entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.action mustEqual 131
-            entries.head.listing.get.unk mustEqual false
-            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.unk1 mustEqual 131
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.unk3.isDefined mustEqual false
             entries.head.listing.get.info.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.isDefined mustEqual true
             entries.head.listing.get.info.get.leader.get mustEqual "madmuj"
@@ -1062,6 +1098,19 @@ class GamePacketTest extends Specification {
           case _ =>
             ko
         }
+      }
+
+      "decode (fails)" in {
+        PacketCoding.DecodePacket(stringCodecFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringListOneFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringListTwoFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateLeaderFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateTaskFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateContinentFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateSizeFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateLeaderSizeFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateTaskContinentFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringUpdateAllFail) must throwA[RuntimeException]
       }
 
       "encode (clear)" in {
@@ -1129,7 +1178,7 @@ class GamePacketTest extends Specification {
       "encode (update leader)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(2, Some(SquadHeader(128, true, Some(0), Some(SquadInfo("FateJHNC", None))))),
+            SquadListing(2, Some(SquadHeader(128, true, Some(0), SquadInfo("FateJHNC", None)))),
             SquadListing(255)
           )
         )
@@ -1141,7 +1190,7 @@ class GamePacketTest extends Specification {
       "encode (update task)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(5, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(None, "RIP PS1, visit PSForever.net"))))),
+            SquadListing(5, Some(SquadHeader(128, true, Some(1), SquadInfo(None, "RIP PS1, visit PSForever.net")))),
             SquadListing(255)
           )
         )
@@ -1153,7 +1202,7 @@ class GamePacketTest extends Specification {
       "encode (update continent)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(3, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(PlanetSideGUID(10)))))),
+            SquadListing(3, Some(SquadHeader(128, true, Some(1), SquadInfo(PlanetSideGUID(10))))),
             SquadListing(255)
           )
         )
@@ -1165,7 +1214,7 @@ class GamePacketTest extends Specification {
       "encode (update size)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(1, Some(SquadHeader(128, true, Some(2), Some(SquadInfo(6, None))))),
+            SquadListing(1, Some(SquadHeader(128, true, Some(2), SquadInfo(6, None)))),
             SquadListing(255)
           )
         )
@@ -1177,7 +1226,7 @@ class GamePacketTest extends Specification {
       "encode (update leader and size)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(5, Some(SquadHeader(129, false, Some(0), Some(SquadInfo("Jimmyn", 3))))),
+            SquadListing(5, Some(SquadHeader(129, false, Some(0), SquadInfo("Jimmyn", 3)))),
             SquadListing(255)
           )
         )
@@ -1189,7 +1238,7 @@ class GamePacketTest extends Specification {
       "encode (update task and continent)" in {
         val msg = ReplicationStreamMessage(6, None, Some(false),
           Vector(
-            SquadListing(5, Some(SquadHeader(129, false, Some(1), Some(SquadInfo("2", PlanetSideGUID(4)))))),
+            SquadListing(5, Some(SquadHeader(129, false, Some(1), SquadInfo("2", PlanetSideGUID(4))))),
             SquadListing(255)
           )
         )
@@ -1208,6 +1257,119 @@ class GamePacketTest extends Specification {
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringUpdateAll
+      }
+
+      "encode (fails)" in {
+        //encode codec fail
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(1, None, None,
+            Vector(
+              SquadListing(5, Some(SquadHeader(0, false, Some(4)))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode one
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(5, Some(6), Some(false),
+            Vector(
+              SquadListing(0, Some(SquadHeader(131, false, None, Some(SquadInfo(Some("FragLANdINC"), Some("Frag"), None, Some(0),Some(10), Some(PlanetSideGUID(1))))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode two
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(5, Some(6), Some(false),
+            Vector(
+              SquadListing(0, Some(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
+              SquadListing(1, Some(SquadHeader(131, false, None, Some(SquadInfo(Some("KOKkiasMFCN"), Some("Squad 2"), None, Some(6), Some(10), Some(PlanetSideGUID(4))))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode leader
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(2, Some(SquadHeader(128, true, Some(0), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode task
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(5, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode continent
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(3, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode task or continent
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(3, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(None, Some(""), Some(PlanetSideGUID(10)), None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode size
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(1, Some(SquadHeader(128, true, Some(2), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode leader and size
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(5, Some(SquadHeader(129, false, Some(0), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode task and continent
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(5, Some(SquadHeader(129, false, Some(1), Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
+
+        //encode all
+        PacketCoding.EncodePacket(
+          ReplicationStreamMessage(6, None, Some(false),
+            Vector(
+              SquadListing(7, Some(SquadHeader(131, false, None, Some(SquadInfo(None, None, None, None, None, None))))),
+              SquadListing(255)
+            )
+          )
+        ).require.toByteVector must throwA[RuntimeException]
       }
     }
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -730,7 +730,8 @@ class GamePacketTest extends Specification {
             entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
             entries.head.listing.get.unk2 mustEqual 0
-            entries.head.listing.get.unk3 mustEqual 128
+            entries.head.listing.get.squad_guid mustEqual 4
+            entries.head.listing.get.unk3 mustEqual 0
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "FragLANdINC"
             entries.head.listing.get.name mustEqual "Frag"
@@ -752,7 +753,8 @@ class GamePacketTest extends Specification {
             entries.head.index mustEqual 0
             entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual 3
+            entries.head.listing.get.unk2 mustEqual 0
+            entries.head.listing.get.squad_guid mustEqual 24
             entries.head.listing.get.unk3 mustEqual 0
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "GeneralGorgutz"
@@ -763,7 +765,8 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.capacity mustEqual 10
             entries(1).index mustEqual 1
             entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual 2
+            entries(1).listing.get.unk2 mustEqual 0
+            entries(1).listing.get.squad_guid mustEqual 16
             entries(1).listing.get.unk3 mustEqual 0
             entries(1).listing.get.unk4 mustEqual false
             entries(1).listing.get.leader mustEqual "KOKkiasMFCN"
@@ -786,7 +789,8 @@ class GamePacketTest extends Specification {
             entries.head.index mustEqual 0
             entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual 3
+            entries.head.listing.get.unk2 mustEqual 0
+            entries.head.listing.get.squad_guid mustEqual 24
             entries.head.listing.get.unk3 mustEqual 0
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "GeneralGorgutz"
@@ -797,8 +801,9 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.capacity mustEqual 10
             entries(1).index mustEqual 1
             entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual 1
-            entries(1).listing.get.unk3 mustEqual 128
+            entries(1).listing.get.unk2 mustEqual 0
+            entries(1).listing.get.squad_guid mustEqual 12
+            entries(1).listing.get.unk3 mustEqual 0
             entries(1).listing.get.unk4 mustEqual false
             entries(1).listing.get.leader mustEqual "NIGHT88RAVEN"
             entries(1).listing.get.name mustEqual "All Welcome"
@@ -808,7 +813,8 @@ class GamePacketTest extends Specification {
             entries(1).listing.get.capacity mustEqual 10
             entries(2).index mustEqual 2
             entries(2).listing.get.unk1 mustEqual 131
-            entries(2).listing.get.unk2 mustEqual 2
+            entries(2).listing.get.unk2 mustEqual 0
+            entries(2).listing.get.squad_guid mustEqual 16
             entries(2).listing.get.unk3 mustEqual 0
             entries(2).listing.get.unk4 mustEqual false
             entries(2).listing.get.leader mustEqual "KOKkiasMFCN"
@@ -832,7 +838,7 @@ class GamePacketTest extends Specification {
 
       "encode (one)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 128, false, "FragLANdINC", "Frag", PlanetSideGUID(10), 0, 0, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 4, 0, false, "FragLANdINC", "Frag", PlanetSideGUID(10), 0, 0, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -841,8 +847,8 @@ class GamePacketTest extends Specification {
 
       "encode (two)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 3, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 2, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 24, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
+          SquadListing(1, Option(SquadHeader(131, 0, 16, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -851,9 +857,9 @@ class GamePacketTest extends Specification {
 
       "encode (three)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 3, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 1, 128, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
-          SquadListing(2, Option(SquadHeader(131, 2, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 24, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
+          SquadListing(1, Option(SquadHeader(131, 0, 12, 0, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
+          SquadListing(2, Option(SquadHeader(131, 0, 16, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -704,19 +704,25 @@ class GamePacketTest extends Specification {
     }
 
     "ReplicationStreamMessage" should {
-      val stringNone = hex"E6 B9 FE"
+      val stringClear = hex"E6 B9 FE"
       val stringOne = hex"E6 B8 01 06 01 00 8B 46007200610067004C0041004E00640049004E004300 84 4600720061006700 0A00 00 00 0A FF"
       val stringTwo = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
       val stringThree = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 01 80 4600 4E0049004700480054003800380052004100560045004E00 8B 41006C006C002000570065006C0063006F006D006500 0A 00 00 00 4A 02 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
 
-      "decode (none)" in {
-        PacketCoding.DecodePacket(stringNone).require match {
-          case ReplicationStreamMessage(action, unk, entries) =>
-            action mustEqual 5
-            unk mustEqual 12
-            entries.length mustEqual 1
-            entries.head.index mustEqual 255
-            entries.head.listing.isDefined mustEqual false
+      "decode (clear)" in {
+        PacketCoding.DecodePacket(stringClear).require match {
+          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+            behavior mustEqual 5
+            init.isDefined mustEqual true
+            init.get.behavior mustEqual 6
+            init.get.init.isDefined mustEqual false
+            init.get.unk.isDefined mustEqual true
+            init.get.unk.get mustEqual false
+            init.get.entries.length mustEqual 1
+            init.get.entries.head.index mustEqual 255
+            init.get.entries.head.listing.isDefined mustEqual false
+            unk.isDefined mustEqual false
+            entries.length mustEqual 0
           case _ =>
             ko
         }
@@ -724,22 +730,35 @@ class GamePacketTest extends Specification {
 
       "decode (one)" in {
         PacketCoding.DecodePacket(stringOne).require match {
-          case ReplicationStreamMessage(action, unk, entries) =>
-            action mustEqual 5
-            unk mustEqual 12
-            entries.length mustEqual 2
-            entries.head.index mustEqual 0
-            entries.head.listing.isDefined mustEqual true
-            entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual false
-            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(1)
-            entries.head.listing.get.info.leader mustEqual "FragLANdINC"
-            entries.head.listing.get.info.task mustEqual "Frag"
-            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(10)
-            entries.head.listing.get.info.size mustEqual 0
-            entries.head.listing.get.info.capacity mustEqual 10
-            entries(1).index mustEqual 255
-            entries(1).listing.isDefined mustEqual false
+          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+            behavior mustEqual 5
+            init.isDefined mustEqual true
+            init.get.behavior mustEqual 6
+            init.get.init.isDefined mustEqual false
+            init.get.unk.isDefined mustEqual true
+            init.get.unk.get mustEqual false
+            init.get.entries.length mustEqual 2
+            init.get.entries.head.index mustEqual 0
+            init.get.entries.head.listing.isDefined mustEqual true
+            init.get.entries.head.listing.get.action mustEqual 131
+            init.get.entries.head.listing.get.unk mustEqual false
+            init.get.entries.head.listing.get.action2.isDefined mustEqual false
+            init.get.entries.head.listing.get.info.leader.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.leader.get mustEqual "FragLANdINC"
+            init.get.entries.head.listing.get.info.task.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.task.get mustEqual "Frag"
+            init.get.entries.head.listing.get.info.continent_guid.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(10)
+            init.get.entries.head.listing.get.info.size.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.size.get mustEqual 0
+            init.get.entries.head.listing.get.info.capacity.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
+            init.get.entries.head.listing.get.info.squad_guid.isDefined mustEqual true
+            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(1)
+            init.get.entries(1).index mustEqual 255
+            init.get.entries(1).listing.isDefined mustEqual false
+            unk.isDefined mustEqual false
+            entries.length mustEqual 0
           case _ =>
             ko
         }
@@ -747,29 +766,35 @@ class GamePacketTest extends Specification {
 
       "decode (two)" in {
         PacketCoding.DecodePacket(stringTwo).require match {
-          case ReplicationStreamMessage(action, unk, entries) =>
-            action mustEqual 5
-            unk mustEqual 12
-            entries.length mustEqual 3
-            entries.head.index mustEqual 0
-            entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual false
-            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(6)
-            entries.head.listing.get.info.leader mustEqual "GeneralGorgutz"
-            entries.head.listing.get.info.task mustEqual "FLY,All welcome,cn last night!!!!"
-            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
-            entries.head.listing.get.info.size mustEqual 7
-            entries.head.listing.get.info.capacity mustEqual 10
-            entries(1).index mustEqual 1
-            entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual false
-            entries(1).listing.get.squad_guid mustEqual PlanetSideGUID(4)
-            entries(1).listing.get.info.leader mustEqual "KOKkiasMFCN"
-            entries(1).listing.get.info.task mustEqual "Squad 2"
-            entries(1).listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
-            entries(1).listing.get.info.size mustEqual 6
-            entries(1).listing.get.info.capacity mustEqual 10
-            entries(2).index mustEqual 255
+          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+            behavior mustEqual 5
+            init.isDefined mustEqual true
+            init.get.behavior mustEqual 6
+            init.get.init.isDefined mustEqual false
+            init.get.unk.isDefined mustEqual true
+            init.get.unk.get mustEqual false
+            init.get.entries.length mustEqual 3
+            init.get.entries.head.index mustEqual 0
+            init.get.entries.head.listing.get.action mustEqual 131
+            init.get.entries.head.listing.get.unk mustEqual false
+            init.get.entries.head.listing.get.action2.isDefined mustEqual false
+            init.get.entries.head.listing.get.info.leader.get mustEqual "GeneralGorgutz"
+            init.get.entries.head.listing.get.info.task.get mustEqual "FLY,All welcome,cn last night!!!!"
+            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries.head.listing.get.info.size.get mustEqual 7
+            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
+            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(6)
+            init.get.entries(1).index mustEqual 1
+            init.get.entries(1).listing.get.action mustEqual 131
+            init.get.entries(1).listing.get.unk mustEqual false
+            init.get.entries(1).listing.get.action2.isDefined mustEqual false
+            init.get.entries(1).listing.get.info.leader.get mustEqual "KOKkiasMFCN"
+            init.get.entries(1).listing.get.info.task.get mustEqual "Squad 2"
+            init.get.entries(1).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries(1).listing.get.info.size.get mustEqual 6
+            init.get.entries(1).listing.get.info.capacity.get mustEqual 10
+            init.get.entries(1).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries(2).index mustEqual 255
           case _ =>
             ko
         }
@@ -777,75 +802,95 @@ class GamePacketTest extends Specification {
 
       "decode (three)" in {
         PacketCoding.DecodePacket(stringThree).require match {
-          case ReplicationStreamMessage(action, unk, entries) =>
-            action mustEqual 5
-            unk mustEqual 12
-            entries.length mustEqual 4
-            entries.head.index mustEqual 0
-            entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual false
-            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(6)
-            entries.head.listing.get.info.leader mustEqual "GeneralGorgutz"
-            entries.head.listing.get.info.task mustEqual "FLY,All welcome,cn last night!!!!"
-            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
-            entries.head.listing.get.info.size mustEqual 7
-            entries.head.listing.get.info.capacity mustEqual 10
-            entries(1).index mustEqual 1
-            entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual false
-            entries(1).listing.get.squad_guid mustEqual PlanetSideGUID(3)
-            entries(1).listing.get.info.leader mustEqual "NIGHT88RAVEN"
-            entries(1).listing.get.info.task mustEqual "All Welcome"
-            entries(1).listing.get.info.continent_guid mustEqual PlanetSideGUID(10)
-            entries(1).listing.get.info.size mustEqual 4
-            entries(1).listing.get.info.capacity mustEqual 10
-            entries(2).index mustEqual 2
-            entries(2).listing.get.unk1 mustEqual 131
-            entries(2).listing.get.unk2 mustEqual false
-            entries(2).listing.get.squad_guid mustEqual PlanetSideGUID(4)
-            entries(2).listing.get.info.leader mustEqual "KOKkiasMFCN"
-            entries(2).listing.get.info.task mustEqual "Squad 2"
-            entries(2).listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
-            entries(2).listing.get.info.size mustEqual 6
-            entries(2).listing.get.info.capacity mustEqual 10
-            entries(3).index mustEqual 255
+          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+            behavior mustEqual 5
+            init.isDefined mustEqual true
+            init.get.behavior mustEqual 6
+            init.get.init.isDefined mustEqual false
+            init.get.unk.isDefined mustEqual true
+            init.get.unk.get mustEqual false
+            init.get.entries.length mustEqual 4
+            init.get.entries.head.index mustEqual 0
+            init.get.entries.head.listing.get.action mustEqual 131
+            init.get.entries.head.listing.get.unk mustEqual false
+            init.get.entries.head.listing.get.action2.isDefined mustEqual false
+            init.get.entries.head.listing.get.info.leader.get mustEqual "GeneralGorgutz"
+            init.get.entries.head.listing.get.info.task.get mustEqual "FLY,All welcome,cn last night!!!!"
+            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries.head.listing.get.info.size.get mustEqual 7
+            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
+            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(6)
+            init.get.entries(1).index mustEqual 1
+            init.get.entries(1).listing.get.action mustEqual 131
+            init.get.entries(1).listing.get.unk mustEqual false
+            init.get.entries(1).listing.get.action2.isDefined mustEqual false
+            init.get.entries(1).listing.get.info.leader.get mustEqual "NIGHT88RAVEN"
+            init.get.entries(1).listing.get.info.task.get mustEqual "All Welcome"
+            init.get.entries(1).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(10)
+            init.get.entries(1).listing.get.info.size.get mustEqual 4
+            init.get.entries(1).listing.get.info.capacity.get mustEqual 10
+            init.get.entries(1).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(3)
+            init.get.entries(2).index mustEqual 2
+            init.get.entries(2).listing.get.action mustEqual 131
+            init.get.entries(2).listing.get.unk mustEqual false
+            init.get.entries(2).listing.get.action2.isDefined mustEqual false
+            init.get.entries(2).listing.get.info.leader.get mustEqual "KOKkiasMFCN"
+            init.get.entries(2).listing.get.info.task.get mustEqual "Squad 2"
+            init.get.entries(2).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries(2).listing.get.info.size.get mustEqual 6
+            init.get.entries(2).listing.get.info.capacity.get mustEqual 10
+            init.get.entries(2).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(4)
+            init.get.entries(3).index mustEqual 255
           case _ =>
             ko
         }
       }
 
-      "encode (none)" in {
-        val msg = ReplicationStreamMessage(5, 12, Vector(SquadListing(255)))
+      "encode (clear)" in {
+        val msg = ReplicationStreamMessage(5,
+          Some(ReplicationStreamMessage(6, None, Some(false),
+            Vector(SquadListing(255))
+          ))
+        )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual stringNone
+        pkt mustEqual stringClear
       }
 
       "encode (one)" in {
-        val msg = ReplicationStreamMessage(5, 12, Vector(
-          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(1), SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10)))),
-          SquadListing(255)))
+        val msg = ReplicationStreamMessage(5,
+          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
+            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10, PlanetSideGUID(1))))),
+            SquadListing(255))
+          ))
+        )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringOne
       }
 
       "encode (two)" in {
-        val msg = ReplicationStreamMessage(5, 12, Vector(
-          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(6), SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10)))),
-          SquadListing(1, Option(SquadHeader(131, false, PlanetSideGUID(4), SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10)))),
-          SquadListing(255)))
+        val msg = ReplicationStreamMessage(5,
+          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
+            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
+            SquadListing(1, Option(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
+            SquadListing(255))
+          ))
+        )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringTwo
       }
 
       "encode (three)" in {
-        val msg = ReplicationStreamMessage(5, 12, Vector(
-          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(6), SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10)))),
-          SquadListing(1, Option(SquadHeader(131, false, PlanetSideGUID(3), SquadInfo("NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 4, 10)))),
-          SquadListing(2, Option(SquadHeader(131, false, PlanetSideGUID(4), SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10)))),
-          SquadListing(255)))
+        val msg = ReplicationStreamMessage(5,
+          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
+            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
+            SquadListing(1, Option(SquadHeader(131, false, None, SquadInfo("NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 4, 10, PlanetSideGUID(3))))),
+            SquadListing(2, Option(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
+            SquadListing(255))
+          ))
+        )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringThree

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -841,7 +841,7 @@ class GamePacketTest extends Specification {
             ko
         }
       }
-//TODO not working
+
       "decode (remove)" in {
         PacketCoding.DecodePacket(stringListRemove).require match {
           case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
@@ -1031,38 +1031,38 @@ class GamePacketTest extends Specification {
             ko
         }
       }
-//TODO "all" currently can not be used
-//      "decode (update all)" in {
-//        PacketCoding.DecodePacket(stringUpdateAll).require match {
-//          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
-//            behavior mustEqual 6
-//            behavior2.isDefined mustEqual false
-//            unk.isDefined mustEqual true
-//            unk.get mustEqual false
-//            entries.length mustEqual 2
-//            entries.head.index mustEqual 1
-//            entries.head.listing.isDefined mustEqual true
-//            entries.head.listing.get.action mustEqual 131
-//            entries.head.listing.get.unk mustEqual false
-//            entries.head.listing.get.action2.isDefined mustEqual false
-//            entries.head.listing.get.info.isDefined mustEqual true
-//            entries.head.listing.get.info.get.leader.isDefined mustEqual true
-//            entries.head.listing.get.info.get.leader.get mustEqual "madmuj"
-//            entries.head.listing.get.info.get.task.isDefined mustEqual true
-//            entries.head.listing.get.info.get.task.get mustEqual ""
-//            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
-//            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
-//            entries.head.listing.get.info.get.size.isDefined mustEqual true
-//            entries.head.listing.get.info.get.size.get mustEqual 0
-//            entries.head.listing.get.info.get.capacity.isDefined mustEqual true
-//            entries.head.listing.get.info.get.capacity.get mustEqual 10
-//            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual true
-//            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(11)
-//            entries(1).index mustEqual 255
-//          case _ =>
-//            ko
-//        }
-//      }
+
+      "decode (update all)" in {
+        PacketCoding.DecodePacket(stringUpdateAll).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 7
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 131
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.get mustEqual "madmuj"
+            entries.head.listing.get.info.get.task.isDefined mustEqual true
+            entries.head.listing.get.info.get.task.get mustEqual ""
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.get.size.isDefined mustEqual true
+            entries.head.listing.get.info.get.size.get mustEqual 0
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual true
+            entries.head.listing.get.info.get.capacity.get mustEqual 10
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(11)
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
 
       "encode (clear)" in {
         val msg = ReplicationStreamMessage(5, Some(6), Some(false),
@@ -1197,18 +1197,18 @@ class GamePacketTest extends Specification {
 
         pkt mustEqual stringUpdateTaskContinent
       }
-//TODO "all" currently can not be used
-//      "encode (update all)" in {
-//        val msg = ReplicationStreamMessage(6, None, Some(false),
-//          Vector(
-//            SquadListing(7, Some(SquadHeader(131, false, None, SquadInfo("madmuj", "", PlanetSideGUID(4), 0, 10, PlanetSideGUID(11))))),
-//            SquadListing(255)
-//          )
-//        )
-//        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
-//
-//        pkt mustEqual stringUpdateAll
-//      }
+
+      "encode (update all)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(7, Some(SquadHeader(131, false, None, SquadInfo("madmuj", "", PlanetSideGUID(4), 0, 10, PlanetSideGUID(11))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateAll
+      }
     }
 
     "ZonePopulationUpdateMessage" should {

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -842,25 +842,25 @@ class GamePacketTest extends Specification {
         }
       }
 //TODO not working
-//      "decode (remove)" in {
-//        PacketCoding.DecodePacket(stringListRemove).require match {
-//          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
-//            behavior mustEqual 1
-//            behavior2.isDefined mustEqual false
-//            unk.isDefined mustEqual false
-//            entries.length mustEqual 2
-//            entries.head.index mustEqual 5
-//            entries.head.listing.isDefined mustEqual true
-//            entries.head.listing.get.action mustEqual 0
-//            entries.head.listing.get.unk mustEqual true
-//            entries.head.listing.get.action2.isDefined mustEqual true
-//            entries.head.listing.get.action2.get mustEqual 4
-//            entries.head.listing.get.info.isDefined mustEqual false
-//            entries(1).index mustEqual 255
-//          case _ =>
-//            ko
-//        }
-//      }
+      "decode (remove)" in {
+        PacketCoding.DecodePacket(stringListRemove).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 1
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 5
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 0
+            entries.head.listing.get.unk mustEqual true
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 4
+            entries.head.listing.get.info.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
 
       "decode (update leader)" in {
         PacketCoding.DecodePacket(stringUpdateLeader).require match {
@@ -1031,7 +1031,7 @@ class GamePacketTest extends Specification {
             ko
         }
       }
-//TODO not working
+//TODO "all" currently can not be used
 //      "decode (update all)" in {
 //        PacketCoding.DecodePacket(stringUpdateAll).require match {
 //          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
@@ -1057,7 +1057,7 @@ class GamePacketTest extends Specification {
 //            entries.head.listing.get.info.get.capacity.isDefined mustEqual true
 //            entries.head.listing.get.info.get.capacity.get mustEqual 10
 //            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual true
-//            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(12)
+//            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(11)
 //            entries(1).index mustEqual 255
 //          case _ =>
 //            ko
@@ -1197,21 +1197,19 @@ class GamePacketTest extends Specification {
 
         pkt mustEqual stringUpdateTaskContinent
       }
-
-      "encode (update all)" in {
-        val msg = ReplicationStreamMessage(6, None, Some(false),
-          Vector(
-            SquadListing(7, Some(SquadHeader(131, false, None, SquadInfo("madmuj", "", PlanetSideGUID(4), 0, 10, PlanetSideGUID(12))))),
-            SquadListing(255)
-          )
-        )
-        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
-
-        pkt mustEqual stringUpdateAll
-      }
+//TODO "all" currently can not be used
+//      "encode (update all)" in {
+//        val msg = ReplicationStreamMessage(6, None, Some(false),
+//          Vector(
+//            SquadListing(7, Some(SquadHeader(131, false, None, SquadInfo("madmuj", "", PlanetSideGUID(4), 0, 10, PlanetSideGUID(11))))),
+//            SquadListing(255)
+//          )
+//        )
+//        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+//
+//        pkt mustEqual stringUpdateAll
+//      }
     }
-
-
 
     "ZonePopulationUpdateMessage" should {
       val string = hex"B6 0400 9E010000 8A000000 25000000 8A000000 25000000 8A000000 25000000 8A000000 25000000"

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -704,198 +704,514 @@ class GamePacketTest extends Specification {
     }
 
     "ReplicationStreamMessage" should {
-      val stringClear = hex"E6 B9 FE"
-      val stringOne = hex"E6 B8 01 06 01 00 8B 46007200610067004C0041004E00640049004E004300 84 4600720061006700 0A00 00 00 0A FF"
-      val stringTwo = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
-      val stringThree = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 01 80 4600 4E0049004700480054003800380052004100560045004E00 8B 41006C006C002000570065006C0063006F006D006500 0A 00 00 00 4A 02 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
+      val stringListClear = hex"E6 B9 FE"
+      val stringListOne = hex"E6 B8 01 06 01 00 8B 46007200610067004C0041004E00640049004E004300 84 4600720061006700 0A00 00 00 0A FF"
+      val stringListTwo = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
+      val stringListThree = hex"E6 B8 01 06 06 00 8E 470065006E006500720061006C0047006F0072006700750074007A00 A1 46004C0059002C0041006C006C002000770065006C0063006F006D0065002C0063006E0020006C0061007300740020006E0069006700680074002100210021002100 0400 00 00 7A 01 83 01 80 4600 4E0049004700480054003800380052004100560045004E00 8B 41006C006C002000570065006C0063006F006D006500 0A 00 00 00 4A 02 83 02 00 45 80 4B004F004B006B006900610073004D00460043004E00 87 5300710075006100640020003200 0400 00 00 6A FF"
+      val stringListRemove = hex"E6 20 A0 19 FE"
+      val stringUpdateLeader = hex"E6 C0 28 08 C4 00 46006100740065004A0048004E004300 FF"
+      val stringUpdateTask = hex"E6 C0 58 094E00 52004900500020005000530031002C0020007600690073006900740020005000530046006F00720065007600650072002E006E0065007400 FF"
+      val stringUpdateContinent = hex"E6 C0 38 09 85000000 7F80"
+      val stringUpdateSize = hex"E6 C0 18 0A 37 F8"
+      val stringUpdateLeaderSize = hex"E6 C0 58 10 C3 00 4A0069006D006D0079006E00 43 FF"
+      val stringUpdateTaskContinent = hex"E6 C0 58 11 40 80 3200 3 04000000 FF0"
+      val stringUpdateAll = hex"E6 C0 78 30 58 0430 6D00610064006D0075006A00 80 040000000A FF"
 
       "decode (clear)" in {
-        PacketCoding.DecodePacket(stringClear).require match {
-          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+        PacketCoding.DecodePacket(stringListClear).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
             behavior mustEqual 5
-            init.isDefined mustEqual true
-            init.get.behavior mustEqual 6
-            init.get.init.isDefined mustEqual false
-            init.get.unk.isDefined mustEqual true
-            init.get.unk.get mustEqual false
-            init.get.entries.length mustEqual 1
-            init.get.entries.head.index mustEqual 255
-            init.get.entries.head.listing.isDefined mustEqual false
-            unk.isDefined mustEqual false
-            entries.length mustEqual 0
+            behavior2.isDefined mustEqual true
+            behavior2.get mustEqual 6
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 1
+            entries.head.index mustEqual 255
+            entries.head.listing.isDefined mustEqual false
           case _ =>
             ko
         }
       }
 
       "decode (one)" in {
-        PacketCoding.DecodePacket(stringOne).require match {
-          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+        PacketCoding.DecodePacket(stringListOne).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
             behavior mustEqual 5
-            init.isDefined mustEqual true
-            init.get.behavior mustEqual 6
-            init.get.init.isDefined mustEqual false
-            init.get.unk.isDefined mustEqual true
-            init.get.unk.get mustEqual false
-            init.get.entries.length mustEqual 2
-            init.get.entries.head.index mustEqual 0
-            init.get.entries.head.listing.isDefined mustEqual true
-            init.get.entries.head.listing.get.action mustEqual 131
-            init.get.entries.head.listing.get.unk mustEqual false
-            init.get.entries.head.listing.get.action2.isDefined mustEqual false
-            init.get.entries.head.listing.get.info.leader.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.leader.get mustEqual "FragLANdINC"
-            init.get.entries.head.listing.get.info.task.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.task.get mustEqual "Frag"
-            init.get.entries.head.listing.get.info.continent_guid.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(10)
-            init.get.entries.head.listing.get.info.size.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.size.get mustEqual 0
-            init.get.entries.head.listing.get.info.capacity.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
-            init.get.entries.head.listing.get.info.squad_guid.isDefined mustEqual true
-            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(1)
-            init.get.entries(1).index mustEqual 255
-            init.get.entries(1).listing.isDefined mustEqual false
-            unk.isDefined mustEqual false
-            entries.length mustEqual 0
+            behavior2.get mustEqual 6
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 0
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 131
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.get mustEqual "FragLANdINC"
+            entries.head.listing.get.info.get.task.isDefined mustEqual true
+            entries.head.listing.get.info.get.task.get mustEqual "Frag"
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(10)
+            entries.head.listing.get.info.get.size.isDefined mustEqual true
+            entries.head.listing.get.info.get.size.get mustEqual 0
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual true
+            entries.head.listing.get.info.get.capacity.get mustEqual 10
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(1)
+            entries(1).index mustEqual 255
+            entries(1).listing.isDefined mustEqual false
           case _ =>
             ko
         }
       }
 
       "decode (two)" in {
-        PacketCoding.DecodePacket(stringTwo).require match {
-          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+        PacketCoding.DecodePacket(stringListTwo).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
             behavior mustEqual 5
-            init.isDefined mustEqual true
-            init.get.behavior mustEqual 6
-            init.get.init.isDefined mustEqual false
-            init.get.unk.isDefined mustEqual true
-            init.get.unk.get mustEqual false
-            init.get.entries.length mustEqual 3
-            init.get.entries.head.index mustEqual 0
-            init.get.entries.head.listing.get.action mustEqual 131
-            init.get.entries.head.listing.get.unk mustEqual false
-            init.get.entries.head.listing.get.action2.isDefined mustEqual false
-            init.get.entries.head.listing.get.info.leader.get mustEqual "GeneralGorgutz"
-            init.get.entries.head.listing.get.info.task.get mustEqual "FLY,All welcome,cn last night!!!!"
-            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries.head.listing.get.info.size.get mustEqual 7
-            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
-            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(6)
-            init.get.entries(1).index mustEqual 1
-            init.get.entries(1).listing.get.action mustEqual 131
-            init.get.entries(1).listing.get.unk mustEqual false
-            init.get.entries(1).listing.get.action2.isDefined mustEqual false
-            init.get.entries(1).listing.get.info.leader.get mustEqual "KOKkiasMFCN"
-            init.get.entries(1).listing.get.info.task.get mustEqual "Squad 2"
-            init.get.entries(1).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries(1).listing.get.info.size.get mustEqual 6
-            init.get.entries(1).listing.get.info.capacity.get mustEqual 10
-            init.get.entries(1).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries(2).index mustEqual 255
+            behavior2.get mustEqual 6
+            unk.get mustEqual false
+            entries.length mustEqual 3
+            entries.head.index mustEqual 0
+            entries.head.listing.get.action mustEqual 131
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.info.get.leader.get mustEqual "GeneralGorgutz"
+            entries.head.listing.get.info.get.task.get mustEqual "FLY,All welcome,cn last night!!!!"
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.get.size.get mustEqual 7
+            entries.head.listing.get.info.get.capacity.get mustEqual 10
+            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(6)
+            entries(1).index mustEqual 1
+            entries(1).listing.get.action mustEqual 131
+            entries(1).listing.get.unk mustEqual false
+            entries(1).listing.get.action2.isDefined mustEqual false
+            entries(1).listing.get.info.get.leader.get mustEqual "KOKkiasMFCN"
+            entries(1).listing.get.info.get.task.get mustEqual "Squad 2"
+            entries(1).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries(1).listing.get.info.get.size.get mustEqual 6
+            entries(1).listing.get.info.get.capacity.get mustEqual 10
+            entries(1).listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(4)
+            entries(2).index mustEqual 255
           case _ =>
             ko
         }
       }
 
       "decode (three)" in {
-        PacketCoding.DecodePacket(stringThree).require match {
-          case ReplicationStreamMessage(behavior, init, unk, entries) =>
+        PacketCoding.DecodePacket(stringListThree).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
             behavior mustEqual 5
-            init.isDefined mustEqual true
-            init.get.behavior mustEqual 6
-            init.get.init.isDefined mustEqual false
-            init.get.unk.isDefined mustEqual true
-            init.get.unk.get mustEqual false
-            init.get.entries.length mustEqual 4
-            init.get.entries.head.index mustEqual 0
-            init.get.entries.head.listing.get.action mustEqual 131
-            init.get.entries.head.listing.get.unk mustEqual false
-            init.get.entries.head.listing.get.action2.isDefined mustEqual false
-            init.get.entries.head.listing.get.info.leader.get mustEqual "GeneralGorgutz"
-            init.get.entries.head.listing.get.info.task.get mustEqual "FLY,All welcome,cn last night!!!!"
-            init.get.entries.head.listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries.head.listing.get.info.size.get mustEqual 7
-            init.get.entries.head.listing.get.info.capacity.get mustEqual 10
-            init.get.entries.head.listing.get.info.squad_guid.get mustEqual PlanetSideGUID(6)
-            init.get.entries(1).index mustEqual 1
-            init.get.entries(1).listing.get.action mustEqual 131
-            init.get.entries(1).listing.get.unk mustEqual false
-            init.get.entries(1).listing.get.action2.isDefined mustEqual false
-            init.get.entries(1).listing.get.info.leader.get mustEqual "NIGHT88RAVEN"
-            init.get.entries(1).listing.get.info.task.get mustEqual "All Welcome"
-            init.get.entries(1).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(10)
-            init.get.entries(1).listing.get.info.size.get mustEqual 4
-            init.get.entries(1).listing.get.info.capacity.get mustEqual 10
-            init.get.entries(1).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(3)
-            init.get.entries(2).index mustEqual 2
-            init.get.entries(2).listing.get.action mustEqual 131
-            init.get.entries(2).listing.get.unk mustEqual false
-            init.get.entries(2).listing.get.action2.isDefined mustEqual false
-            init.get.entries(2).listing.get.info.leader.get mustEqual "KOKkiasMFCN"
-            init.get.entries(2).listing.get.info.task.get mustEqual "Squad 2"
-            init.get.entries(2).listing.get.info.continent_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries(2).listing.get.info.size.get mustEqual 6
-            init.get.entries(2).listing.get.info.capacity.get mustEqual 10
-            init.get.entries(2).listing.get.info.squad_guid.get mustEqual PlanetSideGUID(4)
-            init.get.entries(3).index mustEqual 255
+            behavior2.get mustEqual 6
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 4
+            entries.head.index mustEqual 0
+            entries.head.listing.get.action mustEqual 131
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual false
+            entries.head.listing.get.info.get.leader.get mustEqual "GeneralGorgutz"
+            entries.head.listing.get.info.get.task.get mustEqual "FLY,All welcome,cn last night!!!!"
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.get.size.get mustEqual 7
+            entries.head.listing.get.info.get.capacity.get mustEqual 10
+            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(6)
+            entries(1).index mustEqual 1
+            entries(1).listing.get.action mustEqual 131
+            entries(1).listing.get.unk mustEqual false
+            entries(1).listing.get.action2.isDefined mustEqual false
+            entries(1).listing.get.info.get.leader.get mustEqual "NIGHT88RAVEN"
+            entries(1).listing.get.info.get.task.get mustEqual "All Welcome"
+            entries(1).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(10)
+            entries(1).listing.get.info.get.size.get mustEqual 4
+            entries(1).listing.get.info.get.capacity.get mustEqual 10
+            entries(1).listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(3)
+            entries(2).index mustEqual 2
+            entries(2).listing.get.action mustEqual 131
+            entries(2).listing.get.unk mustEqual false
+            entries(2).listing.get.action2.isDefined mustEqual false
+            entries(2).listing.get.info.get.leader.get mustEqual "KOKkiasMFCN"
+            entries(2).listing.get.info.get.task.get mustEqual "Squad 2"
+            entries(2).listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries(2).listing.get.info.get.size.get mustEqual 6
+            entries(2).listing.get.info.get.capacity.get mustEqual 10
+            entries(2).listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(4)
+            entries(3).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+//TODO not working
+//      "decode (remove)" in {
+//        PacketCoding.DecodePacket(stringListRemove).require match {
+//          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+//            behavior mustEqual 1
+//            behavior2.isDefined mustEqual false
+//            unk.isDefined mustEqual false
+//            entries.length mustEqual 2
+//            entries.head.index mustEqual 5
+//            entries.head.listing.isDefined mustEqual true
+//            entries.head.listing.get.action mustEqual 0
+//            entries.head.listing.get.unk mustEqual true
+//            entries.head.listing.get.action2.isDefined mustEqual true
+//            entries.head.listing.get.action2.get mustEqual 4
+//            entries.head.listing.get.info.isDefined mustEqual false
+//            entries(1).index mustEqual 255
+//          case _ =>
+//            ko
+//        }
+//      }
+
+      "decode (update leader)" in {
+        PacketCoding.DecodePacket(stringUpdateLeader).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 2
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 128
+            entries.head.listing.get.unk mustEqual true
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 0
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.get mustEqual "FateJHNC"
+            entries.head.listing.get.info.get.task.isDefined mustEqual false
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual false
+            entries.head.listing.get.info.get.size.isDefined mustEqual false
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
           case _ =>
             ko
         }
       }
 
+      "decode (update task)" in {
+        PacketCoding.DecodePacket(stringUpdateTask).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 5
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 128
+            entries.head.listing.get.unk mustEqual true
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual false
+            entries.head.listing.get.info.get.task.isDefined mustEqual true
+            entries.head.listing.get.info.get.task.get mustEqual "RIP PS1, visit PSForever.net"
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual false
+            entries.head.listing.get.info.get.size.isDefined mustEqual false
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
+      "decode (update continent)" in {
+        PacketCoding.DecodePacket(stringUpdateContinent).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 3
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 128
+            entries.head.listing.get.unk mustEqual true
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual false
+            entries.head.listing.get.info.get.task.isDefined mustEqual false
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(10)
+            entries.head.listing.get.info.get.size.isDefined mustEqual false
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
+      "decode (update size)" in {
+        PacketCoding.DecodePacket(stringUpdateSize).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 1
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 128
+            entries.head.listing.get.unk mustEqual true
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 2
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual false
+            entries.head.listing.get.info.get.task.isDefined mustEqual false
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual false
+            entries.head.listing.get.info.get.size.isDefined mustEqual true
+            entries.head.listing.get.info.get.size.get mustEqual 6
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
+      "decode (update leader and size)" in {
+        PacketCoding.DecodePacket(stringUpdateLeaderSize).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 5
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 129
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 0
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.get mustEqual "Jimmyn"
+            entries.head.listing.get.info.get.task.isDefined mustEqual false
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual false
+            entries.head.listing.get.info.get.size.isDefined mustEqual true
+            entries.head.listing.get.info.get.size.get mustEqual 3
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
+      "decode (update task and continent)" in {
+        PacketCoding.DecodePacket(stringUpdateTaskContinent).require match {
+          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+            behavior mustEqual 6
+            behavior2.isDefined mustEqual false
+            unk.isDefined mustEqual true
+            unk.get mustEqual false
+            entries.length mustEqual 2
+            entries.head.index mustEqual 5
+            entries.head.listing.isDefined mustEqual true
+            entries.head.listing.get.action mustEqual 129
+            entries.head.listing.get.unk mustEqual false
+            entries.head.listing.get.action2.isDefined mustEqual true
+            entries.head.listing.get.action2.get mustEqual 1
+            entries.head.listing.get.info.isDefined mustEqual true
+            entries.head.listing.get.info.get.leader.isDefined mustEqual false
+            entries.head.listing.get.info.get.task.isDefined mustEqual true
+            entries.head.listing.get.info.get.task.get mustEqual "2"
+            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
+            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.get.size.isDefined mustEqual false
+            entries.head.listing.get.info.get.capacity.isDefined mustEqual false
+            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual false
+            entries(1).index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+//TODO not working
+//      "decode (update all)" in {
+//        PacketCoding.DecodePacket(stringUpdateAll).require match {
+//          case ReplicationStreamMessage(behavior, behavior2, unk, entries) =>
+//            behavior mustEqual 6
+//            behavior2.isDefined mustEqual false
+//            unk.isDefined mustEqual true
+//            unk.get mustEqual false
+//            entries.length mustEqual 2
+//            entries.head.index mustEqual 1
+//            entries.head.listing.isDefined mustEqual true
+//            entries.head.listing.get.action mustEqual 131
+//            entries.head.listing.get.unk mustEqual false
+//            entries.head.listing.get.action2.isDefined mustEqual false
+//            entries.head.listing.get.info.isDefined mustEqual true
+//            entries.head.listing.get.info.get.leader.isDefined mustEqual true
+//            entries.head.listing.get.info.get.leader.get mustEqual "madmuj"
+//            entries.head.listing.get.info.get.task.isDefined mustEqual true
+//            entries.head.listing.get.info.get.task.get mustEqual ""
+//            entries.head.listing.get.info.get.continent_guid.isDefined mustEqual true
+//            entries.head.listing.get.info.get.continent_guid.get mustEqual PlanetSideGUID(4)
+//            entries.head.listing.get.info.get.size.isDefined mustEqual true
+//            entries.head.listing.get.info.get.size.get mustEqual 0
+//            entries.head.listing.get.info.get.capacity.isDefined mustEqual true
+//            entries.head.listing.get.info.get.capacity.get mustEqual 10
+//            entries.head.listing.get.info.get.squad_guid.isDefined mustEqual true
+//            entries.head.listing.get.info.get.squad_guid.get mustEqual PlanetSideGUID(12)
+//            entries(1).index mustEqual 255
+//          case _ =>
+//            ko
+//        }
+//      }
+
       "encode (clear)" in {
-        val msg = ReplicationStreamMessage(5,
-          Some(ReplicationStreamMessage(6, None, Some(false),
-            Vector(SquadListing(255))
-          ))
+        val msg = ReplicationStreamMessage(5, Some(6), Some(false),
+          Vector(
+            SquadListing(255)
+          )
         )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual stringClear
+        pkt mustEqual stringListClear
       }
 
       "encode (one)" in {
-        val msg = ReplicationStreamMessage(5,
-          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
-            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10, PlanetSideGUID(1))))),
-            SquadListing(255))
-          ))
+        val msg = ReplicationStreamMessage(5, Some(6), Some(false),
+          Vector(
+            SquadListing(0, Some(SquadHeader(131, false, None, SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10, PlanetSideGUID(1))))),
+            SquadListing(255)
+          )
         )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual stringOne
+        pkt mustEqual stringListOne
       }
 
       "encode (two)" in {
-        val msg = ReplicationStreamMessage(5,
-          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
-            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
-            SquadListing(1, Option(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
-            SquadListing(255))
-          ))
+        val msg = ReplicationStreamMessage(5, Some(6), Some(false),
+          Vector(
+            SquadListing(0, Some(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
+            SquadListing(1, Some(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
+            SquadListing(255)
+          )
         )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual stringTwo
+        pkt mustEqual stringListTwo
       }
 
       "encode (three)" in {
-        val msg = ReplicationStreamMessage(5,
-          Some(ReplicationStreamMessage(6, None, Some(false), Vector(
-            SquadListing(0, Option(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
-            SquadListing(1, Option(SquadHeader(131, false, None, SquadInfo("NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 4, 10, PlanetSideGUID(3))))),
-            SquadListing(2, Option(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
-            SquadListing(255))
-          ))
+        val msg = ReplicationStreamMessage(5, Some(6), Some(false),
+          Vector(
+            SquadListing(0, Some(SquadHeader(131, false, None, SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10, PlanetSideGUID(6))))),
+            SquadListing(1, Some(SquadHeader(131, false, None, SquadInfo("NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 4, 10, PlanetSideGUID(3))))),
+            SquadListing(2, Some(SquadHeader(131, false, None, SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10, PlanetSideGUID(4))))),
+            SquadListing(255)
+          )
         )
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-        pkt mustEqual stringThree
+        pkt mustEqual stringListThree
+      }
+
+      "encode (remove)" in {
+        val msg = ReplicationStreamMessage(1, None, None,
+          Vector(
+            SquadListing(5, Some(SquadHeader(0, true, Some(4)))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringListRemove
+      }
+
+      "encode (update leader)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(2, Some(SquadHeader(128, true, Some(0), Some(SquadInfo("FateJHNC", None))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateLeader
+      }
+
+      "encode (update task)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(5, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(None, "RIP PS1, visit PSForever.net"))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateTask
+      }
+
+      "encode (update continent)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(3, Some(SquadHeader(128, true, Some(1), Some(SquadInfo(PlanetSideGUID(10)))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateContinent
+      }
+
+      "encode (update size)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(1, Some(SquadHeader(128, true, Some(2), Some(SquadInfo(6, None))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateSize
+      }
+
+      "encode (update leader and size)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(5, Some(SquadHeader(129, false, Some(0), Some(SquadInfo("Jimmyn", 3))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateLeaderSize
+      }
+
+      "encode (update task and continent)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(5, Some(SquadHeader(129, false, Some(1), Some(SquadInfo("2", PlanetSideGUID(4)))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateTaskContinent
+      }
+
+      "encode (update all)" in {
+        val msg = ReplicationStreamMessage(6, None, Some(false),
+          Vector(
+            SquadListing(7, Some(SquadHeader(131, false, None, SquadInfo("madmuj", "", PlanetSideGUID(4), 0, 10, PlanetSideGUID(12))))),
+            SquadListing(255)
+          )
+        )
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringUpdateAll
       }
     }
+
+
 
     "ZonePopulationUpdateMessage" should {
       val string = hex"B6 0400 9E010000 8A000000 25000000 8A000000 25000000 8A000000 25000000 8A000000 25000000"

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -703,6 +703,28 @@ class GamePacketTest extends Specification {
       }
     }
 
+    "ReplicationStreamMessage" should {
+      val stringNone = hex"E6 B9 FE"
+
+      "decode (none)" in {
+        PacketCoding.DecodePacket(stringNone).require match {
+          case ReplicationStreamMessage(unk, entries) =>
+            unk mustEqual 92
+            entries.length mustEqual 1
+            entries.head.index mustEqual 255
+          case _ =>
+            ko
+        }
+      }
+
+      "encode (none)" in {
+        val msg = ReplicationStreamMessage(92, Vector(SquadListing(255)))
+        val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+        pkt mustEqual stringNone
+      }
+    }
+
     "ZonePopulationUpdateMessage" should {
       val string = hex"B6 0400 9E010000 8A000000 25000000 8A000000 25000000 8A000000 25000000 8A000000 25000000"
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -1101,16 +1101,16 @@ class GamePacketTest extends Specification {
       }
 
       "decode (fails)" in {
-        PacketCoding.DecodePacket(stringCodecFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringListOneFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringListTwoFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateLeaderFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateTaskFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateContinentFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateSizeFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateLeaderSizeFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateTaskContinentFail) must throwA[RuntimeException]
-        PacketCoding.DecodePacket(stringUpdateAllFail) must throwA[RuntimeException]
+        PacketCoding.DecodePacket(stringCodecFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringListOneFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringListTwoFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateLeaderFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateTaskFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateContinentFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateSizeFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateLeaderSizeFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateTaskContinentFail).isFailure mustEqual true
+        PacketCoding.DecodePacket(stringUpdateAllFail).isFailure mustEqual true
       }
 
       "encode (clear)" in {
@@ -1268,7 +1268,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode one
         PacketCoding.EncodePacket(
@@ -1278,7 +1278,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode two
         PacketCoding.EncodePacket(
@@ -1289,7 +1289,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode leader
         PacketCoding.EncodePacket(
@@ -1299,7 +1299,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode task
         PacketCoding.EncodePacket(
@@ -1309,7 +1309,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode continent
         PacketCoding.EncodePacket(
@@ -1319,7 +1319,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode task or continent
         PacketCoding.EncodePacket(
@@ -1329,7 +1329,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode size
         PacketCoding.EncodePacket(
@@ -1339,7 +1339,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode leader and size
         PacketCoding.EncodePacket(
@@ -1349,7 +1349,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode task and continent
         PacketCoding.EncodePacket(
@@ -1359,7 +1359,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
 
         //encode all
         PacketCoding.EncodePacket(
@@ -1369,7 +1369,7 @@ class GamePacketTest extends Specification {
               SquadListing(255)
             )
           )
-        ).require.toByteVector must throwA[RuntimeException]
+        ).isFailure mustEqual true
       }
     }
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -711,8 +711,9 @@ class GamePacketTest extends Specification {
 
       "decode (none)" in {
         PacketCoding.DecodePacket(stringNone).require match {
-          case ReplicationStreamMessage(unk, entries) =>
-            unk mustEqual 92
+          case ReplicationStreamMessage(action, unk, entries) =>
+            action mustEqual 5
+            unk mustEqual 12
             entries.length mustEqual 1
             entries.head.index mustEqual 255
             entries.head.listing.isDefined mustEqual false
@@ -723,22 +724,20 @@ class GamePacketTest extends Specification {
 
       "decode (one)" in {
         PacketCoding.DecodePacket(stringOne).require match {
-          case ReplicationStreamMessage(unk, entries) =>
-            unk mustEqual 92
+          case ReplicationStreamMessage(action, unk, entries) =>
+            action mustEqual 5
+            unk mustEqual 12
             entries.length mustEqual 2
             entries.head.index mustEqual 0
             entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual 0
-            entries.head.listing.get.squad_guid mustEqual 4
-            entries.head.listing.get.unk3 mustEqual false
-            entries.head.listing.get.unk4 mustEqual false
-            entries.head.listing.get.leader mustEqual "FragLANdINC"
-            entries.head.listing.get.name mustEqual "Frag"
-            entries.head.listing.get.continent_guid mustEqual PlanetSideGUID(10)
-            entries.head.listing.get.unk5 mustEqual 0
-            entries.head.listing.get.size mustEqual 0
-            entries.head.listing.get.capacity mustEqual 10
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(1)
+            entries.head.listing.get.info.leader mustEqual "FragLANdINC"
+            entries.head.listing.get.info.task mustEqual "Frag"
+            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(10)
+            entries.head.listing.get.info.size mustEqual 0
+            entries.head.listing.get.info.capacity mustEqual 10
             entries(1).index mustEqual 255
             entries(1).listing.isDefined mustEqual false
           case _ =>
@@ -748,33 +747,28 @@ class GamePacketTest extends Specification {
 
       "decode (two)" in {
         PacketCoding.DecodePacket(stringTwo).require match {
-          case ReplicationStreamMessage(unk, entries) =>
-            unk mustEqual 92
+          case ReplicationStreamMessage(action, unk, entries) =>
+            action mustEqual 5
+            unk mustEqual 12
             entries.length mustEqual 3
             entries.head.index mustEqual 0
             entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual 0
-            entries.head.listing.get.squad_guid mustEqual 24
-            entries.head.listing.get.unk3 mustEqual false
-            entries.head.listing.get.unk4 mustEqual false
-            entries.head.listing.get.leader mustEqual "GeneralGorgutz"
-            entries.head.listing.get.name mustEqual "FLY,All welcome,cn last night!!!!"
-            entries.head.listing.get.continent_guid mustEqual PlanetSideGUID(4)
-            entries.head.listing.get.unk5 mustEqual 0
-            entries.head.listing.get.size mustEqual 7
-            entries.head.listing.get.capacity mustEqual 10
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(6)
+            entries.head.listing.get.info.leader mustEqual "GeneralGorgutz"
+            entries.head.listing.get.info.task mustEqual "FLY,All welcome,cn last night!!!!"
+            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.size mustEqual 7
+            entries.head.listing.get.info.capacity mustEqual 10
             entries(1).index mustEqual 1
             entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual 0
-            entries(1).listing.get.squad_guid mustEqual 16
-            entries(1).listing.get.unk3 mustEqual false
-            entries(1).listing.get.unk4 mustEqual false
-            entries(1).listing.get.leader mustEqual "KOKkiasMFCN"
-            entries(1).listing.get.name mustEqual "Squad 2"
-            entries(1).listing.get.continent_guid mustEqual PlanetSideGUID(4)
-            entries(1).listing.get.unk5 mustEqual 0
-            entries(1).listing.get.size mustEqual 6
-            entries(1).listing.get.capacity mustEqual 10
+            entries(1).listing.get.unk2 mustEqual false
+            entries(1).listing.get.squad_guid mustEqual PlanetSideGUID(4)
+            entries(1).listing.get.info.leader mustEqual "KOKkiasMFCN"
+            entries(1).listing.get.info.task mustEqual "Squad 2"
+            entries(1).listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
+            entries(1).listing.get.info.size mustEqual 6
+            entries(1).listing.get.info.capacity mustEqual 10
             entries(2).index mustEqual 255
           case _ =>
             ko
@@ -783,45 +777,37 @@ class GamePacketTest extends Specification {
 
       "decode (three)" in {
         PacketCoding.DecodePacket(stringThree).require match {
-          case ReplicationStreamMessage(unk, entries) =>
-            unk mustEqual 92
+          case ReplicationStreamMessage(action, unk, entries) =>
+            action mustEqual 5
+            unk mustEqual 12
             entries.length mustEqual 4
             entries.head.index mustEqual 0
             entries.head.listing.get.unk1 mustEqual 131
-            entries.head.listing.get.unk2 mustEqual 0
-            entries.head.listing.get.squad_guid mustEqual 24
-            entries.head.listing.get.unk3 mustEqual false
-            entries.head.listing.get.unk4 mustEqual false
-            entries.head.listing.get.leader mustEqual "GeneralGorgutz"
-            entries.head.listing.get.name mustEqual "FLY,All welcome,cn last night!!!!"
-            entries.head.listing.get.continent_guid mustEqual PlanetSideGUID(4)
-            entries.head.listing.get.unk5 mustEqual 0
-            entries.head.listing.get.size mustEqual 7
-            entries.head.listing.get.capacity mustEqual 10
+            entries.head.listing.get.unk2 mustEqual false
+            entries.head.listing.get.squad_guid mustEqual PlanetSideGUID(6)
+            entries.head.listing.get.info.leader mustEqual "GeneralGorgutz"
+            entries.head.listing.get.info.task mustEqual "FLY,All welcome,cn last night!!!!"
+            entries.head.listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
+            entries.head.listing.get.info.size mustEqual 7
+            entries.head.listing.get.info.capacity mustEqual 10
             entries(1).index mustEqual 1
             entries(1).listing.get.unk1 mustEqual 131
-            entries(1).listing.get.unk2 mustEqual 0
-            entries(1).listing.get.squad_guid mustEqual 12
-            entries(1).listing.get.unk3 mustEqual false
-            entries(1).listing.get.unk4 mustEqual false
-            entries(1).listing.get.leader mustEqual "NIGHT88RAVEN"
-            entries(1).listing.get.name mustEqual "All Welcome"
-            entries(1).listing.get.continent_guid mustEqual PlanetSideGUID(10)
-            entries(1).listing.get.unk5 mustEqual 0
-            entries(1).listing.get.size mustEqual 4
-            entries(1).listing.get.capacity mustEqual 10
+            entries(1).listing.get.unk2 mustEqual false
+            entries(1).listing.get.squad_guid mustEqual PlanetSideGUID(3)
+            entries(1).listing.get.info.leader mustEqual "NIGHT88RAVEN"
+            entries(1).listing.get.info.task mustEqual "All Welcome"
+            entries(1).listing.get.info.continent_guid mustEqual PlanetSideGUID(10)
+            entries(1).listing.get.info.size mustEqual 4
+            entries(1).listing.get.info.capacity mustEqual 10
             entries(2).index mustEqual 2
             entries(2).listing.get.unk1 mustEqual 131
-            entries(2).listing.get.unk2 mustEqual 0
-            entries(2).listing.get.squad_guid mustEqual 16
-            entries(2).listing.get.unk3 mustEqual false
-            entries(2).listing.get.unk4 mustEqual false
-            entries(2).listing.get.leader mustEqual "KOKkiasMFCN"
-            entries(2).listing.get.name mustEqual "Squad 2"
-            entries(2).listing.get.continent_guid mustEqual PlanetSideGUID(4)
-            entries(2).listing.get.unk5 mustEqual 0
-            entries(2).listing.get.size mustEqual 6
-            entries(2).listing.get.capacity mustEqual 10
+            entries(2).listing.get.unk2 mustEqual false
+            entries(2).listing.get.squad_guid mustEqual PlanetSideGUID(4)
+            entries(2).listing.get.info.leader mustEqual "KOKkiasMFCN"
+            entries(2).listing.get.info.task mustEqual "Squad 2"
+            entries(2).listing.get.info.continent_guid mustEqual PlanetSideGUID(4)
+            entries(2).listing.get.info.size mustEqual 6
+            entries(2).listing.get.info.capacity mustEqual 10
             entries(3).index mustEqual 255
           case _ =>
             ko
@@ -829,15 +815,15 @@ class GamePacketTest extends Specification {
       }
 
       "encode (none)" in {
-        val msg = ReplicationStreamMessage(92, Vector(SquadListing(255)))
+        val msg = ReplicationStreamMessage(5, 12, Vector(SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
         pkt mustEqual stringNone
       }
 
       "encode (one)" in {
-        val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 4, false, false, "FragLANdINC", "Frag", PlanetSideGUID(10), 0, 0, 10))),
+        val msg = ReplicationStreamMessage(5, 12, Vector(
+          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(1), SquadInfo("FragLANdINC", "Frag", PlanetSideGUID(10), 0, 10)))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -845,9 +831,9 @@ class GamePacketTest extends Specification {
       }
 
       "encode (two)" in {
-        val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 24, false, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 0, 16, false, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+        val msg = ReplicationStreamMessage(5, 12, Vector(
+          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(6), SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10)))),
+          SquadListing(1, Option(SquadHeader(131, false, PlanetSideGUID(4), SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10)))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -855,10 +841,10 @@ class GamePacketTest extends Specification {
       }
 
       "encode (three)" in {
-        val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 24, false, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 0, 12, false, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
-          SquadListing(2, Option(SquadHeader(131, 0, 16, false, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+        val msg = ReplicationStreamMessage(5, 12, Vector(
+          SquadListing(0, Option(SquadHeader(131, false, PlanetSideGUID(6), SquadInfo("GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 7, 10)))),
+          SquadListing(1, Option(SquadHeader(131, false, PlanetSideGUID(3), SquadInfo("NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 4, 10)))),
+          SquadListing(2, Option(SquadHeader(131, false, PlanetSideGUID(4), SquadInfo("KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 6, 10)))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -731,7 +731,7 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.unk1 mustEqual 131
             entries.head.listing.get.unk2 mustEqual 0
             entries.head.listing.get.squad_guid mustEqual 4
-            entries.head.listing.get.unk3 mustEqual 0
+            entries.head.listing.get.unk3 mustEqual false
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "FragLANdINC"
             entries.head.listing.get.name mustEqual "Frag"
@@ -740,6 +740,7 @@ class GamePacketTest extends Specification {
             entries.head.listing.get.size mustEqual 0
             entries.head.listing.get.capacity mustEqual 10
             entries(1).index mustEqual 255
+            entries(1).listing.isDefined mustEqual false
           case _ =>
             ko
         }
@@ -751,11 +752,10 @@ class GamePacketTest extends Specification {
             unk mustEqual 92
             entries.length mustEqual 3
             entries.head.index mustEqual 0
-            entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
             entries.head.listing.get.unk2 mustEqual 0
             entries.head.listing.get.squad_guid mustEqual 24
-            entries.head.listing.get.unk3 mustEqual 0
+            entries.head.listing.get.unk3 mustEqual false
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "GeneralGorgutz"
             entries.head.listing.get.name mustEqual "FLY,All welcome,cn last night!!!!"
@@ -767,7 +767,7 @@ class GamePacketTest extends Specification {
             entries(1).listing.get.unk1 mustEqual 131
             entries(1).listing.get.unk2 mustEqual 0
             entries(1).listing.get.squad_guid mustEqual 16
-            entries(1).listing.get.unk3 mustEqual 0
+            entries(1).listing.get.unk3 mustEqual false
             entries(1).listing.get.unk4 mustEqual false
             entries(1).listing.get.leader mustEqual "KOKkiasMFCN"
             entries(1).listing.get.name mustEqual "Squad 2"
@@ -787,11 +787,10 @@ class GamePacketTest extends Specification {
             unk mustEqual 92
             entries.length mustEqual 4
             entries.head.index mustEqual 0
-            entries.head.listing.isDefined mustEqual true
             entries.head.listing.get.unk1 mustEqual 131
             entries.head.listing.get.unk2 mustEqual 0
             entries.head.listing.get.squad_guid mustEqual 24
-            entries.head.listing.get.unk3 mustEqual 0
+            entries.head.listing.get.unk3 mustEqual false
             entries.head.listing.get.unk4 mustEqual false
             entries.head.listing.get.leader mustEqual "GeneralGorgutz"
             entries.head.listing.get.name mustEqual "FLY,All welcome,cn last night!!!!"
@@ -803,7 +802,7 @@ class GamePacketTest extends Specification {
             entries(1).listing.get.unk1 mustEqual 131
             entries(1).listing.get.unk2 mustEqual 0
             entries(1).listing.get.squad_guid mustEqual 12
-            entries(1).listing.get.unk3 mustEqual 0
+            entries(1).listing.get.unk3 mustEqual false
             entries(1).listing.get.unk4 mustEqual false
             entries(1).listing.get.leader mustEqual "NIGHT88RAVEN"
             entries(1).listing.get.name mustEqual "All Welcome"
@@ -815,7 +814,7 @@ class GamePacketTest extends Specification {
             entries(2).listing.get.unk1 mustEqual 131
             entries(2).listing.get.unk2 mustEqual 0
             entries(2).listing.get.squad_guid mustEqual 16
-            entries(2).listing.get.unk3 mustEqual 0
+            entries(2).listing.get.unk3 mustEqual false
             entries(2).listing.get.unk4 mustEqual false
             entries(2).listing.get.leader mustEqual "KOKkiasMFCN"
             entries(2).listing.get.name mustEqual "Squad 2"
@@ -838,7 +837,7 @@ class GamePacketTest extends Specification {
 
       "encode (one)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 4, 0, false, "FragLANdINC", "Frag", PlanetSideGUID(10), 0, 0, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 4, false, false, "FragLANdINC", "Frag", PlanetSideGUID(10), 0, 0, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -847,8 +846,8 @@ class GamePacketTest extends Specification {
 
       "encode (two)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 24, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 0, 16, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 24, false, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
+          SquadListing(1, Option(SquadHeader(131, 0, 16, false, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
@@ -857,9 +856,9 @@ class GamePacketTest extends Specification {
 
       "encode (three)" in {
         val msg = ReplicationStreamMessage(92, Vector(
-          SquadListing(0, Option(SquadHeader(131, 0, 24, 0, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
-          SquadListing(1, Option(SquadHeader(131, 0, 12, 0, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
-          SquadListing(2, Option(SquadHeader(131, 0, 16, 0, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
+          SquadListing(0, Option(SquadHeader(131, 0, 24, false, false, "GeneralGorgutz", "FLY,All welcome,cn last night!!!!", PlanetSideGUID(4), 0, 7, 10))),
+          SquadListing(1, Option(SquadHeader(131, 0, 12, false, false, "NIGHT88RAVEN", "All Welcome", PlanetSideGUID(10), 0, 4, 10))),
+          SquadListing(2, Option(SquadHeader(131, 0, 16, false, false, "KOKkiasMFCN", "Squad 2", PlanetSideGUID(4), 0, 6, 10))),
           SquadListing(255)))
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 


### PR DESCRIPTION
Who named this thing?

You would think something called "ReplicationStreamMessage" performed an incredibly technical operation when it really only seems to manage the list of squads.  It still may do something more; but, future decompilation aside, that's the only thing this packet did on live, so that is the only evidence of what we have it doing.  To its credit, the mysteriousness of the name belies the complexity of the format.  I have done a lot of pattern matching of the binary that goes into the data section.  While I can explain how to assemble each known form, I still don't know for certain how to disassemble all of the fields, especially the ones that explain what each entry does to the list of squads.  They are currently separated into what I think are logical groupings that seem consistent across the different forms and I have left some things in a state that hedges my bets should they have to change.

The class structure of this file is `A ( B ( C ( D ) ) )` proceeding from `ReplicationStreamMessage`, `SquadListing`, `SquadHeader`, and to `SquadInfo`, in that order.  `SquadInfo` is the only part I think is perfectly represented.  The rest is just the most convenient way I have found to represent all of the information in the known packets.  Starting from the bottom, it switches between `Codec`s progressively as it dives deeper into the nest, sometimes switching directly with `scodec` branching, and, finally, with a blatant `if...else` declaration to determine how to pull information from the "non-formulaic" parts of the data.  I wanted to depict the execution pathways with an ASCII drawing but I am not good at those.

The fun part is that the next parts of squad representation seem just as complicated as the first.  I thought this might be a good distraction from ObjectCreateMessage but it's really just a can of worms unto itself and I really need to go back ...