### PR TITLE
Proliferation of PlanetSideEmpire

### DIFF
--- a/common/src/main/scala/net/psforever/packet/game/BuildingInfoUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BuildingInfoUpdateMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideEmpire
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ContinentalLockUpdateMessage.scala
@@ -2,21 +2,21 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideEmpire
 import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Create a dispatched game packet that instructs the client to update the user about continents that are conquered.
-  *
+  * Create a dispatched game packet that instructs the client to update the user about continents that are conquered.<br>
+  * <br>
   * This generates the event message "The [empire] have captured [continent]."
   * If the continent_guid is not a valid zone, no message is displayed.
-  * If empire is not a valid empire, no message is displayed.
-  *
+  * If empire is not a valid empire, or refers to the neutral or Black Ops forces, no message is displayed.
   * @param continent_guid identifies the zone (continent)
-  * @param empire identifies the empire; this value is matchable against PlanetSideEmpire
+  * @param empire identifies the empire
   */
 final case class ContinentalLockUpdateMessage(continent_guid : PlanetSideGUID,
-                                              empire : PlanetSideEmpire.Value) // 00 for TR, 40 for NC, 80 for VS; C0 generates no message
+                                              empire : PlanetSideEmpire.Value)
   extends PlanetSideGamePacket {
   type Packet = ContinentalLockUpdateMessage
   def opcode = GamePacketOpcode.ContinentalLockUpdateMessage

--- a/common/src/main/scala/net/psforever/packet/game/DestroyDisplayMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DestroyDisplayMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideEmpire
 import scodec.Codec
 import scodec.codecs._
 
@@ -24,8 +25,8 @@ import scodec.codecs._
   * In the case of absentee kills, for example, where there is no killer listed, this field has been zero'd (`00000000`).<br>
   * <br>
   * The faction affiliation is different from the normal way `PlanetSideEmpire` values are recorded.
-  * The higher nibble will reflect the first part of the `PlanetSideEmpire` value - `0` for TR, `4` for NC `8` for TR, `C` for Neutral/BOPs.
-  * An extra `20` will be added if the player is in a vehicle or turret at the time - `2` for TR, `6` for NC, `A` for VS, `E` for Neutral/BOPs.
+  * The higher nibble will reflect the first part of the `PlanetSideEmpire` value.
+  * An extra `20` will be added if the player is in a vehicle or turret at the time.
   * When marked as being in a vehicle or turret, the player's name will be enclosed within square brackets.
   * The length of the player's name found at the start of the wide character string does not reflect whether or not there will be square brackets (fortunately).<br>
   * <br>
@@ -36,26 +37,24 @@ import scodec.codecs._
   * It is also unknown what the two bytes preceding `method` specify, as changing them does nothing to the displayed message.
   * @param killer the name of the player who did the killing
   * @param killer_unk See above
-  * @param killer_empire the empire affiliation of the killer:
-  *                      0 - TR, 1 - NC, 2 - VS, 3 - Neutral/BOPs
+  * @param killer_empire the empire affiliation of the killer
   * @param killer_inVehicle true, if the killer was in a vehicle at the time of the kill; false, otherwise
   * @param unk na; but does not like being set to 0
   * @param method modifies the icon in the message, related to the way the victim was killed
   * @param victim the name of the player who was killed
   * @param victim_unk See above
-  * @param victim_empire the empire affiliation of the victim:
-  *                      0 - TR, 1 - NC, 2 - VS, 3 - Neutral/BOPs
+  * @param victim_empire the empire affiliation of the victim
   * @param victim_inVehicle true, if the victim was in a vehicle when he was killed; false, otherwise
   */
 final case class DestroyDisplayMessage(killer : String,
                                        killer_unk : Long,
-                                       killer_empire : Int,
+                                       killer_empire : PlanetSideEmpire.Value,
                                        killer_inVehicle : Boolean,
-                                       unk : PlanetSideGUID,
-                                       method : PlanetSideGUID,
+                                       unk : Int,
+                                       method : Int,
                                        victim : String,
                                        victim_unk : Long,
-                                       victim_empire : Int,
+                                       victim_empire : PlanetSideEmpire.Value,
                                        victim_inVehicle : Boolean
 )
   extends PlanetSideGamePacket {
@@ -68,13 +67,13 @@ object DestroyDisplayMessage extends Marshallable[DestroyDisplayMessage] {
   implicit val codec : Codec[DestroyDisplayMessage] = (
     ("killer" | PacketHelpers.encodedWideString) ::
       ("killer_unk" | ulongL(32)) ::
-      ("killer_empire" | uintL(2)) ::
+      ("killer_empire" | PlanetSideEmpire.codec) ::
       ("killer_inVehicle" | bool) ::
-      ("unk" | PlanetSideGUID.codec) ::
-      ("method" | PlanetSideGUID.codec) ::
+      ("unk" | uint16L) ::
+      ("method" | uint16L) ::
       ("victim" | PacketHelpers.encodedWideStringAligned(5)) ::
       ("victim_unk" | ulongL(32)) ::
-      ("victim_empire" | uintL(2)) ::
+      ("victim_empire" | PlanetSideEmpire.codec) ::
       ("victim_inVehicle" | bool)
     ).as[DestroyDisplayMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/SetEmpireMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SetEmpireMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideEmpire
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/VNLWorldStatusMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VNLWorldStatusMessage.scala
@@ -4,6 +4,7 @@ package net.psforever.packet.game
 import java.net.{InetAddress, InetSocketAddress}
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideEmpire
 import scodec._
 import scodec.bits._
 import scodec.codecs._
@@ -20,13 +21,6 @@ object ServerType extends Enumeration(1) {
   val Development, Beta, Released = Value
 
   implicit val codec = PacketHelpers.createEnumerationCodec(this, uint8L)
-}
-
-object PlanetSideEmpire extends Enumeration {
-  type Type = Value
-  val TR, NC, VS, NEUTRAL = Value
-
-  implicit val codec = PacketHelpers.createEnumerationCodec(this, uint2L)
 }
 
 final case class WorldConnectionInfo(address : InetSocketAddress)

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
@@ -421,7 +421,6 @@ object ObjectClass {
       case ObjectClass.battlewagon_weapon_systemb => WeaponData.genericCodec
       case ObjectClass.battlewagon_weapon_systemc => WeaponData.genericCodec
       case ObjectClass.battlewagon_weapon_systemd => WeaponData.genericCodec
-      case ObjectClass.beamer => WeaponData.genericCodec
       case ObjectClass.bolt_driver => WeaponData.genericCodec
       case ObjectClass.chainblade => WeaponData.genericCodec
       case ObjectClass.chaingun_p => WeaponData.genericCodec

--- a/common/src/main/scala/net/psforever/types/PlanetSideEmpire.scala
+++ b/common/src/main/scala/net/psforever/types/PlanetSideEmpire.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.types
+
+import net.psforever.packet.PacketHelpers
+import scodec.codecs.uint2L
+
+/**
+  * Values for the three empires and the neutral/Black Ops group.
+  */
+object PlanetSideEmpire extends Enumeration {
+  type Type = Value
+  val TR, NC, VS, NEUTRAL = Value
+
+  implicit val codec = PacketHelpers.createEnumerationCodec(this, uint2L)
+}

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -374,7 +374,7 @@ class GamePacketTest extends Specification {
             char.appearance.pos.y mustEqual 2726.789f
             char.appearance.pos.z mustEqual 91.15625f
             char.appearance.objYaw mustEqual 19
-            char.appearance.faction mustEqual 2 //vs
+            char.appearance.faction mustEqual PlanetSideEmpire.VS
             char.appearance.bops mustEqual false
             char.appearance.unk1 mustEqual 4
             char.appearance.name mustEqual "IlllIIIlllIlIllIlllIllI"
@@ -529,7 +529,7 @@ class GamePacketTest extends Specification {
         val app = CharacterAppearanceData(
           Vector3(3674.8438f, 2726.789f, 91.15625f),
           19,
-          2,
+          PlanetSideEmpire.VS,
           false,
           4,
           "IlllIIIlllIlIllIlllIllI",
@@ -1332,13 +1332,13 @@ class GamePacketTest extends Specification {
           case DestroyDisplayMessage(killer, killer_unk, killer_empire, killer_inVehicle, unk, method, victim, victim_unk, victim_empire, victim_inVehicle) =>
             killer mustEqual "Angello"
             killer_unk mustEqual 30981173
-            killer_empire mustEqual 2
+            killer_empire mustEqual PlanetSideEmpire.VS
             killer_inVehicle mustEqual false
-            unk mustEqual PlanetSideGUID(121)
-            method mustEqual PlanetSideGUID(969)
+            unk mustEqual 121
+            method mustEqual 969
             victim mustEqual "HMFIC"
             victim_unk mustEqual 31035057
-            victim_empire mustEqual 0
+            victim_empire mustEqual PlanetSideEmpire.TR
             victim_inVehicle mustEqual false
           case default =>
             ko
@@ -1346,7 +1346,7 @@ class GamePacketTest extends Specification {
       }
 
       "encode" in {
-        val msg = DestroyDisplayMessage("Angello", 30981173, 2, false, PlanetSideGUID(121), PlanetSideGUID(969), "HMFIC", 31035057, 0, false)
+        val msg = DestroyDisplayMessage("Angello", 30981173, PlanetSideEmpire.VS, false, 121, 969, "HMFIC", 31035057, PlanetSideEmpire.TR, false)
         val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
         pkt mustEqual string
       }

--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -9,6 +9,7 @@ import org.log4s.MDC
 import scodec.Attempt.{Failure, Successful}
 import scodec.bits._
 import MDCContextAware.Implicits._
+import net.psforever.types.PlanetSideEmpire
 
 import scala.concurrent.duration._
 import scala.util.Random

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -10,7 +10,7 @@ import scodec.bits._
 import org.log4s.MDC
 import MDCContextAware.Implicits._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{ChatMessageType, Vector3}
+import net.psforever.types.{ChatMessageType, PlanetSideEmpire, Vector3}
 
 class WorldSessionActor extends Actor with MDCContextAware {
   private[this] val log = org.log4s.getLogger
@@ -113,7 +113,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
   val app = CharacterAppearanceData(
     Vector3(3674.8438f, 2726.789f, 91.15625f),
     19,
-    2,
+    PlanetSideEmpire.VS,
     false,
     4,
     "IlllIIIlllIlIllIlllIllI",


### PR DESCRIPTION
Substituted purely numeric input for aforementioned Enumeration to reflect faction/empire.
I took the liberty of moving that Enumeration to a more pulbic location, as it is being used in a variety of packets now.

A small, unrelated fix was included that removed a doubled ObjectClass entry in the  `@switch` statement, resulting in the `@switch` statement being broken and removed entry being unreachable.