### PR TITLE
Exclude Equipment from Loadouts

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -5803,6 +5803,7 @@ object GlobalDefinitions {
     order_terminala.Tab += 2 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.supportAmmunition ++ EquipmentTerminalDefinition.supportWeapons)
     order_terminala.Tab += 3 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.vehicleAmmunition)
     order_terminala.Tab += 4 -> OrderTerminalDefinition.InfantryLoadoutPage()
+    order_terminala.Tab(4).asInstanceOf[OrderTerminalDefinition.InfantryLoadoutPage].Exclude = ExoSuitType.MAX
     order_terminala.SellEquipmentByDefault = true
 
     order_terminalb.Name = "order_terminalb"
@@ -5811,6 +5812,7 @@ object GlobalDefinitions {
     order_terminalb.Tab += 2 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.supportAmmunition ++ EquipmentTerminalDefinition.supportWeapons)
     order_terminalb.Tab += 3 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.vehicleAmmunition)
     order_terminalb.Tab += 4 -> OrderTerminalDefinition.InfantryLoadoutPage()
+    order_terminalb.Tab(4).asInstanceOf[OrderTerminalDefinition.InfantryLoadoutPage].Exclude = ExoSuitType.MAX
     order_terminalb.SellEquipmentByDefault = true
 
     cert_terminal.Name = "cert_terminal"

--- a/common/src/main/scala/net/psforever/objects/definition/ExoSuitDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/ExoSuitDefinition.scala
@@ -94,6 +94,7 @@ class SpecialExoSuitDefinition(private val suitType : ExoSuitType.Value) extends
 
   override def Use : ExoSuitDefinition = {
     val obj = new SpecialExoSuitDefinition(SuitType)
+    obj.Permissions = Permissions
     obj.MaxArmor = MaxArmor
     obj.InventoryScale = InventoryScale
     obj.InventoryOffset = InventoryOffset

--- a/common/src/main/scala/net/psforever/objects/loadouts/InfantryLoadout.scala
+++ b/common/src/main/scala/net/psforever/objects/loadouts/InfantryLoadout.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.loadouts
 
-import net.psforever.types.ExoSuitType
+import net.psforever.types.{CertificationType, ExoSuitType}
 
 /**
   * A blueprint of a player's uniform, their holster items, and their inventory items, saved in a specific state.
@@ -98,5 +98,20 @@ object InfantryLoadout {
       case ExoSuitType.MAX => 3 + subtype //4, 5, 6
       case ExoSuitType.Infiltration => 7
     }
+  }
+
+  /**
+    * Assuming the exo-suit is a mechanized assault type,
+    * use the subtype to determine what certifications would be valid for permitted access to that specific exo-suit.
+    * The "C" does not stand for "certification."
+    * @see `CertificationType`
+    * @param subtype the numeric subtype
+    * @return a `Set` of all certifications that would grant access to the mechanized assault exo-suit subtype
+    */
+  def DetermineSubtypeC(subtype : Int) : Set[CertificationType.Value] = subtype match {
+    case 1 => Set(CertificationType.AIMAX, CertificationType.UniMAX)
+    case 2 => Set(CertificationType.AVMAX, CertificationType.UniMAX)
+    case 3 => Set(CertificationType.AAMAX, CertificationType.UniMAX)
+    case _ => Set.empty[CertificationType.Value]
   }
 }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1575,24 +1575,31 @@ class WorldSessionActor extends Actor with MDCContextAware {
 
       case Terminal.InfantryLoadout(exosuit, subtype, holsters, inventory) =>
         log.info(s"$tplayer wants to change equipment loadout to their option #${msg.unk1 + 1}")
-        //TODO check exo-suit permissions
         sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Loadout, true))
         //prepare lists of valid objects
         val beforeFreeHand = tplayer.FreeHand.Equipment
         val dropPred = DropPredicate(tplayer)
         val (dropHolsters, beforeHolsters) = clearHolsters(tplayer.Holsters().iterator).partition(dropPred)
         val (dropInventory, beforeInventory) = tplayer.Inventory.Clear().partition(dropPred)
-        val (_, afterHolsters) = holsters.partition(dropPred) //dropped items are forgotten
-        val (_, afterInventory) = inventory.partition(dropPred) //dropped items are forgotten
-        //change suit (clear inventory and change holster sizes; holsters must be empty before this point)
         tplayer.FreeHand.Equipment = None //terminal and inventory will close, so prematurely dropping should be fine
+        //sanitize exo-suit for change
         val originalSuit = player.ExoSuit
         val originalSubtype = Loadout.DetermineSubtype(tplayer)
         val originalArmor = player.Armor
-        tplayer.ExoSuit = exosuit
+        val fallbackSuit = ExoSuitType.Standard
+        //a loadout with an unpermited exo-suit type will result in a standard exo-suit
+        val (nextSuit : ExoSuitType.Value, nextSubtype : Int) = if(exosuit != fallbackSuit && tplayer.Certifications.intersect(ExoSuitDefinition.Select(exosuit).Permissions.toSet).nonEmpty) {
+          (exosuit, subtype)
+        }
+        else {
+          log.warn(s"$tplayer no longer has permission to wear the exo-suit type $exosuit; will wear $fallbackSuit instead")
+          (fallbackSuit, 0)
+        }
+        //update suit interally (holsters must be empty before this point)
+        tplayer.ExoSuit = nextSuit
         val toMaxArmor = tplayer.MaxArmor
-        if(originalSuit != exosuit || originalSubtype != subtype || originalArmor > toMaxArmor) {
-          tplayer.History(HealFromExoSuitChange(PlayerSource(tplayer), exosuit))
+        if(originalSuit != nextSuit || originalSubtype != nextSubtype || originalArmor > toMaxArmor) {
+          tplayer.History(HealFromExoSuitChange(PlayerSource(tplayer), nextSuit))
           tplayer.Armor = toMaxArmor
           sendResponse(PlanetsideAttributeMessage(tplayer.GUID, 4, toMaxArmor))
           avatarService ! AvatarServiceMessage(player.Continent, AvatarAction.PlanetsideAttribute(tplayer.GUID, 4, toMaxArmor))
@@ -1606,6 +1613,44 @@ class WorldSessionActor extends Actor with MDCContextAware {
           sendResponse(ObjectHeldMessage(tplayer.GUID, Player.HandsDownSlot, true))
           avatarService ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ObjectHeld(tplayer.GUID, tplayer.LastDrawnSlot))
         }
+        //a change due to exo-suit permissions mismatch will result in (more) items being re-arranged and/or dropped
+        //dropped items can be forgotten safely
+        val (afterHolsters, afterInventory) = if(nextSuit == exosuit) {
+          (
+            holsters.filterNot(dropPred),
+            inventory.filterNot(dropPred)
+          )
+        }
+        else {
+          val newSuitDef = ExoSuitDefinition.Select(nextSuit)
+          val (afterInventory, extra) = GridInventory.recoverInventory(
+            inventory.filterNot(dropPred),
+            tplayer.Inventory
+          )
+          val afterHolsters = {
+            val preservedHolsters = if(exosuit == ExoSuitType.MAX) {
+              holsters.filter(_.start == 4) //melee slot perservation
+            }
+            else {
+              holsters
+                .filterNot(dropPred)
+                .collect {
+                  case item@InventoryItem(obj, index) if newSuitDef.Holster(index) == obj.Size => item
+                }
+            }
+            val size = newSuitDef.Holsters.size
+            val indexMap = preservedHolsters.map { entry => entry.start }
+            preservedHolsters ++ (extra.map { obj =>
+              tplayer.Fit(obj) match {
+                case Some(index : Int) if index < size && !indexMap.contains(index) =>
+                  InventoryItem(obj, index)
+                case _ =>
+                  InventoryItem(obj, -1)
+              }
+            }).filterNot(entry => entry.start == -1)
+          }
+          (afterHolsters, afterInventory)
+        }
         //delete everything (not dropped)
         beforeHolsters.foreach({ elem =>
           avatarService ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ObjectDelete(tplayer.GUID, elem.obj.GUID))
@@ -1615,9 +1660,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
           taskResolver ! GUIDTask.UnregisterEquipment(elem.obj)(continent.GUID)
         })
         //report change
-        sendResponse(ArmorChangedMessage(tplayer.GUID, exosuit, subtype))
-        avatarService ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ArmorChanged(tplayer.GUID, exosuit, subtype))
-        if(exosuit == ExoSuitType.MAX) {
+        sendResponse(ArmorChangedMessage(tplayer.GUID, nextSuit, nextSubtype))
+        avatarService ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ArmorChanged(tplayer.GUID, nextSuit, nextSubtype))
+        if(nextSuit == ExoSuitType.MAX) {
           val (maxWeapons, otherWeapons) = afterHolsters.partition(entry => { entry.obj.Size == EquipmentSize.Max })
           taskResolver ! DelayedObjectHeld(tplayer, 0, List(PutEquipmentInSlot(tplayer, maxWeapons.head.obj, 0)))
           otherWeapons
@@ -2638,7 +2683,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
     val (inf, veh) = avatar.Loadouts.partition { case (index, _) => index < 10 }
     inf.foreach {
       case (index, loadout : InfantryLoadout) =>
-        sendResponse(FavoritesMessage(LoadoutType.Infantry, guid, index, loadout.label, loadout.exosuit.id + loadout.subtype))
+        sendResponse(FavoritesMessage(LoadoutType.Infantry, guid, index, loadout.label, InfantryLoadout.DetermineSubtypeB(loadout.exosuit, loadout.subtype)))
     }
     veh.foreach {
       case (index, loadout : VehicleLoadout) =>


### PR DESCRIPTION
In response to https://trello.com/c/rs2X5SqT/27-anti-infantry-max-armor-can-be-acquired-at-an-ams-terminal, loadouts can now be blocked in whole or in part.