### PR TITLE
GUID Fix

### DIFF
--- a/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
@@ -208,7 +208,7 @@ class NumberPoolHub(private val source : NumberSource) {
         import net.psforever.objects.guid.selector.SpecificSelector
         val specific = new SpecificSelector
         pool.Selector = specific
-        specific.SelectionIndex = number
+        specific.SelectionIndex = pool.Numbers.indexOf(number)
         pool.Get()
         pool.Selector = slctr
         register_GetAvailableNumberFromSource(number)
@@ -281,10 +281,10 @@ class NumberPoolHub(private val source : NumberSource) {
   }
 
   private def register_GetMonitorFromSource(number : Int) : Try[LoanedKey] = {
-    source.Available(number) match {
-      case Some(key) =>
+    register_GetAvailableNumberFromSource(number) match {
+      case Success(key) =>
         Success(key)
-      case _ =>
+      case Failure(_) =>
         throw NoGUIDException(s"a pool gave us a number $number that is actually unavailable") //stop the show; this is terrible!
     }
   }

--- a/common/src/test/scala/objects/number/NumberPoolHubTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolHubTest.scala
@@ -136,15 +136,33 @@ class NumberPoolHubTest extends Specification {
       }
     }
 
-    "register an object to a specific, pooled number" in {
-      val hub = new NumberPoolHub(new LimitedNumberSource(51))
+    "register an object to a specific, pooled number (list 1)" in {
+      val src = new LimitedNumberSource(51)
+      val hub = new NumberPoolHub(src)
       hub.AddPool("fibonacci", numberList)
+      val obj = new EntityTestClass()
+      obj.GUID must throwA[Exception]
+      hub.register(obj, 5) match {
+        case Success(number) =>
+          obj.GUID mustEqual PlanetSideGUID(number)
+          hub.WhichPool(obj) mustEqual Some("fibonacci")
+          src.Available(5) mustEqual None
+        case _ =>
+          ko
+      }
+    }
+
+    "register an object to a specific, pooled number (list 2)" in {
+      val src = new LimitedNumberSource(51)
+      val hub = new NumberPoolHub(src)
+      hub.AddPool("fibonacci", numberList2)
       val obj = new EntityTestClass()
       obj.GUID must throwA[Exception]
       hub.register(obj, 13) match {
         case Success(number) =>
           obj.GUID mustEqual PlanetSideGUID(number)
           hub.WhichPool(obj) mustEqual Some("fibonacci")
+          src.Available(13) mustEqual None
         case _ =>
           ko
       }

--- a/common/src/test/scala/objects/number/NumberPoolTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolTest.scala
@@ -25,13 +25,17 @@ class NumberPoolTest extends Specification {
     }
 
     "get a number" in {
-      val obj = new SimplePool((0 to 10).toList)
+      val min = 10
+      val max = 20
+      val domain = (min to max).toList
+      val obj = new SimplePool(domain)
       obj.Get() match {
         case Success(number) =>
-          (-1 < number && number < 11) mustEqual true
+          (min <= number && number <= max) mustEqual true
         case _ =>
           ko
       }
+      ok
     }
 
     "used number count is always zero" in {
@@ -70,22 +74,28 @@ class NumberPoolTest extends Specification {
     }
 
     "get a number" in {
-      val obj = new ExclusivePool((0 to 10).toList)
+      val min = 10
+      val max = 20
+      val domain = (min to max).toList
+      val obj = new ExclusivePool(domain)
       obj.Get() match {
         case Success(number) =>
-          (-1 < number && number < 11) mustEqual true
+          (min <= number && number <= max) mustEqual true
         case _ =>
           ko
       }
+      ok
     }
 
     "get all the numbers" in {
-      val range = 0 to 10
-      val obj = new ExclusivePool((0 to 10).toList)
-      range.foreach(_ => {
+      val min = 10
+      val max = 20
+      val domain = (min to max).toList
+      val obj = new ExclusivePool(domain)
+      domain.foreach(_ => {
         obj.Get() match {
           case Success(number) =>
-            (-1 < number && number < 11) mustEqual true
+            (min <= number && number <= max) mustEqual true
           case _ =>
             ko
         }

--- a/common/src/test/scala/objects/number/NumberSelectorTest.scala
+++ b/common/src/test/scala/objects/number/NumberSelectorTest.scala
@@ -5,26 +5,28 @@ import net.psforever.objects.guid.selector.{RandomSequenceSelector, _}
 import org.specs2.mutable.Specification
 
 class NumberSelectorTest extends Specification {
-  def randArrayGen(n : Int = 26) : Array[Int] = {
+  def randArrayGen(n : Int = 26, dx : Int = 0) : Array[Int] = {
     val obj = Array.ofDim[Int](n)
-    (0 to 25).foreach(x => { obj(x) = x } )
+    (0 to 25).foreach(x => { obj(x) = x + dx } )
     obj
   }
 
-  "RandomSequenceSelector" should {
+  "RandomSequenceSelector (0, default)" should {
     "construct" in {
       new RandomSequenceSelector
       ok
     }
 
     "get a number" in {
+      val n : Int = 26
       val obj = new RandomSequenceSelector
-      obj.Get(randArrayGen()) mustNotEqual -1
+      obj.Get(randArrayGen(n)) mustNotEqual -1
     }
 
     "return a number" in {
+      val n : Int = 26
       val obj = new RandomSequenceSelector
-      val ary = randArrayGen()
+      val ary = randArrayGen(n)
       val number = obj.Get(ary)
       number mustNotEqual -1
       ary.head mustEqual -1 //regardless of which number we actually got, the head of the array is now -1


### PR DESCRIPTION
After the update that introduced wall turrets, but not visible while working on said update, an issue regarding the globally unique identifiers for the turret weapon components began to arise.  When trying to register one object, the system would complain that the number was already reserved for some other object, even though the system was willing to provide the number in the first place.  Without spending too much time talking about how the system works, the issue was how the numbers were indexed and how they were being accessed between a randomized selection and a specific number selection.

I updated the tests in hopes of demonstrating that the issue existed and was resolved.