### PR TITLE
Fix for test leaking a DH crypto object

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+# Too spammy for us
+comment: off

--- a/common/src/test/scala/CryptoInterfaceTest.scala
+++ b/common/src/test/scala/CryptoInterfaceTest.scala
@@ -109,13 +109,11 @@ class CryptoInterfaceTest extends Specification { args(stopOnFail = true)
 
     "safely handle multiple starts" in {
       val dontCare = ByteVector.fill(16)(0x42)
-      var dh = new CryptoDHState()
+      val dh = new CryptoDHState()
 
       dh.start()
       dh.start() must throwA[IllegalStateException]
       dh.close
-
-      dh = new CryptoDHState()
 
       ok
     }


### PR DESCRIPTION
Error was: net.psforever.crypto.CryptoInterface.CryptoDHState: class not closed.
memory leaked