### PR TITLE
Degraded Lash Damage

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/mount/MountableBehavior.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/mount/MountableBehavior.scala
@@ -79,9 +79,10 @@ object MountableBehavior {
     val dismountBehavior : Receive = {
       case Mountable.TryDismount(user, seat_num) =>
         val obj = MountableObject
+        val velocity = obj.Velocity.getOrElse(Vector3.Zero)
         obj.Seat(seat_num) match {
           case Some(seat) =>
-            if(seat.Bailable || obj.Velocity.isEmpty || Vector3.MagnitudeSquared(obj.Velocity.get).toInt == 0) {
+            if(seat.Bailable || velocity == Vector3.Zero || Vector3.MagnitudeSquared(velocity).toInt == 0) {
               seat.Occupant = None
               user.VehicleSeated = None
               sender ! Mountable.MountMessages(user, Mountable.CanDismount(obj, seat_num))

--- a/common/src/main/scala/net/psforever/objects/vital/StandardResistances.scala
+++ b/common/src/main/scala/net/psforever/objects/vital/StandardResistances.scala
@@ -22,7 +22,7 @@ object InfantrySplashResistance extends ResistanceCalculations[PlayerSource](
 
 object InfantryLashResistance extends ResistanceCalculations[PlayerSource](
   ResistanceCalculations.ValidInfantryTarget,
-  ResistanceCalculations.ExoSuitDirectExtractor
+  ResistanceCalculations.MaximumResistance
 )
 
 object InfantryAggravatedResistance extends ResistanceCalculations[PlayerSource](

--- a/common/src/main/scala/net/psforever/objects/vital/damage/DamageCalculations.scala
+++ b/common/src/main/scala/net/psforever/objects/vital/damage/DamageCalculations.scala
@@ -135,16 +135,16 @@ object DamageCalculations {
   /**
     * Calculate a lash damage value.
     * The target needs to be more than five meters away.
-    * Minimum damage before maximum distance is 1.
+    * Since lash damage occurs after the direct hit projectile's damage begins to degrade,
+    * the minimum of five less than distance or zero is calculated.
     * @param projectile information about the weapon discharge (itself)
     * @param rawDamage the accumulated amount of damage
     * @param distance how far the source was from the target
     * @return the modified damage value
     */
   def LashDamage(projectile : Projectile, rawDamage : Int, distance : Float) : Int = {
-    val profile = projectile.profile
-    if(distance > 5 || distance <= profile.DistanceMax) {
-      math.max(DirectHitDamageWithDegrade(projectile, rawDamage, distance) * 0.2f, 1f).toInt
+    if(distance > 5) {
+      (DirectHitDamageWithDegrade(projectile, rawDamage, math.max(distance - 5, 0f)) * 0.2f) toInt
     }
     else {
       0
@@ -162,8 +162,8 @@ object DamageCalculations {
   }
 
   def DistanceFromExplosionToTarget(data : ResolvedProjectile) : Float = {
-    //Vector3.Distance(data.target.Position, data.hit_pos)
-    DistanceBetweenOriginAndImpact(data)
+    math.max(Vector3.Distance(data.target.Position, data.hit_pos) - 1, 0)
+    //DistanceBetweenOriginAndImpact(data)
   }
 
   def DistanceBetweenOriginAndImpact(data : ResolvedProjectile) : Float = {

--- a/common/src/main/scala/net/psforever/objects/vital/damage/DamageCalculations.scala
+++ b/common/src/main/scala/net/psforever/objects/vital/damage/DamageCalculations.scala
@@ -167,6 +167,6 @@ object DamageCalculations {
   }
 
   def DistanceBetweenOriginAndImpact(data : ResolvedProjectile) : Float = {
-    Vector3.Distance(data.projectile.shot_origin, data.hit_pos) - 0.5f
+    math.max(Vector3.Distance(data.projectile.shot_origin, data.hit_pos) - 0.5f, 0)
   }
 }

--- a/common/src/main/scala/net/psforever/objects/vital/resistance/ResistanceCalculations.scala
+++ b/common/src/main/scala/net/psforever/objects/vital/resistance/ResistanceCalculations.scala
@@ -24,8 +24,8 @@ import scala.util.{Failure, Success, Try}
   *                    in essence, should match the type of object container to which these resistances belong;
   *                    never has to be defined explicitly, but will be checked upon object definition
   */
-abstract class ResistanceCalculations[TargetType](validate : (ResolvedProjectile)=>Try[TargetType],
-                                                  extractor : (TargetType)=>Int) extends ProjectileCalculations {
+abstract class ResistanceCalculations[TargetType](validate : ResolvedProjectile=>Try[TargetType],
+                                                  extractor : TargetType=>Int) extends ProjectileCalculations {
   /**
     * Get resistance valuess.
     * @param data the historical `ResolvedProjectile` information
@@ -121,4 +121,6 @@ object ResistanceCalculations {
   def VehicleAggravatedExtractor(target : VehicleSource) : Int = target.Definition.ResistanceAggravated
 
   def VehicleRadiationExtractor(target : VehicleSource) : Float = target.Definition.RadiationShielding
+
+  def MaximumResistance(target : SourceEntry) : Int = Integer.MAX_VALUE
 }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -4443,7 +4443,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
                 Some(Projectile(tool.Projectile, tool.Definition, tool.FireMode, player, attribution, shot_origin, angle))
             }
             else {
-              log.warn(s"WeaponFireMessage: $player's shot is too far from owner position at time of discharge ($distanceToOwner > $acceptableDistanceToOwner); suspect")
+              log.warn(s"WeaponFireMessage: $player's ${tool.Definition.Name} projectile is too far from owner position at time of discharge ($distanceToOwner > $acceptableDistanceToOwner); suspect")
             }
           }
         case _ => ;


### PR DESCRIPTION
"Enchancement" is a weird way of labeling it.  The degrading process follow the linear degrade of the standard projectile, but starts count at the distance where lashing damage is valid, not where the projectile originates.

Included are primitive and just barely sufficient tests for validation of shot origin respect to the shooter.  In turns out, claculating the distance when the player is moving changes the value to something a bit greater or something a bit less.  Eventually, velocity will be factored into the calculations and the values will recede a bit.  For now, they are what they are.  Keep an eye on the logs for that warning message for me.

Apparently, the Galaxy tailgun is _pretty_ far away.