### PR TITLE
Packet: DeployObjectMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -428,7 +428,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x5a => noDecoder(DelayedPathMountMsg)
     case 0x5b => noDecoder(OrbitalShuttleTimeMsg)
     case 0x5c => noDecoder(AIDamage)
-    case 0x5d => noDecoder(DeployObjectMessage)
+    case 0x5d => game.DeployObjectMessage.decode
     case 0x5e => noDecoder(FavoritesRequest)
     case 0x5f => noDecoder(FavoritesResponse)
 

--- a/common/src/main/scala/net/psforever/packet/game/DeployObjectMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployObjectMessage.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.Vector3
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * For completion's sake.
+  * We've never actually sent or received this packet during session captures on Gemini Live.
+  * @param guid na
+  * @param unk1 na
+  * @param pos na
+  * @param unk2 na
+  * @param unk3 na
+  * @param unk4 na
+  * @param unk5 na
+  */
+final case class DeployObjectMessage(guid : PlanetSideGUID,
+                                     unk1 : Long,
+                                     pos : Vector3,
+                                     unk2 : Int,
+                                     unk3 : Int,
+                                     unk4 : Int,
+                                     unk5 : Long)
+  extends PlanetSideGamePacket {
+  type Packet = DeployObjectMessage
+  def opcode = GamePacketOpcode.DeployObjectMessage
+  def encode = DeployObjectMessage.encode(this)
+}
+
+object DeployObjectMessage extends Marshallable[DeployObjectMessage] {
+  implicit val codec : Codec[DeployObjectMessage] = (
+    ("guid1" | PlanetSideGUID.codec) ::
+      ("unk1" | uint32L) ::
+      ("pos" | Vector3.codec_pos) ::
+      ("unk2" | uint8L) ::
+      ("unk3" | uint8L) ::
+      ("unk4" | uint8L) ::
+      ("unk5" | uint32L)
+    ).as[DeployObjectMessage]
+}

--- a/common/src/test/scala/game/DeployObjectMessageTest.scala
+++ b/common/src/test/scala/game/DeployObjectMessageTest.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.types.Vector3
+import scodec.bits._
+
+class DeployObjectMessageTest extends Specification {
+  //fake data; see comments in packet; this test exists to maintain code coverage
+  val string = hex"5D 0000 00000000 00000 00000 0000 00 00 00 00000000"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case DeployObjectMessage(guid, unk1, pos, unk2, unk3, unk4, unk5) =>
+        guid mustEqual PlanetSideGUID(0)
+        unk1 mustEqual 0L
+        pos.x mustEqual 0f
+        pos.y mustEqual 0f
+        pos.z mustEqual 0f
+        unk2 mustEqual 0
+        unk3 mustEqual 0
+        unk4 mustEqual 0
+        unk5 mustEqual 0L
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = DeployObjectMessage(PlanetSideGUID(0), 0L, Vector3(0f, 0f, 0f), 0, 0, 0, 0L)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
This packet submission exists only for the sake of completion.
We did not capture it from Gemini Live.