### PR TITLE
Packet: DamageWithPositionMessage

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -515,7 +515,7 @@ object GamePacketOpcode extends Enumeration {
     case 0xa3 => noDecoder(UplinkResponse)
     case 0xa4 => game.WarpgateRequest.decode
     case 0xa5 => noDecoder(WarpgateResponse)
-    case 0xa6 => noDecoder(DamageWithPositionMessage)
+    case 0xa6 => game.DamageWithPositionMessage.decode
     case 0xa7 => game.GenericActionMessage.decode
     // 0xa8
     case 0xa8 => game.ContinentalLockUpdateMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/DamageWithPositionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DamageWithPositionMessage.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.Vector3
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Dispatched by the server to indicate a source of damage affecting the player.
+  * Unlike `HitHint` the damage source is defined by an actual coordinate location rather than a physical target.<br>
+  * <br>
+  * The player will be shown a fading, outwards drifting, red tick mark.
+  * The location will indicate a general direction towards the source.
+  * If the option `Game/Show Damage Flash` is set, the player's screen will flash red briefly when a mark is displayed.
+  * @param unk the intensity of the damage tick marks
+  * @param pos the position
+  * @see `HitHint`
+  */
+final case class DamageWithPositionMessage(unk : Int,
+                                           pos : Vector3)
+  extends PlanetSideGamePacket {
+  type Packet = DamageWithPositionMessage
+  def opcode = GamePacketOpcode.DamageWithPositionMessage
+  def encode = DamageWithPositionMessage.encode(this)
+}
+
+object DamageWithPositionMessage extends Marshallable[DamageWithPositionMessage] {
+  implicit val codec : Codec[DamageWithPositionMessage] = (
+    ("unk" | uint8L) ::
+      ("pos" | Vector3.codec_pos)
+  ).as[DamageWithPositionMessage]
+}

--- a/common/src/test/scala/game/DamageWithPositionMessageTest.scala
+++ b/common/src/test/scala/game/DamageWithPositionMessageTest.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import net.psforever.types.{MeritCommendation, Vector3}
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class DamageWithPositionMessageTest extends Specification {
+  val string = hex"A6 11 6C2D7 65535 CA16"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case DamageWithPositionMessage(unk, pos) =>
+        unk mustEqual 17
+        pos.x mustEqual 3674.8438f
+        pos.y mustEqual 2726.789f
+        pos.z mustEqual 91.15625f
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = DamageWithPositionMessage(17, Vector3(3674.8438f, 2726.789f, 91.15625f))
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
Exactly the same purpose as `HitHint` but applied when the damage source is a location and not a GUID-registered target.  Quick packet work.