### PR TITLE
Packet: GenericCollisionMsg

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -389,7 +389,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x39 => game.ChangeFireStateMessage_Start.decode
     case 0x3a => game.ChangeFireStateMessage_Stop.decode
     case 0x3b => noDecoder(UnknownMessage59)
-    case 0x3c => noDecoder(GenericCollisionMsg)
+    case 0x3c => game.GenericCollisionMsg.decode
     case 0x3d => game.QuantityUpdateMessage.decode
     case 0x3e => game.ArmorChangedMessage.decode
     case 0x3f => noDecoder(ProjectileStateMessage)

--- a/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
@@ -6,6 +6,26 @@ import net.psforever.types.Vector3
 import scodec.Codec
 import scodec.codecs._
 
+/**
+  * Dispatched by the client when the player has encountered a physical interaction that would cause damage.
+  * Being run over by vehicles and falling from an exceptional height (without hot drop) are common causes.
+  * @param unk1 na
+  * @param player the player or player-controlled vehicle
+  * @param target the other party in the collision
+  * @param player_health the player's health
+  * @param target_health the target's health
+  * @param player_velocity_x the x-component of the player's velocity
+  * @param player_velocity_y the y-component of the player's velocity
+  * @param player_velocity_z the z-component of the player's velocity
+  * @param target_velocity_x the x-component of the target's velocity
+  * @param target_velocity_y the y-component of the target's velocity
+  * @param target_velocity_z the z-component of the target's velocity
+  * @param player_pos the player's world coordinates
+  * @param target_pos the target's world coordinates
+  * @param unk2 na
+  * @param unk3 na
+  * @param unk4 na
+  */
 final case class GenericCollisionMsg(unk1 : Int,
                                      player : PlanetSideGUID,
                                      target : PlanetSideGUID,

--- a/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
@@ -7,8 +7,12 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Dispatched by the client when the player has encountered a physical interaction that would cause damage.
-  * Being run over by vehicles and falling from an exceptional height (without hot drop) are common causes.
+  * Dispatched by the client when the player has encountered a physical interaction that would cause damage.<br>
+  * <br>
+  * Collision information reports about two subjects who were involved in an altercation.
+  * The first is the `player`, that is, the client's avatar.
+  * The second is the `target` with respect to the `player` - whatever the avatar ran into, or whatever ran into the avatar.
+  * In the case of isolated forms of collision such as fall damage the `target` fields are blank or zero'd.
   * @param unk1 na
   * @param player the player or player-controlled vehicle
   * @param target the other party in the collision

--- a/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.Vector3
+import scodec.Codec
+import scodec.codecs._
+
+final case class GenericCollisionMsg(unk1 : Int,
+                                     player : PlanetSideGUID,
+                                     target : PlanetSideGUID,
+                                     player_health : Int,
+                                     target_health : Int,
+                                     player_velocity_x : Float,
+                                     player_velocity_y : Float,
+                                     player_velocity_z : Float,
+                                     target_velocity_x : Float,
+                                     target_velocity_y : Float,
+                                     target_velocity_z : Float,
+                                     player_pos : Vector3,
+                                     target_pos : Vector3,
+                                     unk2 : Long,
+                                     unk3 : Long,
+                                     unk4 : Long)
+  extends PlanetSideGamePacket {
+  type Packet = GenericCollisionMsg
+  def opcode = GamePacketOpcode.GenericCollisionMsg
+  def encode = GenericCollisionMsg.encode(this)
+}
+
+object GenericCollisionMsg extends Marshallable[GenericCollisionMsg] {
+  implicit val codec : Codec[GenericCollisionMsg] = (
+    ("unk1" | uint2) ::
+      ("p" | PlanetSideGUID.codec) ::
+      ("t" | PlanetSideGUID.codec) ::
+      ("p_health" | uint16L) ::
+      ("t_health" | uint16L) ::
+      ("p_vel_x" | floatL) ::
+      ("p_vel_y" | floatL) ::
+      ("p_vel_z" | floatL) ::
+      ("t_vel_x" | floatL) ::
+      ("t_vel_y" | floatL) ::
+      ("t_vel_z" | floatL) ::
+      ("p_pos" | Vector3.codec_pos) ::
+      ("t_pos" | Vector3.codec_pos) ::
+      ("unk2" | uint32L) ::
+      ("unk3" | uint32L) ::
+      ("unk4" | uint32L)
+    ).as[GenericCollisionMsg]
+}

--- a/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
@@ -18,12 +18,8 @@ import scodec.codecs._
   * @param target the other party in the collision
   * @param player_health the player's health
   * @param target_health the target's health
-  * @param player_velocity_x the x-component of the player's velocity
-  * @param player_velocity_y the y-component of the player's velocity
-  * @param player_velocity_z the z-component of the player's velocity
-  * @param target_velocity_x the x-component of the target's velocity
-  * @param target_velocity_y the y-component of the target's velocity
-  * @param target_velocity_z the z-component of the target's velocity
+  * @param player_velocity the player's velocity
+  * @param target_velocity the target's velocity
   * @param player_pos the player's world coordinates
   * @param target_pos the target's world coordinates
   * @param unk2 na
@@ -35,12 +31,8 @@ final case class GenericCollisionMsg(unk1 : Int,
                                      target : PlanetSideGUID,
                                      player_health : Int,
                                      target_health : Int,
-                                     player_velocity_x : Float,
-                                     player_velocity_y : Float,
-                                     player_velocity_z : Float,
-                                     target_velocity_x : Float,
-                                     target_velocity_y : Float,
-                                     target_velocity_z : Float,
+                                     player_velocity : Vector3,
+                                     target_velocity : Vector3,
                                      player_pos : Vector3,
                                      target_pos : Vector3,
                                      unk2 : Long,
@@ -59,12 +51,8 @@ object GenericCollisionMsg extends Marshallable[GenericCollisionMsg] {
       ("t" | PlanetSideGUID.codec) ::
       ("p_health" | uint16L) ::
       ("t_health" | uint16L) ::
-      ("p_vel_x" | floatL) ::
-      ("p_vel_y" | floatL) ::
-      ("p_vel_z" | floatL) ::
-      ("t_vel_x" | floatL) ::
-      ("t_vel_y" | floatL) ::
-      ("t_vel_z" | floatL) ::
+      ("p_vel" | Vector3.codec_float) ::
+      ("t_vel" | Vector3.codec_float) ::
       ("p_pos" | Vector3.codec_pos) ::
       ("t_pos" | Vector3.codec_pos) ::
       ("unk2" | uint32L) ::

--- a/common/src/main/scala/net/psforever/types/Vector3.scala
+++ b/common/src/main/scala/net/psforever/types/Vector3.scala
@@ -21,4 +21,10 @@ object Vector3 {
       ("y" | newcodecs.q_float(-256.0, 256.0, 14)) ::
       ("z" | newcodecs.q_float(-256.0, 256.0, 14))
     ).as[Vector3]
+
+  implicit val codec_float : Codec[Vector3] = (
+      ("x" | floatL) ::
+      ("y" | floatL) ::
+      ("z" | floatL)
+    ).as[Vector3]
 }

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -1,1 +1,2 @@
 // Copyright (c) 2016 PSForever.net to present
+

--- a/common/src/test/scala/GamePacketTest.scala
+++ b/common/src/test/scala/GamePacketTest.scala
@@ -1,2 +1,1 @@
 // Copyright (c) 2016 PSForever.net to present
-

--- a/common/src/test/scala/game/GenericCollisionMsgTest.scala
+++ b/common/src/test/scala/game/GenericCollisionMsgTest.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 PSForever.net to present
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.types.Vector3
+import scodec.bits._
+
+class GenericCollisionMsgTest extends Specification {
+  //TODO find a better test later
+  val string = hex"3C 92C00000190000001B2A8010932CEF505C70946F00000000000000000000000017725EBC6D6A058000000000000000000000000000003F8FF45140"
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case GenericCollisionMsg(unk1, p, t, php, thp, pvx, pvy, pvz, tvx, tvy, tvz, ppos, tpos, unk2, unk3, unk4) =>
+        unk1 mustEqual 2
+        p mustEqual PlanetSideGUID(75)
+        t mustEqual PlanetSideGUID(0)
+        php mustEqual 100
+        thp mustEqual 0
+        pvx mustEqual 32.166428f
+        pvy mustEqual 23.712547f
+        pvz mustEqual -0.012802706f
+        tvx mustEqual 0.0f
+        tvz mustEqual 0.0f
+        tvx mustEqual 0.0f
+        ppos.x mustEqual 3986.7266f
+        ppos.y mustEqual 2615.3672f
+        ppos.z mustEqual 90.625f
+        tpos.x mustEqual 0.0f
+        tpos.y mustEqual 0.0f
+        tpos.z mustEqual 0.0f
+        unk2 mustEqual 0L
+        unk3 mustEqual 0L
+        unk4 mustEqual 1171341310L
+      case _ =>
+        ko
+    }
+  }
+  "encode" in {
+    val msg = GenericCollisionMsg(2, PlanetSideGUID(75), PlanetSideGUID(0), 100, 0, 32.166428f, 23.712547f, -0.012802706f, 0.0f, 0.0f, 0.0f, Vector3(3986.7266f, 2615.3672f, 90.625f), Vector3(0.0f, 0.0f, 0.0f), 0L, 0L, 1171341310L)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+    pkt mustEqual string
+  }
+}

--- a/common/src/test/scala/game/GenericCollisionMsgTest.scala
+++ b/common/src/test/scala/game/GenericCollisionMsgTest.scala
@@ -12,18 +12,18 @@ class GenericCollisionMsgTest extends Specification {
   val string = hex"3C 92C00000190000001B2A8010932CEF505C70946F00000000000000000000000017725EBC6D6A058000000000000000000000000000003F8FF45140"
   "decode" in {
     PacketCoding.DecodePacket(string).require match {
-      case GenericCollisionMsg(unk1, p, t, php, thp, pvx, pvy, pvz, tvx, tvy, tvz, ppos, tpos, unk2, unk3, unk4) =>
+      case GenericCollisionMsg(unk1, p, t, php, thp, pv, tv, ppos, tpos, unk2, unk3, unk4) =>
         unk1 mustEqual 2
         p mustEqual PlanetSideGUID(75)
         t mustEqual PlanetSideGUID(0)
         php mustEqual 100
         thp mustEqual 0
-        pvx mustEqual 32.166428f
-        pvy mustEqual 23.712547f
-        pvz mustEqual -0.012802706f
-        tvx mustEqual 0.0f
-        tvz mustEqual 0.0f
-        tvx mustEqual 0.0f
+        pv.x mustEqual 32.166428f
+        pv.y mustEqual 23.712547f
+        pv.z mustEqual -0.012802706f
+        tv.x mustEqual 0.0f
+        tv.z mustEqual 0.0f
+        tv.x mustEqual 0.0f
         ppos.x mustEqual 3986.7266f
         ppos.y mustEqual 2615.3672f
         ppos.z mustEqual 90.625f
@@ -38,7 +38,7 @@ class GenericCollisionMsgTest extends Specification {
     }
   }
   "encode" in {
-    val msg = GenericCollisionMsg(2, PlanetSideGUID(75), PlanetSideGUID(0), 100, 0, 32.166428f, 23.712547f, -0.012802706f, 0.0f, 0.0f, 0.0f, Vector3(3986.7266f, 2615.3672f, 90.625f), Vector3(0.0f, 0.0f, 0.0f), 0L, 0L, 1171341310L)
+    val msg = GenericCollisionMsg(2, PlanetSideGUID(75), PlanetSideGUID(0), 100, 0, Vector3(32.166428f, 23.712547f, -0.012802706f), Vector3(0.0f, 0.0f, 0.0f), Vector3(3986.7266f, 2615.3672f, 90.625f), Vector3(0.0f, 0.0f, 0.0f), 0L, 0L, 1171341310L)
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
     pkt mustEqual string
   }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -373,7 +373,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ BugReportMessage(version_major,version_minor,version_date,bug_type,repeatable,location,zone,pos,summary,desc) =>
       log.info("BugReportMessage: " + msg)
 
-    case default => log.debug(s"Unhandled GamePacket ${pkt}")
+    case default => log.error(s"Unhandled GamePacket ${pkt}")
   }
 
   def failWithError(error : String) = {

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -367,11 +367,13 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ SquadDefinitionActionMessage(a, b, c, d, e, f, g, h, i) =>
       log.info("SquadDefinitionAction: " + msg)
 
+    case msg @ GenericCollisionMsg(u1, p, t, php, thp, pvx, pvy, pvz, tvx, tvy, tvz, ppos, tpos, u2, u3, u4) =>
+      log.info("Ouch! " + msg)
+
     case msg @ BugReportMessage(version_major,version_minor,version_date,bug_type,repeatable,location,zone,pos,summary,desc) =>
       log.info("BugReportMessage: " + msg)
 
-    case default => log.error(s"Unhandled GamePacket ${pkt}")
-
+    case default => log.debug(s"Unhandled GamePacket ${pkt}")
   }
 
   def failWithError(error : String) = {


### PR DESCRIPTION
Ouch!

The first field probably indicates the form of collision but I don't have enough information to make certain of that.

Those last few fields are supposedly called "impactForce," as suggested by [this extracted information](https://docs.google.com/document/d/1QPODlBmVXjKZhwqITKb4LCCERgviqmfGD1RHpfrFbjA/edit).  They may be set differently when the collision is between non-environmental aspects but, for things like fall damage, only the last field ever gets set to a number.  It's also a field that doesn't scale well into a value that makes sense, which is why I left it as a `Long` for now.