### PR TITLE
Packet: TargetingInfoMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -414,7 +414,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x4f => game.LashMessage.decode
 
     // OPCODES 0x50-5f
-    case 0x50 => noDecoder(TargetingInfoMessage)
+    case 0x50 => game.TargetingInfoMessage.decode
     case 0x51 => noDecoder(TriggerEffectMessage)
     case 0x52 => game.WeaponDryFireMessage.decode
     case 0x53 => noDecoder(DroppodLaunchRequestMessage)

--- a/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
@@ -35,10 +35,10 @@ object TargetInfo {
     */
   private def rangedFloat(n : Int) : Float = {
     (
-      (if(n < 0) {
+      (if(n <= 0) {
         0
       }
-      else if(n > 255) {
+      else if(n >= 255) {
         255
       }
       else {
@@ -58,6 +58,17 @@ object TargetInfo {
     val unk1_2 : Float = rangedFloat(unk1)
     val unk2_2 : Float = rangedFloat(unk2)
     TargetInfo(target_guid, unk1_2, unk2_2)
+  }
+
+  /**
+    * Overloaded constructor that takes `Integer` values rather than `Float` values and assumes the second `Integer` is zero.
+    * @param target_guid the target
+    * @param unk na
+    * @return a `TargetInfo` object
+    */
+  def apply(target_guid : PlanetSideGUID, unk : Int) : TargetInfo = {
+    val unk1_2 : Float = rangedFloat(unk)
+    TargetInfo(target_guid, unk1_2, 0)
   }
 }
 

--- a/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+import shapeless.{::, HNil}
+
+/**
+  * na
+  * @param target_guid the target
+  * @param unk1 na
+  * @param unk2 na
+  */
+final case class TargetInfo(target_guid : PlanetSideGUID,
+                            unk1 : Float,
+                            unk2 : Float = 0f)
+
+/**
+  * na
+  * @param target_list a list of targets
+  */
+final case class TargetingInfoMessage(target_list : List[TargetInfo])
+  extends PlanetSideGamePacket {
+  type Packet = TargetingInfoMessage
+  def opcode = GamePacketOpcode.TargetingInfoMessage
+  def encode = TargetingInfoMessage.encode(this)
+}
+
+object TargetingInfoMessage extends Marshallable[TargetingInfoMessage] {
+  private final val unit : Double = 0.0039215689 //common constant for 1/255
+
+  private val info_codec : Codec[TargetInfo] = (
+    ("target_guid" | PlanetSideGUID.codec) ::
+      ("unk1" | uint8L) ::
+      ("unk2" | uint8L)
+  ).xmap[TargetInfo] (
+    {
+      case a :: b :: c :: HNil =>
+        val bFloat : Float = (b.toDouble * unit).toFloat
+        val cFloat : Float = (c.toDouble * unit).toFloat
+        TargetInfo(a, bFloat, cFloat)
+    },
+    {
+      case TargetInfo(a, bFloat, cFloat) =>
+        val b : Int = (bFloat.toDouble * 255).toInt
+        val c : Int = (cFloat.toDouble * 255).toInt
+        a :: b :: c :: HNil
+    }
+  )
+
+  implicit val codec : Codec[TargetingInfoMessage] = ("target_list" | listOfN(uint8L, info_codec)).as[TargetingInfoMessage]
+}

--- a/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
@@ -27,8 +27,42 @@ final case class TargetingInfoMessage(target_list : List[TargetInfo])
   def encode = TargetingInfoMessage.encode(this)
 }
 
+object TargetInfo {
+  /**
+    * Transform an unsigned number between 0 and 256 into a percentage of a 255 number.
+    * @param n an unsigned `Integer` number
+    * @return a scaled `Float` number
+    */
+  private def rangedFloat(n : Int) : Float = {
+    (
+      (if(n < 0) {
+        0
+      }
+      else if(n > 255) {
+        255
+      }
+      else {
+        n
+      }).toDouble * TargetingInfoMessage.unit
+    ).toFloat
+  }
+
+  /**
+    * Overloaded constructor that takes `Integer` values rather than `Float` values.
+    * @param target_guid the target
+    * @param unk1 na
+    * @param unk2 na
+    * @return a `TargetInfo` object
+    */
+  def apply(target_guid : PlanetSideGUID, unk1 : Int, unk2 : Int) : TargetInfo = {
+    val unk1_2 : Float = rangedFloat(unk1)
+    val unk2_2 : Float = rangedFloat(unk2)
+    TargetInfo(target_guid, unk1_2, unk2_2)
+  }
+}
+
 object TargetingInfoMessage extends Marshallable[TargetingInfoMessage] {
-  private final val unit : Double = 0.0039215689 //common constant for 1/255
+  final val unit : Double = 0.0039215689 //common constant for 1/255
 
   private val info_codec : Codec[TargetInfo] = (
     ("target_guid" | PlanetSideGUID.codec) ::

--- a/common/src/test/scala/game/TargetingInfoMessageTest.scala
+++ b/common/src/test/scala/game/TargetingInfoMessageTest.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class TargetingInfoMessageTest extends Specification {
+  val string = hex"50 05 3D10C200 570EFF3C 2406EC00 2B068C00 2A069400"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case TargetingInfoMessage(target_list) =>
+        target_list.size mustEqual 5
+        //0
+        target_list.head.target_guid mustEqual PlanetSideGUID(4157)
+        target_list.head.unk1 mustEqual 0.7607844f
+        target_list.head.unk2 mustEqual 0f
+        //1
+        target_list(1).target_guid mustEqual PlanetSideGUID(3671)
+        target_list(1).unk1 mustEqual 1.0000001f
+        target_list(1).unk2 mustEqual 0.23529413f
+        //2
+        target_list(2).target_guid mustEqual PlanetSideGUID(1572)
+        target_list(2).unk1 mustEqual 0.92549026f
+        target_list(2).unk2 mustEqual 0f
+        //3
+        target_list(3).target_guid mustEqual PlanetSideGUID(1579)
+        target_list(3).unk1 mustEqual 0.54901963f
+        target_list(3).unk2 mustEqual 0f
+        //4
+        target_list(4).target_guid mustEqual PlanetSideGUID(1578)
+        target_list(4).unk1 mustEqual 0.5803922f
+        target_list(4).unk2 mustEqual 0f
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = TargetingInfoMessage(
+      TargetInfo(PlanetSideGUID(4157), 0.7607844f) ::
+        TargetInfo(PlanetSideGUID(3671), 1.0000001f, 0.23529413f) ::
+        TargetInfo(PlanetSideGUID(1572), 0.92549026f) ::
+        TargetInfo(PlanetSideGUID(1579), 0.54901963f) ::
+        TargetInfo(PlanetSideGUID(1578), 0.5803922f) ::
+        Nil
+    )
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}

--- a/common/src/test/scala/game/TargetingInfoMessageTest.scala
+++ b/common/src/test/scala/game/TargetingInfoMessageTest.scala
@@ -15,24 +15,24 @@ class TargetingInfoMessageTest extends Specification {
         target_list.size mustEqual 5
         //0
         target_list.head.target_guid mustEqual PlanetSideGUID(4157)
-        target_list.head.unk1 mustEqual 0.7607844f
-        target_list.head.unk2 mustEqual 0f
+        target_list.head.health mustEqual 0.7607844f
+        target_list.head.armor mustEqual 0f
         //1
         target_list(1).target_guid mustEqual PlanetSideGUID(3671)
-        target_list(1).unk1 mustEqual 1.0000001f
-        target_list(1).unk2 mustEqual 0.23529413f
+        target_list(1).health mustEqual 1.0000001f
+        target_list(1).armor mustEqual 0.23529413f
         //2
         target_list(2).target_guid mustEqual PlanetSideGUID(1572)
-        target_list(2).unk1 mustEqual 0.92549026f
-        target_list(2).unk2 mustEqual 0f
+        target_list(2).health mustEqual 0.92549026f
+        target_list(2).armor mustEqual 0f
         //3
         target_list(3).target_guid mustEqual PlanetSideGUID(1579)
-        target_list(3).unk1 mustEqual 0.54901963f
-        target_list(3).unk2 mustEqual 0f
+        target_list(3).health mustEqual 0.54901963f
+        target_list(3).armor mustEqual 0f
         //4
         target_list(4).target_guid mustEqual PlanetSideGUID(1578)
-        target_list(4).unk1 mustEqual 0.5803922f
-        target_list(4).unk2 mustEqual 0f
+        target_list(4).health mustEqual 0.5803922f
+        target_list(4).armor mustEqual 0f
       case _ =>
         ko
     }


### PR DESCRIPTION
Crams numbers down the target's throat.

This packet can be used to update `0x17` object health and armor/shielding values that are normally valued between 0 and 255, or a scaled 0f to 1f value.