### PR TITLE
Add interactive console support for server admins and devs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,11 @@ lazy val root = (project in file(".")).
 
 lazy val pslogin = (project in file("pslogin")).
   settings(commonSettings: _*).
+  settings(libraryDependencies ++= Seq(
+      "org.jline" % "jline-terminal" % "3.2.0",
+      "org.jline" % "jline-reader" % "3.2.0"
+    )
+  ).
   settings(
     name := "pslogin"
   ).

--- a/pslogin/src/main/scala/PsConsole.scala
+++ b/pslogin/src/main/scala/PsConsole.scala
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 PSForever
+import org.jline.reader._;
+import org.jline.terminal._;
+import akka.actor.ActorSystem;
+
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.filter.ThresholdFilter;
+import ch.qos.logback.core.ConsoleAppender;
+
+class PsConsole(system : ActorSystem) {
+  val terminal = TerminalBuilder.terminal()
+  val reader = LineReaderBuilder.builder().
+    terminal(terminal).
+    build()
+
+  // TODO: customize based on current context
+  def getPrompt : String = {
+    return "psf> "
+  }
+
+  def processCommand(sz : String) : Boolean = {
+    if(sz == "")
+      return false
+
+    println("Cmd " + sz)
+
+    val argv = sz.split(" ")
+
+    val cmd = argv{0}
+    val argc = argv.length - 1
+
+    cmd match {
+      case "exit" | "quit" | "shutdown" =>
+        return true
+      case "log" =>
+        import collection.JavaConverters._;
+
+        if(argc != 1)
+          return false
+
+        // Hacks to affect console logging only
+        val root : Logger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+        val stdoutAppender = root.getAppender("STDOUT").asInstanceOf[ConsoleAppender[ILoggingEvent]]
+        val filters = stdoutAppender.getCopyOfAttachedFiltersList
+
+        filters.asScala.find(_.isInstanceOf[ThresholdFilter]).foreach(m => m.asInstanceOf[ThresholdFilter].setLevel(argv{1}))
+        return false
+      case _ =>
+        return false
+    }
+  }
+
+  def process : Unit = {
+    var exit = false
+
+    while(!exit) {
+      try {
+        val line = reader.readLine(getPrompt)
+        exit = processCommand(line)
+      } catch {
+        case e : UserInterruptException =>
+        case e : EndOfFileException =>
+      }
+    }
+
+    close
+    system.terminate()
+  }
+
+  def close : Unit = {
+    terminal.close
+  }
+}

--- a/pslogin/src/main/scala/PsConsole.scala
+++ b/pslogin/src/main/scala/PsConsole.scala
@@ -25,8 +25,6 @@ class PsConsole(system : ActorSystem) {
     if(sz == "")
       return false
 
-    println("Cmd " + sz)
-
     val argv = sz.split(" ")
 
     val cmd = argv{0}
@@ -35,6 +33,41 @@ class PsConsole(system : ActorSystem) {
     cmd match {
       case "exit" | "quit" | "shutdown" =>
         return true
+      case "session" =>
+        if(argc < 1)
+          return false
+
+          val login = system.actorSelection("akka://PsLogin/user/login-udp-endpoint/login-session-router")
+          val world = system.actorSelection("akka://PsLogin/user/world-udp-endpoint/world-session-router")
+
+        argv{1} match {
+          case "list" =>
+            login ! ListSessions()
+            world ! ListSessions()
+          case "drop-login" =>
+            if(argc < 2)
+              return false
+
+            try {
+              login ! DropSession(argv{2}.toLong, "Dropped from console")
+            } catch {
+              case e: NumberFormatException =>
+                println("Invalid session id")
+            }
+          case "drop-world" =>
+            if(argc < 2)
+              return false
+
+            try {
+              world ! DropSession(argv{2}.toLong, "Dropped from console")
+            } catch {
+              case e: NumberFormatException =>
+                println("Invalid session id")
+            }
+          case _ =>
+        }
+
+        return false
       case "log" =>
         import collection.JavaConverters._;
 

--- a/pslogin/src/main/scala/PsLogin.scala
+++ b/pslogin/src/main/scala/PsLogin.scala
@@ -215,6 +215,10 @@ object PsLogin {
     this.args = args
     run()
 
+    // Boot up the console on the main thread
+    val psConsole = new PsConsole(system)
+    psConsole.process
+
     // Wait forever until the actor system shuts down
     Await.result(system.whenTerminated, Duration.Inf)
   }

--- a/pslogin/src/main/scala/Session.scala
+++ b/pslogin/src/main/scala/Session.scala
@@ -86,6 +86,10 @@ class Session(val sessionId : Long,
     bytesSent + bytesReceived
   }
 
+  def getTotalPackets = {
+    outboundPackets + inboundPackets
+  }
+
   def timeSinceLastInboundEvent = {
     (System.nanoTime() - lastInboundEvent)/1000000
   }
@@ -96,6 +100,6 @@ class Session(val sessionId : Long,
 
 
   override def toString : String = {
-    s"Session($sessionId, $getTotalBytes)"
+    s"Session($sessionId - $sessionCreatedTime) - Bytes[TOTAL $getTotalBytes, IN $bytesReceived OUT $bytesSent] Packets[TOTAL $getTotalPackets, IN $inboundPackets, OUT $outboundPackets]"
   }
 }

--- a/pslogin/src/main/scala/SessionRouter.scala
+++ b/pslogin/src/main/scala/SessionRouter.scala
@@ -19,6 +19,7 @@ final case class RawPacket(data : ByteVector) extends SessionRouterAPI
 final case class ResponsePacket(data : ByteVector) extends SessionRouterAPI
 final case class DropSession(id : Long, reason : String) extends SessionRouterAPI
 final case class SessionReaper() extends SessionRouterAPI
+final case class ListSessions() extends SessionRouterAPI
 
 case class SessionPipeline(nameTemplate : String, props : Props)
 
@@ -124,6 +125,10 @@ class SessionRouter(role : String, pipeline : List[SessionPipeline]) extends Act
         } else if(session.timeSinceLastOutboundEvent > 4000) {
           removeSessionById(id, "session timed out (outbound)", graceful = true) // tell client to STFU
         }
+      }
+    case ListSessions() =>
+      sessionById.foreach { case (id, session) =>
+        log.info(session.toString)
       }
     case Terminated(actor) =>
       val terminatedSession = sessionByActor.get(actor)


### PR DESCRIPTION
This is a prototype for console support for administrating the server.
It's an early version and serves as a proof of concept. Many things are missing such as:

* An easy way of adding commands hierarchcally (abuse scala syntax maybe, pickup python argparse)
* Usage statements for commands
* Error handling for more advanced commands
* The logging from the console will overwrite the readline call. I have a fix for this, but I need to hook in the logback ConsoleAppender
* We need a standard way of communicating with actors in order to avoid hardcoding actor paths
* We need a well-defined way of defining an interface individual service APIs (e.g. SessionRouterAPI)
* Thoughts should be made about how we could make these APIs scale to another interface such as REST+JSON (would be better than doing database SELECTS or writing out to a file)

Some available commands:
```
quit, exit, shutdown - stops the server
session list - shows all world and login sessions
session drop-world <id> - drops world session by id
session drop-login <id> - drops login session by id
```

Still this a good first attempt!