### PR TITLE
Packet: TriggerEnvironmentalDamageMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -456,7 +456,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x71 => noDecoder(PlatoonEvent)
     case 0x72 => game.FriendsRequest.decode
     case 0x73 => game.FriendsResponse.decode
-    case 0x74 => noDecoder(TriggerEnvironmentalDamageMessage)
+    case 0x74 => game.TriggerEnvironmentalDamageMessage.decode
     case 0x75 => game.TrainingZoneMessage.decode
     case 0x76 => noDecoder(DeployableObjectsInfoMessage)
     case 0x77 => noDecoder(SquadState)

--- a/common/src/main/scala/net/psforever/packet/game/TriggerEnvironmentalDamageMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TriggerEnvironmentalDamageMessage.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Dispatched by the server to render a "damage cloud" around a target.<br>
+  * <br>
+  * Exploration:<br>
+  * This is not common but it happened while on Gemini Live.
+  * Why does it happen?
+  * @param unk1 na;
+  *             usually 2;
+  *             when 2, will generate a short dust cloud around the `target_guid`;
+  *             if a player, will cause the "damage grunt animation" to occur, whether or not there is a dust cloud
+  * @param target_guid the target around which to generate the temporary damage effect
+  * @param unk2 na;
+  *             usually 5L
+  */
+final case class TriggerEnvironmentalDamageMessage(unk1 : Int,
+                                                   target_guid : PlanetSideGUID,
+                                                   unk2 : Long)
+  extends PlanetSideGamePacket {
+  type Packet = TriggerEnvironmentalDamageMessage
+  def opcode = GamePacketOpcode.TriggerEnvironmentalDamageMessage
+  def encode = TriggerEnvironmentalDamageMessage.encode(this)
+}
+
+object TriggerEnvironmentalDamageMessage extends Marshallable[TriggerEnvironmentalDamageMessage] {
+  implicit val codec : Codec[TriggerEnvironmentalDamageMessage] = (
+    ("unk1" | uint2L) ::
+      ("target_guid" | PlanetSideGUID.codec) ::
+      ("unk2" | uint32L)
+    ).as[TriggerEnvironmentalDamageMessage]
+}

--- a/common/src/test/scala/game/TriggerEnvironmentalDamageMessageTest.scala
+++ b/common/src/test/scala/game/TriggerEnvironmentalDamageMessageTest.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class TriggerEnvironmentalDamageMessageTest extends Specification {
+  val string = hex"74 a7c44140000000"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case TriggerEnvironmentalDamageMessage(unk1, guid, unk2) =>
+        unk1 mustEqual 2
+        guid mustEqual PlanetSideGUID(4511)
+        unk2 mustEqual 5L
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = TriggerEnvironmentalDamageMessage(2, PlanetSideGUID(4511), 5L)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
It's like punching a sand bag.

I can't think of a situation when this packet would be used, performing the minor visual effect that it currently does.