### PR TITLE
Add HackMessage skeleton

### DIFF
--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -418,7 +418,7 @@ object GamePacketOpcode extends Enumeration {
     case 0x51 => game.TriggerEffectMessage.decode
     case 0x52 => game.WeaponDryFireMessage.decode
     case 0x53 => noDecoder(DroppodLaunchRequestMessage)
-    case 0x54 => noDecoder(HackMessage)
+    case 0x54 => game.HackMessage.decode
     case 0x55 => noDecoder(DroppodLaunchResponseMessage)
     case 0x56 => noDecoder(GenericObjectActionMessage)
     case 0x57 => game.AvatarVehicleTimerMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+ *
+ * @param unk1 na
+ * @param unk2 na
+ * @param unk3 na
+ * @param unk4 na
+ * @param unk5 na
+ * @param unk6 na
+ * @param unk7 na
+ */
+final case class HackMessage(unk1 : Int,
+                             unk2 : Int,
+                             unk3 : Int,
+                             unk4 : Int,
+                             unk5 : Long,
+                             unk6 : Int,
+                             unk7 : Long)
+  extends PlanetSideGamePacket {
+  type Packet = HackMessage
+  def opcode = GamePacketOpcode.HackMessage
+  def encode = HackMessage.encode(this)
+}
+
+object HackMessage extends Marshallable[HackMessage] {
+  implicit val codec : Codec[HackMessage] = (
+      ("unk1" | uint2L) ::
+        ("unk2" | uint16L) ::
+        ("unk3" | uint16L) ::
+        ("unk4" | uint8L) ::
+        ("unk5" | uint32L) ::
+        ("unk6" | uint8L) ::
+        ("unk7" | uint32L)
+    ).as[HackMessage]
+}

--- a/common/src/test/scala/game/HackMessageTest.scala
+++ b/common/src/test/scala/game/HackMessageTest.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import scodec.bits._
+
+class HackMessageTest extends Specification {
+  // Record 62 in PSCap-hack-door-tower.gcap
+  val string = hex"54 000105c3800000202fc04200000000"
+
+  "decode" in {
+    PacketCoding.DecodePacket(string).require match {
+      case HackMessage(unk1, unk2, unk3, unk4, unk5, unk6, unk7) =>
+        unk1 mustEqual 0
+        unk2 mustEqual 1024
+        unk3 mustEqual 3607
+        unk4 mustEqual 0
+        unk5 mustEqual 3212836864L
+        unk6 mustEqual 1
+        unk7 mustEqual 8L
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = HackMessage(0,1024,3607,0,3212836864L,1,8L)
+    val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+    pkt mustEqual string
+  }
+}


### PR DESCRIPTION
No frills, just the unnamed fields and their sizes. See capture 23e339d1-ce3a-469f-ba20-afe70990fd40 for examples of this packet.