### PR TITLE
Proximity Terminals/Medical

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -515,6 +515,14 @@ object GlobalDefinitions {
 
   val respawn_tube_tower = new SpawnTubeDefinition(733)
 
+  val adv_med_terminal = new MedicalTerminalDefinition(38)
+
+  val crystals_health_a = new MedicalTerminalDefinition(225)
+
+  val crystals_health_b = new MedicalTerminalDefinition(226)
+
+  val medical_terminal = new MedicalTerminalDefinition(529)
+
   val spawn_pad = new VehicleSpawnPadDefinition
 
   val mb_locker = new LockerDefinition

--- a/common/src/main/scala/net/psforever/objects/serverobject/CommonMessages.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/CommonMessages.scala
@@ -5,6 +5,8 @@ import net.psforever.objects.Player
 
 //temporary location for these messages
 object CommonMessages {
+  final case class Use(player : Player)
+  final case class Unuse(player : Player)
   final case class Hack(player : Player)
   final case class ClearHack()
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/MedicalTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/MedicalTerminalDefinition.scala
@@ -4,6 +4,14 @@ package net.psforever.objects.serverobject.terminals
 import net.psforever.objects.Player
 import net.psforever.packet.game.ItemTransactionMessage
 
+/**
+  * The definition for any `Terminal` that is of a type "medical_terminal".
+  * This includes the limited proximity-based functionality of the formal medical terminals
+  * and the actual proximity-based functionality of the cavern crystals.<br>
+  * <br>
+  * Do not confuse the "medical_terminal" category and the actual `medical_terminal` object (529).
+  * Objects created by this definition being linked by their use of `ProximityTerminalUseMessage` is more accurate.
+  */
 class MedicalTerminalDefinition(objectId : Int) extends TerminalDefinition(objectId) {
   Name = if(objectId == 38) {
     "adv_med_terminal"
@@ -21,7 +29,7 @@ class MedicalTerminalDefinition(objectId : Int) extends TerminalDefinition(objec
     "portable_med_terminal"
   }
   else {
-    throw new IllegalArgumentException("terminal must be either object id 38, object id 529, or object id 689")
+    throw new IllegalArgumentException("medical terminal must be either object id 38, 225, 226, 529, or 689")
   }
 
   def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = Terminal.NoDeal()

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/MedicalTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/MedicalTerminalDefinition.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.serverobject.terminals
+
+import net.psforever.objects.Player
+import net.psforever.packet.game.ItemTransactionMessage
+
+class MedicalTerminalDefinition(objectId : Int) extends TerminalDefinition(objectId) {
+  Name = if(objectId == 38) {
+    "adv_med_terminal"
+  }
+  else if(objectId == 225) {
+    "crystals_health_a"
+  }
+  else if(objectId == 226) {
+    "crystals_health_b"
+  }
+  else if(objectId == 529) {
+    "medical_terminal"
+  }
+  else if(objectId == 689) {
+    "portable_med_terminal"
+  }
+  else {
+    throw new IllegalArgumentException("terminal must be either object id 38, object id 529, or object id 689")
+  }
+
+  def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = Terminal.NoDeal()
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
@@ -1,10 +1,17 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals
 
-import net.psforever.objects.Player
 import net.psforever.packet.game.PlanetSideGUID
 
-class ProximityTerminal(tdef : TerminalDefinition) extends Terminal(tdef) {
+/**
+  * A server object that is a "terminal" that can be accessed for amenities and services,
+  * triggered when a certain distance from the unit itself (proximity-based).<br>
+  * <br>
+  * Unlike conventional terminals, this structure is not necessarily structure-owned.
+  * For example, the cavern crystals are considered owner-neutral elements that are not attached to a `Building` object.
+  * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
+  */
+class ProximityTerminal(tdef : MedicalTerminalDefinition) extends Terminal(tdef) {
   private var users : Set[PlanetSideGUID] = Set.empty
 
   def NumberUsers : Int = users.size
@@ -21,14 +28,11 @@ class ProximityTerminal(tdef : TerminalDefinition) extends Terminal(tdef) {
 }
 
 object ProximityTerminal {
-  final case class Use(player : Player)
-  final case class Unuse(player : Player)
-
   /**
     * Overloaded constructor.
     * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
     */
-  def apply(tdef : TerminalDefinition) : ProximityTerminal = {
+  def apply(tdef : MedicalTerminalDefinition) : ProximityTerminal = {
     new ProximityTerminal(tdef)
   }
 
@@ -41,7 +45,7 @@ object ProximityTerminal {
     * @param context a context to allow the object to properly set up `ActorSystem` functionality
     * @return the `Terminal` object
     */
-  def Constructor(tdef : TerminalDefinition)(id : Int, context : ActorContext) : Terminal = {
+  def Constructor(tdef : MedicalTerminalDefinition)(id : Int, context : ActorContext) : Terminal = {
     import akka.actor.Props
     val obj = ProximityTerminal(tdef)
     obj.Actor = context.actorOf(Props(classOf[ProximityTerminalControl], obj), s"${tdef.Name}_$id")

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.serverobject.terminals
+
+import net.psforever.objects.Player
+import net.psforever.packet.game.PlanetSideGUID
+
+class ProximityTerminal(tdef : TerminalDefinition) extends Terminal(tdef) {
+  private var users : Set[PlanetSideGUID] = Set.empty
+
+  def NumberUsers : Int = users.size
+
+  def AddUser(player_guid : PlanetSideGUID) : Int = {
+    users += player_guid
+    NumberUsers
+  }
+
+  def RemoveUser(player_guid : PlanetSideGUID) : Int = {
+    users -= player_guid
+    NumberUsers
+  }
+}
+
+object ProximityTerminal {
+  final case class Use(player : Player)
+  final case class Unuse(player : Player)
+
+  /**
+    * Overloaded constructor.
+    * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
+    */
+  def apply(tdef : TerminalDefinition) : ProximityTerminal = {
+    new ProximityTerminal(tdef)
+  }
+
+  import akka.actor.ActorContext
+
+  /**
+    * Instantiate an configure a `Terminal` object
+    * @param tdef    the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
+    * @param id      the unique id that will be assigned to this entity
+    * @param context a context to allow the object to properly set up `ActorSystem` functionality
+    * @return the `Terminal` object
+    */
+  def Constructor(tdef : TerminalDefinition)(id : Int, context : ActorContext) : Terminal = {
+    import akka.actor.Props
+    val obj = ProximityTerminal(tdef)
+    obj.Actor = context.actorOf(Props(classOf[ProximityTerminalControl], obj), s"${tdef.Name}_$id")
+    obj
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
@@ -2,20 +2,28 @@
 package net.psforever.objects.serverobject.terminals
 
 import akka.actor.Actor
+import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
 import net.psforever.objects.serverobject.terminals.Terminal.TerminalMessage
 
+/**
+  *
+  * An `Actor` that handles messages being dispatched to a specific `ProximityTerminal`.
+  * Although this "terminal" itself does not accept the same messages as a normal `Terminal` object,
+  * it returns the same type of messages - wrapped in a `TerminalMessage` - to the `sender`.
+  * @param term the proximity unit (terminal)
+  */
 class ProximityTerminalControl(term : ProximityTerminal) extends Actor with FactionAffinityBehavior.Check {
   def FactionObject : FactionAffinity = term
 
   def receive : Receive = checkBehavior.orElse {
-    case ProximityTerminal.Use(player) =>
+    case CommonMessages.Use(player) =>
       val hadNoUsers = term.NumberUsers == 0
       if(term.AddUser(player.GUID) == 1 && hadNoUsers) {
         sender ! TerminalMessage(player, null, Terminal.StartProximityEffect(term))
       }
 
-    case ProximityTerminal.Unuse(player) =>
+    case CommonMessages.Unuse(player) =>
       val hadUsers = term.NumberUsers > 0
       if(term.RemoveUser(player.GUID) == 0 && hadUsers) {
         sender ! TerminalMessage(player, null, Terminal.StopProximityEffect(term))

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.serverobject.terminals
+
+import akka.actor.Actor
+import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.terminals.Terminal.TerminalMessage
+
+class ProximityTerminalControl(term : ProximityTerminal) extends Actor with FactionAffinityBehavior.Check {
+  def FactionObject : FactionAffinity = term
+
+  def receive : Receive = checkBehavior.orElse {
+    case ProximityTerminal.Use(player) =>
+      val hadNoUsers = term.NumberUsers == 0
+      if(term.AddUser(player.GUID) == 1 && hadNoUsers) {
+        sender ! TerminalMessage(player, null, Terminal.StartProximityEffect(term))
+      }
+
+    case ProximityTerminal.Unuse(player) =>
+      val hadUsers = term.NumberUsers > 0
+      if(term.RemoveUser(player.GUID) == 0 && hadUsers) {
+        sender ! TerminalMessage(player, null, Terminal.StopProximityEffect(term))
+      }
+
+    case _ =>
+      sender ! Terminal.NoDeal()
+  }
+
+  override def toString : String = term.Definition.Name
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
@@ -190,8 +190,16 @@ object Terminal {
     */
   final case class InfantryLoadout(exosuit : ExoSuitType.Value, subtype : Int = 0, holsters : List[InventoryItem], inventory : List[InventoryItem]) extends Exchange
 
+  /**
+    * Start the special effects caused by a proximity-base service.
+    * @param terminal the proximity-based unit
+    */
   final case class StartProximityEffect(terminal : ProximityTerminal) extends Exchange
 
+  /**
+    * Stop the special effects caused by a proximity-base service.
+    * @param terminal the proximity-based unit
+    */
   final case class StopProximityEffect(terminal : ProximityTerminal) extends Exchange
 
   /**

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
@@ -190,6 +190,10 @@ object Terminal {
     */
   final case class InfantryLoadout(exosuit : ExoSuitType.Value, subtype : Int = 0, holsters : List[InventoryItem], inventory : List[InventoryItem]) extends Exchange
 
+  final case class StartProximityEffect(terminal : ProximityTerminal) extends Exchange
+
+  final case class StopProximityEffect(terminal : ProximityTerminal) extends Exchange
+
   /**
     * Overloaded constructor.
     * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields

--- a/common/src/test/scala/objects/ServerObjectBuilderTest.scala
+++ b/common/src/test/scala/objects/ServerObjectBuilderTest.scala
@@ -6,6 +6,7 @@ import net.psforever.objects.guid.NumberPoolHub
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.objects.serverobject.ServerObjectBuilder
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.ProximityTerminal
 import net.psforever.objects.zones.Zone
 import net.psforever.types.Vector3
 
@@ -119,6 +120,24 @@ class TerminalObjectBuilderTest extends ActorTest {
     "build" in {
       val hub = ServerObjectBuilderTest.NumberPoolHub
       val actor = system.actorOf(Props(classOf[ServerObjectBuilderTest.BuilderTestActor], ServerObjectBuilder(1, Terminal.Constructor(order_terminal)), hub), "term")
+      actor ! "!"
+
+      val reply = receiveOne(Duration.create(1000, "ms"))
+      assert(reply.isInstanceOf[Terminal])
+      assert(reply.asInstanceOf[Terminal].HasGUID)
+      assert(reply.asInstanceOf[Terminal].GUID == PlanetSideGUID(1))
+      assert(reply == hub(1).get)
+    }
+  }
+}
+
+class ProximityTerminalObjectBuilderTest extends ActorTest {
+  import net.psforever.objects.GlobalDefinitions.medical_terminal
+  import net.psforever.objects.serverobject.terminals.Terminal
+  "Terminal object" should {
+    "build" in {
+      val hub = ServerObjectBuilderTest.NumberPoolHub
+      val actor = system.actorOf(Props(classOf[ServerObjectBuilderTest.BuilderTestActor], ServerObjectBuilder(1, ProximityTerminal.Constructor(medical_terminal)), hub), "term")
       actor ! "!"
 
       val reply = receiveOne(Duration.create(1000, "ms"))

--- a/common/src/test/scala/objects/terminal/MedicalTerminalTest.scala
+++ b/common/src/test/scala/objects/terminal/MedicalTerminalTest.scala
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 PSForever
+package objects.terminal
+
+import akka.actor.ActorRef
+import net.psforever.objects.serverobject.terminals.{MedicalTerminalDefinition, ProximityTerminal, Terminal}
+import net.psforever.objects.{GlobalDefinitions, Player}
+import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
+import net.psforever.types.{CharacterGender, PlanetSideEmpire, TransactionType}
+import org.specs2.mutable.Specification
+
+class MedicalTerminalTest extends Specification {
+  "MedicalTerminal" should {
+    "define (a)" in {
+      val a = new MedicalTerminalDefinition(38)
+      a.ObjectId mustEqual 38
+      a.Name mustEqual "adv_med_terminal"
+    }
+
+    "define (b)" in {
+      val b = new MedicalTerminalDefinition(225)
+      b.ObjectId mustEqual 225
+      b.Name mustEqual "crystals_health_a"
+    }
+
+    "define (c)" in {
+      val c = new MedicalTerminalDefinition(226)
+      c.ObjectId mustEqual 226
+      c.Name mustEqual "crystals_health_b"
+    }
+
+    "define (d)" in {
+      val d = new MedicalTerminalDefinition(529)
+      d.ObjectId mustEqual 529
+      d.Name mustEqual "medical_terminal"
+    }
+
+    "define (e)" in {
+      val e = new MedicalTerminalDefinition(689)
+      e.ObjectId mustEqual 689
+      e.Name mustEqual "portable_med_terminal"
+    }
+
+    "define (invalid)" in {
+      var id : Int = (math.random * Int.MaxValue).toInt
+      if(id == 224) {
+        id += 2
+      }
+      else if(id == 37) {
+        id += 1
+      }
+      else if(id == 528) {
+        id += 1
+      }
+      else if(id == 688) {
+        id += 1
+      }
+
+      new MedicalTerminalDefinition(id) must throwA[IllegalArgumentException]
+    }
+  }
+
+  "Medical_Terminal" should {
+    "construct" in {
+      ProximityTerminal(GlobalDefinitions.medical_terminal).Actor mustEqual ActorRef.noSender
+    }
+
+    "can add a a player to a list of users" in {
+      val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
+      terminal.NumberUsers mustEqual 0
+      terminal.AddUser(PlanetSideGUID(10))
+      terminal.NumberUsers mustEqual 1
+    }
+
+    "can remove a a player to a list of users" in {
+      val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
+      terminal.AddUser(PlanetSideGUID(10))
+      terminal.NumberUsers mustEqual 1
+      terminal.RemoveUser(PlanetSideGUID(10))
+      terminal.NumberUsers mustEqual 0
+    }
+
+    "player can not interact with the proximity terminal normally (buy)" in {
+      val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
+      val player = Player("test", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+      val msg = ItemTransactionMessage(PlanetSideGUID(1), TransactionType.Buy, 1, "lite_armor", 0, PlanetSideGUID(0))
+
+      terminal.Request(player, msg) mustEqual Terminal.NoDeal()
+    }
+  }
+}

--- a/common/src/test/scala/objects/terminal/MedicalTerminalTest.scala
+++ b/common/src/test/scala/objects/terminal/MedicalTerminalTest.scala
@@ -3,7 +3,7 @@ package objects.terminal
 
 import akka.actor.ActorRef
 import net.psforever.objects.serverobject.terminals.{MedicalTerminalDefinition, ProximityTerminal, Terminal}
-import net.psforever.objects.{GlobalDefinitions, Player}
+import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
 import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
 import net.psforever.types.{CharacterGender, PlanetSideEmpire, TransactionType}
 import org.specs2.mutable.Specification
@@ -64,14 +64,14 @@ class MedicalTerminalTest extends Specification {
       ProximityTerminal(GlobalDefinitions.medical_terminal).Actor mustEqual ActorRef.noSender
     }
 
-    "can add a a player to a list of users" in {
+    "can add a player to a list of users" in {
       val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
       terminal.NumberUsers mustEqual 0
       terminal.AddUser(PlanetSideGUID(10))
       terminal.NumberUsers mustEqual 1
     }
 
-    "can remove a a player to a list of users" in {
+    "can remove a player from a list of users" in {
       val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
       terminal.AddUser(PlanetSideGUID(10))
       terminal.NumberUsers mustEqual 1
@@ -81,7 +81,7 @@ class MedicalTerminalTest extends Specification {
 
     "player can not interact with the proximity terminal normally (buy)" in {
       val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
-      val player = Player("test", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+      val player = Player(Avatar("test", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0))
       val msg = ItemTransactionMessage(PlanetSideGUID(1), TransactionType.Buy, 1, "lite_armor", 0, PlanetSideGUID(0))
 
       terminal.Request(player, msg) mustEqual Terminal.NoDeal()

--- a/common/src/test/scala/objects/terminal/ProximityTerminalControlTest.scala
+++ b/common/src/test/scala/objects/terminal/ProximityTerminalControlTest.scala
@@ -3,7 +3,7 @@ package objects.terminal
 
 import akka.actor.{ActorSystem, Props}
 import net.psforever.objects.serverobject.CommonMessages
-import net.psforever.objects.{GlobalDefinitions, Player}
+import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
 import net.psforever.objects.serverobject.terminals._
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.types.{CharacterGender, PlanetSideEmpire}
@@ -35,7 +35,7 @@ class MedicalTerminalControl1Test extends ActorTest() {
   "ProximityTerminalControl sends a message to the first new user only" in {
     val (player, terminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
     player.GUID = PlanetSideGUID(10)
-    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    val player2 = Player(Avatar("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0))
     player2.GUID = PlanetSideGUID(11)
 
     terminal.Actor ! CommonMessages.Use(player)
@@ -58,7 +58,7 @@ class MedicalTerminalControl2Test extends ActorTest() {
   "ProximityTerminalControl sends a message to the last user only" in {
     val (player, terminal) : (Player, ProximityTerminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
     player.GUID = PlanetSideGUID(10)
-    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    val player2 = Player(Avatar("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0))
     player2.GUID = PlanetSideGUID(11)
 
     terminal.Actor ! CommonMessages.Use(player)
@@ -87,7 +87,7 @@ class MedicalTerminalControl3Test extends ActorTest() {
   "ProximityTerminalControl sends a message to the last user only (confirmation of test #2)" in {
     val (player, terminal) : (Player, ProximityTerminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
     player.GUID = PlanetSideGUID(10)
-    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    val player2 = Player(Avatar("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0))
     player2.GUID = PlanetSideGUID(11)
 
     terminal.Actor ! CommonMessages.Use(player)
@@ -116,6 +116,6 @@ object ProximityTerminalControlTest {
   def SetUpAgents(tdef : MedicalTerminalDefinition, faction : PlanetSideEmpire.Value)(implicit system : ActorSystem) : (Player, ProximityTerminal) = {
     val terminal = ProximityTerminal(tdef)
     terminal.Actor = system.actorOf(Props(classOf[ProximityTerminalControl], terminal), "test-term")
-    (Player("test", faction, CharacterGender.Male, 0, 0), terminal)
+    (Player(Avatar("test", faction, CharacterGender.Male, 0, 0)), terminal)
   }
 }

--- a/common/src/test/scala/objects/terminal/ProximityTerminalControlTest.scala
+++ b/common/src/test/scala/objects/terminal/ProximityTerminalControlTest.scala
@@ -1,0 +1,121 @@
+// Copyright (c) 2017 PSForever
+package objects.terminal
+
+import akka.actor.{ActorSystem, Props}
+import net.psforever.objects.serverobject.CommonMessages
+import net.psforever.objects.{GlobalDefinitions, Player}
+import net.psforever.objects.serverobject.terminals._
+import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.{CharacterGender, PlanetSideEmpire}
+import objects.ActorTest
+
+import scala.concurrent.duration.Duration
+
+class ProximityTerminalControl1Test extends ActorTest() {
+  "ProximityTerminalControl" should {
+    "construct (medical terminal)" in {
+      val terminal = ProximityTerminal(GlobalDefinitions.medical_terminal)
+      terminal.Actor = system.actorOf(Props(classOf[ProximityTerminalControl], terminal), "test-term")
+    }
+  }
+}
+
+class ProximityTerminalControl2Test extends ActorTest() {
+  "ProximityTerminalControl can not process wrong messages" in {
+    val (_, terminal) = TerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
+
+    terminal.Actor !"hello"
+    val reply = receiveOne(Duration.create(500, "ms"))
+    assert(reply.isInstanceOf[Terminal.NoDeal])
+  }
+}
+
+//terminal control is mostly a pass-through actor for Terminal.Exchange messages, wrapped in Terminal.TerminalMessage protocol
+class MedicalTerminalControl1Test extends ActorTest() {
+  "ProximityTerminalControl sends a message to the first new user only" in {
+    val (player, terminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
+    player.GUID = PlanetSideGUID(10)
+    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    player2.GUID = PlanetSideGUID(11)
+
+    terminal.Actor ! CommonMessages.Use(player)
+    val reply = receiveOne(Duration.create(500, "ms"))
+    assert(reply.isInstanceOf[Terminal.TerminalMessage])
+    val reply2 = reply.asInstanceOf[Terminal.TerminalMessage]
+    assert(reply2.player == player)
+    assert(reply2.msg == null)
+    assert(reply2.response.isInstanceOf[Terminal.StartProximityEffect])
+    assert(reply2.response.asInstanceOf[Terminal.StartProximityEffect].terminal == terminal)
+    assert(terminal.NumberUsers == 1)
+
+    terminal.Actor ! CommonMessages.Use(player2)
+    expectNoMsg(Duration.create(500, "ms"))
+    assert(terminal.NumberUsers == 2)
+  }
+}
+
+class MedicalTerminalControl2Test extends ActorTest() {
+  "ProximityTerminalControl sends a message to the last user only" in {
+    val (player, terminal) : (Player, ProximityTerminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
+    player.GUID = PlanetSideGUID(10)
+    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    player2.GUID = PlanetSideGUID(11)
+
+    terminal.Actor ! CommonMessages.Use(player)
+    receiveOne(Duration.create(500, "ms"))
+    terminal.Actor ! CommonMessages.Use(player2)
+    expectNoMsg(Duration.create(500, "ms"))
+    assert(terminal.NumberUsers == 2)
+
+    terminal.Actor ! CommonMessages.Unuse(player)
+    expectNoMsg(Duration.create(500, "ms"))
+    assert(terminal.NumberUsers == 1)
+
+    terminal.Actor ! CommonMessages.Unuse(player2)
+    val reply = receiveOne(Duration.create(500, "ms"))
+    assert(reply.isInstanceOf[Terminal.TerminalMessage])
+    val reply2 = reply.asInstanceOf[Terminal.TerminalMessage]
+    assert(reply2.player == player2)
+    assert(reply2.msg == null)
+    assert(reply2.response.isInstanceOf[Terminal.StopProximityEffect])
+    assert(reply2.response.asInstanceOf[Terminal.StopProximityEffect].terminal == terminal)
+    assert(terminal.NumberUsers == 0)
+  }
+}
+
+class MedicalTerminalControl3Test extends ActorTest() {
+  "ProximityTerminalControl sends a message to the last user only (confirmation of test #2)" in {
+    val (player, terminal) : (Player, ProximityTerminal) = ProximityTerminalControlTest.SetUpAgents(GlobalDefinitions.medical_terminal, PlanetSideEmpire.TR)
+    player.GUID = PlanetSideGUID(10)
+    val player2 = Player("someothertest", PlanetSideEmpire.TR, CharacterGender.Male, 0, 0)
+    player2.GUID = PlanetSideGUID(11)
+
+    terminal.Actor ! CommonMessages.Use(player)
+    receiveOne(Duration.create(500, "ms"))
+    terminal.Actor ! CommonMessages.Use(player2)
+    expectNoMsg(Duration.create(500, "ms"))
+    assert(terminal.NumberUsers == 2)
+
+    terminal.Actor ! CommonMessages.Unuse(player2)
+    expectNoMsg(Duration.create(500, "ms"))
+    assert(terminal.NumberUsers == 1)
+
+    terminal.Actor ! CommonMessages.Unuse(player)
+    val reply = receiveOne(Duration.create(500, "ms"))
+    assert(reply.isInstanceOf[Terminal.TerminalMessage])
+    val reply2 = reply.asInstanceOf[Terminal.TerminalMessage]
+    assert(reply2.player == player) //important!
+    assert(reply2.msg == null)
+    assert(reply2.response.isInstanceOf[Terminal.StopProximityEffect])
+    assert(reply2.response.asInstanceOf[Terminal.StopProximityEffect].terminal == terminal)
+    assert(terminal.NumberUsers == 0)
+  }
+}
+
+object ProximityTerminalControlTest {
+  def SetUpAgents(tdef : MedicalTerminalDefinition, faction : PlanetSideEmpire.Value)(implicit system : ActorSystem) : (Player, ProximityTerminal) = {
+    val terminal = ProximityTerminal(tdef)
+    terminal.Actor = system.actorOf(Props(classOf[ProximityTerminalControl], terminal), "test-term")
+    (Player("test", faction, CharacterGender.Male, 0, 0), terminal)
+  }
+}

--- a/pslogin/src/main/scala/Maps.scala
+++ b/pslogin/src/main/scala/Maps.scala
@@ -100,6 +100,8 @@ object Maps {
       LocalObject(1186, Locker.Constructor)
       LocalObject(1187, Locker.Constructor)
       LocalObject(1188, Locker.Constructor)
+      LocalObject(1492, ProximityTerminal.Constructor(medical_terminal)) //lobby
+      LocalObject(1494, ProximityTerminal.Constructor(medical_terminal)) //kitchen
       LocalObject(1564, Terminal.Constructor(order_terminal))
       LocalObject(1568, Terminal.Constructor(order_terminal))
       LocalObject(1569, Terminal.Constructor(order_terminal))
@@ -200,6 +202,8 @@ object Maps {
       ObjectToBuilding(1186, 2)
       ObjectToBuilding(1187, 2)
       ObjectToBuilding(1188, 2)
+      ObjectToBuilding(1492, 2)
+      ObjectToBuilding(1494, 2)
       ObjectToBuilding(1564, 2)
       ObjectToBuilding(1568, 2)
       ObjectToBuilding(1569, 2)

--- a/pslogin/src/main/scala/Maps.scala
+++ b/pslogin/src/main/scala/Maps.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
-import net.psforever.objects.serverobject.terminals.Terminal
+import net.psforever.objects.serverobject.terminals.{ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.types.Vector3
 
@@ -452,6 +452,10 @@ object Maps {
       LocalObject(691, Locker.Constructor)
       LocalObject(692, Locker.Constructor)
       LocalObject(693, Locker.Constructor)
+      LocalObject(778, ProximityTerminal.Constructor(medical_terminal))
+      LocalObject(779, ProximityTerminal.Constructor(medical_terminal))
+      LocalObject(780, ProximityTerminal.Constructor(medical_terminal))
+      LocalObject(781, ProximityTerminal.Constructor(medical_terminal))
       LocalObject(842, Terminal.Constructor(order_terminal))
       LocalObject(843, Terminal.Constructor(order_terminal))
       LocalObject(844, Terminal.Constructor(order_terminal))
@@ -495,6 +499,10 @@ object Maps {
       ObjectToBuilding(691, 2)
       ObjectToBuilding(692, 2)
       ObjectToBuilding(693, 2)
+      ObjectToBuilding(778, 2)
+      ObjectToBuilding(779, 2)
+      ObjectToBuilding(780, 2)
+      ObjectToBuilding(781, 2)
       ObjectToBuilding(842, 2)
       ObjectToBuilding(843, 2)
       ObjectToBuilding(844, 2)

--- a/pslogin/src/main/scala/services/local/LocalAction.scala
+++ b/pslogin/src/main/scala/services/local/LocalAction.scala
@@ -14,5 +14,6 @@ object LocalAction {
   final case class DoorCloses(player_guid : PlanetSideGUID, door_guid : PlanetSideGUID) extends Action
   final case class HackClear(player_guid : PlanetSideGUID, target : PlanetSideServerObject, unk1 : Long, unk2 : Long = 8L) extends Action
   final case class HackTemporarily(player_guid : PlanetSideGUID, continent : Zone, target : PlanetSideServerObject, unk1 : Long, unk2 : Long = 8L) extends Action
+  final case class ProximityTerminalEffect(player_guid : PlanetSideGUID, object_guid : PlanetSideGUID, effectState : Boolean) extends Action
   final case class TriggerSound(player_guid : PlanetSideGUID, sound : TriggeredSound.Value, pos : Vector3, unk : Int, volume : Float) extends Action
 }

--- a/pslogin/src/main/scala/services/local/LocalResponse.scala
+++ b/pslogin/src/main/scala/services/local/LocalResponse.scala
@@ -11,5 +11,6 @@ object LocalResponse {
   final case class DoorCloses(door_guid : PlanetSideGUID) extends Response
   final case class HackClear(target_guid : PlanetSideGUID, unk1 : Long, unk2 : Long) extends Response
   final case class HackObject(target_guid : PlanetSideGUID, unk1 : Long, unk2 : Long) extends Response
+  final case class ProximityTerminalEffect(object_guid : PlanetSideGUID, effectState : Boolean) extends Response
   final case class TriggerSound(sound : TriggeredSound.Value, pos : Vector3, unk : Int, volume : Float) extends Response
 }

--- a/pslogin/src/main/scala/services/local/LocalService.scala
+++ b/pslogin/src/main/scala/services/local/LocalService.scala
@@ -55,6 +55,10 @@ class LocalService extends Actor {
           LocalEvents.publish(
             LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.HackObject(target.GUID, unk1, unk2))
           )
+        case LocalAction.ProximityTerminalEffect(player_guid, object_guid, effectState) =>
+          LocalEvents.publish(
+            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.ProximityTerminalEffect(object_guid, effectState))
+          )
         case LocalAction.TriggerSound(player_guid, sound, pos, unk, volume) =>
           LocalEvents.publish(
             LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.TriggerSound(sound, pos, unk, volume))

--- a/pslogin/src/test/scala/LocalServiceTest.scala
+++ b/pslogin/src/test/scala/LocalServiceTest.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2017 PSForever
+import akka.actor.Props
+import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.{PlanetSideEmpire, Vector3}
+import services.Service
+import services.local._
+
+class LocalService1Test extends ActorTest {
+  "LocalService" should {
+    "construct" in {
+      system.actorOf(Props[LocalService], "service")
+      assert(true)
+    }
+  }
+}
+
+class LocalService2Test extends ActorTest {
+  "LocalService" should {
+    "subscribe" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      assert(true)
+    }
+  }
+}
+
+class LocalService3Test extends ActorTest {
+  "LocalService" should {
+    "subscribe to a specific channel" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! Service.Leave()
+      assert(true)
+    }
+  }
+}
+
+class LocalService4Test extends ActorTest {
+  "LocalService" should {
+    "subscribe" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! Service.LeaveAll()
+      assert(true)
+    }
+  }
+}
+
+class LocalService5Test extends ActorTest {
+  "LocalService" should {
+    "pass an unhandled message" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! "hello"
+      expectNoMsg()
+    }
+  }
+}
+
+class DoorClosesTest extends ActorTest {
+  "LocalService" should {
+    "pass DoorCloses" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.DoorCloses(PlanetSideGUID(10), PlanetSideGUID(40)))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.DoorCloses(PlanetSideGUID(40))))
+    }
+  }
+}
+
+class HackClearTest extends ActorTest {
+  val obj = new PlanetSideServerObject() {
+    def Faction  = PlanetSideEmpire.NEUTRAL
+    def Definition = null
+    GUID = PlanetSideGUID(40)
+  }
+
+  "LocalService" should {
+    "pass HackClear" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.HackClear(PlanetSideGUID(10), obj, 0L, 1000L))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.HackClear(PlanetSideGUID(40), 0L, 1000L)))
+    }
+  }
+}
+
+class ProximityTerminalEffectTest extends ActorTest {
+  "LocalService" should {
+    "pass ProximityTerminalEffect" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.ProximityTerminalEffect(PlanetSideGUID(10), PlanetSideGUID(40), true))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.ProximityTerminalEffect(PlanetSideGUID(40), true)))
+    }
+  }
+}
+
+class TriggerSoundTest extends ActorTest {
+  import net.psforever.packet.game.TriggeredSound
+
+  "LocalService" should {
+    "pass TriggerSound" in {
+      val service = system.actorOf(Props[LocalService], "service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.TriggerSound(PlanetSideGUID(10), TriggeredSound.LockedOut, Vector3(1.1f, 2.2f, 3.3f), 0, 0.75f))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.TriggerSound(TriggeredSound.LockedOut, Vector3(1.1f, 2.2f, 3.3f), 0, 0.75f)))
+    }
+  }
+}
+
+object LocalServiceTest {
+  //decoy
+}


### PR DESCRIPTION
I spent more time on this than I intended.

While I should not have to explain how to test the medical terminals, I should remind you to try kill yourself on the terminal while it is working to make certain it deactivates.  Check that the terminal deactivates when your character moves during its operation too.

Due to being based on the `spawn-tube` pull request, your character is still on Ceryshen in the middle of nowhere.  Anguta's two medical terms are operational, however, and respawning always resets your health to 50 and armor to 25.  The four terminals in the `home3` HART C building also work if you respawn to that sanctuary continent.

Caveats:
- Although the code suggests that other proximity-based utilities are prepared, only the medical terminals should be expected to correctly operate.  The cavern crystals are peculiar.  If, somehow, normal 
repair silos respond, assume that this functionality is unintended behavior.
- Be cautious of constantly inching oneself forward on the terminal platform, waiting only long enough for the terminal to activate, before starting to inch again.  While most hiccups have been ironed out, this sort of treatment did cause the terminals to enter into an unstable state in an earlier tests.