### PR TITLE
Packet: ZoneForcedCavernConnectionsMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -588,7 +588,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xe0 => noDecoder(SquadBindInfoMessage)
     case 0xe1 => noDecoder(AudioSequenceMessage)
     case 0xe2 => noDecoder(SquadFacilityBindInfoMessage)
-    case 0xe3 => noDecoder(ZoneForcedCavernConnectionsMessage)
+    case 0xe3 => game.ZoneForcedCavernConnectionsMessage.decode
     case 0xe4 => noDecoder(MissionActionMessage)
     case 0xe5 => noDecoder(MissionKillTriggerMessage)
     case 0xe6 => game.ReplicationStreamMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/ZoneForcedCavernConnectionsMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ZoneForcedCavernConnectionsMessage.scala
@@ -6,10 +6,9 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Dispatched to the client.
+  * Dispatched to the client in regards to cavern connections via geowarp gates.
   * @param zone the zone
-  * @param unk na;
-  *            usually 0
+  * @param unk na
   */
 final case class ZoneForcedCavernConnectionsMessage(zone : PlanetSideGUID,
                                                     unk : Int)
@@ -21,7 +20,7 @@ final case class ZoneForcedCavernConnectionsMessage(zone : PlanetSideGUID,
 
 object ZoneForcedCavernConnectionsMessage extends Marshallable[ZoneForcedCavernConnectionsMessage] {
   implicit val codec : Codec[ZoneForcedCavernConnectionsMessage] = (
-    ("zone_guid" | PlanetSideGUID.codec) ::
+    ("zone" | PlanetSideGUID.codec) ::
       ("unk" | uint2L)
     ).as[ZoneForcedCavernConnectionsMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ZoneForcedCavernConnectionsMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ZoneForcedCavernConnectionsMessage.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Dispatched to the client.
+  * @param zone the zone
+  * @param unk na;
+  *            usually 0
+  */
+final case class ZoneForcedCavernConnectionsMessage(zone : PlanetSideGUID,
+                                                    unk : Int)
+  extends PlanetSideGamePacket {
+  type Packet = ZoneForcedCavernConnectionsMessage
+  def opcode = GamePacketOpcode.ZoneForcedCavernConnectionsMessage
+  def encode = ZoneForcedCavernConnectionsMessage.encode(this)
+}
+
+object ZoneForcedCavernConnectionsMessage extends Marshallable[ZoneForcedCavernConnectionsMessage] {
+  implicit val codec : Codec[ZoneForcedCavernConnectionsMessage] = (
+    ("zone_guid" | PlanetSideGUID.codec) ::
+      ("unk" | uint2L)
+    ).as[ZoneForcedCavernConnectionsMessage]
+}

--- a/common/src/test/scala/game/ZoneForcedCavernConnectionsMessageTest.scala
+++ b/common/src/test/scala/game/ZoneForcedCavernConnectionsMessageTest.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.types.Vector3
+import scodec.bits._
+
+class ZoneForcedCavernConnectionsMessageTest extends Specification {
+  val string = hex"E3130000"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case ZoneForcedCavernConnectionsMessage(zone, unk) =>
+        zone mustEqual PlanetSideGUID(19)
+        unk mustEqual 0
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = ZoneForcedCavernConnectionsMessage(PlanetSideGUID(19), 0)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}

--- a/common/src/test/scala/game/ZoneForcedCavernConnectionsMessageTest.scala
+++ b/common/src/test/scala/game/ZoneForcedCavernConnectionsMessageTest.scala
@@ -8,20 +8,20 @@ import net.psforever.types.Vector3
 import scodec.bits._
 
 class ZoneForcedCavernConnectionsMessageTest extends Specification {
-  val string = hex"E3130000"
+  val string = hex"E3200040"
 
   "decode" in {
     PacketCoding.DecodePacket(string).require match {
       case ZoneForcedCavernConnectionsMessage(zone, unk) =>
-        zone mustEqual PlanetSideGUID(19)
-        unk mustEqual 0
+        zone mustEqual PlanetSideGUID(32)
+        unk mustEqual 1
       case _ =>
         ko
     }
   }
 
   "encode" in {
-    val msg = ZoneForcedCavernConnectionsMessage(PlanetSideGUID(19), 0)
+    val msg = ZoneForcedCavernConnectionsMessage(PlanetSideGUID(32), 1)
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string


### PR DESCRIPTION
This packet is being included because it is part of the common packet updates that occur during login, and possibly also during continent lock changes and during geowarp accessibility changes.

While I am uncertain what exactly the unknown field does at the moment, it's worth noting that 0 is the most common value, followed by 1, and I have not yet seen a 2 or a 3.  Nexus, a continent whose geowarp is almost never normally active, as it is not in the rotation, is almost always 1 and the other continents fluctuate between 0 (common) and 1 (uncommon).