### PR TITLE
Add 1.5 to Z axis when spawning at respawn tubes to prevent clipping with new spawn tube positions from ubr files

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -493,6 +493,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
       spawn_tube.Owner match {
         case building : Building =>
           log.info(s"Zone.Lattice.SpawnPoint: spawn point on $zone_id in building ${building.Id} selected")
+          pos = pos + (Vector3(0, 0, 1.5f))
         case vehicle : Vehicle =>
 //          vehicleService ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), continent))
 //          vehicleService ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, continent, vehicle.Definition.DeconstructionTime))


### PR DESCRIPTION
As evidenced by the folllowing property from `startup.pak/game_objects.adb.lst`

`add_property mb_respawn_tube respawn_z_offset -1.5`

As for why the property has a negative Z offset I can only assume the world is upside down when that property was applied on live.