### PR TITLE
Remove passwords being logged in plaintext on logins

### DIFF
--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -128,7 +128,7 @@ class LoginSessionActor extends Actor with MDCContextAware {
         if(token.isDefined)
           log.info(s"New login UN:$username Token:${token.get}. $clientVersion")
         else
-          log.info(s"New login UN:$username PW:$password. $clientVersion")
+          log.info(s"New login UN:$username. $clientVersion")
 
         // This is temporary until a schema has been developed
         //val loginSucceeded = accountLookup(username, password.getOrElse(token.get))


### PR DESCRIPTION
The server really shouldn't output user passwords to the console / logs, even if the account system isn't fully functional yet. Could result in a potential security issue.