### PR TITLE
Packet: AvatarImplantMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -423,7 +423,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x56 => noDecoder(GenericObjectActionMessage)
     case 0x57 => noDecoder(AvatarVehicleTimerMessage)
     // 0x58
-    case 0x58 => noDecoder(AvatarImplantMessage)
+    case 0x58 => game.AvatarImplantMessage.decode
     case 0x59 => noDecoder(UnknownMessage89)
     case 0x5a => noDecoder(DelayedPathMountMsg)
     case 0x5b => noDecoder(OrbitalShuttleTimeMsg)

--- a/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 PSForever.net to present
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+final case class AvatarImplantMessage(player_guid : PlanetSideGUID,
+                                      unk1 : Int,
+                                      unk2 : Int)
+  extends PlanetSideGamePacket {
+  type Packet = AvatarImplantMessage
+  def opcode = GamePacketOpcode.AvatarImplantMessage
+  def encode = AvatarImplantMessage.encode(this)
+}
+
+object AvatarImplantMessage extends Marshallable[AvatarImplantMessage] {
+  implicit val codec : Codec[AvatarImplantMessage] = (
+    ("plyaer_guid" | PlanetSideGUID.codec) ::
+      ("unk1" | uint8L) ::
+      ("unk2" | uint8L)
+    ).as[AvatarImplantMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
@@ -10,16 +10,16 @@ import scodec.codecs._
   */
 object ImplantType extends Enumeration {
   type Type = Value
-  val advanced_regen,
-      targeting,
-      audio_amplifier,
-      darklight_vision,
-      melee_booster,
-      personal_shield,
-      range_magnifier,
-      unknown7,
-      silent_run,
-      surge = Value
+  val AdvancedRegen,
+      Targeting,
+      AudioAmplifier,
+      DarklightVision,
+      MeleeBooster,
+      PersonalShield,
+      RangeMagnifier,
+      Unknown7,
+      SilentRun,
+      Surge = Value
 
   implicit val codec = PacketHelpers.createEnumerationCodec(this, uint4L)
 }

--- a/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
@@ -1,13 +1,58 @@
 // Copyright (c) 2016 PSForever.net to present
 package net.psforever.packet.game
 
-import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
 import scodec.Codec
 import scodec.codecs._
 
+/**
+  * An `Enumeration` of the available implants.
+  */
+object ImplantType extends Enumeration {
+  type Type = Value
+  val REGENERATION,
+      ENHANCED_TARGETING,
+      AUDIO_AMPLIFIER,
+      DARKLIGHT_VISION,
+      MELEE_BOOSTER,
+      PERSONAL_SHIELD,
+      RANGE_MAGNIFIER,
+      UNKNOWN7,
+      SENSOR_SHIELD,
+      SURGE = Value
+
+  implicit val codec = PacketHelpers.createEnumerationCodec(this, uint4L)
+}
+
+/**
+  * Change the state of the implant.<br>
+  * Write better comments.
+  * <br>
+  * Implant:<br>
+  * `
+  * 00 - Regeneration (advanced_regen)<br>
+  * 01 - Enhanced Targeting (targeting)<br>
+  * 02 - Audio Amplifier (audio_amplifier)<br>
+  * 03 - Darklight Vision (darklight_vision)<br>
+  * 04 - Melee Booster (melee_booster)<br>
+  * 05 - Personal Shield (personal_shield)<br>
+  * 06 - Range Magnifier (range_magnifier)<br>
+  * 07 - `None`<br>
+  * 08 - Sensor Shield (silent_run)<br>
+  * 09 - Surge (surge)<br>
+  * `
+  * <br>
+  * Exploration<br>
+  * Where is Second Wind (second_wind)?
+  * @param player_guid the player
+  * @param unk1 na
+  * @param unk2 na
+  * @param implant the implant
+  */
 final case class AvatarImplantMessage(player_guid : PlanetSideGUID,
                                       unk1 : Int,
-                                      unk2 : Int)
+                                      unk2 : Int,
+                                      implant : ImplantType.Value)
   extends PlanetSideGamePacket {
   type Packet = AvatarImplantMessage
   def opcode = GamePacketOpcode.AvatarImplantMessage
@@ -16,8 +61,9 @@ final case class AvatarImplantMessage(player_guid : PlanetSideGUID,
 
 object AvatarImplantMessage extends Marshallable[AvatarImplantMessage] {
   implicit val codec : Codec[AvatarImplantMessage] = (
-    ("plyaer_guid" | PlanetSideGUID.codec) ::
-      ("unk1" | uint8L) ::
-      ("unk2" | uint8L)
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("unk1" | uintL(3)) ::
+      ("unk2" | uint2L) ::
+      ("implant" | ImplantType.codec)
     ).as[AvatarImplantMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
@@ -10,16 +10,16 @@ import scodec.codecs._
   */
 object ImplantType extends Enumeration {
   type Type = Value
-  val REGENERATION,
-      ENHANCED_TARGETING,
-      AUDIO_AMPLIFIER,
-      DARKLIGHT_VISION,
-      MELEE_BOOSTER,
-      PERSONAL_SHIELD,
-      RANGE_MAGNIFIER,
-      UNKNOWN7,
-      SENSOR_SHIELD,
-      SURGE = Value
+  val advanced_regen,
+      targeting,
+      audio_amplifier,
+      darklight_vision,
+      melee_booster,
+      personal_shield,
+      range_magnifier,
+      unknown7,
+      silent_run,
+      surge = Value
 
   implicit val codec = PacketHelpers.createEnumerationCodec(this, uint4L)
 }

--- a/common/src/test/scala/game/AvatarImplantMessageTest.scala
+++ b/common/src/test/scala/game/AvatarImplantMessageTest.scala
@@ -15,14 +15,14 @@ class AvatarImplantMessageTest extends Specification {
         player_guid mustEqual PlanetSideGUID(3171)
         unk1 mustEqual 3
         unk2 mustEqual 1
-        implant mustEqual ImplantType.ENHANCED_TARGETING
+        implant mustEqual ImplantType.targeting
       case _ =>
         ko
     }
   }
 
   "encode" in {
-    val msg = AvatarImplantMessage(PlanetSideGUID(3171), 3, 1, ImplantType.ENHANCED_TARGETING)
+    val msg = AvatarImplantMessage(PlanetSideGUID(3171), 3, 1, ImplantType.targeting)
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string

--- a/common/src/test/scala/game/AvatarImplantMessageTest.scala
+++ b/common/src/test/scala/game/AvatarImplantMessageTest.scala
@@ -15,14 +15,14 @@ class AvatarImplantMessageTest extends Specification {
         player_guid mustEqual PlanetSideGUID(3171)
         unk1 mustEqual 3
         unk2 mustEqual 1
-        implant mustEqual ImplantType.targeting
+        implant mustEqual ImplantType.Targeting
       case _ =>
         ko
     }
   }
 
   "encode" in {
-    val msg = AvatarImplantMessage(PlanetSideGUID(3171), 3, 1, ImplantType.targeting)
+    val msg = AvatarImplantMessage(PlanetSideGUID(3171), 3, 1, ImplantType.Targeting)
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string

--- a/common/src/test/scala/game/AvatarImplantMessageTest.scala
+++ b/common/src/test/scala/game/AvatarImplantMessageTest.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 PSForever.net to present
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class AvatarImplantMessageTest extends Specification {
+  val string = hex"58 630C 68 80"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case AvatarImplantMessage(player_guid, unk1, unk2, implant) =>
+        player_guid mustEqual PlanetSideGUID(3171)
+        unk1 mustEqual 3
+        unk2 mustEqual 1
+        implant mustEqual ImplantType.ENHANCED_TARGETING
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = AvatarImplantMessage(PlanetSideGUID(3171), 3, 1, ImplantType.ENHANCED_TARGETING)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
Something something implants write better comments.

Right now, I honestly don't remember how I determined the data in this packet, save that I knew that the test was accurate for what I learned from it.  I was able to figure out which implants were which number in the last field and I was reliably able to determine that second wind was not represented in that group.  Implants need to be activated properly before testing on this packet can proceed.