### PR TITLE
Packet: DeployRequestMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -407,7 +407,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x48 => game.TimeOfDayMessage.decode
     case 0x49 => noDecoder(UnknownMessage73)
     case 0x4a => noDecoder(SpawnRequestMessage)
-    case 0x4b => noDecoder(DeployRequestMessage)
+    case 0x4b => game.DeployRequestMessage.decode
     case 0x4c => noDecoder(UnknownMessage76)
     case 0x4d => game.RepairMessage.decode
     case 0x4e => noDecoder(ServerVehicleOverrideMsg)

--- a/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
@@ -6,8 +6,31 @@ import net.psforever.types.Vector3
 import scodec.Codec
 import scodec.codecs._
 
-final case class DeployRequestMessage(guid1 : PlanetSideGUID,
-                                      guid2 : PlanetSideGUID,
+/**
+  * Dispatched by the client when the player attempts to deploy a vehicle.
+  * Dispatched by the server to cause a specific vehicle to be deployed.<br>
+  * <br>
+  * "Deployment" usually isn't enough by itself.
+  * It only changes the physical configuration of the vehicle.
+  * (It's an animation request/trigger?)
+  * Anything that can be "deployed" does so for a very specific reason, to perform a complex function.
+  * These functions are not immediately available.
+  * Attributes must be set properly for the transition between behaviors to occur properly.
+  * In addition, the recently-deployed vehicles will hang in a state of limbo if not configured properly.
+  * It will not even dispatch an un-deploy request upon command in this state.
+  * <br>
+  * This packet has nothing to do with ACE deployables.
+  * @param player_guid the player requesting the deployment
+  * @param vehicle_guid the vehicle to be deployed
+  * @param unk1 na;
+  *             usually 2
+  * @param unk2 na;
+  *             usually 0
+  * @param unk3 na
+  * @param pos the position where the object will deploy itself
+  */
+final case class DeployRequestMessage(player_guid : PlanetSideGUID,
+                                      vehicle_guid : PlanetSideGUID,
                                       unk1 : Int,
                                       unk2 : Int,
                                       unk3 : Boolean,
@@ -20,8 +43,8 @@ final case class DeployRequestMessage(guid1 : PlanetSideGUID,
 
 object DeployRequestMessage extends Marshallable[DeployRequestMessage] {
   implicit val codec : Codec[DeployRequestMessage] = (
-    ("guid1" | PlanetSideGUID.codec) ::
-      ("guid2" | PlanetSideGUID.codec) ::
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("deploy_guid" | PlanetSideGUID.codec) ::
       ("unk1" | uint(3)) ::
       ("unk2" | uint(5)) ::
       ("unk3" | bool) ::

--- a/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.Vector3
+import scodec.Codec
+import scodec.codecs._
+
+final case class DeployRequestMessage(guid1 : PlanetSideGUID,
+                                      guid2 : PlanetSideGUID,
+                                      unk1 : Int,
+                                      unk2 : Int,
+                                      unk3 : Boolean,
+                                      pos : Vector3)
+  extends PlanetSideGamePacket {
+  type Packet = DeployRequestMessage
+  def opcode = GamePacketOpcode.DeployRequestMessage
+  def encode = DeployRequestMessage.encode(this)
+}
+
+object DeployRequestMessage extends Marshallable[DeployRequestMessage] {
+  implicit val codec : Codec[DeployRequestMessage] = (
+    ("guid1" | PlanetSideGUID.codec) ::
+      ("guid2" | PlanetSideGUID.codec) ::
+      ("unk1" | uint(3)) ::
+      ("unk2" | uint(5)) ::
+      ("unk3" | bool) ::
+      ("pos" | Vector3.codec_pos)
+    ).as[DeployRequestMessage]
+}

--- a/common/src/test/scala/game/DeployRequestMessageTest.scala
+++ b/common/src/test/scala/game/DeployRequestMessageTest.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.types.Vector3
+import scodec.bits._
+
+class DeployRequestMessageTest extends Specification {
+  val string = hex"4b 4b00 7c01 40 0cf73b52aa6a9300"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case DeployRequestMessage(player_guid, vehicle_guid, unk1, unk2, unk3, pos) =>
+        player_guid mustEqual PlanetSideGUID(75)
+        vehicle_guid mustEqual PlanetSideGUID(380)
+        unk1 mustEqual 2
+        unk2 mustEqual 0
+        unk3 mustEqual false
+        pos.x mustEqual 4060.1953f
+        pos.y mustEqual 2218.8281f
+        pos.z mustEqual 155.32812f
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = DeployRequestMessage(
+      PlanetSideGUID(75),
+      PlanetSideGUID(380),
+      2, 0, false,
+      Vector3(4060.1953f, 2218.8281f, 155.32812f)
+    )
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -190,7 +190,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               log.debug("Object: " + obj)
               // LoadMapMessage 13714 in mossy .gcap
               // XXX: hardcoded shit
-              sendResponse(PacketCoding.CreateGamePacket(0, LoadMapMessage("map10","z10",40100,25,true,3770441820L))) //VS Sanctuary
+              sendResponse(PacketCoding.CreateGamePacket(0, LoadMapMessage("map13","home3",40100,25,true,3770441820L))) //VS Sanctuary
               sendResponse(PacketCoding.CreateGamePacket(0, ZonePopulationUpdateMessage(PlanetSideGUID(13), 414, 138, 0, 138, 0, 138, 0, 138, 0)))
               sendResponse(PacketCoding.CreateGamePacket(0, objectHex))
 
@@ -402,6 +402,10 @@ class WorldSessionActor extends Actor with MDCContextAware {
     case msg @ DismountVehicleMsg(player_guid, unk1, unk2) =>
       sendResponse(PacketCoding.CreateGamePacket(0, msg)) //should be safe; replace with ObjectDetachMessage later
       log.info("DismountVehicleMsg: " + msg)
+
+    case msg @ DeployRequestMessage(player, entity, unk1, unk2, unk3, pos) =>
+      //if you try to deploy, can not undeploy
+      log.info("DeployRequest: " + msg)
 
     case msg @ AvatarGrenadeStateMessage(player_guid, state) =>
       log.info("AvatarGrenadeStateMessage: " + msg)


### PR DESCRIPTION
Planetmans, deploy and spawn in!

Tested with an ANT and with an AMS.  The ANT spread its wings to fly but forgot it was sterile.  The AMS loosened its belt and its belly hit the ground.  Changes were entirely cosmetic except for some message display changes.  Obviously, analysis involving setting the objects' attributes to get the vehicles working is required.