### PR TITLE
Initital functionality for cargo passengers

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2864,6 +2864,7 @@ object GlobalDefinitions {
     dropship.Weapons += 12 -> cannon_dropship_20mm
     dropship.Weapons += 13 -> cannon_dropship_20mm
     dropship.Weapons += 14 -> dropship_rear_turret
+    dropship.Cargo += 15 -> new CargoDefinition()
     dropship.MountPoints += 1 -> 0
     dropship.MountPoints += 2 -> 11
     dropship.MountPoints += 3 -> 1
@@ -2876,6 +2877,7 @@ object GlobalDefinitions {
     dropship.MountPoints += 10 -> 8
     dropship.MountPoints += 11 -> 9
     dropship.MountPoints += 12 -> 10
+    dropship.MountPoints += 13 -> 15
     dropship.TrunkSize = InventoryTile.Tile1612
     dropship.TrunkOffset = 30
     dropship.AutoPilotSpeeds = (0, 4)
@@ -2912,6 +2914,8 @@ object GlobalDefinitions {
     lodestar.Name = "lodestar"
     lodestar.Seats += 0 -> new SeatDefinition()
     lodestar.MountPoints += 1 -> 0
+    lodestar.MountPoints += 2 -> 1
+    lodestar.Cargo += 1 -> new CargoDefinition()
     lodestar.TrunkSize = InventoryTile.Tile1612
     lodestar.TrunkOffset = 30
     lodestar.AutoPilotSpeeds = (0, 4)

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.serverobject.deploy.Deployment
-import net.psforever.objects.vehicles.{AccessPermissionGroup, Seat, Utility, VehicleLockState}
+import net.psforever.objects.vehicles._
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.types.PlanetSideEmpire
 
@@ -54,9 +54,16 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
     */
   private val groupPermissions : Array[VehicleLockState.Value] = Array(VehicleLockState.Locked, VehicleLockState.Empire, VehicleLockState.Empire, VehicleLockState.Locked)
   private var seats : Map[Int, Seat] = Map.empty
+  private var cargoHolds : Map[Int, Cargo] = Map.empty
   private var weapons : Map[Int, EquipmentSlot] = Map.empty
   private var utilities : Map[Int, Utility] = Map()
   private val trunk : GridInventory = GridInventory()
+
+  /**
+    * Records the GUID of the cargo vehicle (galaxy/lodestar) this vehicle is stored in for DismountVehicleCargoMsg use
+    * DismountVehicleCargoMsg only passes the player_guid and this vehicle's guid
+    */
+  private var mountedIn : Option[PlanetSideGUID] = None
 
   //init
   LoadDefinition()
@@ -76,6 +83,22 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
   override def Faction_=(faction : PlanetSideEmpire.Value) : PlanetSideEmpire.Value = {
     this.faction = faction
     faction
+  }
+
+  def MountedIn : Option[PlanetSideGUID] = {
+    this.mountedIn
+  }
+
+  def MountedIn_=(cargo_vehicle_guid : PlanetSideGUID) : Option[PlanetSideGUID] = MountedIn_=(Some(cargo_vehicle_guid))
+
+  def MountedIn_=(cargo_vehicle_guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    cargo_vehicle_guid match {
+      case Some(_) =>
+        this.mountedIn = cargo_vehicle_guid
+      case None =>
+        this.mountedIn = None
+    }
+    MountedIn
   }
 
   def Owner : Option[PlanetSideGUID] = {
@@ -231,6 +254,19 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
     seats
   }
 
+  def CargoHold(cargoNumber : Int) : Option[Cargo] = {
+    if(cargoNumber >= 0) {
+      this.cargoHolds.get(cargoNumber)
+    }
+    else {
+      None
+    }
+  }
+
+  def CargoHolds : Map[Int, Cargo] = {
+    cargoHolds
+  }
+
   def SeatPermissionGroup(seatNumber : Int) : Option[AccessPermissionGroup.Value] = {
     if(seatNumber == 0) {
       Some(AccessPermissionGroup.Driver)
@@ -244,6 +280,12 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
             case None =>
               Some(AccessPermissionGroup.Passenger)
           }
+        case None =>
+          None
+      }
+      CargoHold(seatNumber) match {
+        case Some(_) =>
+          Some(AccessPermissionGroup.Passenger)
         case None =>
           None
       }
@@ -516,6 +558,9 @@ object Vehicle {
     }).toMap
     //create seats
     vehicle.seats = vdef.Seats.map({ case(num, definition) => num -> Seat(definition)}).toMap
+    // create cargo holds
+    vehicle.cargoHolds = vdef.Cargo.map({ case(num, definition) => num -> Cargo(definition)}).toMap
+
     //create utilities
     vehicle.utilities = vdef.Utilities.map({ case(num, util) => num -> Utility(util, vehicle) }).toMap
     //trunk

--- a/common/src/main/scala/net/psforever/objects/definition/CargoDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/CargoDefinition.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.definition
+
+import net.psforever.objects.vehicles.CargoVehicleRestriction
+
+/**
+  * The definition for a cargo hold.
+  */
+class CargoDefinition extends BasicDefinition {
+  /** a restriction on the type of exo-suit a person can wear */
+  private var vehicleRestriction : CargoVehicleRestriction.Value = CargoVehicleRestriction.Small
+  /** the user can escape while the vehicle is moving */
+  private var bailable : Boolean = true
+  Name = "cargo"
+
+  def CargoRestriction : CargoVehicleRestriction.Value = {
+    this.vehicleRestriction
+  }
+
+  def CargoRestriction_=(restriction : CargoVehicleRestriction.Value) : CargoVehicleRestriction.Value = {
+    this.vehicleRestriction = restriction
+    restriction
+  }
+
+  def Bailable : Boolean = {
+    this.bailable
+  }
+
+  def Bailable_=(canBail : Boolean) : Boolean = {
+    this.bailable = canBail
+    canBail
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
@@ -16,6 +16,7 @@ class VehicleDefinition(objectId : Int) extends ObjectDefinition(objectId) {
   private var maxShields : Int = 0
   /* key - seat index, value - seat object */
   private val seats : mutable.HashMap[Int, SeatDefinition] = mutable.HashMap[Int, SeatDefinition]()
+  private val cargo : mutable.HashMap[Int, CargoDefinition] = mutable.HashMap[Int, CargoDefinition]()
   /* key - entry point index, value - seat index */
   private val mountPoints : mutable.HashMap[Int, Int] = mutable.HashMap()
   /* key - seat index (where this weapon attaches during object construction), value - the weapon on an EquipmentSlot */
@@ -47,6 +48,7 @@ class VehicleDefinition(objectId : Int) extends ObjectDefinition(objectId) {
   }
 
   def Seats : mutable.HashMap[Int, SeatDefinition] = seats
+  def Cargo : mutable.HashMap[Int, CargoDefinition] = cargo
 
   def MountPoints : mutable.HashMap[Int, Int] = mountPoints
 

--- a/common/src/main/scala/net/psforever/objects/vehicles/Cargo.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/Cargo.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.vehicles
+
+import net.psforever.objects.{Player, Vehicle}
+import net.psforever.objects.definition.{CargoDefinition}
+
+/**
+  * Server-side support for a slot that vehicles can occupy
+  * @param cargoDef the Definition that constructs this item and maintains some of its unchanging fields
+  */
+class Cargo(private val cargoDef : CargoDefinition) {
+  private var occupant : Option[Vehicle] = None
+
+  /**
+    * Is the cargo hold occupied?
+    * @return The vehicle in the cargo hold, or `None` if it is left vacant
+    */
+  def Occupant : Option[Vehicle] = {
+    this.occupant
+  }
+
+  /**
+    * A vehicle is trying to board the cargo hold
+    * Cargo holds are exclusive positions that can only hold one vehicle at a time.
+    * @param vehicle the vehicle boarding the cargo hold, or `None` if the vehicle is leaving
+    * @return the vehicle sitting in this seat, or `None` if it is left vacant
+    */
+  def Occupant_=(vehicle : Vehicle) : Option[Vehicle] = Occupant_=(Some(vehicle))
+
+  def Occupant_=(vehicle : Option[Vehicle]) : Option[Vehicle] = {
+    if(vehicle.isDefined) {
+      if(this.occupant.isEmpty) {
+        this.occupant = vehicle
+      }
+    }
+    else {
+      this.occupant = None
+    }
+    this.occupant
+  }
+
+  /**
+    * Is this cargo hold occupied?
+    * @return `true`, if it is occupied; `false`, otherwise
+    */
+  def isOccupied : Boolean = {
+    this.occupant.isDefined
+  }
+
+  def CargoRestriction : CargoVehicleRestriction.Value = {
+    cargoDef.CargoRestriction
+  }
+
+  def Bailable : Boolean = {
+    cargoDef.Bailable
+  }
+
+  /**
+    * Override the string representation to provide additional information.
+    * @return the string output
+    */
+  override def toString : String = {
+    Cargo.toString(this)
+  }
+}
+
+object Cargo {
+  /**
+    * Overloaded constructor.
+    * @return a `Cargo` object
+    */
+  def apply(cargoDef : CargoDefinition) : Cargo = {
+    new Cargo(cargoDef)
+  }
+
+  /**
+    * Provide a fixed string representation.
+    * @return the string output
+    */
+  def toString(obj : Cargo) : String = {
+    val cargoStr = if(obj.isOccupied) {
+      s", occupied by vehicle ${obj.Occupant.get.GUID}"
+    }
+    else {
+      ""
+    }
+    s"cargo$cargoStr"
+  }
+}
+
+

--- a/common/src/main/scala/net/psforever/objects/vehicles/CargoVehicleRestriction.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/CargoVehicleRestriction.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.vehicles
+
+/**
+  * An `Enumeration` of exo-suit-based seat access restrictions.<br>
+  * <br>
+  * The default value is `NoMax` as that is the most common seat.
+  * `NoReinforcedOrMax` is next most common.
+  * `MaxOnly` is a rare seat restriction found in pairs on Galaxies and on the large "Ground Transport" vehicles.
+  */
+object CargoVehicleRestriction extends Enumeration {
+  type Type = Value
+
+  val
+  Small,
+  Large
+  = Value
+}

--- a/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/common/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -395,9 +395,9 @@ object GamePacketOpcode extends Enumeration {
     case 0x3f => game.ProjectileStateMessage.decode
 
     // OPCODES 0x40-4f
-    case 0x40 => noDecoder(MountVehicleCargoMsg)
-    case 0x41 => noDecoder(DismountVehicleCargoMsg)
-    case 0x42 => noDecoder(CargoMountPointStatusMessage)
+    case 0x40 => game.MountVehicleCargoMsg.decode
+    case 0x41 => game.DismountVehicleCargoMsg.decode
+    case 0x42 => game.CargoMountPointStatusMessage.decode
     case 0x43 => game.BeginZoningMessage.decode
     case 0x44 => game.ItemTransactionMessage.decode
     case 0x45 => game.ItemTransactionResultMessage.decode

--- a/common/src/main/scala/net/psforever/packet/game/CargoMountPointStatusMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/CargoMountPointStatusMessage.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.CargoStatus
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  *
+  * @param cargo_vehicle_guid Cargo vehicle GUID (galaxy / lodestar)
+  * @param requesting_vehicle Seems to be vehicle that requested mounting (0 after mount)
+  * @param mounted_vehicle Seems to be vehicle that requested mounting after mount (0 before mount)
+  * @param dismounted_vehicle Seems to be vehicle that was mounted after disembarking (0 before embark or reset to 0 when MountVehicleCargoMsg received)
+  * @param slot Mount point for cargo bay 1 = lodestar, 15 = galaxy
+  * @param mount_status Mount status? 0 = None, 1 = Mount/Dismount in progress, 3 = Mounted
+  * @param orientation 0 = normal, 1 = sideways (e.g. router in lodestar)
+  */
+final case class CargoMountPointStatusMessage(cargo_vehicle_guid : PlanetSideGUID,
+                                              requesting_vehicle: PlanetSideGUID,
+                                              mounted_vehicle: PlanetSideGUID,
+                                              dismounted_vehicle: PlanetSideGUID,
+                                              slot: Int,
+                                              mount_status: CargoStatus.Value,
+                                              orientation: Int)
+  extends PlanetSideGamePacket {
+  type Packet = CargoMountPointStatusMessage
+
+  def opcode = GamePacketOpcode.CargoMountPointStatusMessage
+
+  def encode = CargoMountPointStatusMessage.encode(this)
+}
+
+object CargoMountPointStatusMessage extends Marshallable[CargoMountPointStatusMessage] {
+  implicit val codec : Codec[CargoMountPointStatusMessage] = (
+    ("cargo_vehicle_guid" | PlanetSideGUID.codec) ::
+    ("requesting_vehicle" | PlanetSideGUID.codec) ::
+    ("mounted_vehicle" | PlanetSideGUID.codec) ::
+    ("dismounted_vehicle" | PlanetSideGUID.codec) ::
+    ("slot" | uint8L) ::
+    ("mount_status" | CargoStatus.codec) ::
+    ("orientation" | uint2L)
+    ).as[CargoMountPointStatusMessage]
+}
+

--- a/common/src/main/scala/net/psforever/packet/game/DismountVehicleCargoMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountVehicleCargoMsg.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * Note: For some reason this packet does not include the GUID of the vehicle that is being dismounted from. As a workaround vehicle.MountedIn in manually set/removed
+  * @param player_guid // GUID of the player that is rqeuesting dismount
+  * @param vehicle_guid GUID of the vehicle that is requesting dismount
+  * @param bailed If the vehicle bailed out of the cargo vehicle
+  * @param requestedByPassenger If a passenger of the vehicle in the cargo bay requests dismount this bit will be set
+  * @param kicked If the vehicle was kicked by the cargo vehicle pilot
+  */
+final case class DismountVehicleCargoMsg(player_guid : PlanetSideGUID, vehicle_guid: PlanetSideGUID, bailed: Boolean, requestedByPassenger: Boolean, kicked: Boolean)
+  extends PlanetSideGamePacket {
+  type Packet = DismountVehicleCargoMsg
+
+  def opcode = GamePacketOpcode.DismountVehicleCargoMsg
+
+  def encode = DismountVehicleCargoMsg.encode(this)
+}
+
+object DismountVehicleCargoMsg extends Marshallable[DismountVehicleCargoMsg] {
+  implicit val codec : Codec[DismountVehicleCargoMsg] = (
+    ("player_guid" | PlanetSideGUID.codec) ::
+      ("vehicle_guid" | PlanetSideGUID.codec) ::
+      ("unk3" | bool) :: // bailed?
+      ("unk4" | bool) ::
+      ("unk5" | bool)
+    ).as[DismountVehicleCargoMsg]
+}

--- a/common/src/main/scala/net/psforever/packet/game/DismountVehicleMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountVehicleMsg.scala
@@ -10,11 +10,11 @@ import net.psforever.types.BailType
   * Dispatched by the client when the player wishes to get out of a vehicle.
   * @param player_guid the player
   * @param bailType The dismount action e.g. normal dismount, kicked by owner, bailed
-  * @param unk2 na
+  * @param wasKickedByDriver Seems to be true if a passenger was manually kicked by the vehicle owner
   */
 final case class DismountVehicleMsg(player_guid : PlanetSideGUID,
                                     bailType : BailType.Value,
-                                    wasKickedByDriver : Boolean) // Seems to be true if a passenger was manually kicked by the vehicle owner
+                                    wasKickedByDriver : Boolean)
   extends PlanetSideGamePacket {
   type Packet = DismountVehicleMsg
   def opcode = GamePacketOpcode.DismountVehicleMsg

--- a/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
@@ -12,6 +12,10 @@ import shapeless.{::, HNil}
   * (Write more some other time.)
   * @param object_guid the target object
   * @param code the action code
+  *             96, 97, 98, 99 - Makes the vehicle bounce slightly. Have seen this in packet captures after taking a vehicle through a warpgate
+  *             200, 201, 202, 203 - For aircraft - client shows "THe bailing mechanism failed! To fix the mechanism, land and repair the vehicle!"
+  *             224 - Sets vehicle or player to be black ops
+  *             228 - Reverts player from black ops
   */
 final case class GenericObjectActionMessage(object_guid : PlanetSideGUID,
                                             code : Int)

--- a/common/src/main/scala/net/psforever/packet/game/MountVehicleCargoMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/MountVehicleCargoMsg.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  *
+  * @param player_guid The guid of the player sending the request to board another vehicle with a cargo vehicle
+  * @param vehicle_guid The guid of the vehicle for the requesting player
+  * @param target_vehicle The cargo vehicle guid e.g. Galaxy / Lodestar
+  * @param unk4
+  */
+final case class MountVehicleCargoMsg(player_guid : PlanetSideGUID, vehicle_guid: PlanetSideGUID, target_vehicle: PlanetSideGUID, unk4: Int)
+  extends PlanetSideGamePacket {
+  type Packet = MountVehicleCargoMsg
+
+  def opcode = GamePacketOpcode.MountVehicleCargoMsg
+
+  def encode = MountVehicleCargoMsg.encode(this)
+}
+
+object MountVehicleCargoMsg extends Marshallable[MountVehicleCargoMsg] {
+  implicit val codec : Codec[MountVehicleCargoMsg] = (
+      ("unk1" | PlanetSideGUID.codec) ::
+        ("unk2" | PlanetSideGUID.codec)::
+        ("unk3" | PlanetSideGUID.codec) ::
+        ("unk4" | uint8L)
+    ).as[MountVehicleCargoMsg]
+}

--- a/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -129,6 +129,7 @@ import scodec.codecs._
   * `21 - Asserts first time event eligibility / makes owner if no owner is assigned`<br>
   * `22 - Toggles gunner and passenger mount points (1 = hides, 0 = reveals; this also locks their permissions)`<br>
   * `68 - ???`<br>
+  * `79 - ???`<br>
   * `80 - Damage vehicle (unknown value)`<br>
   * `81 - ???`<br>
   * `113 - ???`

--- a/common/src/main/scala/net/psforever/packet/game/ServerVehicleOverrideMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ServerVehicleOverrideMsg.scala
@@ -33,14 +33,19 @@ import scodec.codecs._
   * @param lock_accelerator driver has no control over vehicle acceleration
   * @param lock_wheel driver has no control over vehicle turning
   * @param reverse move in reverse
+  *                0 = forward
+  *                1 = reverse
   * @param unk4 na;
   *             something to do with vehicle bailable speed
   * @param lock_vthrust pilot has no control over vertical thrust;
   *                     asserts a constant positive vertical thrust;
   *                     the only valid setting appears to be 1
   * @param lock_strafe pilot has no control over strafing thrust;
-  *                    the only valid setting appears to be 1
-  * @param forward_speed "something like speed"
+  *                    0 = not locked
+  *                    1 = no strafing
+  *                    2 = strafe left automatically
+  *                    3 = strafe right automatically
+  * @param movement_speed "something like speed"
   * @param unk8 na;
   *             set `lock_wheel` to `true` to expose this value
   */
@@ -50,7 +55,7 @@ final case class ServerVehicleOverrideMsg(lock_accelerator : Boolean,
                                           unk4 : Boolean,
                                           lock_vthrust : Int,
                                           lock_strafe : Int,
-                                          forward_speed : Int,
+                                          movement_speed : Int,
                                           unk8 : Option[Long]
                                          ) extends PlanetSideGamePacket {
   type Packet = ServerVehicleOverrideMsg
@@ -66,7 +71,7 @@ object ServerVehicleOverrideMsg extends Marshallable[ServerVehicleOverrideMsg] {
           ("unk4" | bool) ::
           ("lock_vthrust" | uint2L) ::
           ("lock_strafe" | uint2L) ::
-          ("forward_speed" | uintL(9)) ::
+          ("movement_speed" | uintL(9)) ::
           conditional(test, "unk8" | uint32L)
       })
     ).as[ServerVehicleOverrideMsg]

--- a/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
@@ -21,7 +21,7 @@ import scodec.codecs._
   *                        15 for straight;
   *                        0 for hard right;
   *                        30 for hard left
-  * @param unk5 na
+  * @param unk5 na - Possibly a flag to indicate the vehicle is attached to something else e.g. is in a galaxy/lodestar cargo bay
   * @param unk6 na
   * @see `PlacementData`
   */

--- a/common/src/main/scala/net/psforever/types/CargoStatus.scala
+++ b/common/src/main/scala/net/psforever/types/CargoStatus.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.types
+
+import net.psforever.packet.PacketHelpers
+import scodec.codecs._
+
+object CargoStatus extends Enumeration {
+  type Type = Value
+
+  val Empty = Value(0)
+  val InProgress = Value(1)
+  val Occupied = Value(3)
+
+  implicit val codec = PacketHelpers.createEnumerationCodec(this, uint4L)
+}

--- a/pslogin/src/main/scala/services/avatar/AvatarAction.scala
+++ b/pslogin/src/main/scala/services/avatar/AvatarAction.scala
@@ -4,7 +4,8 @@ package services.avatar
 import net.psforever.objects.Player
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{PlanetSideGUID, PlayerStateMessageUpstream}
+import net.psforever.packet.PlanetSideGamePacket
+import net.psforever.packet.game.{CargoMountPointStatusMessage, PlanetSideGUID, PlayerStateMessageUpstream}
 import net.psforever.packet.game.objectcreate.ConstructorData
 import net.psforever.types.{ExoSuitType, Vector3}
 
@@ -30,7 +31,10 @@ object AvatarAction {
   final case class Reload(player_guid : PlanetSideGUID, weapon_guid : PlanetSideGUID) extends Action
   final case class StowEquipment(player_guid : PlanetSideGUID, target_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Action
   final case class WeaponDryFire(player_guid : PlanetSideGUID, weapon_guid : PlanetSideGUID) extends Action
-//  final case class PlayerStateShift(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
+
+  final case class SendResponse(player_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
+
+  //  final case class PlayerStateShift(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
 //  final case class DestroyDisplay(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
 //  final case class HitHintReturn(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
 //  final case class ChangeWeapon(unk1 : Int, sessionId : Long) extends Action

--- a/pslogin/src/main/scala/services/avatar/AvatarResponse.scala
+++ b/pslogin/src/main/scala/services/avatar/AvatarResponse.scala
@@ -3,6 +3,7 @@ package services.avatar
 
 import net.psforever.objects.Player
 import net.psforever.objects.equipment.Equipment
+import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.{PlanetSideGUID, PlayerStateMessageUpstream}
 import net.psforever.packet.game.objectcreate.ConstructorData
 import net.psforever.types.{ExoSuitType, Vector3}
@@ -29,6 +30,8 @@ object AvatarResponse {
   final case class Reload(weapon_guid : PlanetSideGUID) extends Response
   final case class StowEquipment(target_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Response
   final case class WeaponDryFire(weapon_guid : PlanetSideGUID) extends Response
+
+  final case class SendResponse(msg: PlanetSideGamePacket) extends Response
   //  final case class PlayerStateShift(itemID : PlanetSideGUID) extends Response
   //  final case class DestroyDisplay(itemID : PlanetSideGUID) extends Response
   //  final case class HitHintReturn(itemID : PlanetSideGUID) extends Response

--- a/pslogin/src/main/scala/services/avatar/AvatarService.scala
+++ b/pslogin/src/main/scala/services/avatar/AvatarService.scala
@@ -110,6 +110,10 @@ class AvatarService extends Actor {
           AvatarEvents.publish(
             AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.WeaponDryFire(weapon_guid))
           )
+        case AvatarAction.SendResponse(player_guid, msg) =>
+          AvatarEvents.publish(
+            AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.SendResponse(msg))
+          )
 
         case _ => ;
     }

--- a/pslogin/src/main/scala/services/vehicle/VehicleAction.scala
+++ b/pslogin/src/main/scala/services/vehicle/VehicleAction.scala
@@ -4,9 +4,10 @@ package services.vehicle
 import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.zones.Zone
+import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.types.{DriveState, Vector3, BailType}
+import net.psforever.types.{BailType, DriveState, Vector3}
 
 object VehicleAction {
   trait Action
@@ -25,6 +26,6 @@ object VehicleAction {
   final case class UnloadVehicle(player_guid : PlanetSideGUID, continent : Zone, vehicle : Vehicle) extends Action
   final case class UnstowEquipment(player_guid : PlanetSideGUID, item_guid : PlanetSideGUID) extends Action
   final case class VehicleState(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Action
-
+  final case class SendResponse(player_guid: PlanetSideGUID, msg : PlanetSideGamePacket) extends Action
   final case class UpdateAmsSpawnPoint(zone : Zone) extends Action
 }

--- a/pslogin/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/pslogin/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -3,9 +3,10 @@ package services.vehicle
 
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects.{PlanetSideGameObject, Vehicle}
+import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.types.{DriveState, Vector3, BailType}
+import net.psforever.types.{BailType, DriveState, Vector3}
 
 object VehicleResponse {
   trait Response
@@ -29,6 +30,6 @@ object VehicleResponse {
   final case class UnloadVehicle(vehicle_guid : PlanetSideGUID) extends Response
   final case class UnstowEquipment(item_guid : PlanetSideGUID) extends Response
   final case class VehicleState(vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Response
-
+  final case class SendResponse(msg: PlanetSideGamePacket) extends Response
   final case class UpdateAmsSpawnPoint(list : List[SpawnTube]) extends Response
 }

--- a/pslogin/src/main/scala/services/vehicle/VehicleService.scala
+++ b/pslogin/src/main/scala/services/vehicle/VehicleService.scala
@@ -95,6 +95,10 @@ class VehicleService extends Actor {
           VehicleEvents.publish(
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.VehicleState(vehicle_guid, unk1, pos, ang, vel, unk2, unk3, unk4, wheel_direction, unk5, unk6))
           )
+        case VehicleAction.SendResponse(player_guid, msg) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.SendResponse(msg))
+          )
 
         //unlike other messages, just return to sender, don't publish
         case VehicleAction.UpdateAmsSpawnPoint(zone : Zone) =>


### PR DESCRIPTION
This PR contains the initial functionality for cargo holds & cargo vehicles

**Stuff that doesn't quite work as intended:**
- Synchronising cargo state to players joining the zone. The cargo attaches correctly, but the visible effect is incorrect and the cargo hold is not locked properly
- Passengers of the vehicle in the cargo hold can't bail out. Eventually they should be able to bail without bailing the entire vehicle out
- Changing vehicle permissions to disallow passengers doesn't kick cargo vehicles out


**Stuff that needs implementing in the future:**
- Taking cargo through warp gates
- Proper bailing functionality for cargo (currently the vehicle bails and drops, but is not in a true bail state so will take damage on landing when collision damage is implemented)
- Mounting BFRs as cargo. This **should** be as easy as including them in the same logic as the router for mounting/dismounting sideways, but can't be tested until BFR functionality is done
- Kicked cargo vehicles currently always use the bail procedure. There's a small chance this could place them under the world if the galaxy/lodestar is landed. Once the server has functionality for determining the height from the floor this needs to be addressed
- Pilots bailing out will cause players in the cargo hold to bug out as their avatar gets deleted from their clients. This needs to be addressed after PR #216 is merged as this relates to vehicle deconstruction


**Stuff that does work / stuff to verify working:**
- Mounting small vehicles in the galaxy cargo
- Mounting large vehicles in the lodestar cargo hold
- Mounting horizontally large vehicles in the lodestar (e.g. router).
- Passengers can also be present in the vehicle in the cargo hold
- Vehicle driver can bail out of cargo hold
- Vehicle can be auto disembarked (with auto-drive) from the cargo hold (both normally & sideways for router)
- Auto disembark will stop if the vehicle gets far enough away, or the vehicle takes too long to move away (e.g. the vehicle got stuck on another object)
- Vehicles that take too long to mount will have their mount request cancelled (to prevent griefing, as the pilot can't take off while loading a cargo passenger)
- Vehicles that move away from cargo vehicle will have their mount request cancelled (see above)
- The lodestar/galaxy pilot can kick vehicles out by selecting them and using the "kick" button