### PR TITLE
Cargo Bail

### DIFF
--- a/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
+++ b/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
@@ -38,4 +38,28 @@ trait OwnableByPlayer {
     }
     OwnerName
   }
+
+  /**
+    * na
+    * @param player na
+    * @return na
+    */
+  def AssignOwnership(player : Player) : OwnableByPlayer = AssignOwnership(Some(player))
+
+  /**
+    * na
+    * @param playerOpt na
+    * @return na
+    */
+  def AssignOwnership(playerOpt : Option[Player]) : OwnableByPlayer = {
+    playerOpt match {
+      case Some(player) =>
+        Owner = player
+        OwnerName = player
+      case None =>
+        Owner = None
+        OwnerName = None
+    }
+    this
+  }
 }

--- a/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
+++ b/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 PSForever
+package net.psforever.objects
+
+import net.psforever.packet.game.PlanetSideGUID
+
+trait OwnableByPlayer {
+  private var owner : Option[PlanetSideGUID] = None
+  private var ownerName : Option[String] = None
+
+  def Owner : Option[PlanetSideGUID] = owner
+
+  def Owner_=(owner : PlanetSideGUID) : Option[PlanetSideGUID] = Owner_=(Some(owner))
+
+  def Owner_=(owner : Player) : Option[PlanetSideGUID] = Owner_=(Some(owner.GUID))
+
+  def Owner_=(owner : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    owner match {
+      case Some(_) =>
+        this.owner = owner
+      case None =>
+        this.owner = None
+    }
+    Owner
+  }
+
+  def OwnerName : Option[String] = ownerName
+
+  def OwnerName_=(owner : String) : Option[String] = OwnerName_=(Some(owner))
+
+  def OwnerName_=(owner : Player) : Option[String] = OwnerName_=(Some(owner.Name))
+
+  def OwnerName_=(owner : Option[String]) : Option[String] = {
+    owner match {
+      case Some(_) =>
+        ownerName = owner
+      case None =>
+        ownerName = None
+    }
+    OwnerName
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -72,10 +72,10 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
   with MountedWeapons
   with Deployment
   with Vitality
+  with OwnableByPlayer
   with StandardResistanceProfile
   with Container {
   private var faction : PlanetSideEmpire.Value = PlanetSideEmpire.TR
-  private var owner : Option[PlanetSideGUID] = None
   private var health : Int = 1
   private var shields : Int = 0
   private var decal : Int = 0
@@ -137,26 +137,6 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
         this.mountedIn = None
     }
     MountedIn
-  }
-
-  def Owner : Option[PlanetSideGUID] = {
-    this.owner
-  }
-
-  def Owner_=(owner : PlanetSideGUID) : Option[PlanetSideGUID] = Owner_=(Some(owner))
-
-  def Owner_=(owner : Player) : Option[PlanetSideGUID] = Owner_=(Some(owner.GUID))
-
-  def Owner_=(owner : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
-    owner match {
-      case Some(_) =>
-        if(Definition.CanBeOwned) {
-          this.owner = owner
-        }
-      case None =>
-        this.owner = None
-    }
-    Owner
   }
 
   def Health : Int = {
@@ -499,7 +479,7 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends PlanetSideServ
     if(trunkAccess.isEmpty || trunkAccess.contains(player.GUID)) {
       groupPermissions(3) match {
         case VehicleLockState.Locked => //only the owner
-          owner.isEmpty || (owner.isDefined && player.GUID == owner.get)
+          Owner.isEmpty || (Owner.isDefined && player.GUID == Owner.get)
         case VehicleLockState.Group => //anyone in the owner's squad or platoon
           faction == player.Faction //TODO this is not correct
         case VehicleLockState.Empire => //anyone of the owner's faction

--- a/common/src/main/scala/net/psforever/objects/ce/Deployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/Deployable.scala
@@ -9,12 +9,11 @@ import net.psforever.packet.game.{DeployableIcon, PlanetSideGUID}
 import net.psforever.types.PlanetSideEmpire
 
 trait Deployable extends FactionAffinity
-  with Vitality {
+  with Vitality
+  with OwnableByPlayer {
   this : PlanetSideGameObject =>
   private var health : Int = 1
   private var faction : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
-  private var owner : Option[PlanetSideGUID] = None
-  private var ownerName : Option[String] = None
 
   def Health : Int = health
 
@@ -30,38 +29,6 @@ trait Deployable extends FactionAffinity
   override def Faction_=(toFaction : PlanetSideEmpire.Value) : PlanetSideEmpire.Value = {
     faction = toFaction
     Faction
-  }
-
-  def Owner : Option[PlanetSideGUID] = owner
-
-  def Owner_=(owner : PlanetSideGUID) : Option[PlanetSideGUID] = Owner_=(Some(owner))
-
-  def Owner_=(owner : Player) : Option[PlanetSideGUID] = Owner_=(Some(owner.GUID))
-
-  def Owner_=(owner : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
-    owner match {
-      case Some(_) =>
-        this.owner = owner
-      case None =>
-        this.owner = None
-    }
-    Owner
-  }
-
-  def OwnerName : Option[String] = ownerName
-
-  def OwnerName_=(owner : String) : Option[String] = OwnerName_=(Some(owner))
-
-  def OwnerName_=(owner : Player) : Option[String] = OwnerName_=(Some(owner.Name))
-
-  def OwnerName_=(owner : Option[String]) : Option[String] = {
-    owner match {
-      case Some(_) =>
-        ownerName = owner
-      case None =>
-        ownerName = None
-    }
-    OwnerName
   }
 
   def DamageModel : DamageResistanceModel = Definition.asInstanceOf[DamageResistanceModel]

--- a/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -155,11 +155,11 @@ import scodec.codecs._
   * `81 - ???`<br>
   * `113 - Vehicle capacitor - e.g. Leviathan EMP charge`
   *
-  * @param player_guid the player
-  * @param attribute_type na
-  * @param attribute_value na
+  * @param guid the object
+  * @param attribute_type the field
+  * @param attribute_value the value
   */
-final case class PlanetsideAttributeMessage(player_guid : PlanetSideGUID,
+final case class PlanetsideAttributeMessage(guid : PlanetSideGUID,
                                             attribute_type : Int,
                                             attribute_value : Long)
   extends PlanetSideGamePacket {
@@ -169,12 +169,16 @@ final case class PlanetsideAttributeMessage(player_guid : PlanetSideGUID,
 }
 
 object PlanetsideAttributeMessage extends Marshallable[PlanetsideAttributeMessage] {
-  def apply(player_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Int) : PlanetsideAttributeMessage = {
-    PlanetsideAttributeMessage(player_guid, attribute_type, attribute_value.toLong)
+  def apply(guid : PlanetSideGUID, attribute_type : Int, attribute_value : Int) : PlanetsideAttributeMessage = {
+    PlanetsideAttributeMessage(guid, attribute_type, attribute_value.toLong)
+  }
+
+  def apply(guid : PlanetSideGUID, attribute_type : Int, attribute_value : PlanetSideGUID) : PlanetsideAttributeMessage = {
+    PlanetsideAttributeMessage(guid, attribute_type, attribute_value.guid)
   }
 
   implicit val codec : Codec[PlanetsideAttributeMessage] = (
-    ("player_guid" | PlanetSideGUID.codec) ::
+    ("guid" | PlanetSideGUID.codec) ::
       ("attribute_type" | uint8L) ::
       ("attribute_value" | uint32L)
     ).as[PlanetsideAttributeMessage]

--- a/common/src/main/scala/services/vehicle/VehicleAction.scala
+++ b/common/src/main/scala/services/vehicle/VehicleAction.scala
@@ -36,5 +36,6 @@ object VehicleAction {
   final case class TransferPassengerChannel(player_guid : PlanetSideGUID, temp_channel : String, new_channel : String, vehicle : Vehicle) extends Action
   final case class TransferPassenger(player_guid : PlanetSideGUID, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Action
 
-  final case class KickCargo(player_guid : PlanetSideGUID, cargo : Vehicle, speed : Int) extends Action
+  final case class ForceDismountVehicleCargo(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Action
+  final case class KickCargo(player_guid : PlanetSideGUID, cargo : Vehicle, speed : Int, delay : Long) extends Action
 }

--- a/common/src/main/scala/services/vehicle/VehicleResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleResponse.scala
@@ -40,5 +40,6 @@ object VehicleResponse {
   final case class TransferPassengerChannel(old_channel : String, temp_channel : String, vehicle : Vehicle) extends Response
   final case class TransferPassenger(temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Response
 
-  final case class KickCargo(cargo : Vehicle, speed : Int) extends Response
+  final case class ForceDismountVehicleCargo(vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Response
+  final case class KickCargo(cargo : Vehicle, speed : Int, delay : Long) extends Response
 }

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -140,9 +140,13 @@ class VehicleService extends Actor {
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.TransferPassenger(temp_channel, vehicle, vehicle_to_delete))
           )
 
-        case VehicleAction.KickCargo(player_guid, cargo, speed) =>
+        case VehicleAction.ForceDismountVehicleCargo(player_guid, vehicle_guid, bailed, requestedByPassenger, kicked) =>
           VehicleEvents.publish(
-            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.KickCargo(cargo, speed))
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.ForceDismountVehicleCargo(vehicle_guid, bailed, requestedByPassenger, kicked))
+          )
+        case VehicleAction.KickCargo(player_guid, cargo, speed, delay) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.KickCargo(cargo, speed, delay))
           )
         case _ => ;
     }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3364,7 +3364,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
           deadState = DeadState.Release //cancel movement updates
           PlayerActionsToCancel()
           continent.GUID(player.VehicleSeated) match {
-            case Some(vehicle : Vehicle) =>
+            case Some(vehicle : Vehicle) if vehicle.MountedIn.isEmpty =>
               vehicle.PassengerInSeat(player) match {
                 case Some(0) =>
                   vehicle.Position = pos
@@ -3376,7 +3376,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               player.Position = pos
               //avatarService ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(player.GUID, player.GUID))
               LoadZonePhysicalSpawnPoint(zone, pos, Vector3.Zero, 0)
-            case _ => //seated in something that is not a vehicle, or we're dead, in which case we can't move
+            case _ => //seated in something that is not a vehicle or the vehicle is cargo, in which case we can't move
               deadState = DeadState.Alive
           }
 
@@ -3388,7 +3388,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
           deadState = DeadState.Release //cancel movement updates
           PlayerActionsToCancel()
           continent.GUID(player.VehicleSeated) match {
-            case Some(vehicle : Vehicle) if player.isAlive =>
+            case Some(vehicle : Vehicle) if vehicle.MountedIn.isEmpty =>
               vehicle.PassengerInSeat(player) match {
                 case Some(0) =>
                   vehicle.Position = pos
@@ -3400,7 +3400,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
               player.Position = pos
               sendResponse(PlayerStateShiftMessage(ShiftState(0, pos, player.Orientation.z, None)))
               deadState = DeadState.Alive //must be set here
-            case _ => //seated in something that is not a vehicle, or we're dead, in which case we can't move
+            case _ => //seated in something that is not a vehicle or the vehicle is cargo, in which case we can't move
               deadState = DeadState.Alive
           }
 


### PR DESCRIPTION
Let us review the current.

As things stand, when a vehicle is deconstructed, all of its passengers are kicked out of their seats.  This includes the driver seat occupant.  If a vehicle's driver seat occupant bails, and the vehicle is a flying vehicle, the vehicle deconstructs to clear away a now inaccessible hunk of metal.  When a vehicle deconstructs, it deconstructs everything about the vehicle - its still-mounted passengers, its cargo, its trunk contents, and its utilities.  This is, of course, bad in a variety of ways, such as the example when a carrier vehicle deconstructs abruptly and it still has a cargo vehicle that stops existing, including on the client of the former cargo driver.  Further issues occur when players disconnect from the game, resulting in similar instances of game objects being deconstructed and player's being stranded in a state of nonexistence.  The entire process becoming stranded, leaving ghosts of the previous objects that no longer exist, either on specific clients or all clients, was also always a possibility.

To avert this problem, the following conditions have been implemented: 
1. if a deconstructing vehicle is cargo for some other carrier vehicle, it will dismount as cargo before the carrier deconstructs; (`VehicleRemover`)
2. passengers will not be kicked out of a deconstructing vehicle until it is no longer counted as cargo to some other carrier vehicle; (`RemoverActor`)
3. if a deconstructing vehicle is the carrier vehicle for some cargo vehicle, it will dismount that cargo vehicle before before deconstructing; (`VehicleRemover`)
4. if a dismounting cargo vehicle has no driver, that cargo vehicle will be submitted to the `VehicleRemover` for immediate deconstruction. (`WorldSessionActor`)

It is important to note that the second point is a current condition and actually expresses task priority rather than enhancements.  This is a workflow with cyclical potential.  Not being a cargo vehicle is necessary for any passengers being kicked from that same vehicle to avoid misappropriating the camera to one of a permanent bailing view, with no first person privileges.  Additionally, this covers the potential case of a carrier vehicle ferrying a driver-less cargo vehicle with only a passenger in it; and, the carrier vehicle's driver bailing.  Previously, the passenger would stop existing when the chain of parent-child entities dissolves.  Now, that passenger is ensured a proper bail before any chance of accidentally being eliminated from the game world when both vehicles are cleaned up.

__Caveats__
- We are still relying on the `VehicleRemover` to play catch-up against the fact that vehicles still can not be moved independent of a client-connected driver.

__Addenda__
- The same ownership operations extracted from deployables into the `trait` `OwnableByPlayer` is now also used by `Vehicle` entities.  The GUID-based owner field is used for transient ownership; the name-based owner field is used for more permanent ownership identification.  Half of this functionality was already native to vehicles.  Now, it is inherited by both deployables and vehicles.  It was extended to vehicles to assist in management ownership between zone loading and avatar respawn operations.
- Vehicles are now disowned more explicitly and less haphazardly.  The process of losing ownership is still kept distinct from the process of being submitted to `VehicleRemover` for deconstruction.  The only special condition should be for a vehicle in flight.
- As was mentioned, the logic for regaining ownership of vehicles on both zone loading and avatar respawn (both of which are piped though similar protocol) has been tuned.  One should retain control of vehicles in conditions where it is important.
- As a product of giving vehicles the same ownership fields as deployables, logic could be implemented that coming back to a zone with a previously-used vehicle in it allows the player to regain ownership of the vehicle in a way similar to how ownership of deployables may be retained.  As no evidence of the vehicle re-inheritance was observed on Gemini Live, unlike minor evidence of deployable re-inheritance, this logic has not been realized.
- The first four of these Addenda notes involved ownership.  So does this one.