### PR TITLE
Turret Fix

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3504,10 +3504,12 @@ class WorldSessionActor extends Actor with MDCContextAware {
       }
       if(messagetype == ChatMessageType.CMT_DESTROY) {
         val guid = contents.toInt
-        continent.Map.TerminalToSpawnPad.get(guid) match {
-          case Some(padGUID) =>
-            continent.GUID(padGUID).get.asInstanceOf[VehicleSpawnPad].Actor ! VehicleSpawnControl.ProcessControl.Flush
-          case None =>
+        continent.GUID(continent.Map.TerminalToSpawnPad.getOrElse(guid, guid)) match {
+          case Some(pad : VehicleSpawnPad) =>
+            pad.Actor ! VehicleSpawnControl.ProcessControl.Flush
+          case Some(turret : FacilityTurret) if turret.isUpgrading =>
+            FinishUpgradingMannedTurret(turret, TurretUpgrade.None)
+          case _ =>
             self ! PacketCoding.CreateGamePacket(0, RequestDestroyMessage(PlanetSideGUID(guid)))
         }
       }
@@ -3870,12 +3872,6 @@ class WorldSessionActor extends Actor with MDCContextAware {
         case Some(obj : PlanetSideGameObject with Deployable) =>
           localService ! LocalServiceMessage.Deployables(RemoverActor.ClearSpecific(List(obj), continent))
           localService ! LocalServiceMessage.Deployables(RemoverActor.AddTask(obj, continent, Some(0 seconds)))
-
-        case Some(obj : FacilityTurret) =>
-          //obj.Health = 1
-          if(obj.isUpgrading) {
-            FinishUpgradingMannedTurret(obj, TurretUpgrade.None)
-          }
 
         case Some(thing) =>
           log.warn(s"RequestDestroy: not allowed to delete object $thing")


### PR DESCRIPTION
It's kinda like the vehicle terminal - stop breaking it.

The latter part of the facility turret update is now indicated by an on/off value.  The flag is not actually attached to any work in the backend; rather, it merely indicates when the `TurretUpgrader` operations believes that the turret is ready to be used.  It blocks allowing people to mount the turret and it also stops the turret weapon from rendering on client initialization of a zone.  (The turret weapon should be drawn normally by the `TurretUpdater` operations when it is ready.)  An additional change was performed on the sequencing of `AmmoBox` registrations and de-registrations to make certain that the turret knows it is ready only once the new `AmmoBox` objects are ready, and make certain that the same `AmmoBox` object isn't worked on in both operations.

`Caveats`:
* If any turret gets stuck during its update process, it will block entry and, on zone loading, appear as a turret without a weapon.  Use `/destroy` while pointing at the turret to force it to downgrade to standard setting - `None`, i.e., SGL Heavy Gattling Cannon - and that should correct the hang-up.
* We are still subject to the "immortal turret" hack which will endure until static server objects are ready to be revived from a destroyed state.