### PR TITLE
Gating Fixes

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1039,14 +1039,12 @@ object GlobalDefinitions {
   val warpgate : ObjectDefinition with SpawnPointDefinition = new ObjectDefinition(993) with SpawnPointDefinition
   warpgate.Name = "warpgate"
   warpgate.UseRadius = 301.8713f
-  warpgate.Delay = 10
   warpgate.VehicleAllowance = true
   warpgate.SpecificPointFunc = SpawnPoint.Gate
 
   val hst : ObjectDefinition with SpawnPointDefinition = new ObjectDefinition(402) with SpawnPointDefinition
   hst.Name = "hst"
   hst.UseRadius = 20.4810f
-  hst.Delay = 10
   hst.VehicleAllowance = true
   hst.NoWarp += dropship
   hst.NoWarp += galaxy_gunship
@@ -1062,7 +1060,6 @@ object GlobalDefinitions {
   val warpgate_cavern : ObjectDefinition with SpawnPointDefinition = new ObjectDefinition(994) with SpawnPointDefinition
   warpgate_cavern.Name = "warpgate_cavern"
   warpgate_cavern.UseRadius = 55.0522f
-  warpgate_cavern.Delay = 10
   warpgate_cavern.VehicleAllowance = true
   warpgate_cavern.SpecificPointFunc = SpawnPoint.Gate
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
@@ -9,11 +9,15 @@ import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.{Additional1, Additional2, Additional3, PlanetSideGeneratorState}
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 
+import scala.collection.mutable
+
 class WarpGate(building_guid : Int, map_id : Int, zone : Zone, buildingDefinition : ObjectDefinition with SpawnPointDefinition)
   extends Building(building_guid, map_id, zone, StructureType.WarpGate, buildingDefinition)
     with SpawnPoint {
+  /** can this building be used as an active warp gate */
   private var active : Boolean = true
-  private var broadcast : Boolean = false
+  /** what faction views this warp gate as a broadcast gate */
+  private var broadcast : mutable.Set[PlanetSideEmpire.Value] = mutable.Set.empty[PlanetSideEmpire.Value]
 
   override def Info : (
     Int,
@@ -48,18 +52,105 @@ class WarpGate(building_guid : Int, map_id : Int, zone : Zone, buildingDefinitio
     )
   }
 
+  /**
+    * If a warp gate is active, it can be used to transport faction-affiliated forces between other gates.
+    * For transportation of faction-opposed forces, use broadcast logic for that faction.
+    * @return `true`, if the warp gate can be used for transport;
+    *        `false`, otherwise
+    */
   def Active : Boolean = active
 
+  /**
+    * Control whether a warp gate is usable for transporting faction-affiliated forces between other gates.
+    * @param state `true`, to activate the gate;
+    *             `false`, otherwise
+    * @return `true`, if the gate is active;
+    *        `false`, otherwise
+    */
   def Active_=(state : Boolean) : Boolean = {
     active = state
     Active
   }
 
-  def Broadcast : Boolean = Active && broadcast
+  /**
+    * Determine whether any faction interacts with this warp gate as "broadcast."
+    * The gate must be active first.
+    * @return `true`, if some faction sees this warp gate as a "broadcast gate";
+    *        `false`, otherwise
+    */
+  def Broadcast : Boolean = Active && broadcast.nonEmpty
 
-  def Broadcast_=(cast : Boolean) : Boolean = {
-    broadcast = cast
-    Broadcast
+  /**
+    * Determine whether a specific faction interacts with this warp gate as "broadcast."
+    * The warp gate being `NEUTRAL` should allow for any polled faction to interact.
+    * The gate must be active first.
+    * @return `true`, if the given faction interacts with this warp gate as a "broadcast gate";
+    *        `false`, otherwise
+    */
+  def Broadcast(faction : PlanetSideEmpire.Value) : Boolean = {
+    Active && (broadcast.contains(faction) || broadcast.contains(PlanetSideEmpire.NEUTRAL))
+  }
+
+  /**
+    * Toggle whether the warp gate's faction-affiliated force interacts with this warp gate as "broadcast."
+    * Other "broadcast" associations are not affected.
+    * The gate must be active first.
+    * @param bcast `true`, if the faction-affiliated force interacts with this gate as broadcast;
+    *             `false`, if not
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def Broadcast_=(bcast : Boolean) : Set[PlanetSideEmpire.Value] = {
+    if(Active) {
+      if(bcast) {
+        broadcast += Faction
+      }
+      else {
+        broadcast -= Faction
+      }
+    }
+    broadcast.toSet
+  }
+
+  /**
+    * Which factions interact with this warp gate as "broadcast?"
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def BroadcastFor : Set[PlanetSideEmpire.Value] = broadcast.toSet
+
+  /**
+    * Allow a faction to interact with a given warp gate as "broadcast" if it is active.
+    * @param bcast the faction
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def BroadcastFor_=(bcast : PlanetSideEmpire.Value) : Set[PlanetSideEmpire.Value] = {
+    (broadcast += bcast).toSet
+  }
+
+  /**
+    * Allow some factions to interact with a given warp gate as "broadcast" if it is active.
+    * @param bcast the factions
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def BroadcastFor_=(bcast : Set[PlanetSideEmpire.Value]) : Set[PlanetSideEmpire.Value] = {
+    (broadcast ++= bcast).toSet
+  }
+
+  /**
+    * Disallow a faction to interact with a given warp gate as "broadcast."
+    * @param bcast the faction
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def StopBroadcastFor_=(bcast : PlanetSideEmpire.Value) : Set[PlanetSideEmpire.Value] = {
+    (broadcast -= bcast).toSet
+  }
+
+  /**
+    * Disallow some factions to interact with a given warp gate as "broadcast."
+    * @param bcast the factions
+    * @return the set of all factions who interact with this warp gate as "broadcast"
+    */
+  def StopBroadcastFor_=(bcast : Set[PlanetSideEmpire.Value]) : Set[PlanetSideEmpire.Value] = {
+    (broadcast --= bcast).toSet
   }
 
   def Owner : PlanetSideServerObject = this

--- a/common/src/main/scala/net/psforever/packet/game/BroadcastWarpgateUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BroadcastWarpgateUpdateMessage.scala
@@ -6,28 +6,26 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Promotes a warpgate's "broadcast" functionality.<br>
+  * Dispatched by the server to promote a warp gate's broadcast functionality.<br>
   * <br>
-  * Change the map name of a warpgate into "Broadcast" when the proper state is set.
-  * If a proper warpgate is not designated, nothing happens.
-  * If not set, the map name of the warpgate will default to whatever is normally written on the map.
-  * The map designation of geowarps is not affected by this packet.<br>
-  * <br>
-  * Exploration:<br>
-  * I believe these `Boolean` values actually indicate some measure of warpgate operation.
-  * Geowarps, for example, though their appearance does not change, recieve this packet.
-  * Moreover, they can operate as a receiving-end broadcast gate.
-  * @param continent_id the zone
-  * @param building_id the warp gate (see `BuildingInfoUpdateMessage`)
-  * @param unk1 na
-  * @param unk2 na
-  * @param broadcast if true, the gate replaces its destination text with "Broadcast"
+  * Changes the map name of a warp gate into "Broadcast"
+  * and allow a given faction to access the gate's intercontinental transport functionality to/from that gate,
+  * even if the gate is not properly owned.
+  * If an actual warp gate is not designated, nothing happens.
+  * If not set, the map name of the warp gate will default to whatever is normally written on the map.
+  * The map designation of geowarps is not affected by this packet.
+  * @see `BuildingInfoUpdateMessage`
+  * @param zone_id the zone ordinal number
+  * @param building_id the warp gate map id
+  * @param tr players belonging to the Terran Republic interact with this warp gate as a "broadcast gate"
+  * @param nc players belonging to the New Conglomerate interact with this warp gate as a "broadcast gate"
+  * @param vs players belonging to the Vanu Sovereignty interact with this warp gate as a "broadcast gate"
   */
-final case class BroadcastWarpgateUpdateMessage(continent_id : Int,
+final case class BroadcastWarpgateUpdateMessage(zone_id : Int,
                                                 building_id : Int,
-                                                unk1 : Boolean,
-                                                unk2 : Boolean,
-                                                broadcast : Boolean)
+                                                tr : Boolean,
+                                                nc : Boolean,
+                                                vs : Boolean)
   extends PlanetSideGamePacket {
   type Packet = BroadcastWarpgateUpdateMessage
   def opcode = GamePacketOpcode.BroadcastWarpgateUpdateMessage
@@ -36,10 +34,10 @@ final case class BroadcastWarpgateUpdateMessage(continent_id : Int,
 
 object BroadcastWarpgateUpdateMessage extends Marshallable[BroadcastWarpgateUpdateMessage] {
   implicit val codec : Codec[BroadcastWarpgateUpdateMessage] = (
-    ("continent_id" | uint16L) ::
+    ("zone_id" | uint16L) ::
       ("building_id" | uint16L) ::
-      ("unk1" | bool) ::
-      ("unk2" | bool) ::
-      ("broadcast" | bool)
+      ("tr" | bool) ::
+      ("nc" | bool) ::
+      ("vs" | bool)
     ).as[BroadcastWarpgateUpdateMessage]
 }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3280,7 +3280,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               deadState = DeadState.Alive
           }
 
-        case (false, _, _) => ;
+        case (_, _, _) => ;
       }
 
       CSRWarp.read(traveler, msg) match {
@@ -3304,7 +3304,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               deadState = DeadState.Alive
           }
 
-        case (false, _) => ;
+        case (_, _) => ;
       }
 
       // TODO: Prevents log spam, but should be handled correctly
@@ -6306,7 +6306,16 @@ class WorldSessionActor extends Actor with MDCContextAware {
           )
         )
         sendResponse(DensityLevelUpdateMessage(continentNumber, buildingNumber, List(0,0, 0,0, 0,0, 0,0)))
-        sendResponse(BroadcastWarpgateUpdateMessage(continentNumber, buildingNumber, false, false, wg.Broadcast))
+        //TODO one faction knows which gates are broadcast for another faction?
+        sendResponse(
+          BroadcastWarpgateUpdateMessage(
+            continentNumber,
+            buildingNumber,
+            wg.Broadcast(PlanetSideEmpire.TR),
+            wg.Broadcast(PlanetSideEmpire.NC),
+            wg.Broadcast(PlanetSideEmpire.VS)
+          )
+        )
       case _ => ;
     }
   }
@@ -7880,7 +7889,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
     else {
       LoadZoneCommonTransferActivity()
       val original = player
-      if(tplayer.isBackpack) {
+      if(player.isBackpack) {
         //unregister avatar locker + GiveWorld
         player = tplayer
         (taskResolver, TaskBeforeZoneChange(GUIDTask.UnregisterLocker(original.Locker)(continent.GUID), zone_id))

--- a/pslogin/src/main/scala/Zones.scala
+++ b/pslogin/src/main/scala/Zones.scala
@@ -7,7 +7,16 @@ import net.psforever.objects.zones.Zone
 import net.psforever.types.PlanetSideEmpire
 
 object Zones {
-  val z1 = new Zone("z1", Maps.map1, 1)
+  val z1 = new Zone("z1", Maps.map1, 1) {
+    override def Init(implicit context : ActorContext) : Unit = {
+      super.Init(context)
+
+      BuildingByMapId(1).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.TR
+      BuildingByMapId(2).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.TR
+      BuildingByMapId(3).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.TR
+      BuildingByMapId(4).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.TR
+    }
+  }
 
   val z2 = new Zone("z2", Maps.map2, 2)
 
@@ -101,10 +110,10 @@ object Zones {
       }
       import net.psforever.types.PlanetSideEmpire
       BuildingByMapId(2).get.Faction = PlanetSideEmpire.VS
-      BuildingByMapId(10).get.asInstanceOf[WarpGate].Broadcast = true
-      BuildingByMapId(11).get.asInstanceOf[WarpGate].Broadcast = true
-      BuildingByMapId(12).get.asInstanceOf[WarpGate].Broadcast = true
-      BuildingByMapId(13).get.asInstanceOf[WarpGate].Broadcast = true
+      BuildingByMapId(10).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.VS
+      BuildingByMapId(11).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.VS
+      BuildingByMapId(12).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.VS
+      BuildingByMapId(13).get.asInstanceOf[WarpGate].BroadcastFor = PlanetSideEmpire.VS
       BuildingByMapId(48).get.Faction = PlanetSideEmpire.VS
       BuildingByMapId(49).get.Faction = PlanetSideEmpire.VS
       BuildingByMapId(18657).get.asInstanceOf[WarpGate].Active = false
@@ -135,6 +144,9 @@ object Zones {
 
       import net.psforever.types.PlanetSideEmpire
       Buildings.values.foreach { _.Faction = PlanetSideEmpire.TR }
+      BuildingByMapId(1).get.asInstanceOf[WarpGate].Broadcast = true
+      BuildingByMapId(2).get.asInstanceOf[WarpGate].Broadcast = true
+      BuildingByMapId(3).get.asInstanceOf[WarpGate].Broadcast = true
     }
   }
 


### PR DESCRIPTION
In response to feedback from the last `gating` PR and in an attempt to resolve some lingering concerns.

Spawn times when traveling via warp gates is now as instantaneous as possible.

Subsequent clicks on the same deployment map options will not process the additional invalid data.

Broadcast gating now works per faction rather than just for the Vanu Soverneigty.  To demontsrate, some gates have been made active for the Terran Republic only, while other gates have been made active for the VS only.