### PR TITLE
MAX Fix

### DIFF
--- a/common/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
@@ -51,7 +51,7 @@ class AvatarConverter extends ObjectCreateConverter[Player]() {
           MakeAppearanceData(obj),
           MakeDetailedCharacterData(obj),
           MakeDetailedInventoryData(obj),
-          DrawnSlot.None
+          GetDrawnSlot(obj)
         )
       }
     )
@@ -372,6 +372,9 @@ object AvatarConverter {
     * @return the holster's Enumeration value
     */
   def GetDrawnSlot(obj : Player) : DrawnSlot.Value = {
-    try { DrawnSlot(obj.DrawnSlot) } catch { case _ : Exception => DrawnSlot.None }
+    obj.DrawnSlot match {
+      case Player.HandsDownSlot | Player.FreeHandSlot => DrawnSlot.None
+      case n => DrawnSlot(n)
+    }
   }
 }


### PR DESCRIPTION
The actual issue is that any sitting player, as constructed by an `OCDM` packet, has his arm naturally un-drawn.  No equipment slots are selected.  This makes sense for all exosuits since they're inside the vehicle and would have no use for a drawn tool -- save for the mechanical exosuit.  The MAX always has its weapons drawn.  It cannot manipulate its hands the way a squishy infantry player can.  Efforts are even made elsewhere to ensure that its weapon arm is always drawn and gets re-drawn when changing equipment or exo-suit type.