### PR TITLE
Cloak Fix

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -341,7 +341,7 @@ class Player(private val core : Avatar) extends PlanetSideGameObject
     Jumping
   }
 
-  def Cloaked : Boolean = jumping
+  def Cloaked : Boolean = cloaked
 
   def Cloaked_=(isCloaked : Boolean) : Boolean = {
     cloaked = isCloaked

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -34,6 +34,7 @@ class VehicleSpawnControlLoadVehicle(pad : VehicleSpawnPad) extends VehicleSpawn
           //load the vehicle in the spawn pad trench, underground, initially
           vehicle.Position = vehicle.Position - Vector3(0, 0, if(GlobalDefinitions.isFlightVehicle(vehicle.Definition)) 9 else 5)
         }
+        vehicle.Cloaked = vehicle.Definition.CanCloak && entry.driver.Cloaked
         Continent.VehicleEvents ! VehicleSpawnPad.LoadVehicle(vehicle, Continent)
         context.system.scheduler.scheduleOnce(100 milliseconds, railJack, VehicleSpawnControl.Process.RailJackAction(entry))
       }

--- a/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
@@ -26,7 +26,7 @@ import scodec.codecs._
   *                        values in between are possible;
   *                        vehicles that hover also influence this field as expected
   * @param unk5 na - Possibly a flag to indicate the vehicle is attached to something else e.g. is in a galaxy/lodestar cargo bay
-  * @param unk6 na
+  * @param is_cloaked vehicle is cloaked
   * @see `PlacementData`
   */
 
@@ -54,7 +54,7 @@ final case class VehicleStateMessage(vehicle_guid : PlanetSideGUID,
                                      unk4 : Int,
                                      wheel_direction : Int,
                                      unk5 : Boolean,
-                                     unk6 : Boolean
+                                     is_cloaked : Boolean
                                     ) extends PlanetSideGamePacket {
   type Packet = VehicleStateMessage
   def opcode = GamePacketOpcode.VehicleStateMessage
@@ -85,6 +85,6 @@ object VehicleStateMessage extends Marshallable[VehicleStateMessage] {
       ("unk4" | uint4L) ::
       ("wheel_direction" | uintL(5)) ::
       ("int5" | bool) ::
-      ("int6" | bool)
+      ("is_cloaked" | bool)
     ).as[VehicleStateMessage]
 }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1393,6 +1393,11 @@ class WorldSessionActor extends Actor with MDCContextAware {
             case None => ;
           }
           OwnVehicle(obj, tplayer)
+          if(obj.Definition == GlobalDefinitions.quadstealth) {
+            //wraith cloak state matches the cloak state of the driver
+            //phantasm doesn't uncloak if the driver is uncloaked and no other vehicle cloaks
+            obj.Cloaked = tplayer.Cloaked
+          }
         }
         AccessContents(obj)
         UpdateWeaponAtSeatPosition(obj, seat_num)

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1993,9 +1993,8 @@ class WorldSessionActor extends Actor with MDCContextAware {
         }
 
       case VehicleResponse.ConcealPlayer(player_guid) =>
-        //TODO this is the correct message; but, I don't know how to undo the effects of it
-        //sendResponse(GenericObjectActionMessage(player_guid, 36))
-        sendResponse(PlanetsideAttributeMessage(player_guid, 29, 1))
+        sendResponse(GenericObjectActionMessage(player_guid, 36))
+        //sendResponse(PlanetsideAttributeMessage(player_guid, 29, 1))
 
       case VehicleResponse.DismountVehicle(bailType, wasKickedByDriver) =>
         if(tplayer_guid != guid) {
@@ -3263,6 +3262,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
         player.FacingYawUpper = yaw_upper
         player.Crouching = is_crouching
         player.Jumping = is_jumping
+        player.Cloaked = player.ExoSuit == ExoSuitType.Infiltration && is_cloaking
 
         if(vel.isDefined && usingMedicalTerminal.isDefined) {
           continent.GUID(usingMedicalTerminal) match {
@@ -3319,7 +3319,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
           //log.warn(s"ChildObjectState: player $player not related to anything with a controllable agent")
       }
 
-    case msg @ VehicleStateMessage(vehicle_guid, unk1, pos, ang, vel, flight, unk6, unk7, wheels, unk9, unkA) =>
+    case msg @ VehicleStateMessage(vehicle_guid, unk1, pos, ang, vel, flight, unk6, unk7, wheels, unk9, is_cloaked) =>
       if(deadState == DeadState.Alive) {
         GetVehicleAndSeat() match {
           case (Some(obj), Some(0)) =>
@@ -3336,7 +3336,8 @@ class WorldSessionActor extends Actor with MDCContextAware {
               if(obj.Definition.CanFly) {
                 obj.Flying = flight.nonEmpty //usually Some(7)
               }
-              vehicleService ! VehicleServiceMessage(continent.Id, VehicleAction.VehicleState(player.GUID, vehicle_guid, unk1, pos, ang, vel, flight, unk6, unk7, wheels, unk9, unkA))
+              obj.Cloaked = obj.Definition.CanCloak && is_cloaked
+              vehicleService ! VehicleServiceMessage(continent.Id, VehicleAction.VehicleState(player.GUID, vehicle_guid, unk1, pos, ang, vel, flight, unk6, unk7, wheels, unk9, is_cloaked))
             }
           case (None, _) =>
             //log.error(s"VehicleState: no vehicle $vehicle_guid found in zone")


### PR DESCRIPTION
And now you don't.

Only two amusing things exist in regards to this fix.

The first is how the cloak status was related to the jump status.  In theory, if you loaded a game while an Infiltration Suit wearer was jumping somewhere, they would be cloaked for reasons of the `OCM` packet and not for reasons of their eventual `PSM` packet and that's the only instance when they would be cloaked upon zone loading.  In the end, they'd appear cloaked on your screen if they really were cloaked all the same, but it's the principle of the matter.

The second is how the Wraith and the Phantasm, the only two cloaking vehicles that have controlled cloaking in conjunction with the Infiltration Suit, behave differently.  If you mount a cloaked Wraith while uncloaked, the Wraith uncloaks.  If you mount a cloaked Phantasm while uncloaked, the Phantasm does not uncloak.  Additionally, if you uncloak while mounted on a cloaked Wraith, both your character and the vehicle uncloak.  If you uncloak while mounted in a cloaked Phantasm, only the vehicle uncloaks.  The reason for this difference in behaviors is probably due to the open-seat nature of the Wraith.  Or dev insanity.  Or player insistence.  You make the call.