### PR TITLE
Utilities Fix

### DIFF
--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.vehicles
 
-import akka.actor.Actor
+import akka.actor.{Actor, ActorRef}
 import net.psforever.objects.Vehicle
 import net.psforever.objects.ballistics.VehicleSource
 import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
@@ -32,6 +32,14 @@ class VehicleControl(vehicle : Vehicle) extends Actor
   def DeploymentObject = vehicle
 
   def receive : Receive = Enabled
+
+  override def postStop() : Unit = {
+    super.postStop()
+    vehicle.Utilities.values.foreach { util =>
+      util().Actor ! akka.actor.PoisonPill
+      util().Actor = ActorRef.noSender
+    }
+  }
 
   def Enabled : Receive = checkBehavior
     .orElse(deployBehavior)


### PR DESCRIPTION
This problem should have actually affected all forms of vehicular utilities that were transported from one zone to another.  Only the AMS's equipment terminals were being called-out.  In short, while a vehicle's control object was correctly being transported over to the new zone on transfer, the vehicle's utiltities did not have the benefit of their control objects moved over to the new zone.  The control objects had to properly be destroyed before they could be properly rebuilt.

Also included are some quality checks for dropping items and picking up items.