### PR TITLE
Packet: HitHint

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -330,7 +330,7 @@ object GamePacketOpcode extends Enumeration {
     // 0x08
     case 0x08 => game.PlayerStateMessage.decode
     case 0x09 => game.HitMessage.decode
-    case 0x0a => noDecoder(HitHint)
+    case 0x0a => game.HitHint.decode
     case 0x0b => noDecoder(DamageMessage)
     case 0x0c => noDecoder(DestroyMessage)
     case 0x0d => game.ReloadMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/HitHint.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HitHint.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * na
+  * @param unk1 na
+  * @param unk2 na
+  * @param x this parameter should not exist
+  */
+final case class HitHint(unk1 : Int,
+                         unk2 : Int,
+                         x : Int)
+  extends PlanetSideGamePacket {
+  type Packet = HitHint
+  def opcode = GamePacketOpcode.HitHint
+  def encode = HitHint.encode(this)
+}
+
+object HitHint extends Marshallable[HitHint] {
+  implicit val codec : Codec[HitHint] = (
+    ("unk1" | uintL(10)) ::
+      ("unk2" | uintL(10)) ::
+      ("x" | uintL(12))
+    ).as[HitHint]
+}

--- a/common/src/main/scala/net/psforever/packet/game/HitHint.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HitHint.scala
@@ -6,14 +6,18 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * na
-  * @param unk1 na
-  * @param unk2 na
-  * @param x this parameter should not exist
+  * Dispatched by the server to indicate a target or source of damage affecting the player.<br>
+  * <br>
+  * When a source is provided, and within render distance, the player will be shown a fading, outwards drifting, red tick mark.
+  * The location and movement of the mark will indicate a general direction towards the source.
+  * If the option `Game/Show Damage Flash` is set, the player's screen will flash red briefly when a mark is displayed.<br>
+  * <br>
+  * For while some mark is being displayed, the player will also make a grunt of pain.
+  * @param source_guid the source of implied damage
+  * @param player_guid the player
   */
-final case class HitHint(unk1 : Int,
-                         unk2 : Int,
-                         x : Int)
+final case class HitHint(source_guid : PlanetSideGUID,
+                         player_guid : PlanetSideGUID)
   extends PlanetSideGamePacket {
   type Packet = HitHint
   def opcode = GamePacketOpcode.HitHint
@@ -22,8 +26,7 @@ final case class HitHint(unk1 : Int,
 
 object HitHint extends Marshallable[HitHint] {
   implicit val codec : Codec[HitHint] = (
-    ("unk1" | uintL(10)) ::
-      ("unk2" | uintL(10)) ::
-      ("x" | uintL(12))
+    ("source_guid" | PlanetSideGUID.codec) ::
+      ("player_guid" | PlanetSideGUID.codec)
     ).as[HitHint]
 }

--- a/common/src/test/scala/game/HitHintTest.scala
+++ b/common/src/test/scala/game/HitHintTest.scala
@@ -11,9 +11,9 @@ class HitHintTest extends Specification {
 
   "decode" in {
     PacketCoding.DecodePacket(string).require match {
-      case HitHint(unk1, unk2) =>
-        unk1 mustEqual PlanetSideGUID(2886)
-        unk2 mustEqual PlanetSideGUID(1)
+      case HitHint(source, player) =>
+        source mustEqual PlanetSideGUID(2886)
+        player mustEqual PlanetSideGUID(1)
       case _ =>
         ko
     }

--- a/common/src/test/scala/game/HitHintTest.scala
+++ b/common/src/test/scala/game/HitHintTest.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016 PSForever.net to present
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class HitHintTest extends Specification {
+  val string = hex"0A 460B 0100"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case HitHint(unk1, unk2) =>
+        unk1 mustEqual PlanetSideGUID(2886)
+        unk2 mustEqual PlanetSideGUID(1)
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = HitHint(PlanetSideGUID(2886), PlanetSideGUID(1))
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
In plain terms, this packet tells players from where they're being killed.

Apparently, any valid game object with a uid can be a "source of damage."