### PR TITLE
Locker Container

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2,7 +2,7 @@
 package net.psforever.objects
 
 import net.psforever.objects.definition._
-import net.psforever.objects.definition.converter.{CommandDetonaterConverter, REKConverter}
+import net.psforever.objects.definition.converter.{CommandDetonaterConverter, LockerContainerConverter, REKConverter}
 import net.psforever.objects.equipment.CItem.DeployedItem
 import net.psforever.objects.equipment._
 import net.psforever.objects.inventory.InventoryTile
@@ -239,6 +239,13 @@ object GlobalDefinitions {
       case _ =>
         false
     }
+  }
+
+  val
+  locker_container = new EquipmentDefinition(456) {
+    Name = "locker container"
+    Size = EquipmentSize.Inventory
+    Packet = new LockerContainerConverter()
   }
 
   val

--- a/common/src/main/scala/net/psforever/objects/LockerContainer.scala
+++ b/common/src/main/scala/net/psforever/objects/LockerContainer.scala
@@ -7,17 +7,13 @@ import net.psforever.objects.equipment.{Equipment, EquipmentSize}
 import net.psforever.objects.inventory.GridInventory
 
 class LockerContainer extends Equipment {
-  private val inventory = GridInventory() //?
+  private val inventory = GridInventory(30, 20)
 
   def Inventory : GridInventory = inventory
 
   def Fit(obj : Equipment) : Option[Int] = inventory.Fit(obj.Definition.Tile)
 
-  def Definition : EquipmentDefinition = new EquipmentDefinition(456) {
-    Name = "locker container"
-    Size = EquipmentSize.Inventory
-    Packet = new LockerContainerConverter()
-  }
+  def Definition : EquipmentDefinition = GlobalDefinitions.locker_container
 }
 
 object LockerContainer {

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -70,6 +70,7 @@ class Player(private val name : String,
   var PlanetsideAttribute : Array[Long] = Array.ofDim(120)
 
   Player.SuitSetup(this, ExoSuit)
+  fifthSlot.Equipment = new LockerContainer() //the fifth slot is the player's "locker"
 
   def Name : String = name
 
@@ -158,7 +159,9 @@ class Player(private val name : String,
       holsters(slot)
     }
     else if(slot == 5) {
-      fifthSlot
+      new OffhandEquipmentSlot(EquipmentSize.Inventory) {
+        Equipment = fifthSlot.Equipment
+      }
     }
     else if(slot == Player.FreeHandSlot) {
       freeHand

--- a/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
@@ -5,7 +5,7 @@ import net.psforever.objects.LockerContainer
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.GridInventory
 import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.packet.game.objectcreate.{DetailedAmmoBoxData, InternalSlot, InventoryData, LockerContainerData}
+import net.psforever.packet.game.objectcreate._
 
 import scala.util.{Success, Try}
 
@@ -14,8 +14,8 @@ class LockerContainerConverter extends ObjectCreateConverter[LockerContainer]() 
     Success(LockerContainerData(InventoryData(MakeInventory(obj.Inventory))))
   }
 
-  override def DetailedConstructorData(obj : LockerContainer) : Try[DetailedAmmoBoxData] = {
-    Success(DetailedAmmoBoxData(8, 1)) //same format as AmmoBox data
+  override def DetailedConstructorData(obj : LockerContainer) : Try[DetailedLockerContainerData] = {
+    Success(DetailedLockerContainerData(8))
   }
 
   /**

--- a/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
@@ -15,8 +15,12 @@ class LockerContainerConverter extends ObjectCreateConverter[LockerContainer]() 
   }
 
   override def DetailedConstructorData(obj : LockerContainer) : Try[DetailedLockerContainerData] = {
-    val contents : Option[List[InternalSlot]] = if(obj.Inventory.Size > 0) { Some(MakeInventory(obj.Inventory)) } else { None }
-    Success(DetailedLockerContainerData(8, contents))
+    if(obj.Inventory.Size > 0) {
+      Success(DetailedLockerContainerData(8, Some(InventoryData(MakeInventory(obj.Inventory)))))
+    }
+    else {
+      Success(DetailedLockerContainerData(8, None))
+    }
   }
 
   /**

--- a/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
@@ -15,7 +15,8 @@ class LockerContainerConverter extends ObjectCreateConverter[LockerContainer]() 
   }
 
   override def DetailedConstructorData(obj : LockerContainer) : Try[DetailedLockerContainerData] = {
-    Success(DetailedLockerContainerData(8))
+    val contents : Option[List[InternalSlot]] = if(obj.Inventory.Size > 0) { Some(MakeInventory(obj.Inventory)) } else { None }
+    Success(DetailedLockerContainerData(8, contents))
   }
 
   /**

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedLockerContainerData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedLockerContainerData.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game.objectcreate
+
+import net.psforever.packet.Marshallable
+import net.psforever.packet.game.PlanetSideGUID
+import scodec.codecs._
+import scodec.{Attempt, Codec, Err}
+import shapeless.{::, HNil}
+
+/**
+  * A representation of the inventory portion of `ObjectCreateDetailedMessage` packet data that contains the items in the avatar's locker space.<br>
+  * <br>
+  * Although these items are technically always loaded and registered with globally unique identifiers for the current zone,
+  * the actual container for them, in grid format, can only be accessed by interacting with locker objects in the game world.
+  * Items are generally added and removed in the same way as with any other opened inventory.
+  * Unlike other inventories, however, locker space is personal to an avatar and can not be accessed by other players.
+  * @param unk na
+  * @param contents the items in the inventory
+  */
+final case class DetailedLockerContainerData(unk : Int,
+                                             contents : Option[List[InternalSlot]]
+                                            ) extends ConstructorData {
+  override def bitsize : Long = {
+    val base : Long = 40L
+    var invSize : Long = 0L //length of all items in inventory
+    if(contents.isDefined) {
+      invSize = InventoryData.BaseSize
+      for(item <- contents.get) {
+        invSize += item.bitsize
+      }
+    }
+    base + invSize
+  }
+}
+
+object DetailedLockerContainerData extends Marshallable[DetailedLockerContainerData] {
+  /**
+    * Overloaded constructor for creating `DetailedLockerContainerData` without a list of contents.
+    * @param unk na
+    * @return a `DetailedLockerContainerData` object
+    */
+  def apply(unk : Int) : DetailedLockerContainerData =
+    new DetailedLockerContainerData(unk, None)
+
+  /**
+    * Overloaded constructor for creating `DetailedLockerContainerData` containing known items.
+    * @param unk na
+    * @param contents the items in the inventory
+    * @return a `DetailedLockerContainerData` object
+    */
+  def apply(unk : Int, contents : List[InternalSlot]) : DetailedLockerContainerData =
+    new DetailedLockerContainerData(unk, Some(contents))
+
+  /**
+    * Overloaded constructor for creating `DetailedLockerContainerData` while masking use of `InternalSlot`.
+    * @param cls the code for the type of object being constructed
+    * @param guid the GUID this object will be assigned
+    * @param parentSlot a parent-defined slot identifier that explains where the child is to be attached to the parent
+    * @param locker the `DetailedLockerContainerData`
+    * @return an `InternalSlot` object that encapsulates `DetailedLockerContainerData`
+    */
+  def apply(cls : Int, guid : PlanetSideGUID, parentSlot : Int, locker : DetailedLockerContainerData) : InternalSlot =
+    new InternalSlot(cls, guid, parentSlot, locker)
+
+  implicit val codec : Codec[DetailedLockerContainerData] = (
+    uint4L ::
+      ("unk" | uint4L) :: // 8 - common - 4 - safe, 2 - stream misalignment, 1 - safe, 0 - common
+      uint(15) ::
+      uint16L :: //always 1
+      optional(bool, InventoryData.codec_detailed)
+    ).exmap[DetailedLockerContainerData] (
+    {
+      case 0xC :: unk :: 0 :: 1 :: None :: HNil =>
+        Attempt.successful(DetailedLockerContainerData(unk, None))
+
+      case 0xC :: unk :: 0 :: 1 :: Some(InventoryData(list)) :: HNil =>
+        Attempt.successful(DetailedLockerContainerData(unk, Some(list)))
+      case _ =>
+        Attempt.failure(Err(s"invalid locker container data format"))
+    },
+    {
+      case DetailedLockerContainerData(unk, None) =>
+        Attempt.successful(0xC :: unk :: 0 :: 1 :: None :: HNil)
+
+      case DetailedLockerContainerData(unk, Some(list)) =>
+        Attempt.successful(0xC :: unk :: 0 :: 1 :: Some(InventoryData(list)) :: HNil)
+    }
+  )
+}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/InventoryData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/InventoryData.scala
@@ -23,7 +23,7 @@ import shapeless.{::, HNil}
   */
 final case class InventoryData(contents : List[InventoryItem] = List.empty) extends StreamBitSize {
   override def bitsize : Long = {
-    val base : Long = 10L //8u + 1u + 1u
+    val base : Long = InventoryData.BaseSize
     var invSize : Long = 0L //length of all items in inventory
     for(item <- contents) {
       invSize += item.bitsize
@@ -33,6 +33,8 @@ final case class InventoryData(contents : List[InventoryItem] = List.empty) exte
 }
 
 object InventoryData {
+  final val BaseSize : Long = 10L //8u + 1u + 1u
+
   /**
     * The primary `Codec` that parses the common format for an inventory `List`.
     * @param itemCodec a `Codec` that describes each of the contents of the list

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/LockerContainerData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/LockerContainerData.scala
@@ -10,7 +10,7 @@ import shapeless.{::, HNil}
   * A representation for a game object that can contain items.<br>
   * <br>
   * For whatever reason, these "lockers" are typically placed at the origin coordinates.
-  * @param inventory the items inside his locker
+  * @param inventory the items inside this locker
   */
 final case class LockerContainerData(inventory : InventoryData) extends ConstructorData {
   override def bitsize : Long =  105L + inventory.bitsize //81u + 2u + 21u + 1u

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
@@ -638,7 +638,7 @@ object ObjectClass {
       case ObjectClass.boomer_trigger => ConstructorData.genericCodec(DetailedBoomerTriggerData.codec, "boomer trigger")
       //other
       case ObjectClass.avatar => ConstructorData.genericCodec(DetailedCharacterData.codec, "avatar")
-      case ObjectClass.locker_container => ConstructorData.genericCodec(DetailedAmmoBoxData.codec, "locker container")
+      case ObjectClass.locker_container => ConstructorData.genericCodec(DetailedLockerContainerData.codec, "locker container")
 
       //failure case
       case _ => defaultFailureCodec(objClass)

--- a/common/src/test/scala/game/ObjectCreateDetailedMessageTest.scala
+++ b/common/src/test/scala/game/ObjectCreateDetailedMessageTest.scala
@@ -261,7 +261,7 @@ class ObjectCreateDetailedMessageTest extends Specification {
         inventory(3).guid mustEqual PlanetSideGUID(82)
         inventory(3).parentSlot mustEqual 5
         inventory(3).obj.isInstanceOf[DetailedLockerContainerData] mustEqual true
-        inventory(3).obj.asInstanceOf[DetailedLockerContainerData].contents.isDefined mustEqual false
+        inventory(3).obj.asInstanceOf[DetailedLockerContainerData].inventory.isDefined mustEqual false
         //4
         inventory(4).objectClass mustEqual ObjectClass.bullet_9mm
         inventory(4).guid mustEqual PlanetSideGUID(83)

--- a/common/src/test/scala/game/ObjectCreateDetailedMessageTest.scala
+++ b/common/src/test/scala/game/ObjectCreateDetailedMessageTest.scala
@@ -260,7 +260,8 @@ class ObjectCreateDetailedMessageTest extends Specification {
         inventory(3).objectClass mustEqual ObjectClass.locker_container
         inventory(3).guid mustEqual PlanetSideGUID(82)
         inventory(3).parentSlot mustEqual 5
-        inventory(3).obj.asInstanceOf[DetailedAmmoBoxData].magazine mustEqual 1
+        inventory(3).obj.isInstanceOf[DetailedLockerContainerData] mustEqual true
+        inventory(3).obj.asInstanceOf[DetailedLockerContainerData].contents.isDefined mustEqual false
         //4
         inventory(4).objectClass mustEqual ObjectClass.bullet_9mm
         inventory(4).guid mustEqual PlanetSideGUID(83)
@@ -342,7 +343,7 @@ class ObjectCreateDetailedMessageTest extends Specification {
         Nil
     )(2)
     val msg = ObjectCreateDetailedMessage(ObjectClass.punisher, PlanetSideGUID(1703), ObjectCreateMessageParent(PlanetSideGUID(75), 2), obj)
-    var pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string_punisher
   }
@@ -394,7 +395,7 @@ class ObjectCreateDetailedMessageTest extends Specification {
     val inv = InventoryItemData(ObjectClass.beamer, PlanetSideGUID(76), 0, DetailedWeaponData(4, 8, ObjectClass.energy_cell, PlanetSideGUID(77), 0, DetailedAmmoBoxData(8, 16))) ::
       InventoryItemData(ObjectClass.suppressor, PlanetSideGUID(78), 2, DetailedWeaponData(4, 8, ObjectClass.bullet_9mm, PlanetSideGUID(79), 0, DetailedAmmoBoxData(8, 25))) ::
       InventoryItemData(ObjectClass.forceblade, PlanetSideGUID(80), 4, DetailedWeaponData(4, 8, ObjectClass.melee_ammo, PlanetSideGUID(81), 0, DetailedAmmoBoxData(8, 1))) ::
-      InventoryItemData(ObjectClass.locker_container, PlanetSideGUID(82), 5, DetailedAmmoBoxData(8, 1)) ::
+      InventoryItemData(ObjectClass.locker_container, PlanetSideGUID(82), 5, DetailedLockerContainerData(8)) ::
       InventoryItemData(ObjectClass.bullet_9mm, PlanetSideGUID(83), 6, DetailedAmmoBoxData(8, 50)) ::
       InventoryItemData(ObjectClass.bullet_9mm, PlanetSideGUID(84), 9, DetailedAmmoBoxData(8, 50)) ::
       InventoryItemData(ObjectClass.bullet_9mm, PlanetSideGUID(85), 12, DetailedAmmoBoxData(8, 50)) ::

--- a/common/src/test/scala/objects/ConverterTest.scala
+++ b/common/src/test/scala/objects/ConverterTest.scala
@@ -162,6 +162,24 @@ class ConverterTest extends Specification {
     }
   }
 
+  "LockerContainer" should {
+    "convert to packet" in {
+      val obj = LockerContainer()
+      obj.Definition.Packet.DetailedConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual DetailedLockerContainerData(8)
+        case _ =>
+          ko
+      }
+      obj.Definition.Packet.ConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual LockerContainerData(InventoryData(List.empty))
+        case _ =>
+          ko
+      }
+    }
+  }
+
   "Vehicle" should {
     "convert to packet" in {
       val hellfire_ammo = AmmoBoxDefinition(Ammo.hellfire_ammo.id)

--- a/common/src/test/scala/objects/ConverterTest.scala
+++ b/common/src/test/scala/objects/ConverterTest.scala
@@ -155,6 +155,7 @@ class ConverterTest extends Specification {
       tool.AmmoSlots.head.Box = box1
       val obj = Player(PlanetSideGUID(93), "Chord", PlanetSideEmpire.TR, CharacterGender.Male, 0, 5)
       obj.Slot(2).Equipment = tool
+      obj.Slot(5).Equipment.get.GUID = PlanetSideGUID(94)
       obj.Inventory += 8 -> box2
 
       obj.Definition.Packet.DetailedConstructorData(obj).isSuccess mustEqual true
@@ -163,17 +164,38 @@ class ConverterTest extends Specification {
   }
 
   "LockerContainer" should {
-    "convert to packet" in {
+    "convert to packet (empty)" in {
       val obj = LockerContainer()
       obj.Definition.Packet.DetailedConstructorData(obj) match {
         case Success(pkt) =>
-          pkt mustEqual DetailedLockerContainerData(8)
+          pkt mustEqual DetailedLockerContainerData(8, None)
         case _ =>
           ko
       }
       obj.Definition.Packet.ConstructorData(obj) match {
         case Success(pkt) =>
           pkt mustEqual LockerContainerData(InventoryData(List.empty))
+        case _ =>
+          ko
+      }
+    }
+
+    "convert to packet (occupied)" in {
+      import GlobalDefinitions._
+      val obj = LockerContainer()
+      val rek = SimpleItem(remote_electronics_kit)
+      rek.GUID = PlanetSideGUID(1)
+      obj.Inventory += 0 -> rek
+
+      obj.Definition.Packet.DetailedConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual DetailedLockerContainerData(8, InternalSlot(remote_electronics_kit.ObjectId, PlanetSideGUID(1), 0, DetailedREKData(8)) :: Nil)
+        case _ =>
+          ko
+      }
+      obj.Definition.Packet.ConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual LockerContainerData(InventoryData(InternalSlot(remote_electronics_kit.ObjectId, PlanetSideGUID(1), 0, REKData(8,0)) :: Nil))
         case _ =>
           ko
       }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1417,17 +1417,17 @@ class WorldSessionActor extends Actor with MDCContextAware {
     tplayer.Holsters().foreach(holster => {
       SetCharacterSelectScreenGUID_SelectEquipment(holster.Equipment, gen)
     })
-    tplayer.Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
-      SetCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj), gen)
-    })
-    tplayer.Slot(5).Equipment match {
-      case Some(locker) =>
-        locker.GUID = PlanetSideGUID(gen.getAndIncrement)
-        locker.asInstanceOf[LockerContainer].Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
-          SetCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj), gen)
-        })
-      case None => ;
-    }
+//    tplayer.Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
+//      SetCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj), gen)
+//    })
+//    tplayer.Slot(5).Equipment match {
+//      case Some(locker) =>
+//        locker.GUID = PlanetSideGUID(gen.getAndIncrement)
+//        locker.asInstanceOf[LockerContainer].Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
+//          SetCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj), gen)
+//        })
+//      case None => ;
+//    }
     tplayer.GUID = PlanetSideGUID(gen.getAndIncrement)
   }
 
@@ -1459,17 +1459,17 @@ class WorldSessionActor extends Actor with MDCContextAware {
     tplayer.Holsters().foreach(holster => {
       RemoveCharacterSelectScreenGUID_SelectEquipment(holster.Equipment)
     })
-    tplayer.Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
-      RemoveCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj))
-    })
-    tplayer.Slot(5).Equipment match {
-      case Some(locker) =>
-        locker.Invalidate()
-        locker.asInstanceOf[LockerContainer].Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
-          RemoveCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj))
-        })
-      case None => ;
-    }
+//    tplayer.Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
+//      RemoveCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj))
+//    })
+//    tplayer.Slot(5).Equipment match {
+//      case Some(locker) =>
+//        locker.Invalidate()
+//        locker.asInstanceOf[LockerContainer].Inventory.Items.foreach({ case((_, entry : InventoryItem)) =>
+//          RemoveCharacterSelectScreenGUID_SelectEquipment(Some(entry.obj))
+//        })
+//      case None => ;
+//    }
     tplayer.Invalidate()
   }
 


### PR DESCRIPTION
I've found Link's tunic.  We can stuff items into it.

Apparently, that `locker_container` thing that has been occupying mystery inventory slot 5 actually __is__ the player's locker contents.  I was originally hoping it was merely a buffer between the holsters and the formal grid inventory space or that it was a relic of an older method of inventory management that was never cleaned fully up by the developers.  Nope.  Wherever you are in the game, your whole locker was expected to be fully loaded in the background at all times.  That's--terribly inconvenient.  It shares the same encoding as one of the ammo box `Codec`s so I had originally pegged it as one of those; but, to properly parse the contents of this locker, I now have to properly expand a proper `Codec` for it.

This is NOT normal locker functionality.  I still need to do work for that.  This is just to read packet data correctly.

No special tests for the `locker_container` itself.  It already does that elsewhere in the existing test files and is, moreover, just the standardized `InventoryData` `Codec` tagged on after a copy of the `DetailedAmmoBoxData` `Codec`.  I have, however, given the test character a REK in their locker space just to prove that it can be assigned a GUID and encodes and decodes properly.  All converters and iterators have been updated properly.  `OCDM` avatars only, as the `OCM` avatars don't have to worry about something that can't be seen on their person, and the functional `OCM` `locker_container` appears to serve some other purpose ...