### PR TITLE
Re-time Door Close

### DIFF
--- a/common/src/main/scala/services/local/support/DoorCloseActor.scala
+++ b/common/src/main/scala/services/local/support/DoorCloseActor.scala
@@ -43,7 +43,10 @@ class DoorCloseActor() extends Actor {
             true
         }
       })
-      openDoors = (doorsLeftOpen1 ++ doorsLeftOpen2).sortBy(_.time)
+      openDoors = (
+        doorsLeftOpen1 ++
+          doorsLeftOpen2.map(entry => DoorCloseActor.DoorEntry(entry.door, entry.zone, now))
+        ).sortBy(_.time)
       doorsToClose2.foreach(entry => {
         entry.door.Open = None //permissible break from synchronization
         context.parent ! DoorCloseActor.CloseTheDoor(entry.door.GUID, entry.zone.Id) //call up to the main event system


### PR DESCRIPTION
When doors are opened, but will not reclose due to the precense of the player that opened the door, that door will have its entry retimed before being put back into the queue of doors waiting to be closed.