### PR TITLE
Destroy the Vehicle Terminal

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
@@ -163,7 +163,8 @@ object VehicleSpawnPad {
   object Reminders extends Enumeration {
     val
     Queue, //optional data is the numeric position in the queue
-    Blocked //optional data is a message regarding the blockage
+    Blocked, //optional data is a message regarding the blockage
+    Cancelled
     = Value
   }
 


### PR DESCRIPTION
Think of it like maintenance when it has failed to live up to expectations.  Shame it into working by look at it sternly and saying "`/destroy`".

A quick fix for blocked vehicle pads and the congested spawn queues that plague Play-Live (51200), hopefully.