### PR TITLE
Router and Telepad

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Deployables.scala
+++ b/common/src/main/scala/net/psforever/objects/Deployables.scala
@@ -22,7 +22,8 @@ object Deployables {
       DeployedItem.portable_manned_turret_nc -> { ()=> new TurretDeployable(GlobalDefinitions.portable_manned_turret_nc) },
       DeployedItem.portable_manned_turret_tr -> { ()=> new TurretDeployable(GlobalDefinitions.portable_manned_turret_tr) },
       DeployedItem.portable_manned_turret_vs -> { ()=> new TurretDeployable(GlobalDefinitions.portable_manned_turret_vs) },
-      DeployedItem.deployable_shield_generator -> { ()=> new ShieldGeneratorDeployable(GlobalDefinitions.deployable_shield_generator) }
+      DeployedItem.deployable_shield_generator -> { ()=> new ShieldGeneratorDeployable(GlobalDefinitions.deployable_shield_generator) },
+      DeployedItem.router_telepad_deployable -> { () => new TelepadDeployable(GlobalDefinitions.router_telepad_deployable) }
     ).withDefaultValue( { ()=> new ExplosiveDeployable(GlobalDefinitions.boomer) } )
   }
 }

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -861,6 +861,8 @@ object GlobalDefinitions {
   val portable_manned_turret_vs = TurretDeployableDefinition(DeployedItem.portable_manned_turret_vs)
 
   val deployable_shield_generator = new ShieldGeneratorDefinition
+
+  val router_telepad_deployable = DeployableDefinition(DeployedItem.router_telepad_deployable)
   init_deployables()
 
   /*
@@ -5527,5 +5529,11 @@ object GlobalDefinitions {
     deployable_shield_generator.MaxHealth = 1700
     deployable_shield_generator.DeployTime = Duration.create(6000, "ms")
     deployable_shield_generator.Model = StandardResolutions.ComplexDeployables
+
+    router_telepad_deployable.Name = "router_telepad_deployable"
+    router_telepad_deployable.MaxHealth = 100
+    router_telepad_deployable.DeployTime = Duration.create(1, "ms")
+    router_telepad_deployable.Packet = new TelepadDeployableConverter
+    router_telepad_deployable.Model = StandardResolutions.SimpleDeployables
   }
 }

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -863,6 +863,8 @@ object GlobalDefinitions {
   val deployable_shield_generator = new ShieldGeneratorDefinition
 
   val router_telepad_deployable = DeployableDefinition(DeployedItem.router_telepad_deployable)
+
+  val internal_router_telepad_deployable = DeployableDefinition(DeployedItem.router_telepad_deployable)
   init_deployables()
 
   /*
@@ -5135,6 +5137,7 @@ object GlobalDefinitions {
     router.Seats += 0 -> new SeatDefinition()
     router.MountPoints += 1 -> 0
     router.Utilities += 1 -> UtilityType.teleportpad_terminal
+    router.Utilities += 2 -> UtilityType.internal_router_telepad_deployable
     router.TrunkSize = InventoryTile.Tile1511
     router.TrunkOffset = 30
     router.Deployment = true
@@ -5535,5 +5538,10 @@ object GlobalDefinitions {
     router_telepad_deployable.DeployTime = Duration.create(1, "ms")
     router_telepad_deployable.Packet = new TelepadDeployableConverter
     router_telepad_deployable.Model = StandardResolutions.SimpleDeployables
+
+    internal_router_telepad_deployable.Name = "router_telepad_deployable"
+    internal_router_telepad_deployable.MaxHealth = 1
+    internal_router_telepad_deployable.DeployTime = Duration.create(1, "ms")
+    internal_router_telepad_deployable.Packet = new InternalTelepadDeployableConverter
   }
 }

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -4071,7 +4071,7 @@ object GlobalDefinitions {
     router_telepad.Size = EquipmentSize.Pistol
     router_telepad.Modes += new ConstructionFireMode
     router_telepad.Modes.head.Item(DeployedItem.router_telepad_deployable -> Set(CertificationType.GroundSupport))
-    router_telepad.Tile = InventoryTile.Tile11 //TODO fix
+    router_telepad.Tile = InventoryTile.Tile33
     router_telepad.Packet = new TelepadConverter
 
     fury_weapon_systema.Name = "fury_weapon_systema"

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -642,6 +642,8 @@ object GlobalDefinitions {
 
   val advanced_ace = ConstructionItemDefinition(CItem.advanced_ace)
 
+  val router_telepad = ConstructionItemDefinition(CItem.router_telepad)
+
   val fury_weapon_systema = ToolDefinition(ObjectClass.fury_weapon_systema)
 
   val quadassault_weapon_system = ToolDefinition(ObjectClass.quadassault_weapon_system)
@@ -893,6 +895,8 @@ object GlobalDefinitions {
   val respawn_tube = new SpawnTubeDefinition(732)
 
   val respawn_tube_tower = new SpawnTubeDefinition(733)
+
+  val teleportpad_terminal = new TeleportPadTerminalDefinition
 
   val adv_med_terminal = new MedicalTerminalDefinition(38)
 
@@ -4059,6 +4063,13 @@ object GlobalDefinitions {
     advanced_ace.Modes(2).Item(DeployedItem.deployable_shield_generator -> Set(CertificationType.AssaultEngineering))
     advanced_ace.Tile = InventoryTile.Tile93
 
+    router_telepad.Name = "router_telepad"
+    router_telepad.Size = EquipmentSize.Pistol
+    router_telepad.Modes += new ConstructionFireMode
+    router_telepad.Modes.head.Item(DeployedItem.router_telepad_deployable -> Set(CertificationType.GroundSupport))
+    router_telepad.Tile = InventoryTile.Tile11 //TODO fix
+    router_telepad.Packet = new TelepadConverter
+
     fury_weapon_systema.Name = "fury_weapon_systema"
     fury_weapon_systema.Size = EquipmentSize.VehicleWeapon
     fury_weapon_systema.AmmoTypes += hellfire_ammo
@@ -5121,6 +5132,7 @@ object GlobalDefinitions {
     router.MaxShields = 800 + 1
     router.Seats += 0 -> new SeatDefinition()
     router.MountPoints += 1 -> 0
+    router.Utilities += 1 -> UtilityType.teleportpad_terminal
     router.TrunkSize = InventoryTile.Tile1511
     router.TrunkOffset = 30
     router.Deployment = true

--- a/common/src/main/scala/net/psforever/objects/Telepad.scala
+++ b/common/src/main/scala/net/psforever/objects/Telepad.scala
@@ -1,28 +1,11 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects
 
+import net.psforever.objects.ce.TelepadLike
 import net.psforever.objects.definition.ConstructionItemDefinition
-import net.psforever.packet.game.PlanetSideGUID
 
-class Telepad(private val cdef : ConstructionItemDefinition) extends ConstructionItem(cdef) {
-  private var router : Option[PlanetSideGUID] = None
-
-  def Router : Option[PlanetSideGUID] = router
-
-  def Router_=(rguid : PlanetSideGUID) : Option[PlanetSideGUID] = Router_=(Some(rguid))
-
-  def Router_=(rguid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
-    router match {
-      case None =>
-        router = rguid
-      case Some(_) =>
-        if(rguid.isEmpty || rguid.contains(PlanetSideGUID(0))) {
-          router = None
-        }
-    }
-    Router
-  }
-}
+class Telepad(private val cdef : ConstructionItemDefinition) extends ConstructionItem(cdef)
+  with TelepadLike
 
 object Telepad {
   def apply(cdef : ConstructionItemDefinition) : Telepad = {

--- a/common/src/main/scala/net/psforever/objects/Telepad.scala
+++ b/common/src/main/scala/net/psforever/objects/Telepad.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects
+
+import net.psforever.objects.definition.ConstructionItemDefinition
+import net.psforever.packet.game.PlanetSideGUID
+
+class Telepad(private val cdef : ConstructionItemDefinition) extends ConstructionItem(cdef) {
+  private var router : Option[PlanetSideGUID] = None
+
+  def Router : Option[PlanetSideGUID] = router
+
+  def Router_=(rguid : PlanetSideGUID) : Option[PlanetSideGUID] = Router_=(Some(rguid))
+
+  def Router_=(rguid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    router match {
+      case None =>
+        router = rguid
+      case Some(_) =>
+        if(rguid.isEmpty || rguid.contains(PlanetSideGUID(0))) {
+          router = None
+        }
+    }
+    Router
+  }
+}
+
+object Telepad {
+  def apply(cdef : ConstructionItemDefinition) : Telepad = {
+    new Telepad(cdef)
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/TelepadDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/TelepadDeployable.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects
+
+import net.psforever.objects.ce.SimpleDeployable
+import net.psforever.objects.definition.DeployableDefinition
+import net.psforever.packet.game.PlanetSideGUID
+
+class TelepadDeployable(ddef : DeployableDefinition) extends SimpleDeployable(ddef) {
+  private var router : Option[PlanetSideGUID] = None
+  private var activated : Boolean = false
+
+  def Router : Option[PlanetSideGUID] = router
+
+  def Router_=(rguid : PlanetSideGUID) : Option[PlanetSideGUID] = Router_=(Some(rguid))
+
+  def Router_=(rguid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    router match {
+      case None =>
+        router = rguid
+      case Some(_) =>
+        if(rguid.isEmpty || rguid.contains(PlanetSideGUID(0))) {
+          router = None
+        }
+    }
+    Router
+  }
+
+  def Active : Boolean = activated
+
+  def Active_=(state : Boolean) : Boolean = {
+    activated = state
+    Active
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/TelepadDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/TelepadDeployable.scala
@@ -1,34 +1,8 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects
 
-import net.psforever.objects.ce.SimpleDeployable
+import net.psforever.objects.ce.{SimpleDeployable, TelepadLike}
 import net.psforever.objects.definition.DeployableDefinition
-import net.psforever.packet.game.PlanetSideGUID
 
-class TelepadDeployable(ddef : DeployableDefinition) extends SimpleDeployable(ddef) {
-  private var router : Option[PlanetSideGUID] = None
-  private var activated : Boolean = false
-
-  def Router : Option[PlanetSideGUID] = router
-
-  def Router_=(rguid : PlanetSideGUID) : Option[PlanetSideGUID] = Router_=(Some(rguid))
-
-  def Router_=(rguid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
-    router match {
-      case None =>
-        router = rguid
-      case Some(_) =>
-        if(rguid.isEmpty || rguid.contains(PlanetSideGUID(0))) {
-          router = None
-        }
-    }
-    Router
-  }
-
-  def Active : Boolean = activated
-
-  def Active_=(state : Boolean) : Boolean = {
-    activated = state
-    Active
-  }
-}
+class TelepadDeployable(ddef : DeployableDefinition) extends SimpleDeployable(ddef)
+  with TelepadLike

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -378,7 +378,7 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
   def Utilities : Map[Int, Utility] = utilities
 
   /**
-    * Get a referenece ot a certain `Utility` attached to this `Vehicle`.
+    * Get a reference to a certain `Utility` attached to this `Vehicle`.
     * @param utilNumber the attachment number of the `Utility`
     * @return the `Utility` or `None` (if invalid)
     */
@@ -393,6 +393,15 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
     }
     else {
       None
+    }
+  }
+
+  def Utility(utilType : UtilityType.Value) : Option[PlanetSideServerObject] = {
+    utilities.values.find(_.UtilType == utilType) match {
+      case Some(util) =>
+        Some(util())
+      case None =>
+        None
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
@@ -29,12 +29,13 @@ class DeployableToolbox {
     * keys: categories, values: quantity storage object
     */
   private val categoryCounts = DeployableCategory.values.toSeq.map(value => { value -> new DeployableToolbox.Bin }).toMap
-  //)
+  categoryCounts(DeployableCategory.Telepads).Max = 1024
   /**
     * a map of bins for keeping track of the quantities of individual deployables
     * keys: deployable types, values: quantity storage object
     */
   private val deployableCounts = DeployedItem.values.toSeq.map(value => { value -> new DeployableToolbox.Bin }).toMap
+  deployableCounts(DeployedItem.router_telepad_deployable).Max = 1024
   /**
     * a map of tracked/owned individual deployables
     * keys: categories, values: deployable objects
@@ -589,9 +590,9 @@ object DeployableToolbox {
             AddToDeployableQuantities(counts, categories, FortificationEngineering, certificationSet ++ Set(FortificationEngineering))
           }
 
-        case GroundSupport =>
-          counts(DeployedItem.router_telepad_deployable).Max = 1024
-          categories(DeployableCategory.Telepads).Max = 1024
+//        case GroundSupport =>
+//          counts(DeployedItem.router_telepad_deployable).Max = 1024
+//          categories(DeployableCategory.Telepads).Max = 1024
 
         case _ => ;
       }
@@ -657,9 +658,9 @@ object DeployableToolbox {
             RemoveFromDeployablesQuantities(counts, categories, FortificationEngineering, certificationSet)
           }
 
-        case GroundSupport =>
-          counts(DeployedItem.router_telepad_deployable).Max = 0
-          categories(DeployableCategory.Telepads).Max = 0
+//        case GroundSupport =>
+//          counts(DeployedItem.router_telepad_deployable).Max = 0
+//          categories(DeployableCategory.Telepads).Max = 0
 
         case _ => ;
       }

--- a/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
@@ -523,8 +523,8 @@ object DeployableToolbox {
       }
     }
     if(certifications.contains(CertificationType.GroundSupport)) {
-      counts(DeployedItem.router_telepad_deployable).Max = 1
-      categories(DeployableCategory.Telepads).Max = 1
+      counts(DeployedItem.router_telepad_deployable).Max = 1024
+      categories(DeployableCategory.Telepads).Max = 1024
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/ce/Deployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/Deployable.scala
@@ -118,7 +118,8 @@ object Deployable {
       DeployedItem.portable_manned_turret_tr.id -> DeployableIcon.FieldTurret,
       DeployedItem.portable_manned_turret_nc.id -> DeployableIcon.FieldTurret,
       DeployedItem.portable_manned_turret_vs.id -> DeployableIcon.FieldTurret,
-      DeployedItem.deployable_shield_generator.id -> DeployableIcon.AegisShieldGenerator
+      DeployedItem.deployable_shield_generator.id -> DeployableIcon.AegisShieldGenerator,
+      DeployedItem.router_telepad_deployable.id -> DeployableIcon.RouterTelepad
     ).withDefaultValue(DeployableIcon.Boomer)
   }
 

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -51,6 +51,14 @@ object TelepadLike {
     obj.asInstanceOf[TelepadLike].Router = obj.Owner.GUID
   }
 
+  /**
+    * An analysis of the active system of teleportation utilized by Router vehicles.
+    * Information about the two endpoints - an internal telepad and a remote telepad - are collected, if they are applicable.
+    * The vehicle "Router" itself must be in the drive state of `Deployed`.
+    * @param router the vehicle that serves as the container of an internal telepad unit
+    * @param zone where the router is located
+    * @return the pair of units that compose the teleportation system
+    */
   def AppraiseTeleportationSystem(router : Vehicle, zone : Zone) : Option[(Utility.InternalTelepad, TelepadDeployable)] = {
     import net.psforever.objects.vehicles.UtilityType
     import net.psforever.types.DriveState

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.ce
+
+import akka.actor.{ActorContext, Cancellable}
+import net.psforever.objects.{DefaultCancellable, PlanetSideGameObject}
+import net.psforever.objects.serverobject.structures.Amenity
+import net.psforever.packet.game.PlanetSideGUID
+
+trait TelepadLike {
+  private var router : Option[PlanetSideGUID] = None
+  private var activated : Boolean = false
+  private val activation : Cancellable = DefaultCancellable.obj
+
+  def Router : Option[PlanetSideGUID] = router
+
+  def Router_=(rguid : PlanetSideGUID) : Option[PlanetSideGUID] = Router_=(Some(rguid))
+
+  def Router_=(rguid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    router match {
+      case None =>
+        router = rguid
+      case Some(_) =>
+        if(rguid.isEmpty || rguid.contains(PlanetSideGUID(0))) {
+          router = None
+        }
+    }
+    Router
+  }
+
+  def Active : Boolean = activated
+
+  def Active_=(state : Boolean) : Boolean = {
+    activated = state
+    Active
+  }
+}
+
+object TelepadLike {
+  final case class Activate(obj : PlanetSideGameObject with TelepadLike)
+
+  final case class Deactivate(obj : PlanetSideGameObject with TelepadLike)
+
+  /**
+    * Assemble some logic for a provided object.
+    * @param obj an `Amenity` object;
+    *            anticipating a `Terminal` object using this same definition
+    * @param context hook to the local `Actor` system
+    */
+  def Setup(obj : Amenity, context : ActorContext) : Unit = {
+    obj.asInstanceOf[TelepadLike].Router = obj.Owner.GUID
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -1,15 +1,16 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.ce
 
-import akka.actor.{ActorContext, Cancellable}
-import net.psforever.objects.{DefaultCancellable, PlanetSideGameObject}
+import akka.actor.ActorContext
+import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.objects.serverobject.structures.Amenity
+import net.psforever.objects.vehicles.Utility
+import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.PlanetSideGUID
 
 trait TelepadLike {
   private var router : Option[PlanetSideGUID] = None
   private var activated : Boolean = false
-  private val activation : Cancellable = DefaultCancellable.obj
 
   def Router : Option[PlanetSideGUID] = router
 
@@ -48,5 +49,29 @@ object TelepadLike {
     */
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     obj.asInstanceOf[TelepadLike].Router = obj.Owner.GUID
+  }
+
+  def AppraiseTeleportationSystem(router : Vehicle, zone : Zone) : Option[(Utility.InternalTelepad, TelepadDeployable)] = {
+    import net.psforever.objects.vehicles.UtilityType
+    import net.psforever.types.DriveState
+    router.Utility(UtilityType.internal_router_telepad_deployable) match {
+      //if the vehicle has an internal telepad, it is allowed to be a Router (that's a weird way of saying it)
+      case Some(util : Utility.InternalTelepad) =>
+        //check for a readied remote telepad
+        zone.GUID(util.Telepad) match {
+          case Some(telepad : TelepadDeployable) =>
+            //determine whether to activate both the Router's internal telepad and the deployed remote telepad
+            if(router.DeploymentState == DriveState.Deployed && util.Active && telepad.Active) {
+              Some((util, telepad))
+            }
+            else {
+              None
+            }
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/definition/converter/InternalTelepadDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/InternalTelepadDeployableConverter.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.definition.converter
+
+import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.ce.TelepadLike
+import net.psforever.packet.game.objectcreate._
+
+import scala.util.{Success, Try}
+
+class InternalTelepadDeployableConverter extends ObjectCreateConverter[PlanetSideGameObject with TelepadLike]() {
+  override def ConstructorData(obj : PlanetSideGameObject with TelepadLike) : Try[ContainedTelepadDeployableData] = {
+    Success(ContainedTelepadDeployableData(101, obj.Router.get))
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.definition.converter
+
+import net.psforever.objects.Telepad
+import net.psforever.packet.game.objectcreate._
+
+import scala.util.{Success, Try}
+
+class TelepadConverter extends ObjectCreateConverter[Telepad]() {
+  override def ConstructorData(obj : Telepad) : Try[TelepadData] =
+    Success(TelepadData(0, obj.Router))
+
+  override def DetailedConstructorData(obj : Telepad) : Try[DetailedTelepadData] =
+    Success(DetailedTelepadData(0, obj.Router))
+}

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
@@ -4,12 +4,24 @@ package net.psforever.objects.definition.converter
 import net.psforever.objects.Telepad
 import net.psforever.packet.game.objectcreate._
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 class TelepadConverter extends ObjectCreateConverter[Telepad]() {
-  override def ConstructorData(obj : Telepad) : Try[TelepadData] =
-    Success(TelepadData(0, obj.Router))
+  override def ConstructorData(obj : Telepad) : Try[TelepadData] = {
+    obj.Router match {
+      case Some(_) =>
+        Success(TelepadData (0, obj.Router))
+      case None =>
+        Failure(new IllegalStateException("TelepadConverter: telepad needs to know id of its router"))
+    }
+  }
 
-  override def DetailedConstructorData(obj : Telepad) : Try[DetailedTelepadData] =
-    Success(DetailedTelepadData(0, obj.Router))
+  override def DetailedConstructorData(obj : Telepad) : Try[DetailedTelepadData] = {
+    obj.Router match {
+      case Some(_) =>
+        Success(DetailedTelepadData (0, obj.Router))
+      case None =>
+        Failure(new IllegalStateException("TelepadConverter: telepad needs to know id of its router"))
+    }
+  }
 }

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 
 class TelepadDeployableConverter extends ObjectCreateConverter[TelepadDeployable]() {
   override def ConstructorData(obj : TelepadDeployable) : Try[TelepadDeployableData] = {
-    if(obj.Router.isEmpty) {
+    if(obj.Router.isEmpty || obj.Router.contains(PlanetSideGUID(0))) {
       Failure(new IllegalStateException("TelepadDeployableConverter: telepad deployable needs to know id of its router"))
     }
     else {

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.definition.converter
+
+import net.psforever.objects.TelepadDeployable
+import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.packet.game.objectcreate._
+
+import scala.util.{Failure, Success, Try}
+
+class TelepadDeployableConverter extends ObjectCreateConverter[TelepadDeployable]() {
+  override def ConstructorData(obj : TelepadDeployable) : Try[TelepadDeployableData] = {
+    if(obj.Router.isEmpty) {
+      Failure(new IllegalStateException("TelepadDeployableConverter: telepad deployable needs to know id of its router"))
+    }
+    else {
+      if(obj.Health > 0) {
+        Success(TelepadDeployableData(
+          PlacementData(obj.Position, obj.Orientation),
+          obj.Faction,
+          bops = false,
+          destroyed = false,
+          unk1 = 2,
+          unk2 = true,
+          obj.Router.get,
+          obj.Owner.getOrElse(PlanetSideGUID(0)),
+          unk3 = 87,
+          unk4 = 12
+        ))
+      }
+      else {
+        Success(TelepadDeployableData(
+          PlacementData(obj.Position, obj.Orientation),
+          obj.Faction,
+          bops = false,
+          destroyed = true,
+          unk1 = 2,
+          unk2 = true,
+          obj.Router.get,
+          owner_guid = PlanetSideGUID(0),
+          unk3 = 0,
+          unk4 = 6
+        ))
+      }
+    }
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/EquipmentTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/EquipmentTerminalDefinition.scala
@@ -212,6 +212,10 @@ object EquipmentTerminalDefinition {
     "command_detonater" -> MakeSimpleItem(command_detonater),
     "flail_targeting_laser" -> MakeSimpleItem(flail_targeting_laser)
   )
+  /**
+    * A single-element `Map` of the one piece of `Equipment` specific to the Router.
+    */
+  val routerTerminal : Map[String, () => Equipment] = Map("router_telepad" -> MakeTelepad(router_telepad))
 
   /**
     * Create a new `Tool` from provided `EquipmentDefinition` objects.
@@ -333,6 +337,13 @@ object EquipmentTerminalDefinition {
     * @see `GlobalDefinitions`
     */
   private def MakeConstructionItem(cdef : ConstructionItemDefinition)() : ConstructionItem = ConstructionItem(cdef)
+
+  /**
+    * na
+    * @param cdef na
+    * @return na
+    */
+  private def MakeTelepad(cdef : ConstructionItemDefinition)() : Telepad = Telepad(cdef)
 
   /**
     * Accept a simplified blueprint for some piece of `Equipment` and create an actual piece of `Equipment` based on it.

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/TeleportPadTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/TeleportPadTerminalDefinition.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.objects.serverobject.terminals
+
+import akka.actor.ActorContext
+import net.psforever.objects.Player
+import net.psforever.objects.serverobject.structures.Amenity
+import net.psforever.packet.game.ItemTransactionMessage
+
+class TeleportPadTerminalDefinition extends EquipmentTerminalDefinition(853) {
+  Name = "teleport_pad_terminal"
+
+  def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = {
+    Terminal.BuyEquipment(EquipmentTerminalDefinition.routerTerminal("router_telepad")())
+  }
+}
+
+object TeleportPadTerminalDefinition {
+  /**
+    * Assemble some logic for a provided object.
+    * @param obj an `Amenity` object;
+    *            anticipating a `Terminal` object using this same definition
+    * @param context hook to the local `Actor` system
+    */
+  def Setup(obj : Amenity, context : ActorContext) : Unit = {
+    import akka.actor.{ActorRef, Props}
+    if(obj.Actor == ActorRef.noSender) {
+      obj.Actor = context.actorOf(Props(classOf[TerminalControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    }
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
@@ -40,13 +40,13 @@ class Terminal(tdef : TerminalDefinition) extends Amenity with Hackable {
     if(Faction == player.Faction || HackedBy.isDefined) {
       msg.transaction_type match {
         case TransactionType.Buy | TransactionType.Learn =>
-          tdef.Buy(player, msg)
+          Buy(player, msg)
 
         case TransactionType.Sell =>
-          tdef.Sell(player, msg)
+          Sell(player, msg)
 
         case TransactionType.Loadout =>
-          tdef.Loadout(player, msg)
+          Loadout(player, msg)
 
         case _ =>
           Terminal.NoDeal()
@@ -55,6 +55,18 @@ class Terminal(tdef : TerminalDefinition) extends Amenity with Hackable {
     else {
       Terminal.NoDeal()
     }
+  }
+
+  def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = {
+    tdef.Buy(player, msg)
+  }
+
+  def Sell(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = {
+    tdef.Sell(player, msg)
+  }
+
+  def Loadout(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = {
+    tdef.Loadout(player, msg)
   }
 
   def Definition : TerminalDefinition = tdef

--- a/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
@@ -145,8 +145,14 @@ object Utility {
     }
   }
 
+  /**
+    * The internal telepad is a component that is contained by the Router when it deploys
+    * and allows it to serve as one of the terminal points of a Router-telepad teleportation system.
+    * @param ddef na
+    */
   class InternalTelepad(ddef : DeployableDefinition) extends Amenity
     with TelepadLike {
+    /** a link to the telepad that serves as the other endpoint of this teleportation system */
     private var activeTelepad : Option[PlanetSideGUID] = None
 
     def Telepad : Option[PlanetSideGUID] = activeTelepad
@@ -160,6 +166,7 @@ object Utility {
 
     override def Position = Owner.Position
     override def Orientation = Owner.Orientation
+    /** the router is the owner */
     override def Router : Option[PlanetSideGUID] = Some(Owner.GUID)
 
     def Definition = ddef

--- a/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
@@ -104,7 +104,7 @@ object Utility {
     * Override for `SpawnTube` objects so that they inherit the spatial characteristics of their `Owner`.
     * @param tubeDef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
     */
-  private class SpawnTubeUtility(tubeDef : SpawnTubeDefinition) extends SpawnTube(tubeDef) {
+  class SpawnTubeUtility(tubeDef : SpawnTubeDefinition) extends SpawnTube(tubeDef) {
     override def Position = Owner.Position
     override def Orientation = Owner.Orientation
   }
@@ -113,7 +113,7 @@ object Utility {
     * Override for `Terminal` objects so that they inherit the spatial characteristics of their `Owner`.
     * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
     */
-  private class TerminalUtility(tdef : TerminalDefinition) extends Terminal(tdef) {
+  class TerminalUtility(tdef : TerminalDefinition) extends Terminal(tdef) {
     override def Position = Owner.Position
     override def Orientation = Owner.Orientation
   }
@@ -122,7 +122,7 @@ object Utility {
     * na
     * @param tdef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
     */
-  private class TeleportPadTerminalUtility(tdef : TerminalDefinition) extends TerminalUtility(tdef) {
+  class TeleportPadTerminalUtility(tdef : TerminalDefinition) extends TerminalUtility(tdef) {
     private var activeTelepad : Option[PlanetSideGUID] = None
 
     def Telepad : Option[PlanetSideGUID] = activeTelepad

--- a/common/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -238,6 +238,21 @@ class Zone(private val zoneId : String, zoneMap : ZoneMap, zoneNumber : Int) {
     * @return the associated object, if it exists
     * @see `GUID(Int)`
     */
+  def GUID(object_guid : Option[PlanetSideGUID]) : Option[PlanetSideGameObject] = {
+    object_guid match {
+      case Some(oguid) =>
+        GUID(oguid.guid)
+      case None =>
+        None
+    }
+  }
+
+  /**
+    * Recover an object from the globally unique identifier system by the number that was assigned previously.
+    * @param object_guid the globally unique identifier requested
+    * @return the associated object, if it exists
+    * @see `GUID(Int)`
+    */
   def GUID(object_guid : PlanetSideGUID) : Option[PlanetSideGameObject] = GUID(object_guid.guid)
 
   /**

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ContainedTelepadDeployableData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ContainedTelepadDeployableData.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game.objectcreate
+
+import net.psforever.packet.Marshallable
+import net.psforever.packet.game.PlanetSideGUID
+import scodec.{Attempt, Codec, Err}
+import scodec.codecs._
+import shapeless.{::, HNil}
+
+/**
+  * na
+  */
+final case class ContainedTelepadDeployableData(unk : Int,
+                                                router_guid : PlanetSideGUID) extends ConstructorData {
+  override def bitsize : Long = 59L
+}
+
+object ContainedTelepadDeployableData extends Marshallable[ContainedTelepadDeployableData] {
+  implicit val codec : Codec[ContainedTelepadDeployableData] = (
+    ("unk" | uint(7)) ::
+      ("router_guid" | PlanetSideGUID.codec) ::
+      uint16 ::
+      uint4 ::
+      uint16
+    ).exmap[ContainedTelepadDeployableData] (
+    {
+      case unk :: rguid :: 0 :: 8 :: 0 :: HNil  =>
+        Attempt.successful(ContainedTelepadDeployableData(unk, rguid))
+      case _ :: _ :: _ :: _ :: _ :: HNil =>
+        Attempt.failure(Err("invalid rek data format"))
+    },
+    {
+      case ContainedTelepadDeployableData(unk, rguid) =>
+        Attempt.successful(unk :: rguid :: 0 :: 8 :: 0 :: HNil)
+    }
+  )
+}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedTelepadData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedTelepadData.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game.objectcreate
+
+import net.psforever.packet.Marshallable
+import net.psforever.packet.game.PlanetSideGUID
+import scodec.{Attempt, Codec, Err}
+import scodec.codecs._
+import shapeless.{::, HNil}
+
+/**
+  * A representation of the telepad portion of `ObjectCreateDetailedMessage` packet data.
+  * This data will help construct the "cosntruction tool"
+  * that can be obtained from the Router vehicle - the Router telepad.
+  * It issued to construct a bidirectional teleportation point associated with a Router if that Router is deployed.
+  * @param unk na
+  * @param router_guid the Router
+  */
+final case class DetailedTelepadData(unk : Int, router_guid : Option[PlanetSideGUID]) extends ConstructorData {
+  override def bitsize : Long = {
+    val rguidSize = if(router_guid.nonEmpty) 16 else 0
+    51L + rguidSize
+  }
+}
+
+object DetailedTelepadData extends Marshallable[DetailedTelepadData] {
+  def apply(unk : Int) : DetailedTelepadData = DetailedTelepadData(unk, None)
+
+  def apply(unk : Int, router_guid : PlanetSideGUID) : DetailedTelepadData = DetailedTelepadData(unk, Some(router_guid))
+
+  implicit val codec : Codec[DetailedTelepadData] = (
+    ("unk" | uint(6)) ::
+      optional(bool, "router_guid" | PlanetSideGUID.codec) ::
+      uint(24) ::
+      uint(18) ::
+      uint2
+    ).exmap[DetailedTelepadData] (
+    {
+      case unk :: rguid :: 1 :: 1 :: 0 :: HNil =>
+        Attempt.successful(DetailedTelepadData(unk, rguid))
+      case _ =>
+        Attempt.failure(Err("invalid detailed telepad format"))
+    },
+    {
+      case DetailedTelepadData(unk, rguid) =>
+        Attempt.successful(unk :: rguid :: 1 :: 1 :: 0 :: HNil)
+    }
+  )
+}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
@@ -274,7 +274,7 @@ object ObjectClass {
   final val nano_dispenser = 577
   final val command_detonater = 213
   final val flail_targeting_laser = 297
-  //ace deployables
+  //deployables
   final val ace = 32
   final val advanced_ace = 39
   final val boomer = 148
@@ -951,10 +951,11 @@ object ObjectClass {
       case ObjectClass.nano_dispenser => ConstructorData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.remote_electronics_kit => ConstructorData.genericCodec(REKData.codec, "tool")
       case ObjectClass.trek => ConstructorData.genericCodec(WeaponData.codec, "tool")
-      //ace deployables
+      //deployables
       case ObjectClass.ace => ConstructorData.genericCodec(ACEData.codec, "ace")
       case ObjectClass.advanced_ace => ConstructorData.genericCodec(ACEData.codec, "advanced ace")
-      case ObjectClass.router_telepad => ConstructorData.genericCodec(TelepadData.codec, "router telepad") //TODO not correct
+      case ObjectClass.router_telepad => ConstructorData.genericCodec(TelepadData.codec, "router telepad")
+      case ObjectClass.router_telepad_deployable => ConstructorData.genericCodec(ContainedTelepadDeployableData.codec, "router telepad")
       case ObjectClass.boomer_trigger => ConstructorData.genericCodec(BoomerTriggerData.codec, "boomer trigger")
       //vehicles?
       case ObjectClass.orbital_shuttle => ConstructorData.genericCodec(OrbitalShuttleData.codec, "HART")
@@ -1182,7 +1183,7 @@ object ObjectClass {
       case ObjectClass.nano_dispenser => DroppedItemData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.remote_electronics_kit => DroppedItemData.genericCodec(REKData.codec, " tool")
       case ObjectClass.trek => DroppedItemData.genericCodec(WeaponData.codec, "tool")
-      //ace deployables
+      //deployables
       case ObjectClass.ace => DroppedItemData.genericCodec(ACEData.codec, "ace")
       case ObjectClass.advanced_ace => DroppedItemData.genericCodec(ACEData.codec, "advanced ace")
       case ObjectClass.router_telepad => DroppedItemData.genericCodec(TelepadData.codec, "router telepad") //TODO not correct
@@ -1201,6 +1202,7 @@ object ObjectClass {
       case ObjectClass.portable_manned_turret_nc => ConstructorData.genericCodec(OneMannedFieldTurretData.codec, "field turret")
       case ObjectClass.portable_manned_turret_tr => ConstructorData.genericCodec(OneMannedFieldTurretData.codec, "field turret")
       case ObjectClass.portable_manned_turret_vs => ConstructorData.genericCodec(OneMannedFieldTurretData.codec, "field turret")
+      case ObjectClass.router_telepad_deployable => ConstructorData.genericCodec(TelepadDeployableData.codec, "telepad deployable")
       //projectiles
       case ObjectClass.hunter_seeker_missile_projectile => ConstructorData.genericCodec(TrackedProjectileData.codec, "projectile")
       case ObjectClass.oicw_projectile => ConstructorData.genericCodec(TrackedProjectileData.codec, "projectile")

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectClass.scala
@@ -230,8 +230,6 @@ object ObjectClass {
   final val repeater = 730
   final val rocklet = 737
   final val rotarychaingun_mosquito = 740
-  final val router_telepad = 743
-  final val router_telepad_deployable = 744
   final val scythe = 747
   final val six_shooter = 761
   final val skyguard_weapon_system = 788
@@ -284,6 +282,8 @@ object ObjectClass {
   final val he_mine = 388
   final val jammer_mine = 420
   final val motionalarmsensor = 575
+  final val router_telepad = 743
+  final val router_telepad_deployable = 744
   final val sensor_shield = 752
   final val spitfire_aa = 819
   final val spitfire_cloaked = 825
@@ -602,7 +602,6 @@ object ObjectClass {
       case ObjectClass.repeater => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
       case ObjectClass.rocklet => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
 //      case ObjectClass.rotarychaingun_mosquito => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
-      case ObjectClass.router_telepad => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon") //TODO belongs here?
       case ObjectClass.scythe => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
 //      case ObjectClass.skyguard_weapon_system => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
       case ObjectClass.spiker => ConstructorData.genericCodec(DetailedWeaponData.codec, "weapon")
@@ -660,11 +659,11 @@ object ObjectClass {
       case ObjectClass.medicalapplicator => ConstructorData.genericCodec(DetailedWeaponData.codec, "tool")
       case ObjectClass.nano_dispenser => ConstructorData.genericCodec(DetailedWeaponData.codec, "tool")
       case ObjectClass.remote_electronics_kit => ConstructorData.genericCodec(DetailedREKData.codec, "tool")
-      //case ObjectClass.router_telepad => ConstructorData.genericCodec(*.codec, "tool") //TODO
       case ObjectClass.trek => ConstructorData.genericCodec(DetailedWeaponData.codec, "tool")
       //ace deployable
       case ObjectClass.ace => ConstructorData.genericCodec(DetailedACEData.codec, "ace")
       case ObjectClass.advanced_ace => ConstructorData.genericCodec(DetailedACEData.codec, "advanced ace")
+      case ObjectClass.router_telepad => ConstructorData.genericCodec(DetailedTelepadData.codec, "router telepad")
       case ObjectClass.boomer_trigger => ConstructorData.genericCodec(DetailedBoomerTriggerData.codec, "boomer trigger")
       //other
       case ObjectClass.avatar => ConstructorData.genericCodec(DetailedPlayerData.codec(false), "avatar")
@@ -951,11 +950,11 @@ object ObjectClass {
       case ObjectClass.medicalapplicator => ConstructorData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.nano_dispenser => ConstructorData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.remote_electronics_kit => ConstructorData.genericCodec(REKData.codec, "tool")
-      //case ObjectClass.router_telepad => ConstructorData.genericCodec(WeaponData.codec, "tool") //TODO
       case ObjectClass.trek => ConstructorData.genericCodec(WeaponData.codec, "tool")
       //ace deployables
       case ObjectClass.ace => ConstructorData.genericCodec(ACEData.codec, "ace")
       case ObjectClass.advanced_ace => ConstructorData.genericCodec(ACEData.codec, "advanced ace")
+      case ObjectClass.router_telepad => ConstructorData.genericCodec(TelepadData.codec, "router telepad") //TODO not correct
       case ObjectClass.boomer_trigger => ConstructorData.genericCodec(BoomerTriggerData.codec, "boomer trigger")
       //vehicles?
       case ObjectClass.orbital_shuttle => ConstructorData.genericCodec(OrbitalShuttleData.codec, "HART")
@@ -1182,11 +1181,11 @@ object ObjectClass {
       case ObjectClass.medicalapplicator => DroppedItemData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.nano_dispenser => DroppedItemData.genericCodec(WeaponData.codec, "tool")
       case ObjectClass.remote_electronics_kit => DroppedItemData.genericCodec(REKData.codec, " tool")
-      //case ObjectClass.router_telepad => DroppedItemData.genericCodec(WeaponData.codec, "tool") //TODO
       case ObjectClass.trek => DroppedItemData.genericCodec(WeaponData.codec, "tool")
       //ace deployables
       case ObjectClass.ace => DroppedItemData.genericCodec(ACEData.codec, "ace")
-      case ObjectClass.advanced_ace => DroppedItemData.genericCodec(ACEData.codec, "advanced ace") //todo temporary?
+      case ObjectClass.advanced_ace => DroppedItemData.genericCodec(ACEData.codec, "advanced ace")
+      case ObjectClass.router_telepad => DroppedItemData.genericCodec(TelepadData.codec, "router telepad") //TODO not correct
       case ObjectClass.boomer_trigger => DroppedItemData.genericCodec(BoomerTriggerData.codec, "boomer trigger")
       case ObjectClass.boomer => ConstructorData.genericCodec(SmallDeployableData.codec, "ace deployable")
       case ObjectClass.he_mine => ConstructorData.genericCodec(SmallDeployableData.codec, "ace deployable")

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/TelepadData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/TelepadData.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game.objectcreate
+
+import net.psforever.packet.Marshallable
+import net.psforever.packet.game.PlanetSideGUID
+import scodec.{Attempt, Codec, Err}
+import scodec.codecs._
+import shapeless.{::, HNil}
+
+/**
+  * A representation of the telepad portion of `ObjectCreateMessage` packet data.
+  * This data will help construct the "cosntruction tool"
+  * that can be obtained from the Router vehicle - the Router telepad.
+  * It issued to construct a bidirectional teleportation point associated with a Router if that Router is deployed.
+  * @param unk na
+  * @param router_guid the Router
+  */
+final case class TelepadData(unk : Int, router_guid : Option[PlanetSideGUID]) extends ConstructorData {
+  override def bitsize : Long = {
+    val rguidSize = if(router_guid.nonEmpty) 16 else 0
+    34L + rguidSize
+  }
+}
+
+object TelepadData extends Marshallable[TelepadData] {
+  def apply(unk : Int) : TelepadData = TelepadData(unk, None)
+
+  def apply(unk : Int, router_guid : PlanetSideGUID) : TelepadData = TelepadData(unk, Some(router_guid))
+
+  implicit val codec : Codec[TelepadData] = (
+    ("unk" | uint(6)) ::
+      optional(bool, "router_guid" | PlanetSideGUID.codec) ::
+      uint(27)
+    ).exmap[TelepadData] (
+    {
+      case unk :: rguid :: 0 :: HNil =>
+        Attempt.successful(TelepadData(unk, rguid))
+      case _ =>
+        Attempt.failure(Err("invalid telepad format"))
+    },
+    {
+      case TelepadData(unk, rguid) =>
+        Attempt.successful(unk :: rguid :: 0 :: HNil)
+    }
+  )
+}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/TelepadDeployableData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/TelepadDeployableData.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 PSForever
+package net.psforever.packet.game.objectcreate
+
+import net.psforever.packet.Marshallable
+import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideEmpire
+import scodec.Codec
+import scodec.codecs._
+
+/**
+  * A representation of simple objects that are spawned by the adaptive construction engine.
+  * @param pos na
+  * @param faction na
+  * @param bops na
+  * @param destroyed na
+  * @param unk1 na
+  * @param unk2 na
+  * @param router_guid the associated Router vehicle;
+  *                    this is an essential non-blank (16u 0x0) field;
+  *                    a blanked field will cause the client to crash
+  * @param owner_guid the owner of this telepad
+  * @param unk3 na
+  * @param unk4 na
+  */
+//TODO might be CommonFieldData
+final case class TelepadDeployableData(pos : PlacementData,
+                                       faction : PlanetSideEmpire.Value,
+                                       bops : Boolean,
+                                       destroyed : Boolean,
+                                       unk1 : Int,
+                                       unk2 : Boolean,
+                                       router_guid : PlanetSideGUID,
+                                       owner_guid : PlanetSideGUID,
+                                       unk3 : Int,
+                                       unk4 : Int) extends ConstructorData {
+  override def bitsize : Long = {
+    val posSize = pos.bitsize
+    59 + posSize
+  }
+}
+
+object TelepadDeployableData extends Marshallable[TelepadDeployableData] {
+  implicit val codec : Codec[TelepadDeployableData] = (
+    ("pos" | PlacementData.codec) ::
+      ("faction" | PlanetSideEmpire.codec) ::
+      ("bops" | bool) ::
+      ("destroyed" | bool) ::
+      ("unk1" | uint2L) :: //3 - na, 2 - common, 1 - na, 0 - common?
+      ("unk2" | bool) ::
+      ("router_guid" | PlanetSideGUID.codec) ::
+      ("owner_guid" | PlanetSideGUID.codec) ::
+      ("unk3" | uint16L) ::
+      ("unk4" | uint4)
+    ).as[TelepadDeployableData]
+}

--- a/common/src/main/scala/services/RemoverActor.scala
+++ b/common/src/main/scala/services/RemoverActor.scala
@@ -226,6 +226,7 @@ abstract class RemoverActor extends SupportActor[RemoverActor.Entry] {
     * No entries in the first pool.
     */
   def ClearAll() : Unit = {
+    trace("all tasks have been cleared")
     firstTask.cancel
     firstHeap = Nil
   }

--- a/common/src/main/scala/services/local/LocalAction.scala
+++ b/common/src/main/scala/services/local/LocalAction.scala
@@ -23,9 +23,11 @@ object LocalAction {
   final case class ClearTemporaryHack(player_guid: PlanetSideGUID, target: PlanetSideServerObject with Hackable) extends Action
   final case class HackCaptureTerminal(player_guid : PlanetSideGUID, continent : Zone, target : CaptureTerminal, unk1 : Long, unk2 : Long = 8L, isResecured : Boolean) extends Action
   final case class ProximityTerminalEffect(player_guid : PlanetSideGUID, object_guid : PlanetSideGUID, effectState : Boolean) extends Action
+  final case class RouterTelepadDeploy(player_guid : PlanetSideGUID, telepad_guid : PlanetSideGUID) extends Action
+  final case class RouterTelepadTransport(player_guid : PlanetSideGUID, passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Action
+  final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Action
   final case class TriggerEffect(player_guid : PlanetSideGUID, effect : String, target : PlanetSideGUID) extends Action
   final case class TriggerEffectInfo(player_guid : PlanetSideGUID, effect : String, target : PlanetSideGUID, unk1 : Boolean, unk2 : Long) extends Action
   final case class TriggerEffectLocation(player_guid : PlanetSideGUID, effect : String, pos : Vector3, orient : Vector3) extends Action
   final case class TriggerSound(player_guid : PlanetSideGUID, sound : TriggeredSound.Value, pos : Vector3, unk : Int, volume : Float) extends Action
-  final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Action
 }

--- a/common/src/main/scala/services/local/LocalAction.scala
+++ b/common/src/main/scala/services/local/LocalAction.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package services.local
 
-import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.doors.Door
@@ -23,7 +23,7 @@ object LocalAction {
   final case class ClearTemporaryHack(player_guid: PlanetSideGUID, target: PlanetSideServerObject with Hackable) extends Action
   final case class HackCaptureTerminal(player_guid : PlanetSideGUID, continent : Zone, target : CaptureTerminal, unk1 : Long, unk2 : Long = 8L, isResecured : Boolean) extends Action
   final case class ProximityTerminalEffect(player_guid : PlanetSideGUID, object_guid : PlanetSideGUID, effectState : Boolean) extends Action
-  final case class RouterTelepadDeploy(player_guid : PlanetSideGUID, telepad_guid : PlanetSideGUID) extends Action
+  final case class RouterTelepadDeploy(player_guid : PlanetSideGUID, router : Vehicle) extends Action
   final case class RouterTelepadTransport(player_guid : PlanetSideGUID, passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Action
   final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Action
   final case class TriggerEffect(player_guid : PlanetSideGUID, effect : String, target : PlanetSideGUID) extends Action

--- a/common/src/main/scala/services/local/LocalAction.scala
+++ b/common/src/main/scala/services/local/LocalAction.scala
@@ -1,12 +1,13 @@
 // Copyright (c) 2017 PSForever
 package services.local
 
-import net.psforever.objects.{PlanetSideGameObject, Vehicle}
+import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.serverobject.terminals.CaptureTerminal
+import net.psforever.objects.vehicles.Utility
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game._
 import net.psforever.types.{PlanetSideEmpire, Vector3}
@@ -23,9 +24,9 @@ object LocalAction {
   final case class ClearTemporaryHack(player_guid: PlanetSideGUID, target: PlanetSideServerObject with Hackable) extends Action
   final case class HackCaptureTerminal(player_guid : PlanetSideGUID, continent : Zone, target : CaptureTerminal, unk1 : Long, unk2 : Long = 8L, isResecured : Boolean) extends Action
   final case class ProximityTerminalEffect(player_guid : PlanetSideGUID, object_guid : PlanetSideGUID, effectState : Boolean) extends Action
-  final case class RouterTelepadDeploy(player_guid : PlanetSideGUID, router : Vehicle) extends Action
   final case class RouterTelepadTransport(player_guid : PlanetSideGUID, passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Action
   final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Action
+  final case class ToggleTeleportSystem(player_guid : PlanetSideGUID, router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Action
   final case class TriggerEffect(player_guid : PlanetSideGUID, effect : String, target : PlanetSideGUID) extends Action
   final case class TriggerEffectInfo(player_guid : PlanetSideGUID, effect : String, target : PlanetSideGUID, unk1 : Boolean, unk2 : Long) extends Action
   final case class TriggerEffectLocation(player_guid : PlanetSideGUID, effect : String, pos : Vector3, orient : Vector3) extends Action

--- a/common/src/main/scala/services/local/LocalResponse.scala
+++ b/common/src/main/scala/services/local/LocalResponse.scala
@@ -19,7 +19,9 @@ object LocalResponse {
   final case class HackCaptureTerminal(target_guid : PlanetSideGUID, unk1 : Long, unk2 : Long, isResecured: Boolean) extends Response
   final case class ObjectDelete(item_guid : PlanetSideGUID, unk : Int) extends Response
   final case class ProximityTerminalEffect(object_guid : PlanetSideGUID, effectState : Boolean) extends Response
+  final case class RouterTelepadDeploy(telepad_guid : PlanetSideGUID) extends Response
+  final case class RouterTelepadTransport(passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Response
+  final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Response
   final case class TriggerEffect(target: PlanetSideGUID, effect: String, effectInfo: Option[TriggeredEffect] = None, triggeredLocation: Option[TriggeredEffectLocation] = None) extends Response
   final case class TriggerSound(sound : TriggeredSound.Value, pos : Vector3, unk : Int, volume : Float) extends Response
-  final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Response
 }

--- a/common/src/main/scala/services/local/LocalResponse.scala
+++ b/common/src/main/scala/services/local/LocalResponse.scala
@@ -2,7 +2,8 @@
 package services.local
 
 import net.psforever.objects.ce.Deployable
-import net.psforever.objects.{PlanetSideGameObject, Vehicle}
+import net.psforever.objects.vehicles.Utility
+import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.packet.game._
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 
@@ -19,9 +20,10 @@ object LocalResponse {
   final case class HackCaptureTerminal(target_guid : PlanetSideGUID, unk1 : Long, unk2 : Long, isResecured: Boolean) extends Response
   final case class ObjectDelete(item_guid : PlanetSideGUID, unk : Int) extends Response
   final case class ProximityTerminalEffect(object_guid : PlanetSideGUID, effectState : Boolean) extends Response
-  final case class RouterTelepadDeploy(router : Vehicle) extends Response
+  final case class RouterTelepadMessage(msg : String) extends Response
   final case class RouterTelepadTransport(passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Response
   final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Response
+  final case class ToggleTeleportSystem(router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Response
   final case class TriggerEffect(target: PlanetSideGUID, effect: String, effectInfo: Option[TriggeredEffect] = None, triggeredLocation: Option[TriggeredEffectLocation] = None) extends Response
   final case class TriggerSound(sound : TriggeredSound.Value, pos : Vector3, unk : Int, volume : Float) extends Response
 }

--- a/common/src/main/scala/services/local/LocalResponse.scala
+++ b/common/src/main/scala/services/local/LocalResponse.scala
@@ -2,7 +2,7 @@
 package services.local
 
 import net.psforever.objects.ce.Deployable
-import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.packet.game._
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 
@@ -19,7 +19,7 @@ object LocalResponse {
   final case class HackCaptureTerminal(target_guid : PlanetSideGUID, unk1 : Long, unk2 : Long, isResecured: Boolean) extends Response
   final case class ObjectDelete(item_guid : PlanetSideGUID, unk : Int) extends Response
   final case class ProximityTerminalEffect(object_guid : PlanetSideGUID, effectState : Boolean) extends Response
-  final case class RouterTelepadDeploy(telepad_guid : PlanetSideGUID) extends Response
+  final case class RouterTelepadDeploy(router : Vehicle) extends Response
   final case class RouterTelepadTransport(passenger_guid : PlanetSideGUID, src_guid : PlanetSideGUID, dest_guid : PlanetSideGUID) extends Response
   final case class SetEmpire(object_guid: PlanetSideGUID, empire: PlanetSideEmpire.Value) extends Response
   final case class TriggerEffect(target: PlanetSideGUID, effect: String, effectInfo: Option[TriggeredEffect] = None, triggeredLocation: Option[TriggeredEffectLocation] = None) extends Response

--- a/common/src/main/scala/services/local/LocalService.scala
+++ b/common/src/main/scala/services/local/LocalService.scala
@@ -7,18 +7,20 @@ import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.Building
 import net.psforever.objects.serverobject.terminals.CaptureTerminal
 import net.psforever.objects.zones.{InterstellarCluster, Zone}
-import net.psforever.objects.{BoomerDeployable, GlobalDefinitions, PlanetSideGameObject, TurretDeployable}
+import net.psforever.objects._
 import net.psforever.packet.game.{PlanetSideGUID, TriggeredEffect, TriggeredEffectLocation}
 import net.psforever.objects.vital.Vitality
 import net.psforever.types.Vector3
-import services.local.support.{DeployableRemover, DoorCloseActor, HackClearActor, HackCaptureActor}
+import services.local.support.{DeployableRemover, DoorCloseActor, HackCaptureActor, HackClearActor}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 import services.{GenericEventBus, Service, ServiceManager}
 
 import scala.util.Success
 import scala.concurrent.duration._
 import akka.pattern.ask
+import net.psforever.objects.vehicles.{Utility, UtilityType}
 import services.ServiceManager.Lookup
+
 import scala.concurrent.duration.Duration
 
 class LocalService extends Actor {
@@ -111,9 +113,9 @@ class LocalService extends Actor {
           LocalEvents.publish(
             LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.ProximityTerminalEffect(object_guid, effectState))
           )
-        case LocalAction.RouterTelepadDeploy(player_guid, telepad_guid) =>
+        case LocalAction.RouterTelepadDeploy(player_guid, router) =>
           LocalEvents.publish(
-            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.RouterTelepadDeploy(telepad_guid))
+            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.RouterTelepadDeploy(router))
           )
         case LocalAction.RouterTelepadTransport(player_guid, passenger_guid, src_guid, dest_guid) =>
           LocalEvents.publish(
@@ -226,6 +228,10 @@ class LocalService extends Actor {
           log.warn(s"LocalService: deconstructing boomer in ${zone.Id}, but trigger@${trigger.GUID.guid} still exists")
         case _ => ;
       }
+
+    case DeployableRemover.EliminateDeployable(obj : TelepadDeployable, guid, pos, zone) =>
+      obj.Active = false
+      EliminateDeployable(obj, guid, pos, zone.Id)
 
     case DeployableRemover.EliminateDeployable(obj, guid, pos, zone) =>
       EliminateDeployable(obj, guid, pos, zone.Id)

--- a/common/src/main/scala/services/local/LocalService.scala
+++ b/common/src/main/scala/services/local/LocalService.scala
@@ -111,6 +111,14 @@ class LocalService extends Actor {
           LocalEvents.publish(
             LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.ProximityTerminalEffect(object_guid, effectState))
           )
+        case LocalAction.RouterTelepadDeploy(player_guid, telepad_guid) =>
+          LocalEvents.publish(
+            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.RouterTelepadDeploy(telepad_guid))
+          )
+        case LocalAction.RouterTelepadTransport(player_guid, passenger_guid, src_guid, dest_guid) =>
+          LocalEvents.publish(
+            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.RouterTelepadTransport(passenger_guid, src_guid, dest_guid))
+          )
         case LocalAction.SetEmpire(object_guid, empire) =>
           LocalEvents.publish(
             LocalServiceResponse(s"/$forChannel/Local", Service.defaultPlayerGUID, LocalResponse.SetEmpire(object_guid, empire))

--- a/common/src/main/scala/services/local/LocalServiceMessage.scala
+++ b/common/src/main/scala/services/local/LocalServiceMessage.scala
@@ -5,4 +5,6 @@ final case class LocalServiceMessage(forChannel : String, actionMessage : LocalA
 
 object LocalServiceMessage {
   final case class Deployables(msg : Any)
+
+  final case class Telepads(msg : Any)
 }

--- a/common/src/main/scala/services/local/support/RouterTelepadActivation.scala
+++ b/common/src/main/scala/services/local/support/RouterTelepadActivation.scala
@@ -1,58 +1,50 @@
 // Copyright (c) 2017 PSForever
-package services.vehicle.support
+package services.local.support
 
 import akka.actor.Cancellable
-import net.psforever.objects.vehicles.{Utility, UtilityType}
-import net.psforever.objects.{DefaultCancellable, GlobalDefinitions, PlanetSideGameObject, Vehicle}
 import net.psforever.objects.zones.Zone
-import net.psforever.types.DriveState
+import net.psforever.objects._
 import services.support.{SimilarityComparator, SupportActor}
 
 import scala.concurrent.duration._
 
-class RouterActivation extends SupportActor[RouterActivation.Entry] {
+class RouterTelepadActivation extends SupportActor[RouterTelepadActivation.Entry] {
   var activationTask : Cancellable = DefaultCancellable.obj
-  var routerList : List[RouterActivation.Entry] = List()
-  val sameEntryComparator = new SimilarityComparator[RouterActivation.Entry]() {
-    def Test(entry1 : RouterActivation.Entry, entry2 : RouterActivation.Entry) : Boolean = {
+  var telepadList : List[RouterTelepadActivation.Entry] = List()
+  val sameEntryComparator = new SimilarityComparator[RouterTelepadActivation.Entry]() {
+    def Test(entry1 : RouterTelepadActivation.Entry, entry2 : RouterTelepadActivation.Entry) : Boolean = {
       entry1.obj == entry2.obj && entry1.zone == entry2.zone && entry1.obj.GUID == entry2.obj.GUID
     }
   }
-  val firstStandardTime : FiniteDuration = 10000 milliseconds //TODO 10s for testing
+  val firstStandardTime : FiniteDuration = 60 seconds
 
-  def InclusionTest(entry : RouterActivation.Entry) : Boolean = {
+  def InclusionTest(entry : RouterTelepadActivation.Entry) : Boolean = {
     val obj = entry.obj
-    obj.Definition == GlobalDefinitions.router &&
-      (obj.asInstanceOf[Vehicle].DeploymentState == DriveState.Deployed ||
-        obj.asInstanceOf[Vehicle].DeploymentState == DriveState.Deploying) &&
-      (obj.asInstanceOf[Vehicle].Utility(UtilityType.internal_router_telepad_deployable) match {
-        case Some(ipad : Utility.InternalTelepad) => !ipad.Active
-        case _ => false
-      })
+    obj.isInstanceOf[TelepadDeployable] && !obj.asInstanceOf[TelepadDeployable].Active
   }
 
   def receive : Receive = entryManagementBehaviors
     .orElse {
-      case RouterActivation.AddTask(obj, zone, duration) =>
-        val entry = RouterActivation.Entry(obj, zone, duration.getOrElse(firstStandardTime).toNanos)
-        if(InclusionTest(entry) && !routerList.exists(test => sameEntryComparator.Test(test, entry))) {
+      case RouterTelepadActivation.AddTask(obj, zone, duration) =>
+        val entry = RouterTelepadActivation.Entry(obj, zone, duration.getOrElse(firstStandardTime).toNanos)
+        if(InclusionTest(entry) && !telepadList.exists(test => sameEntryComparator.Test(test, entry))) {
           if(entry.duration == 0) {
             //skip the queue altogether
             ActivationTask(entry)
           }
-          else if(routerList.isEmpty) {
+          else if(telepadList.isEmpty) {
             //we were the only entry so the event must be started from scratch
-            routerList = List(entry)
+            telepadList = List(entry)
             trace(s"an activation task has been added: $entry")
             RetimeFirstTask()
           }
           else {
             //unknown number of entries; append, sort, then re-time tasking
-            val oldHead = routerList.head
-            if(!routerList.exists(test => sameEntryComparator.Test(test, entry))) {
-              routerList = (routerList :+ entry).sortBy(entry => entry.time + entry.duration)
+            val oldHead = telepadList.head
+            if(!telepadList.exists(test => sameEntryComparator.Test(test, entry))) {
+              telepadList = (telepadList :+ entry).sortBy(entry => entry.time + entry.duration)
               trace(s"an activation task has been added: $entry")
-              if(oldHead != routerList.head) {
+              if(oldHead != telepadList.head) {
                 RetimeFirstTask()
               }
             }
@@ -66,11 +58,11 @@ class RouterActivation extends SupportActor[RouterActivation.Entry] {
         }
 
       //private messages from self to self
-      case RouterActivation.TryActivate() =>
+      case RouterTelepadActivation.TryActivate() =>
         activationTask.cancel
         val now : Long = System.nanoTime
-        val (in, out) = routerList.partition(entry => { now - entry.time >= entry.duration })
-        routerList = out
+        val (in, out) = telepadList.partition(entry => { now - entry.time >= entry.duration })
+        telepadList = out
         in.foreach { ActivationTask }
         RetimeFirstTask()
         trace(s"router activation task has found ${in.size} items to process")
@@ -86,20 +78,20 @@ class RouterActivation extends SupportActor[RouterActivation.Entry] {
     */
   def RetimeFirstTask(now : Long = System.nanoTime) : Unit = {
     activationTask.cancel
-    if(routerList.nonEmpty) {
-      val short_timeout : FiniteDuration = math.max(1, routerList.head.duration - (now - routerList.head.time)) nanoseconds
+    if(telepadList.nonEmpty) {
+      val short_timeout : FiniteDuration = math.max(1, telepadList.head.duration - (now - telepadList.head.time)) nanoseconds
       import scala.concurrent.ExecutionContext.Implicits.global
-      activationTask = context.system.scheduler.scheduleOnce(short_timeout, self, RouterActivation.TryActivate())
+      activationTask = context.system.scheduler.scheduleOnce(short_timeout, self, RouterTelepadActivation.TryActivate())
     }
   }
 
   def HurrySpecific(targets : List[PlanetSideGameObject], zone : Zone) : Unit = {
-    PartitionTargetsFromList(routerList, targets.map { RouterActivation.Entry(_, zone, 0) }, zone) match {
+    PartitionTargetsFromList(telepadList, targets.map { RouterTelepadActivation.Entry(_, zone, 0) }, zone) match {
       case (Nil, _) =>
         debug(s"no tasks matching the targets $targets have been hurried")
       case (in, out) =>
         debug(s"the following tasks have been hurried: $in")
-        routerList = out //.sortBy(entry => entry.time + entry.duration)
+        telepadList = out //.sortBy(entry => entry.time + entry.duration)
         if(out.nonEmpty) {
           RetimeFirstTask()
         }
@@ -110,17 +102,17 @@ class RouterActivation extends SupportActor[RouterActivation.Entry] {
   def HurryAll() : Unit = {
     trace("all tasks have been hurried")
     activationTask.cancel
-    routerList.foreach { ActivationTask }
-    routerList = Nil
+    telepadList.foreach { ActivationTask }
+    telepadList = Nil
   }
 
   def ClearSpecific(targets : List[PlanetSideGameObject], zone : Zone) : Unit = {
-    PartitionTargetsFromList(routerList, targets.map { RouterActivation.Entry(_, zone, 0) }, zone) match {
+    PartitionTargetsFromList(telepadList, targets.map { RouterTelepadActivation.Entry(_, zone, 0) }, zone) match {
       case (Nil, _) =>
         debug(s"no tasks matching the targets $targets have been cleared")
       case (in, out) =>
         debug(s"the following tasks have been cleared: $in")
-        routerList = out //.sortBy(entry => entry.time + entry.duration)
+        telepadList = out //.sortBy(entry => entry.time + entry.duration)
         if(out.nonEmpty) {
           RetimeFirstTask()
         }
@@ -130,20 +122,21 @@ class RouterActivation extends SupportActor[RouterActivation.Entry] {
   def ClearAll() : Unit = {
     trace("all tasks have been cleared")
     activationTask.cancel
-    routerList = Nil
+    telepadList = Nil
   }
 
   def ActivationTask(entry : SupportActor.Entry) : Unit = {
-    context.parent ! RouterActivation.ActivateTeleportSystem(entry.obj, entry.zone)
+    entry.obj.asInstanceOf[TelepadDeployable].Active = true
+    context.parent ! RouterTelepadActivation.ActivateTeleportSystem(entry.obj, entry.zone)
   }
 }
 
-object RouterActivation {
+object RouterTelepadActivation {
   final case class Entry(_obj : PlanetSideGameObject, _zone : Zone, _duration : Long) extends SupportActor.Entry(_obj, _zone, _duration)
 
   final case class AddTask(obj : PlanetSideGameObject, zone : Zone, duration : Option[FiniteDuration] = None)
 
   final case class TryActivate()
 
-  final case class ActivateTeleportSystem(router : PlanetSideGameObject, zone : Zone)
+  final case class ActivateTeleportSystem(telepad : PlanetSideGameObject, zone : Zone)
 }

--- a/common/src/main/scala/services/local/support/RouterTelepadActivation.scala
+++ b/common/src/main/scala/services/local/support/RouterTelepadActivation.scala
@@ -13,7 +13,7 @@ class RouterTelepadActivation extends SupportActor[RouterTelepadActivation.Entry
   var telepadList : List[RouterTelepadActivation.Entry] = List()
   val sameEntryComparator = new SimilarityComparator[RouterTelepadActivation.Entry]() {
     def Test(entry1 : RouterTelepadActivation.Entry, entry2 : RouterTelepadActivation.Entry) : Boolean = {
-      entry1.obj == entry2.obj && entry1.zone == entry2.zone && entry1.obj.GUID == entry2.obj.GUID
+      (entry1.obj eq entry2.obj) && (entry1.zone eq entry2.zone) && entry1.obj.GUID == entry2.obj.GUID
     }
   }
   val firstStandardTime : FiniteDuration = 60 seconds
@@ -91,7 +91,7 @@ class RouterTelepadActivation extends SupportActor[RouterTelepadActivation.Entry
         debug(s"no tasks matching the targets $targets have been hurried")
       case (in, out) =>
         debug(s"the following tasks have been hurried: $in")
-        telepadList = out //.sortBy(entry => entry.time + entry.duration)
+        telepadList = out
         if(out.nonEmpty) {
           RetimeFirstTask()
         }

--- a/common/src/main/scala/services/support/SupportActor.scala
+++ b/common/src/main/scala/services/support/SupportActor.scala
@@ -73,17 +73,12 @@ abstract class SupportActor[A <: SupportActor.Entry] extends Actor {
         //a - find targets from entries
         val locatedTargets = for {
           a <- targets
-          b <- list//.filter(entry => entry.zone == zone)
+          b <- list
           if b.obj.HasGUID && a.obj.HasGUID && comparator.Test(b, a)
         } yield b
         if(locatedTargets.nonEmpty) {
           //b - entries, after the found targets are removed (cull any non-GUID entries while at it)
-          val retained = for {
-            a <- locatedTargets
-            b <- list
-            if b.obj.HasGUID && a.obj.HasGUID && !comparator.Test(b, a)
-          } yield b
-          (locatedTargets, retained)
+          (locatedTargets, list filterNot locatedTargets.toSet)
         }
         else {
           (Nil, list)

--- a/common/src/main/scala/services/vehicle/VehicleAction.scala
+++ b/common/src/main/scala/services/vehicle/VehicleAction.scala
@@ -27,7 +27,7 @@ object VehicleAction {
   final case class PlanetsideAttribute(player_guid : PlanetSideGUID, target_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Long) extends Action
   final case class SeatPermissions(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Action
   final case class StowEquipment(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Action
-  final case class UnloadVehicle(player_guid : PlanetSideGUID, continent : Zone, vehicle : Vehicle) extends Action
+  final case class UnloadVehicle(player_guid : PlanetSideGUID, continent : Zone, vehicle : Vehicle, vehicle_guid : PlanetSideGUID) extends Action
   final case class UnstowEquipment(player_guid : PlanetSideGUID, item_guid : PlanetSideGUID) extends Action
   final case class VehicleState(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Action
   final case class SendResponse(player_guid: PlanetSideGUID, msg : PlanetSideGamePacket) extends Action

--- a/common/src/main/scala/services/vehicle/VehicleAction.scala
+++ b/common/src/main/scala/services/vehicle/VehicleAction.scala
@@ -1,8 +1,9 @@
 // Copyright (c) 2017 PSForever
 package services.vehicle
 
-import net.psforever.objects.{PlanetSideGameObject, Vehicle}
+import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.objects.equipment.Equipment
+import net.psforever.objects.vehicles.Utility
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.PlanetSideGUID
@@ -26,6 +27,7 @@ object VehicleAction {
   final case class PlanetsideAttribute(player_guid : PlanetSideGUID, target_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Long) extends Action
   final case class SeatPermissions(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Action
   final case class StowEquipment(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Action
+  final case class ToggleTeleportSystem(player_guid : PlanetSideGUID, router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Action
   final case class UnloadVehicle(player_guid : PlanetSideGUID, continent : Zone, vehicle : Vehicle) extends Action
   final case class UnstowEquipment(player_guid : PlanetSideGUID, item_guid : PlanetSideGUID) extends Action
   final case class VehicleState(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Action

--- a/common/src/main/scala/services/vehicle/VehicleAction.scala
+++ b/common/src/main/scala/services/vehicle/VehicleAction.scala
@@ -27,7 +27,6 @@ object VehicleAction {
   final case class PlanetsideAttribute(player_guid : PlanetSideGUID, target_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Long) extends Action
   final case class SeatPermissions(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Action
   final case class StowEquipment(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Action
-  final case class ToggleTeleportSystem(player_guid : PlanetSideGUID, router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Action
   final case class UnloadVehicle(player_guid : PlanetSideGUID, continent : Zone, vehicle : Vehicle) extends Action
   final case class UnstowEquipment(player_guid : PlanetSideGUID, item_guid : PlanetSideGUID) extends Action
   final case class VehicleState(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Action

--- a/common/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -11,6 +11,7 @@ import net.psforever.types.{BailType, DriveState, Vector3}
 object VehicleResponse {
   trait Response
 
+  final case class ToggleTeleportSystem(router : Vehicle) extends Response
   final case class AttachToRails(vehicle_guid : PlanetSideGUID, rails_guid : PlanetSideGUID) extends Response
   final case class ChildObjectState(object_guid : PlanetSideGUID, pitch : Float, yaw : Float) extends Response
   final case class ConcealPlayer(player_guid : PlanetSideGUID) extends Response

--- a/common/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -31,7 +31,6 @@ object VehicleResponse {
   final case class RevealPlayer(player_guid : PlanetSideGUID) extends Response
   final case class SeatPermissions(vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Response
   final case class StowEquipment(vehicle_guid : PlanetSideGUID, slot : Int, itype : Int, iguid : PlanetSideGUID, idata : ConstructorData) extends Response
-  final case class ToggleTeleportSystem(router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Response
   final case class UnloadVehicle(vehicle : Vehicle) extends Response
   final case class UnstowEquipment(item_guid : PlanetSideGUID) extends Response
   final case class VehicleState(vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Response

--- a/common/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -2,7 +2,8 @@
 package services.vehicle
 
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.{PlanetSideGameObject, Vehicle}
+import net.psforever.objects.vehicles.Utility
+import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
 import net.psforever.packet.game.objectcreate.ConstructorData
@@ -11,7 +12,6 @@ import net.psforever.types.{BailType, DriveState, Vector3}
 object VehicleResponse {
   trait Response
 
-  final case class ToggleTeleportSystem(router : Vehicle) extends Response
   final case class AttachToRails(vehicle_guid : PlanetSideGUID, rails_guid : PlanetSideGUID) extends Response
   final case class ChildObjectState(object_guid : PlanetSideGUID, pitch : Float, yaw : Float) extends Response
   final case class ConcealPlayer(player_guid : PlanetSideGUID) extends Response
@@ -31,7 +31,8 @@ object VehicleResponse {
   final case class RevealPlayer(player_guid : PlanetSideGUID) extends Response
   final case class SeatPermissions(vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Response
   final case class StowEquipment(vehicle_guid : PlanetSideGUID, slot : Int, itype : Int, iguid : PlanetSideGUID, idata : ConstructorData) extends Response
-  final case class UnloadVehicle(vehicle_guid : PlanetSideGUID) extends Response
+  final case class ToggleTeleportSystem(router : Vehicle, systemPlan : Option[(Utility.InternalTelepad, TelepadDeployable)]) extends Response
+  final case class UnloadVehicle(vehicle : Vehicle) extends Response
   final case class UnstowEquipment(item_guid : PlanetSideGUID) extends Response
   final case class VehicleState(vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Response
   final case class SendResponse(msg: PlanetSideGamePacket) extends Response

--- a/common/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -31,7 +31,7 @@ object VehicleResponse {
   final case class RevealPlayer(player_guid : PlanetSideGUID) extends Response
   final case class SeatPermissions(vehicle_guid : PlanetSideGUID, seat_group : Int, permission : Long) extends Response
   final case class StowEquipment(vehicle_guid : PlanetSideGUID, slot : Int, itype : Int, iguid : PlanetSideGUID, idata : ConstructorData) extends Response
-  final case class UnloadVehicle(vehicle : Vehicle) extends Response
+  final case class UnloadVehicle(vehicle : Vehicle, vehicle_guid : PlanetSideGUID) extends Response
   final case class UnstowEquipment(item_guid : PlanetSideGUID) extends Response
   final case class VehicleState(vehicle_guid : PlanetSideGUID, unk1 : Int, pos : Vector3, ang : Vector3, vel : Option[Vector3], unk2 : Option[Int], unk3 : Int, unk4 : Int, wheel_direction : Int, unk5 : Boolean, unk6 : Boolean) extends Response
   final case class SendResponse(msg: PlanetSideGamePacket) extends Response

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -105,10 +105,10 @@ class VehicleService extends Actor {
           VehicleEvents.publish(
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.StowEquipment(vehicle_guid, slot, definition.ObjectId, item.GUID, definition.Packet.DetailedConstructorData(item).get))
           )
-        case VehicleAction.UnloadVehicle(player_guid, continent, vehicle) =>
+        case VehicleAction.UnloadVehicle(player_guid, continent, vehicle, vehicle_guid) =>
           vehicleDecon ! RemoverActor.ClearSpecific(List(vehicle), continent) //precaution
           VehicleEvents.publish(
-            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.UnloadVehicle(vehicle))
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.UnloadVehicle(vehicle, vehicle_guid))
           )
         case VehicleAction.UnstowEquipment(player_guid, item_guid) =>
           VehicleEvents.publish(

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -14,7 +14,5 @@ object VehicleServiceMessage {
 
   final case class TurretUpgrade(msg : Any)
 
-  final case class Router(msg : Any)
-
   final case class AMSDeploymentChange(zone : Zone)
 }

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -14,5 +14,7 @@ object VehicleServiceMessage {
 
   final case class TurretUpgrade(msg : Any)
 
+  final case class Router(msg : Any)
+
   final case class AMSDeploymentChange(zone : Zone)
 }

--- a/common/src/main/scala/services/vehicle/support/RouterActivation.scala
+++ b/common/src/main/scala/services/vehicle/support/RouterActivation.scala
@@ -1,0 +1,149 @@
+// Copyright (c) 2017 PSForever
+package services.vehicle.support
+
+import akka.actor.Cancellable
+import net.psforever.objects.vehicles.{Utility, UtilityType}
+import net.psforever.objects.{DefaultCancellable, GlobalDefinitions, PlanetSideGameObject, Vehicle}
+import net.psforever.objects.zones.Zone
+import net.psforever.types.DriveState
+import services.support.{SimilarityComparator, SupportActor}
+
+import scala.concurrent.duration._
+
+class RouterActivation extends SupportActor[RouterActivation.Entry] {
+  var activationTask : Cancellable = DefaultCancellable.obj
+  var routerList : List[RouterActivation.Entry] = List()
+  val sameEntryComparator = new SimilarityComparator[RouterActivation.Entry]() {
+    def Test(entry1 : RouterActivation.Entry, entry2 : RouterActivation.Entry) : Boolean = {
+      entry1.obj == entry2.obj && entry1.zone == entry2.zone && entry1.obj.GUID == entry2.obj.GUID
+    }
+  }
+  val firstStandardTime : FiniteDuration = 10000 milliseconds //TODO 10s for testing
+
+  def InclusionTest(entry : RouterActivation.Entry) : Boolean = {
+    val obj = entry.obj
+    obj.Definition == GlobalDefinitions.router &&
+      (obj.asInstanceOf[Vehicle].DeploymentState == DriveState.Deployed ||
+        obj.asInstanceOf[Vehicle].DeploymentState == DriveState.Deploying) &&
+      (obj.asInstanceOf[Vehicle].Utility(UtilityType.internal_router_telepad_deployable) match {
+        case Some(ipad : Utility.InternalTelepad) => !ipad.Active
+        case _ => false
+      })
+  }
+
+  def receive : Receive = entryManagementBehaviors
+    .orElse {
+      case RouterActivation.AddTask(obj, zone, duration) =>
+        val entry = RouterActivation.Entry(obj, zone, duration.getOrElse(firstStandardTime).toNanos)
+        if(InclusionTest(entry) && !routerList.exists(test => sameEntryComparator.Test(test, entry))) {
+          if(entry.duration == 0) {
+            //skip the queue altogether
+            ActivationTask(entry)
+          }
+          else if(routerList.isEmpty) {
+            //we were the only entry so the event must be started from scratch
+            routerList = List(entry)
+            trace(s"an activation task has been added: $entry")
+            RetimeFirstTask()
+          }
+          else {
+            //unknown number of entries; append, sort, then re-time tasking
+            val oldHead = routerList.head
+            if(!routerList.exists(test => sameEntryComparator.Test(test, entry))) {
+              routerList = (routerList :+ entry).sortBy(entry => entry.time + entry.duration)
+              trace(s"an activation task has been added: $entry")
+              if(oldHead != routerList.head) {
+                RetimeFirstTask()
+              }
+            }
+            else {
+              trace(s"$obj is already queued")
+            }
+          }
+        }
+        else {
+          trace(s"$obj either does not qualify for this behavior or is already queued")
+        }
+
+      //private messages from self to self
+      case RouterActivation.TryActivate() =>
+        activationTask.cancel
+        val now : Long = System.nanoTime
+        val (in, out) = routerList.partition(entry => { now - entry.time >= entry.duration })
+        routerList = out
+        in.foreach { ActivationTask }
+        RetimeFirstTask()
+        trace(s"router activation task has found ${in.size} items to process")
+
+      case _ => ;
+    }
+
+  /**
+    * Common function to reset the first task's delayed execution.
+    * Cancels the scheduled timer and will only restart the timer if there is at least one entry in the first pool.
+    * @param now the time (in nanoseconds);
+    *            defaults to the current time (in nanoseconds)
+    */
+  def RetimeFirstTask(now : Long = System.nanoTime) : Unit = {
+    activationTask.cancel
+    if(routerList.nonEmpty) {
+      val short_timeout : FiniteDuration = math.max(1, routerList.head.duration - (now - routerList.head.time)) nanoseconds
+      import scala.concurrent.ExecutionContext.Implicits.global
+      activationTask = context.system.scheduler.scheduleOnce(short_timeout, self, RouterActivation.TryActivate())
+    }
+  }
+
+  def HurrySpecific(targets : List[PlanetSideGameObject], zone : Zone) : Unit = {
+    PartitionTargetsFromList(routerList, targets.map { RouterActivation.Entry(_, zone, 0) }, zone) match {
+      case (Nil, _) =>
+        debug(s"no tasks matching the targets $targets have been hurried")
+      case (in, out) =>
+        debug(s"the following tasks have been hurried: $in")
+        routerList = out //.sortBy(entry => entry.time + entry.duration)
+        if(out.nonEmpty) {
+          RetimeFirstTask()
+        }
+        in.foreach { ActivationTask }
+    }
+  }
+
+  def HurryAll() : Unit = {
+    trace("all tasks have been hurried")
+    activationTask.cancel
+    routerList.foreach { ActivationTask }
+    routerList = Nil
+  }
+
+  def ClearSpecific(targets : List[PlanetSideGameObject], zone : Zone) : Unit = {
+    PartitionTargetsFromList(routerList, targets.map { RouterActivation.Entry(_, zone, 0) }, zone) match {
+      case (Nil, _) =>
+        debug(s"no tasks matching the targets $targets have been cleared")
+      case (in, out) =>
+        debug(s"the following tasks have been cleared: $in")
+        routerList = out //.sortBy(entry => entry.time + entry.duration)
+        if(out.nonEmpty) {
+          RetimeFirstTask()
+        }
+    }
+  }
+
+  def ClearAll() : Unit = {
+    trace("all tasks have been cleared")
+    activationTask.cancel
+    routerList = Nil
+  }
+
+  def ActivationTask(entry : SupportActor.Entry) : Unit = {
+    context.parent ! RouterActivation.ActivateTeleportSystem(entry.obj, entry.zone)
+  }
+}
+
+object RouterActivation {
+  final case class Entry(_obj : PlanetSideGameObject, _zone : Zone, _duration : Long) extends SupportActor.Entry(_obj, _zone, _duration)
+
+  final case class AddTask(obj : PlanetSideGameObject, zone : Zone, duration : Option[FiniteDuration] = None)
+
+  final case class TryActivate()
+
+  final case class ActivateTeleportSystem(router : PlanetSideGameObject, zone : Zone)
+}

--- a/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
+++ b/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
@@ -4,6 +4,7 @@ package services.vehicle.support
 import net.psforever.objects.Vehicle
 import net.psforever.objects.guid.{GUIDTask, TaskResolver}
 import net.psforever.objects.zones.Zone
+import net.psforever.types.DriveState
 import services.{RemoverActor, Service}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
@@ -43,8 +44,9 @@ class VehicleRemover extends RemoverActor {
   override def SecondJob(entry : RemoverActor.Entry) : Unit = {
     val vehicle = entry.obj.asInstanceOf[Vehicle]
     val zone = entry.zone
+    vehicle.DeploymentState = DriveState.Mobile
     zone.Transport ! Zone.Vehicle.Despawn(vehicle)
-    context.parent ! VehicleServiceMessage(zone.Id, VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, zone, vehicle))
+    context.parent ! VehicleServiceMessage(zone.Id, VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, zone, vehicle, vehicle.GUID))
     super.SecondJob(entry)
   }
 

--- a/common/src/test/scala/game/objectcreate/ContainedTelepadDeployableDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/ContainedTelepadDeployableDataTest.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 PSForever
+package game.objectcreate
+
+import net.psforever.packet.PacketCoding
+import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.objectcreate._
+import org.specs2.mutable._
+import scodec.bits._
+
+class ContainedTelepadDeployableDataTest extends Specification {
+  val string = hex"178f0000004080f42b00182cb0202000100000"
+
+  "ContainedTelepadDeployableData" should {
+    "decode" in {
+      PacketCoding.DecodePacket(string).require match {
+        case ObjectCreateMessage(len, cls, guid, parent, data) =>
+          len mustEqual 143
+          cls mustEqual 744
+          guid mustEqual PlanetSideGUID(432)
+          parent.isDefined mustEqual true
+          parent.get.guid mustEqual PlanetSideGUID(385)
+          parent.get.slot mustEqual 2
+          data.isDefined mustEqual true
+          data.get.isInstanceOf[ContainedTelepadDeployableData] mustEqual true
+          data.get.asInstanceOf[ContainedTelepadDeployableData].unk mustEqual 101
+          data.get.asInstanceOf[ContainedTelepadDeployableData].router_guid mustEqual PlanetSideGUID(385)
+        case _ =>
+          ko
+      }
+    }
+    "encode" in {
+      val obj = ContainedTelepadDeployableData(101, PlanetSideGUID(385))
+      val msg = ObjectCreateMessage(744, PlanetSideGUID(432), ObjectCreateMessageParent(PlanetSideGUID(385), 2), obj)
+      val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+      pkt mustEqual string
+    }
+  }
+}

--- a/common/src/test/scala/game/objectcreate/TelepadDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/TelepadDataTest.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 PSForever
+package game.objectcreate
+
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.packet.game.objectcreate._
+import org.specs2.mutable._
+import scodec.bits._
+
+class TelepadDataTest extends Specification {
+  val string = hex"17 86000000 5700 f3a a201 80 0302020000000"
+  //TODO validate the unknown fields before router_guid for testing
+
+  "TelepadData" should {
+    "decode" in {
+      PacketCoding.DecodePacket(string).require match {
+        case ObjectCreateMessage(len, cls, guid, parent, data) =>
+          len mustEqual 134
+          cls mustEqual ObjectClass.router_telepad
+          guid mustEqual PlanetSideGUID(418)
+          parent.isDefined mustEqual true
+          parent.get.guid mustEqual PlanetSideGUID(430)
+          parent.get.slot mustEqual 0
+          data.isDefined mustEqual true
+          data.get.isInstanceOf[TelepadData] mustEqual true
+          data.get.asInstanceOf[TelepadData].router_guid mustEqual Some(PlanetSideGUID(385))
+        case _ =>
+          ko
+      }
+    }
+
+    "encode" in {
+      val obj = TelepadData(0, PlanetSideGUID(385))
+      val msg = ObjectCreateMessage(ObjectClass.router_telepad, PlanetSideGUID(418), ObjectCreateMessageParent(PlanetSideGUID(430), 0), obj)
+      val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+      pkt mustEqual string
+    }
+  }
+}

--- a/common/src/test/scala/game/objectcreate/TelepadDeployableDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/TelepadDeployableDataTest.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 PSForever
+package game.objectcreate
+
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.packet.game.objectcreate._
+import net.psforever.types.{PlanetSideEmpire, Vector3}
+import org.specs2.mutable._
+import scodec.bits._
+
+class TelepadDeployableDataTest extends Specification {
+  val string = hex"17 c8000000 f42 6101 fbcfc 0fd43 6903 00 00 79 05 8101 ae01 5700c"
+  //TODO validate the unknown fields before router_guid for testing
+
+  "TelepadData" should {
+    "decode" in {
+      PacketCoding.DecodePacket(string).require match {
+        case ObjectCreateMessage(len, cls, guid, parent, data) =>
+          len mustEqual 200
+          cls mustEqual ObjectClass.router_telepad_deployable
+          guid mustEqual PlanetSideGUID(353)
+          parent.isDefined mustEqual false
+          data.isDefined mustEqual true
+          data.get.isInstanceOf[TelepadDeployableData] mustEqual true
+          val teledata = data.get.asInstanceOf[TelepadDeployableData]
+          teledata.pos.coord mustEqual Vector3(6559.961f, 1960.1172f, 13.640625f)
+          teledata.pos.orient mustEqual Vector3.z(109.6875f)
+          teledata.pos.vel.isDefined mustEqual false
+          teledata.faction mustEqual PlanetSideEmpire.TR
+          teledata.bops mustEqual false
+          teledata.destroyed mustEqual false
+          teledata.unk1 mustEqual 2
+          teledata.unk2 mustEqual true
+          teledata.router_guid mustEqual PlanetSideGUID(385)
+          teledata.owner_guid mustEqual PlanetSideGUID(430)
+          teledata.unk3 mustEqual 87
+          teledata.unk4 mustEqual 12
+        case _ =>
+          ko
+      }
+    }
+
+    "encode" in {
+      val obj = TelepadDeployableData(
+        PlacementData(
+          Vector3(6559.961f, 1960.1172f, 13.640625f),
+          Vector3.z(109.6875f)
+        ),
+        PlanetSideEmpire.TR,
+        false, false, 2, true,
+        PlanetSideGUID(385),
+        PlanetSideGUID(430),
+        87, 12
+      )
+      val msg = ObjectCreateMessage(ObjectClass.router_telepad_deployable, PlanetSideGUID(353), obj)
+      val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+      pkt mustEqual string
+    }
+  }
+}

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedTelepadDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedTelepadDataTest.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2017 PSForever
+package game.objectcreatedetailed
+
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.packet.game.objectcreate._
+import org.specs2.mutable._
+import scodec.bits._
+
+class DetailedTelepadDataTest extends Specification {
+  val string = hex"18 97000000 4f00 f3a e301 80 4a680400000200008"
+  val string_short = hex"18 87000000 2a00 f3a 5d01 89 8000000200008"
+  //TODO validate the unknown fields before router_guid for testing
+
+  "DetailedTelepadData" should {
+    "decode" in {
+      PacketCoding.DecodePacket(string).require match {
+        case ObjectCreateDetailedMessage(len, cls, guid, parent, data) =>
+          len mustEqual 151
+          cls mustEqual ObjectClass.router_telepad
+          guid mustEqual PlanetSideGUID(483)
+          parent.isDefined mustEqual true
+          parent.get.guid mustEqual PlanetSideGUID(414)
+          parent.get.slot mustEqual 0
+          data.isDefined mustEqual true
+          data.get.isInstanceOf[DetailedTelepadData] mustEqual true
+          data.get.asInstanceOf[DetailedTelepadData].router_guid mustEqual Some(PlanetSideGUID(564))
+        case _ =>
+          ko
+      }
+    }
+
+    "decode (short)" in {
+      PacketCoding.DecodePacket(string_short).require match {
+        case ObjectCreateDetailedMessage(len, cls, guid, parent, data) =>
+          len mustEqual 135
+          cls mustEqual ObjectClass.router_telepad
+          guid mustEqual PlanetSideGUID(349)
+          parent.isDefined mustEqual true
+          parent.get.guid mustEqual PlanetSideGUID(340)
+          parent.get.slot mustEqual 9
+          data.isDefined mustEqual true
+          data.get.isInstanceOf[DetailedTelepadData] mustEqual true
+          data.get.asInstanceOf[DetailedTelepadData].router_guid mustEqual None
+        case _ =>
+          ko
+      }
+    }
+
+    "encode" in {
+      val obj = DetailedTelepadData(18, PlanetSideGUID(564))
+      val msg = ObjectCreateDetailedMessage(ObjectClass.router_telepad, PlanetSideGUID(483), ObjectCreateMessageParent(PlanetSideGUID(414), 0), obj)
+      val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+      pkt mustEqual string
+    }
+
+    "encode (short)" in {
+      val obj = DetailedTelepadData(32)
+      val msg = ObjectCreateDetailedMessage(ObjectClass.router_telepad, PlanetSideGUID(349), ObjectCreateMessageParent(PlanetSideGUID(340), 9), obj)
+      val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
+
+      pkt mustEqual string_short
+    }
+  }
+}

--- a/common/src/test/scala/objects/ConverterTest.scala
+++ b/common/src/test/scala/objects/ConverterTest.scala
@@ -8,6 +8,7 @@ import net.psforever.objects.equipment._
 import net.psforever.objects.inventory.InventoryTile
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.vehicles.UtilityType
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
 import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
@@ -166,6 +167,35 @@ class ConverterTest extends Specification {
     }
   }
 
+  "Telepad" should {
+    "convert (success)" in {
+      val obj = new Telepad(GlobalDefinitions.router_telepad)
+      obj.Router = PlanetSideGUID(1001)
+      obj.Definition.Packet.ConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual TelepadData(0, PlanetSideGUID(1001))
+        case _ =>
+          ko
+      }
+
+      obj.Definition.Packet.DetailedConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual DetailedTelepadData(0, PlanetSideGUID(1001))
+        case _ =>
+          ko
+      }
+    }
+
+    "convert (failure; no router)" in {
+      val obj = new Telepad(GlobalDefinitions.router_telepad)
+      //obj.Router = PlanetSideGUID(1001)
+      obj.Definition.Packet.ConstructorData(obj).isFailure mustEqual true
+
+
+      obj.Definition.Packet.DetailedConstructorData(obj).isFailure mustEqual true
+    }
+  }
+
   "SmallDeployable" should {
     "convert" in {
       val obj = new SensorDeployable(GlobalDefinitions.motionalarmsensor)
@@ -296,6 +326,79 @@ class ConverterTest extends Specification {
         case _ =>
           ko
       }
+    }
+  }
+
+  "TelepadDeployable" should {
+    "convert (success)" in {
+      val obj = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      obj.Faction = PlanetSideEmpire.TR
+      obj.GUID = PlanetSideGUID(90)
+      obj.Router = PlanetSideGUID(1001)
+      obj.Owner = PlanetSideGUID(5001)
+      obj.Health = 1
+      obj.Definition.Packet.ConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual TelepadDeployableData(
+            PlacementData(Vector3.Zero, Vector3.Zero),
+            PlanetSideEmpire.TR,
+            bops = false,
+            destroyed = false,
+            unk1 = 2, unk2 = true,
+            router_guid = PlanetSideGUID(1001),
+            owner_guid = PlanetSideGUID(5001),
+            unk3 = 87, unk4 = 12
+          )
+        case _ =>
+          ko
+      }
+    }
+
+    "convert (success; destroyed)" in {
+      val obj = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      obj.Faction = PlanetSideEmpire.TR
+      obj.GUID = PlanetSideGUID(90)
+      obj.Router = PlanetSideGUID(1001)
+      obj.Owner = PlanetSideGUID(5001)
+      obj.Health = 0
+      obj.Definition.Packet.ConstructorData(obj) match {
+        case Success(pkt) =>
+          pkt mustEqual TelepadDeployableData(
+            PlacementData(Vector3.Zero, Vector3.Zero),
+            PlanetSideEmpire.TR,
+            bops = false,
+            destroyed = true,
+            unk1 = 2, unk2 = true,
+            router_guid = PlanetSideGUID(1001),
+            owner_guid = PlanetSideGUID(0),
+            unk3 = 0, unk4 = 6
+          )
+        case _ =>
+          ko
+      }
+    }
+
+    "convert (failure; no router)" in {
+      val obj = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      obj.Faction = PlanetSideEmpire.TR
+      obj.GUID = PlanetSideGUID(90)
+      //obj.Router = PlanetSideGUID(1001)
+      obj.Owner = PlanetSideGUID(5001)
+      obj.Health = 1
+      obj.Definition.Packet.ConstructorData(obj).isFailure mustEqual true
+
+      obj.Router = PlanetSideGUID(0)
+      obj.Definition.Packet.ConstructorData(obj).isFailure mustEqual true
+    }
+
+    "convert (failure; detailed)" in {
+      val obj = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      obj.Faction = PlanetSideEmpire.TR
+      obj.GUID = PlanetSideGUID(90)
+      obj.Router = PlanetSideGUID(1001)
+      obj.Owner = PlanetSideGUID(5001)
+      obj.Health = 1
+      obj.Definition.Packet.DetailedConstructorData(obj).isFailure mustEqual true
     }
   }
 
@@ -524,6 +627,15 @@ class ConverterTest extends Specification {
 
       ams.Definition.Packet.ConstructorData(ams).isSuccess mustEqual true
       //did not initialize the utilities, but the converter did not fail
+    }
+
+    "convert to packet (4)" in {
+      val
+      router = Vehicle(GlobalDefinitions.router)
+      router.GUID = PlanetSideGUID(413)
+      router.Utility(UtilityType.teleportpad_terminal).get.GUID = PlanetSideGUID(1413)
+      router.Utility(UtilityType.internal_router_telepad_deployable).get.GUID = PlanetSideGUID(2413)
+      router.Definition.Packet.ConstructorData(router).isSuccess mustEqual true
     }
   }
 

--- a/common/src/test/scala/objects/DeployableTest.scala
+++ b/common/src/test/scala/objects/DeployableTest.scala
@@ -318,6 +318,38 @@ class TurretControlBetrayalMountTest extends ActorTest {
   }
 }
 
+class TelepadDeployableTest extends Specification {
+  "Telepad" should {
+    "construct" in {
+      val obj = new Telepad(GlobalDefinitions.router_telepad)
+      obj.Active mustEqual false
+      obj.Router mustEqual None
+    }
+
+    "activate and deactivate" in {
+      val obj = new Telepad(GlobalDefinitions.router_telepad)
+      obj.Active mustEqual false
+      obj.Active = true
+      obj.Active mustEqual true
+      obj.Active = false
+      obj.Active mustEqual false
+    }
+
+    "keep track of a Router" in {
+      val obj = new Telepad(GlobalDefinitions.router_telepad)
+      obj.Router mustEqual None
+      obj.Router = PlanetSideGUID(1)
+      obj.Router mustEqual Some(PlanetSideGUID(1))
+      obj.Router = None
+      obj.Router mustEqual None
+      obj.Router = PlanetSideGUID(1)
+      obj.Router mustEqual Some(PlanetSideGUID(1))
+      obj.Router = PlanetSideGUID(0)
+      obj.Router mustEqual None
+    }
+  }
+}
+
 object DeployableTest {
   class TurretInitializer(obj : TurretDeployable) extends Actor {
     def receive : Receive = {

--- a/common/src/test/scala/objects/DeployableToolboxTest.scala
+++ b/common/src/test/scala/objects/DeployableToolboxTest.scala
@@ -440,7 +440,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         GroundSupport,

--- a/common/src/test/scala/objects/DeployableToolboxTest.scala
+++ b/common/src/test/scala/objects/DeployableToolboxTest.scala
@@ -20,10 +20,12 @@ class DeployableToolboxTest extends Specification {
       obj.Initialize(Set())
       val list = obj.UpdateUI()
       list.size mustEqual DeployedItem.values.size - 3 //extra field turrets
-      list.foreach({case(_,curr,_,max) =>
+      val (routers, allOthers) = list.partition({ case((_,_,_,max)) => max == 1024 })
+      allOthers.foreach({case(_,curr,_,max) =>
         curr mustEqual 0
         max mustEqual 0
       })
+      routers.length mustEqual 1
       ok
     }
 
@@ -44,7 +46,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (AssaultEngineering)" in {
@@ -64,7 +66,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (FortificationEngineering)" in {
@@ -84,7 +86,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (AdvancedEngineering)" in {
@@ -104,7 +106,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (AdvancedHacking)" in {
@@ -124,7 +126,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (without CombatEngineering)" in {
@@ -144,7 +146,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "initialization (GroundSupport)" in {
@@ -164,6 +166,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "can not initialize twice" in {
@@ -183,7 +186,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.Initialize(Set(AdvancedEngineering)) mustEqual false
       obj.CountDeployable(DeployedItem.boomer)._2 mustEqual 0
@@ -200,7 +203,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "uninitialized fields can not accept deployables" in {
@@ -240,7 +243,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         CombatEngineering,
@@ -260,7 +263,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         FortificationEngineering,
@@ -280,7 +283,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         AssaultEngineering,
@@ -300,7 +303,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         AssaultEngineering,
@@ -320,7 +323,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         AdvancedHacking,
@@ -340,7 +343,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "change accessible fields by adding by certification type (GroundSupport)" in {
@@ -360,7 +363,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         GroundSupport,
@@ -400,7 +403,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.AddToDeployableQuantities(
         AdvancedEngineering,
@@ -420,7 +423,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "change accessible fields by removing by certification types (all)" in {
@@ -460,7 +463,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         AdvancedHacking,
@@ -480,7 +483,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         FortificationEngineering,
@@ -500,7 +503,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         AssaultEngineering,
@@ -520,7 +523,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         CombatEngineering,
@@ -540,7 +543,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "change accessible fields by removing by certification type (AdvancedEngineering)" in {
@@ -560,7 +563,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 1
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 1
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
 
       obj.RemoveFromDeployableQuantities(
         AdvancedEngineering,
@@ -580,7 +583,7 @@ class DeployableToolboxTest extends Specification {
       obj.CountDeployable(DeployedItem.portable_manned_turret_tr)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.portable_manned_turret_vs)._2 mustEqual 0
       obj.CountDeployable(DeployedItem.deployable_shield_generator)._2 mustEqual 0
-      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 0
+      obj.CountDeployable(DeployedItem.router_telepad_deployable)._2 mustEqual 1024
     }
 
     "can not remove deployables from an unpopulated field" in {

--- a/common/src/test/scala/objects/EquipmentTest.scala
+++ b/common/src/test/scala/objects/EquipmentTest.scala
@@ -5,7 +5,7 @@ import net.psforever.objects._
 import net.psforever.objects.equipment._
 import net.psforever.objects.inventory.InventoryTile
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.ce.DeployedItem
+import net.psforever.objects.ce.{DeployedItem, TelepadLike}
 import net.psforever.objects.definition._
 import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.types.CertificationType

--- a/common/src/test/scala/objects/UtilityTest.scala
+++ b/common/src/test/scala/objects/UtilityTest.scala
@@ -3,7 +3,7 @@ package objects
 
 import akka.actor.{Actor, ActorRef, Props}
 import base.ActorTest
-import net.psforever.objects.{GlobalDefinitions, Vehicle}
+import net.psforever.objects._
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.vehicles._
 import net.psforever.packet.game.PlanetSideGUID
@@ -18,7 +18,7 @@ class UtilityTest extends Specification {
       obj.UtilType mustEqual UtilityType.order_terminala
       obj().isInstanceOf[Terminal] mustEqual true
       obj().asInstanceOf[Terminal].Definition.ObjectId mustEqual 613
-      obj().asInstanceOf[Terminal].Actor == ActorRef.noSender
+      obj().asInstanceOf[Terminal].Actor mustEqual ActorRef.noSender
     }
 
     "create an order_terminalb object" in {
@@ -26,7 +26,7 @@ class UtilityTest extends Specification {
       obj.UtilType mustEqual UtilityType.order_terminalb
       obj().isInstanceOf[Terminal] mustEqual true
       obj().asInstanceOf[Terminal].Definition.ObjectId mustEqual 614
-      obj().asInstanceOf[Terminal].Actor == ActorRef.noSender
+      obj().asInstanceOf[Terminal].Actor mustEqual ActorRef.noSender
     }
 
     "create a matrix_terminalc object" in {
@@ -34,7 +34,7 @@ class UtilityTest extends Specification {
       obj.UtilType mustEqual UtilityType.matrix_terminalc
       obj().isInstanceOf[Terminal] mustEqual true
       obj().asInstanceOf[Terminal].Definition.ObjectId mustEqual 519
-      obj().asInstanceOf[Terminal].Actor == ActorRef.noSender
+      obj().asInstanceOf[Terminal].Actor mustEqual ActorRef.noSender
     }
 
     "create an ams_respawn_tube object" in {
@@ -43,7 +43,53 @@ class UtilityTest extends Specification {
       obj.UtilType mustEqual UtilityType.ams_respawn_tube
       obj().isInstanceOf[SpawnTube] mustEqual true
       obj().asInstanceOf[SpawnTube].Definition.ObjectId mustEqual 49
-      obj().asInstanceOf[SpawnTube].Actor == ActorRef.noSender
+      obj().asInstanceOf[SpawnTube].Actor mustEqual ActorRef.noSender
+    }
+
+    "create a teleportpad_terminal object" in {
+      val obj = Utility(UtilityType.teleportpad_terminal, UtilityTest.vehicle)
+      obj.UtilType mustEqual UtilityType.teleportpad_terminal
+      obj().isInstanceOf[Terminal] mustEqual true
+      obj().asInstanceOf[Terminal].Definition.ObjectId mustEqual 853
+      obj().asInstanceOf[Terminal].Actor mustEqual ActorRef.noSender
+    }
+
+    "teleportpad_terminal produces a telepad object (router_telepad)" in {
+      import net.psforever.packet.game.ItemTransactionMessage
+      import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, TransactionType}
+      val veh = Vehicle(GlobalDefinitions.quadstealth)
+      val obj = Utility(UtilityType.teleportpad_terminal, UtilityTest.vehicle)
+      veh.GUID = PlanetSideGUID(101)
+      obj().Owner = veh //hack
+      obj().GUID = PlanetSideGUID(1)
+
+      val msg = obj().asInstanceOf[Terminal].Buy(
+        Player(Avatar("TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute)),
+        ItemTransactionMessage(PlanetSideGUID(853), TransactionType.Buy, 0, "router_telepad", 0, PlanetSideGUID(0))
+      )
+      msg.isInstanceOf[Terminal.BuyEquipment] mustEqual true
+      msg.asInstanceOf[Terminal.BuyEquipment].item.isInstanceOf[Telepad] mustEqual true
+    }
+
+    "create an internal_router_telepad_deployable object" in {
+      val obj = Utility(UtilityType.internal_router_telepad_deployable, UtilityTest.vehicle)
+      obj.UtilType mustEqual UtilityType.internal_router_telepad_deployable
+      obj().isInstanceOf[Utility.InternalTelepad] mustEqual true
+      obj().asInstanceOf[Utility.InternalTelepad].Definition.ObjectId mustEqual 744
+      obj().asInstanceOf[Utility.InternalTelepad].Actor mustEqual ActorRef.noSender
+    }
+
+    "internal_router_telepad_deployable can keep track of an object's GUID (presumedly, it's a Telepad)" in {
+      val obj = Utility(UtilityType.internal_router_telepad_deployable, UtilityTest.vehicle)
+      val inpad = obj().asInstanceOf[Utility.InternalTelepad]
+
+      inpad.Telepad mustEqual None
+      inpad.Telepad = PlanetSideGUID(5)
+      inpad.Telepad mustEqual Some(PlanetSideGUID(5))
+      inpad.Telepad = PlanetSideGUID(6)
+      inpad.Telepad mustEqual Some(PlanetSideGUID(6))
+      inpad.Telepad = None
+      inpad.Telepad mustEqual None
     }
 
     "be located with their owner (terminal)" in {
@@ -71,10 +117,25 @@ class UtilityTest extends Specification {
       obj().Position mustEqual veh.Position
       obj().Orientation mustEqual veh.Orientation
     }
+
+    "be located with their owner (internal telepad)" in {
+      val veh = Vehicle(GlobalDefinitions.quadstealth)
+      val obj = Utility(UtilityType.internal_router_telepad_deployable, veh)
+      obj().Position mustEqual veh.Position
+      obj().Orientation mustEqual veh.Orientation
+
+      import net.psforever.types.Vector3
+      veh.Position = Vector3(1, 2, 3)
+      veh.Orientation = Vector3(4, 5, 6)
+      veh.GUID = PlanetSideGUID(101)
+      obj().Position mustEqual veh.Position
+      obj().Orientation mustEqual veh.Orientation
+      obj().asInstanceOf[Utility.InternalTelepad].Router mustEqual Some(veh.GUID)
+    }
   }
 }
 
-class Utility1Test extends ActorTest {
+class UtilityTerminalATest extends ActorTest {
   "Utility" should {
     "wire an order_terminala Actor" in {
       val obj = Utility(UtilityType.order_terminala, UtilityTest.vehicle)
@@ -88,7 +149,7 @@ class Utility1Test extends ActorTest {
   }
 }
 
-class Utility2Test extends ActorTest {
+class UtilityTerminalBTest extends ActorTest {
   "Utility" should {
     "wire an order_terminalb Actor" in {
       val obj = Utility(UtilityType.order_terminalb, UtilityTest.vehicle)
@@ -102,7 +163,7 @@ class Utility2Test extends ActorTest {
   }
 }
 
-class Utility3Test extends ActorTest {
+class UtilityTerminalCTest extends ActorTest {
   "Utility" should {
     "wire a matrix_terminalc Actor" in {
       val obj = Utility(UtilityType.matrix_terminalc, UtilityTest.vehicle)
@@ -116,7 +177,7 @@ class Utility3Test extends ActorTest {
   }
 }
 
-class Utility4Test extends ActorTest {
+class UtilityRespawnTubeTest extends ActorTest {
   "Utility" should {
     "wire an ams_respawn_tube Actor" in {
       val obj = Utility(UtilityType.ams_respawn_tube, UtilityTest.vehicle)
@@ -126,6 +187,38 @@ class Utility4Test extends ActorTest {
       system.actorOf(Props(classOf[UtilityTest.SetupControl], obj), "test") ! ""
       receiveOne(Duration.create(100, "ms")) //consume and discard
       assert(obj().Actor != ActorRef.noSender)
+    }
+  }
+}
+
+class UtilityTelepadTerminalTest extends ActorTest {
+  "Utility" should {
+    "wire a teleportpad_terminal Actor" in {
+      val obj = Utility(UtilityType.teleportpad_terminal, UtilityTest.vehicle)
+      obj().GUID = PlanetSideGUID(1)
+      assert(obj().Actor == ActorRef.noSender)
+
+      system.actorOf(Props(classOf[UtilityTest.SetupControl], obj), "test") ! ""
+      receiveOne(Duration.create(100, "ms")) //consume and discard
+      assert(obj().Actor != ActorRef.noSender)
+    }
+  }
+}
+
+class UtilityInternalTelepadTest extends ActorTest {
+  "Utility" should {
+    "wire a teleportpad_terminal Actor" in {
+      val veh = Vehicle(GlobalDefinitions.quadstealth)
+      veh.GUID = PlanetSideGUID(101)
+      val obj = Utility(UtilityType.internal_router_telepad_deployable, veh)
+      obj().GUID = PlanetSideGUID(1)
+      assert(obj().Actor == ActorRef.noSender)
+      assert(obj().asInstanceOf[Utility.InternalTelepad].Router.contains(veh.GUID))
+
+      system.actorOf(Props(classOf[UtilityTest.SetupControl], obj), "test") ! ""
+      receiveOne(Duration.create(100, "ms")) //consume and discard
+      assert(obj().Actor == ActorRef.noSender)
+      assert(obj().asInstanceOf[Utility.InternalTelepad].Router.contains(veh.GUID))
     }
   }
 }

--- a/common/src/test/scala/service/LocalServiceTest.scala
+++ b/common/src/test/scala/service/LocalServiceTest.scala
@@ -3,7 +3,7 @@ package service
 
 import akka.actor.Props
 import base.ActorTest
-import net.psforever.objects.{GlobalDefinitions, SensorDeployable}
+import net.psforever.objects.{GlobalDefinitions, SensorDeployable, Vehicle}
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.packet.game._
 import net.psforever.types.{PlanetSideEmpire, Vector3}
@@ -154,6 +154,19 @@ class ProximityTerminalEffectTest extends ActorTest {
   }
 }
 
+class RouterTelepadTransportTest extends ActorTest {
+  ServiceManager.boot(system)
+
+  "LocalService" should {
+    "pass RouterTelepadTransport" in {
+      val service = system.actorOf(Props[LocalService], "l_service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.RouterTelepadTransport(PlanetSideGUID(10), PlanetSideGUID(11), PlanetSideGUID(12), PlanetSideGUID(13)))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.RouterTelepadTransport(PlanetSideGUID(11), PlanetSideGUID(12), PlanetSideGUID(13))))
+    }
+  }
+}
+
 class SetEmpireTest extends ActorTest {
   ServiceManager.boot(system)
   val obj = new SensorDeployable(GlobalDefinitions.motionalarmsensor)
@@ -164,6 +177,20 @@ class SetEmpireTest extends ActorTest {
       service ! Service.Join("test")
       service ! LocalServiceMessage("test", LocalAction.SetEmpire(PlanetSideGUID(10), PlanetSideEmpire.TR))
       expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(0), LocalResponse.SetEmpire(PlanetSideGUID(10), PlanetSideEmpire.TR)))
+    }
+  }
+}
+
+class ToggleTeleportSystemTest extends ActorTest {
+  ServiceManager.boot(system)
+
+  "LocalService" should {
+    "pass ToggleTeleportSystem" in {
+      val router = Vehicle(GlobalDefinitions.router)
+      val service = system.actorOf(Props[LocalService], "l_service")
+      service ! Service.Join("test")
+      service ! LocalServiceMessage("test", LocalAction.ToggleTeleportSystem(PlanetSideGUID(10), router, None))
+      expectMsg(LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.ToggleTeleportSystem(router, None)))
     }
   }
 }

--- a/common/src/test/scala/service/RemoverActorTest.scala
+++ b/common/src/test/scala/service/RemoverActorTest.scala
@@ -5,7 +5,7 @@ import akka.actor.{ActorRef, Props}
 import akka.routing.RandomPool
 import akka.testkit.TestProbe
 import base.ActorTest
-import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.{GlobalDefinitions, PlanetSideGameObject, Tool}
 import net.psforever.objects.definition.{EquipmentDefinition, ObjectDefinition}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.guid.TaskResolver
@@ -21,24 +21,26 @@ import scala.concurrent.duration._
 //  "RemoverActor" should {
 //    "handle a simple task" in {
 //      expectNoMsg(500 milliseconds)
-//      val probe = TestProbe()
-//      val remover = system.actorOf(Props(classOf[RemoverActorTest.TestRemover], probe), "test-remover")
+//      val remover = system.actorOf(
+//        Props(classOf[ActorTest.SupportActorInterface], Props[RemoverActorTest.TestRemover], self),
+//        "test-remover"
+//      )
 //      remover ! RemoverActor.AddTask(RemoverActorTest.TestObject, Zone.Nowhere)
 //
-//      val reply1 = probe.receiveOne(200 milliseconds)
+//      val reply1 = receiveOne(500 milliseconds)
 //      assert(reply1.isInstanceOf[RemoverActorTest.InclusionTestAlert])
-//      val reply2 = probe.receiveOne(200 milliseconds)
+//      val reply2 = receiveOne(500 milliseconds)
 //      assert(reply2.isInstanceOf[RemoverActorTest.InitialJobAlert])
-//      probe.expectNoMsg(1 seconds) //delay
-//      val reply3 = probe.receiveOne(300 milliseconds)
+//      expectNoMsg(1 seconds) //delay
+//      val reply3 = receiveOne(500 milliseconds)
 //      assert(reply3.isInstanceOf[RemoverActorTest.FirstJobAlert])
-//      val reply4 = probe.receiveOne(300 milliseconds)
+//      val reply4 = receiveOne(500 milliseconds)
 //      assert(reply4.isInstanceOf[RemoverActorTest.ClearanceTestAlert])
-//      val reply5 = probe.receiveOne(300 milliseconds)
+//      val reply5 = receiveOne(500 milliseconds)
 //      assert(reply5.isInstanceOf[RemoverActorTest.SecondJobAlert])
-//      val reply6 = probe.receiveOne(500 milliseconds)
+//      val reply6 = receiveOne(500 milliseconds)
 //      assert(reply6.isInstanceOf[RemoverActorTest.DeletionTaskAlert])
-//      val reply7 = probe.receiveOne(500 milliseconds)
+//      val reply7 = receiveOne(500 milliseconds)
 //      assert(reply7.isInstanceOf[RemoverActorTest.DeletionTaskRunAlert])
 //    }
 //  }
@@ -50,29 +52,31 @@ import scala.concurrent.duration._
 //  "RemoverActor" should {
 //    "handle a simple task (timed)" in {
 //      expectNoMsg(500 milliseconds)
-//      val probe = TestProbe()
-//      val remover = system.actorOf(Props(classOf[RemoverActorTest.TestRemover], probe), "test-remover")
+//      val remover = system.actorOf(
+//        Props(classOf[ActorTest.SupportActorInterface], Props[RemoverActorTest.TestRemover], self),
+//        "test-remover"
+//      )
 //      remover ! RemoverActor.AddTask(RemoverActorTest.TestObject, Zone.Nowhere, Some(100 milliseconds))
 //
-//      val reply1 = probe.receiveOne(200 milliseconds)
+//      val reply1 = receiveOne(500 milliseconds)
 //      assert(reply1.isInstanceOf[RemoverActorTest.InclusionTestAlert])
-//      val reply2 = probe.receiveOne(200 milliseconds)
+//      val reply2 = receiveOne(500 milliseconds)
 //      assert(reply2.isInstanceOf[RemoverActorTest.InitialJobAlert])
 //      //no delay
-//      val reply3 = probe.receiveOne(300 milliseconds)
+//      val reply3 = receiveOne(500 milliseconds)
 //      assert(reply3.isInstanceOf[RemoverActorTest.FirstJobAlert])
-//      val reply4 = probe.receiveOne(300 milliseconds)
+//      val reply4 = receiveOne(500 milliseconds)
 //      assert(reply4.isInstanceOf[RemoverActorTest.ClearanceTestAlert])
-//      val reply5 = probe.receiveOne(300 milliseconds)
+//      val reply5 = receiveOne(500 milliseconds)
 //      assert(reply5.isInstanceOf[RemoverActorTest.SecondJobAlert])
-//      val reply6 = probe.receiveOne(300 milliseconds)
+//      val reply6 = receiveOne(500 milliseconds)
 //      assert(reply6.isInstanceOf[RemoverActorTest.DeletionTaskAlert])
-//      val reply7 = probe.receiveOne(300 milliseconds)
+//      val reply7 = receiveOne(500 milliseconds)
 //      assert(reply7.isInstanceOf[RemoverActorTest.DeletionTaskRunAlert])
 //    }
 //  }
 //}
-//
+
 //class ExcludedRemoverActorTest extends ActorTest {
 //  ServiceManager.boot ! ServiceManager.Register(RandomPool(2).props(Props[TaskResolver]), "taskResolver")
 //  val AlternateTestObject = new PlanetSideGameObject() { def Definition = new ObjectDefinition(0) { } }
@@ -81,7 +85,10 @@ import scala.concurrent.duration._
 //    "allow only specific objects" in {
 //      expectNoMsg(500 milliseconds)
 //      val probe = TestProbe()
-//      val remover = system.actorOf(Props(classOf[RemoverActorTest.TestRemover], probe), "test-remover")
+//      val remover = system.actorOf(
+//        Props(classOf[ActorTest.SupportActorInterface], Props[RemoverActorTest.TestRemover], self),
+//        "test-remover"
+//      )
 //      remover ! RemoverActor.AddTask(AlternateTestObject, Zone.Nowhere)
 //
 //      val reply1 = probe.receiveOne(200 milliseconds)
@@ -91,7 +98,7 @@ import scala.concurrent.duration._
 //    }
 //  }
 //}
-//
+
 //class MultipleRemoverActorTest extends ActorTest {
 //  ServiceManager.boot ! ServiceManager.Register(RandomPool(2).props(Props[TaskResolver]), "taskResolver")
 //  final val TestObject2 = new Equipment() { def Definition = new EquipmentDefinition(0) { GUID = PlanetSideGUID(2) } }
@@ -494,44 +501,44 @@ object RemoverActorTest {
 
   final case class DeletionTaskRunAlert()
 
-  class TestRemover(probe : TestProbe) extends RemoverActor {
+  class TestRemover extends RemoverActor {
     import net.psforever.objects.guid.{Task, TaskResolver}
     val FirstStandardDuration = 1 seconds
 
     val SecondStandardDuration = 100 milliseconds
 
     def InclusionTest(entry : RemoverActor.Entry) : Boolean = {
-      probe.ref ! InclusionTestAlert()
-      entry.obj.isInstanceOf[Equipment]
+      context.parent ! InclusionTestAlert()
+      true
     }
 
     def InitialJob(entry : RemoverActor.Entry) : Unit = {
-      probe.ref ! InitialJobAlert()
+      context.parent ! InitialJobAlert()
     }
 
     def FirstJob(entry : RemoverActor.Entry) : Unit = {
-      probe.ref ! FirstJobAlert()
+      context.parent ! FirstJobAlert()
     }
 
     override def SecondJob(entry : RemoverActor.Entry) : Unit = {
-      probe.ref ! SecondJobAlert()
+      context.parent ! SecondJobAlert()
       super.SecondJob(entry)
     }
 
     def ClearanceTest(entry : RemoverActor.Entry) : Boolean = {
-      probe.ref ! ClearanceTestAlert()
+      context.parent ! ClearanceTestAlert()
       true
     }
 
     def DeletionTask(entry : RemoverActor.Entry) : TaskResolver.GiveTask = {
-      probe.ref ! DeletionTaskAlert()
+      context.parent ! DeletionTaskAlert()
       TaskResolver.GiveTask(new Task() {
-        private val localProbe = probe
+        private val localProbe = context.parent
 
         override def isComplete = Task.Resolution.Success
 
         def Execute(resolver : ActorRef) : Unit = {
-          localProbe.ref ! DeletionTaskRunAlert()
+          context.parent ! DeletionTaskRunAlert()
           resolver ! scala.util.Success(this)
         }
       })

--- a/common/src/test/scala/service/RouterTelepadActivationTest.scala
+++ b/common/src/test/scala/service/RouterTelepadActivationTest.scala
@@ -1,0 +1,171 @@
+// Copyright (c) 2017 PSForever
+package service
+
+import akka.actor.Props
+import base.ActorTest
+import net.psforever.objects._
+import net.psforever.objects.zones.Zone
+import net.psforever.packet.game.PlanetSideGUID
+import services.local.support.RouterTelepadActivation
+import services.support.SupportActor
+
+import scala.concurrent.duration._
+
+class RouterTelepadActivationTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "construct" in {
+      system.actorOf(Props[RouterTelepadActivation], "activation-test-actor")
+    }
+  }
+}
+
+class RouterTelepadActivationSimpleTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "handle a task" in {
+      val telepad = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad.GUID = PlanetSideGUID(1)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad, Zone.Nowhere, Some(2 seconds))
+      expectMsg(3 seconds, RouterTelepadActivation.ActivateTeleportSystem(telepad, Zone.Nowhere))
+    }
+  }
+}
+
+class RouterTelepadActivationComplexTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "handle multiple tasks" in {
+      val telepad1 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad1.GUID = PlanetSideGUID(1)
+      val telepad2 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad2.GUID = PlanetSideGUID(2)
+      val telepad3 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad3.GUID = PlanetSideGUID(3)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad1, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad2, Zone.Nowhere, Some(3 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad3, Zone.Nowhere, Some(1 seconds))
+      val msgs = receiveN(3, 5 seconds) //organized by duration
+      assert(msgs.head.isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs.head.asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad3)
+      assert(msgs(1).isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs(1).asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad1)
+      assert(msgs(2).isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs(2).asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad2)
+    }
+  }
+}
+
+class RouterTelepadActivationHurryTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "hurry specific tasks" in {
+      val telepad1 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad1.GUID = PlanetSideGUID(1)
+      val telepad2 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad2.GUID = PlanetSideGUID(2)
+      val telepad3 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad3.GUID = PlanetSideGUID(3)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad1, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad2, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad3, Zone.Nowhere, Some(2 seconds))
+      obj ! SupportActor.HurrySpecific(List(telepad1, telepad2), Zone.Nowhere)
+      val msgs = receiveN(2, 1 seconds)
+      assert(msgs.head.isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs.head.asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad1)
+      assert(msgs(1).isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs(1).asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad2)
+      val last = receiveOne(3 seconds)
+      assert(last.isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(last.asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad3)
+    }
+  }
+}
+
+class RouterTelepadActivationHurryAllTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "hurry all tasks" in {
+      val telepad1 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad1.GUID = PlanetSideGUID(1)
+      val telepad2 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad2.GUID = PlanetSideGUID(2)
+      val telepad3 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad3.GUID = PlanetSideGUID(3)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad1, Zone.Nowhere, Some(7 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad2, Zone.Nowhere, Some(5 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad3, Zone.Nowhere, Some(6 seconds))
+      obj ! SupportActor.HurryAll()
+      val msgs = receiveN(3, 4 seconds) //organized by duration; note: all messages received before the earliest task should be performed
+      assert(msgs.head.isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs.head.asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad2)
+      assert(msgs(1).isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs(1).asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad3)
+      assert(msgs(2).isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs(2).asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad1)
+    }
+  }
+}
+
+class RouterTelepadActivationClearTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "clear specific tasks" in {
+      val telepad1 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad1.GUID = PlanetSideGUID(1)
+      val telepad2 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad2.GUID = PlanetSideGUID(2)
+      val telepad3 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad3.GUID = PlanetSideGUID(3)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad1, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad2, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad3, Zone.Nowhere, Some(2 seconds))
+      obj ! SupportActor.ClearSpecific(List(telepad1, telepad2), Zone.Nowhere)
+      val msgs = receiveN(1, 3 seconds) //should only receive telepad3
+      assert(msgs.head.isInstanceOf[RouterTelepadActivation.ActivateTeleportSystem])
+      assert(msgs.head.asInstanceOf[RouterTelepadActivation.ActivateTeleportSystem].telepad == telepad3)
+    }
+  }
+}
+
+class RouterTelepadActivationClearAllTest extends ActorTest {
+  "RouterTelepadActivation" should {
+    "clear all tasks" in {
+      val telepad1 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad1.GUID = PlanetSideGUID(1)
+      val telepad2 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad2.GUID = PlanetSideGUID(2)
+      val telepad3 = new TelepadDeployable(GlobalDefinitions.router_telepad_deployable)
+      telepad3.GUID = PlanetSideGUID(3)
+      val obj = system.actorOf(
+        Props(classOf[ActorTest.SupportActorInterface], Props[RouterTelepadActivation], self),
+        "activation-test-actor"
+      )
+
+      obj ! RouterTelepadActivation.AddTask(telepad1, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad2, Zone.Nowhere, Some(2 seconds))
+      obj ! RouterTelepadActivation.AddTask(telepad3, Zone.Nowhere, Some(2 seconds))
+      obj ! SupportActor.ClearAll()
+      expectNoMsg(4 seconds)
+    }
+  }
+}

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -2832,7 +2832,6 @@ class WorldSessionActor extends Actor with MDCContextAware {
       })
       StopBundlingPackets()
       self ! SetCurrentAvatar(player)
-sendRawResponse(hex"17 c8000000 f42 6101 33b27 d07b8 9d42 00 00 79 00 8101 ae01 5700c")
 
     case msg @ PlayerStateMessageUpstream(avatar_guid, pos, vel, yaw, pitch, yaw_upper, seq_time, unk3, is_crouching, is_jumping, unk4, is_cloaking, unk5, unk6) =>
       if(player.isAlive) {
@@ -7434,8 +7433,8 @@ sendRawResponse(hex"17 c8000000 f42 6101 33b27 d07b8 9d42 00 00 79 00 8101 ae01 
   }
 
   /**
-    * na
-    * @param vehicle na
+    * Before a vehicle is removed from the game world, the following actions must be performed.
+    * @param vehicle the vehicle
     */
   def BeforeUnloadVehicle(vehicle : Vehicle) : Unit = {
     vehicle.Definition match {


### PR DESCRIPTION
"Ever since I saw that person during the last event who pulled a Router and tried to bring it around to an enemy base, I felt bad for him.  Let's make Routers work, even if just a little bit more."

`Utility.TeleportPadTerminal`:
An `Amenity`-type object that dispenses only router telepads.  It located at the nondescript back of the vehicle and is functional when the Router has deployed.  It has no interface, only producing mesages when close enough to it, and interacting with the unit is enough to place a Router into one's inventory in any available space.

`TelepadLike`:
A common `trait` of units that demonstrate Telepad-like properties.  Actual `Telepad` objects, `TelepadDeployable` objects, and the `InternalTelepad` use this class to bus around a reference to the associated Router vehicle and whether or not the object is ready to serve as the endpoint in a teleportation system.  (The latter feature is inconsequential for telepad objects.)

`Telepad`:
A special `ConstructionItem` object designed to produce a single deployable - the `router_telepad_deployable`.  The only server-imposed limitation on Telepads is that they can not be restored through loadouts.  If the Router associated with the telepad is destroyed or has moved to a different continent, the telepad will refuse to deploy (client-enforced) and a message will be displayed.

`TelepadDeployable`:
A floaty `Deployable` item that will eventually split and produce a blue spheroid used for teleportation when paired with a functional deployed Router vehicle after 60s of being placed.  The 60s activation time can not be skipped.  Walking into a telepad deployable when it is active will instantly move the player to the position of the router, accompanied by a unique teleportation sound.  If the telepad deploys but the Router has shifted to a state of not being ready in the meantime, the telepad will patiently wait to activate and a message will be displayed.  If another telepad is deployed with an association to the same Router, regardless of the condition of the Router, or that old telepad, the old telepad will be deconstructed.  When the Router is destroyed or undeploys, the currently-associated telepad deployable will also be deconstructed.

`Utility.InternalTelepad`:
An `Amenity`-type object that serves as the Router-side endpoint of the teleportation system.  Clients are instructed to normally construct this object every time the Router deploys (or, at least, the first time it deploys ...).  The "beam" underneath the vehicle itself is always a visible component of the deployed Router.  It does not become active, however, until paired with this unit and until the whole of the teleportation system is ready.

`RouterTelepadActivation`:
A `SupportActor` that counts the 60s until `TelepadDeployable` is ready to connect to an active teleportation system.

Caveats:
- The `InternalTelepad` object must exist as a permanent aspect of the vehicle's object create packet due to the automatic way the server translates objects into network data.  Despite that, the code for independent creation (and deletion) of the `InternalTelepad` object occurs each time the system attempts to change its activation state.
- Routers require an indeterminate amount of time from deployment to be ready to attempt to active a teleport system.  This period is typically how long it takes the vehicle to switch between deployment states, with some extra milliseconds.  It takes longer to completely disconnect the client from the server (see `SessionReaper`) so it is permissible to perform this action in the local user space.
- The server attempts to impose a 2s cooldown between teleportations to make certain that the user has time to evacuate the beam before it triggers and attempts to return the user to the original side.  In theory, the user should be able to stand in the beam just after appearing and not be returned back to the other endpoint.  In practice, either the client does not send evenly-spaced packets, it has an internal cooldown of some sort, or the `ActorSystem` incurs some time penalty before processing an otherwise timely packet.  The user is still fully capable of not ping-ponging back and forth between endpoints most of the time despite infrequent slips.
- The number of `TelepadDeployable` objects that may be owned at one time is permanently set to 1024, regardless of the certifications belonging to a character.  This is because, unlike other equipment and vehicles that can be pulled from a terminal, even a person without the `GroundSupport` certification can obtain a router telepad from its vehicle-borne terminal and successfully deploy it.

Addenda:
- To allow other players to obtain a telepad from the terminal, the owner of the Router must permit access to the trunk.  This absolutely normal behavior but I feel that it needs to spelled out clearly.
- To deploy more than 1 of the available 1024 telepads permissible requires using multiple Routers.  Regardless of the number of telepads in the field owned by the player, the chat message for the deployable will always act as if whatever unit has just been created, reported as "1 out of 1."
- Terminal `UseItemMessage` handling code in `WorldSessionActor` has been changed a little.  Please be a second (third, fourth, fifth, and so on) pair of eyes and check all applicable interactions, e.g., hacking.
- Zones now accept `Option[PlanetSideGUID]` as searchable information.  This important not just to eliminate frequent `getOrElse` clauses and `match` cases but it also is much more fluid to read.
- An issue with Maelstrom and Radiator grenade projectiles where hit information exists but an actual hit target isn't defined, thus causing the client to disconnect, is resolved.
- Despite being adjusted slightly, `RemoverActorTest` classes are still commented out because they won't work (in continuous integration testing).