### PR TITLE
Fix for hackable entities not resetting their hack state when resecured by the empire that owns the hackable

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/hackable/Hackable.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/hackable/Hackable.scala
@@ -1,10 +1,11 @@
 package net.psforever.objects.serverobject.hackable
 
 import net.psforever.objects.Player
+import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.packet.game.{PlanetSideGUID, TriggeredSound}
 import net.psforever.types.Vector3
 
-trait Hackable {
+trait Hackable extends FactionAffinity {
   /** An entry that maintains a reference to the `Player`, and the player's GUID and location when the message was received. */
   private var hackedBy : Option[(Player, PlanetSideGUID, Vector3)] = None
   def HackedBy : Option[(Player, PlanetSideGUID, Vector3)] = hackedBy
@@ -24,8 +25,8 @@ trait Hackable {
           hackedBy = Some(agent.get, agent.get.GUID, agent.get.Position)
         }
       case Some(_) =>
-        //clear the hack state
-        if(agent.isEmpty) {
+        //clear the hack state if no agent is provided or the agent's faction matches the object faction
+        if(agent.isEmpty || agent.get.Faction == this.Faction) {
           hackedBy = None
         }
         //override the hack state with a new hack state if the new user has different faction affiliation


### PR DESCRIPTION
Fairly self explanatory. hackedBy was set to the person that resecured the Hackable, which caused it to still think it was hacked, which caused odd behaviour like when sending BuildingInfoUpdateMessage all lattice links would still be disabled after a CC resecure.