### PR TITLE
Packet: ChildObjectStateMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -353,7 +353,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x1b => noDecoder(VehicleStateMessage)
     case 0x1c => noDecoder(FrameVehicleStateMessage)
     case 0x1d => game.GenericObjectStateMsg.decode
-    case 0x1e => noDecoder(ChildObjectStateMessage)
+    case 0x1e => game.ChildObjectStateMessage.decode
     case 0x1f => game.ActionResultMessage.decode
 
     // OPCODES 0x20-2f

--- a/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
@@ -6,16 +6,26 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * na
+  * Dispatched from a client when its user is controlling a secondary object whose state must be updated.<br>
+  * <br>
+  * When `ChildObjectStateMessage` is being sent to the server, it replaces `PlayerStateMessage`.
+  * The packet frequently gets hidden in a `MultiPacket`, though it is not functionally essential to do that.<br>
+  * <br>
+  * Note the lack of position data.
+  * The secondary object in question is updated in position through another means or is stationary.
+  * The only concern is the direction the object is facing.
+  * The angles are relative to the object's normal forward-facing and typically begin tracking at 0, 0 (forward-facing).
   * @param object_guid the object being manipulated (controlled)
   * @param pitch the angle with respect to the sky and the ground towards which the object is directed;
   *              an 8-bit unsigned value;
-  *              0 is perfectly level and forward-facing, wrapping around at 255;
-  *              positive rotation is occurs by rotating downwards from forward-facing
+  *              0 is perfectly level and forward-facing and mapped to 255;
+  *              positive rotation is downwards from forward-facing;
+  *              between 7 (down) and 231 (up), for 32 angles
   * @param yaw the angle with respect to the horizon towards which the object is directed;
-  *              an 8-bit unsigned value;
-  *              0 is forward-facing, wrapping around at 255;
-  *              positive rotation is clockwise of forward-facing
+  *            an 8-bit unsigned value;
+  *            0 is forward-facing, wrapping around at 127;
+  *            positive rotation is counter-clockwise of forward-facing;
+  *            full rotation
   */
 final case class ChildObjectStateMessage(object_guid : PlanetSideGUID,
                                          pitch : Int,

--- a/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
@@ -5,9 +5,21 @@ import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacke
 import scodec.Codec
 import scodec.codecs._
 
-final case class ChildObjectStateMessage(unk1 : Int,
-                                         unk2 : Int,
-                                         unk3 : Int)
+/**
+  * na
+  * @param object_guid the object being manipulated (controlled)
+  * @param pitch the angle with respect to the sky and the ground towards which the object is directed;
+  *              an 8-bit unsigned value;
+  *              0 is perfectly level and forward-facing, wrapping around at 255;
+  *              positive rotation is occurs by rotating downwards from forward-facing
+  * @param yaw the angle with respect to the horizon towards which the object is directed;
+  *              an 8-bit unsigned value;
+  *              0 is forward-facing, wrapping around at 255;
+  *              positive rotation is clockwise of forward-facing
+  */
+final case class ChildObjectStateMessage(object_guid : PlanetSideGUID,
+                                         pitch : Int,
+                                         yaw : Int)
   extends PlanetSideGamePacket {
   type Packet = ChildObjectStateMessage
   def opcode = GamePacketOpcode.ChildObjectStateMessage
@@ -16,8 +28,8 @@ final case class ChildObjectStateMessage(unk1 : Int,
 
 object ChildObjectStateMessage extends Marshallable[ChildObjectStateMessage] {
   implicit val codec : Codec[ChildObjectStateMessage] = (
-    ("unk1" | uint16L) ::
-      ("unk2" | uint8L) ::
-      ("unk3" | uint8L)
+    ("object_guid" | PlanetSideGUID.codec) ::
+      ("pitch" | uint8L) ::
+      ("yaw" | uint8L)
     ).as[ChildObjectStateMessage]
 }

--- a/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
@@ -19,13 +19,11 @@ import scodec.codecs._
   * @param pitch the angle with respect to the sky and the ground towards which the object is directed;
   *              an 8-bit unsigned value;
   *              0 is perfectly level and forward-facing and mapped to 255;
-  *              positive rotation is downwards from forward-facing;
-  *              between 7 (down) and 231 (up), for 32 angles
+  *              positive rotation is downwards from forward-facing
   * @param yaw the angle with respect to the horizon towards which the object is directed;
   *            an 8-bit unsigned value;
   *            0 is forward-facing, wrapping around at 127;
-  *            positive rotation is counter-clockwise of forward-facing;
-  *            full rotation
+  *            positive rotation is counter-clockwise of forward-facing
   */
 final case class ChildObjectStateMessage(object_guid : PlanetSideGUID,
                                          pitch : Int,

--- a/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+final case class ChildObjectStateMessage(unk1 : Int,
+                                         unk2 : Int,
+                                         unk3 : Int)
+  extends PlanetSideGamePacket {
+  type Packet = ChildObjectStateMessage
+  def opcode = GamePacketOpcode.ChildObjectStateMessage
+  def encode = ChildObjectStateMessage.encode(this)
+}
+
+object ChildObjectStateMessage extends Marshallable[ChildObjectStateMessage] {
+  implicit val codec : Codec[ChildObjectStateMessage] = (
+    ("unk1" | uint16L) ::
+      ("unk2" | uint8L) ::
+      ("unk3" | uint8L)
+    ).as[ChildObjectStateMessage]
+}

--- a/common/src/test/scala/game/ChildObjectStateMessageTest.scala
+++ b/common/src/test/scala/game/ChildObjectStateMessageTest.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class ChildObjectStateMessageTest extends Specification {
+  val string = hex"1E 640B 06 47"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case ChildObjectStateMessage(object_guid, pitch, yaw) =>
+        object_guid mustEqual PlanetSideGUID(2916)
+        pitch mustEqual 6
+        yaw mustEqual 71
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = ChildObjectStateMessage(PlanetSideGUID(2916), 6, 71)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -238,6 +238,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ PlayerStateMessageUpstream(avatar_guid, pos, vel, unk1, aim_pitch, unk2, seq_time, unk3, is_crouching, is_jumping, unk4, is_cloaking, unk5, unk6) =>
       //log.info("PlayerState: " + msg)
 
+    case msg @ ChildObjectStateMessage(object_guid : PlanetSideGUID, pitch : Int, yaw : Int) =>
+      //log.info("ChildObjectState: " + msg)
+
     case msg @ ChatMsg(messagetype, has_wide_contents, recipient, contents, note_contents) =>
       // TODO: Prevents log spam, but should be handled correctly
       if (messagetype != ChatMessageType.CMT_TOGGLE_GM) {


### PR DESCRIPTION
Children are usually prohibited from being depicted in violent video games, but we're edgy.

Used by properly outfitted turrets and stuff for reasons similar to `PlayerStateMessageUpstream`.  (I tested using a self-spawned Orion.)