### PR TITLE
Fix "The data on your client does not match the data on the server" error on zoning

### DIFF
--- a/common/src/main/scala/net/psforever/objects/zones/ZoneMap.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZoneMap.scala
@@ -33,6 +33,7 @@ class ZoneMap(private val name : String) {
   private var linkDoorLock : Map[Int, Int] = Map()
   private var linkObjectBase : Map[Int, Int] = Map()
   private var buildings : Map[(Int, Int), FoundationBuilder] = Map()
+  private var checksum : Long = 0
 
   def Name : String = name
 
@@ -41,6 +42,13 @@ class ZoneMap(private val name : String) {
   def Scale_=(dim : MapScale) : MapScale = {
     scale = dim
     Scale
+  }
+
+  def Checksum : Long = checksum
+
+  def Checksum_=(value : Long) : Long = {
+    checksum = value
+    Checksum
   }
 
   /**

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -833,7 +833,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
       log.info(s"Player ${tplayer.Name} has been loaded")
       player = tplayer
       //LoadMapMessage causes the client to send BeginZoningMessage, eventually leading to SetCurrentAvatar
-      sendResponse(LoadMapMessage(continent.Map.Name, continent.Id, 40100, 25, true, 3770441820L))
+      sendResponse(LoadMapMessage(continent.Map.Name, continent.Id, 40100, 25, true, continent.Map.Checksum))
       AvatarCreate() //important! the LoadMapMessage must be processed by the client before the avatar is created
 
     case PlayerLoaded(tplayer) =>

--- a/pslogin/src/main/scala/zonemaps/Map01.scala
+++ b/pslogin/src/main/scala/zonemaps/Map01.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map01 {
   // Solsar
   val ZoneMap = new ZoneMap("map01") {
+    Checksum = 2094187456L
 
     Building10()
 
@@ -990,13 +991,13 @@ object Map01 {
 
     Building19998()
 
-    def Building19998(): Unit = { // Name: "GW_Solsar_S" Type: hst GUID: 32, MapID: 19998
+    def Building19998(): Unit = { // Name: GW_Solsar_S Type: hst GUID: 32, MapID: 19998
       LocalBuilding(32, 19998, FoundationBuilder(WarpGate.Structure(Vector3(3735.49f, 2916.53f, 85.87f), hst)))
     }
 
     Building19999()
 
-    def Building19999(): Unit = { // Name: "GW_Solsar_N" Type: hst GUID: 33, MapID: 19999
+    def Building19999(): Unit = { // Name: GW_Solsar_N Type: hst GUID: 33, MapID: 19999
       LocalBuilding(33, 19999, FoundationBuilder(WarpGate.Structure(Vector3(5712.8f, 4800.53f, 63.29f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map02.scala
+++ b/pslogin/src/main/scala/zonemaps/Map02.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map02 {
   // Hossin
   val ZoneMap = new ZoneMap("map02") {
+    Checksum = 1113780607L
 
     Building12()
 
@@ -1121,13 +1122,13 @@ object Map02 {
 
     Building18907()
 
-    def Building18907(): Unit = { // Name: "GW_Hossin_S" Type: hst GUID: 39, MapID: 18907
+    def Building18907(): Unit = { // Name: GW_Hossin_S Type: hst GUID: 39, MapID: 18907
       LocalBuilding(39, 18907, FoundationBuilder(WarpGate.Structure(Vector3(3949.24f, 2391.62f, 16.04f), hst)))
     }
 
     Building18908()
 
-    def Building18908(): Unit = { // Name: "GW_Hossin_N" Type: hst GUID: 40, MapID: 18908
+    def Building18908(): Unit = { // Name: GW_Hossin_N Type: hst GUID: 40, MapID: 18908
       LocalBuilding(40, 18908, FoundationBuilder(WarpGate.Structure(Vector3(5240.17f, 4912.36f, 39.88f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map03.scala
+++ b/pslogin/src/main/scala/zonemaps/Map03.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map03 {
   // Cyssor
   val ZoneMap = new ZoneMap("map03") {
+    Checksum = 1624200906L
 
     Building1()
 
@@ -1797,13 +1798,13 @@ object Map03 {
 
     Building25936()
 
-    def Building25936(): Unit = { // Name: "GW_Cyssor_N" Type: hst GUID: 57, MapID: 25936
+    def Building25936(): Unit = { // Name: GW_Cyssor_N Type: hst GUID: 57, MapID: 25936
       LocalBuilding(57, 25936, FoundationBuilder(WarpGate.Structure(Vector3(2467.29f, 4261.36f, 52.85f), hst)))
     }
 
     Building25937()
 
-    def Building25937(): Unit = { // Name: "GW_Cyssor_S" Type: hst GUID: 58, MapID: 25937
+    def Building25937(): Unit = { // Name: GW_Cyssor_S Type: hst GUID: 58, MapID: 25937
       LocalBuilding(58, 25937, FoundationBuilder(WarpGate.Structure(Vector3(4762.97f, 2644.8f, 68.15f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map04.scala
+++ b/pslogin/src/main/scala/zonemaps/Map04.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map04 {
   // Ishundar
   val ZoneMap = new ZoneMap("map04") {
+    Checksum = 2455050867L
 
     Building8()
 
@@ -1158,13 +1159,13 @@ object Map04 {
 
     Building26621()
 
-    def Building26621(): Unit = { // Name: "GW_Ishundar_S" Type: hst GUID: 39, MapID: 26621
+    def Building26621(): Unit = { // Name: GW_Ishundar_S Type: hst GUID: 39, MapID: 26621
       LocalBuilding(39, 26621, FoundationBuilder(WarpGate.Structure(Vector3(2440.33f, 1921.26f, 35.77f), hst)))
     }
 
     Building26620()
 
-    def Building26620(): Unit = { // Name: "GW_Ishundar_N" Type: hst GUID: 40, MapID: 26620
+    def Building26620(): Unit = { // Name: GW_Ishundar_N Type: hst GUID: 40, MapID: 26620
       LocalBuilding(40, 26620, FoundationBuilder(WarpGate.Structure(Vector3(4163.3f, 4368.72f, 65.16f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map05.scala
+++ b/pslogin/src/main/scala/zonemaps/Map05.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map05 {
   // Forseral
   val ZoneMap = new ZoneMap("map05") {
+    Checksum = 107922342L
 
     Building13()
 
@@ -1108,13 +1109,13 @@ object Map05 {
 
     Building21074()
 
-    def Building21074(): Unit = { // Name: "GW_Forseral_N" Type: hst GUID: 36, MapID: 21074
+    def Building21074(): Unit = { // Name: GW_Forseral_N Type: hst GUID: 36, MapID: 21074
       LocalBuilding(36, 21074, FoundationBuilder(WarpGate.Structure(Vector3(4908.22f, 5684.55f, 39.16f), hst)))
     }
 
     Building21078()
 
-    def Building21078(): Unit = { // Name: "GW_Forseral_S" Type: hst GUID: 37, MapID: 21078
+    def Building21078(): Unit = { // Name: GW_Forseral_S Type: hst GUID: 37, MapID: 21078
       LocalBuilding(37, 21078, FoundationBuilder(WarpGate.Structure(Vector3(5364.4f, 2560.16f, 44.87f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map06.scala
+++ b/pslogin/src/main/scala/zonemaps/Map06.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map06 {
   // Ceryshen
   val ZoneMap = new ZoneMap("map06") {
+    Checksum = 579139514L
 
     Building1()
 
@@ -899,13 +900,13 @@ object Map06 {
 
     Building18657()
 
-    def Building18657(): Unit = { // Name: "GW_Ceryshen_S" Type: hst GUID: 33, MapID: 18657
+    def Building18657(): Unit = { // Name: GW_Ceryshen_S Type: hst GUID: 33, MapID: 18657
       LocalBuilding(33, 18657, FoundationBuilder(WarpGate.Structure(Vector3(2248.14f, 1712.18f, 224.5f), hst)))
     }
 
     Building18658()
 
-    def Building18658(): Unit = { // Name: "GW_Ceryshen_N" Type: hst GUID: 34, MapID: 18658
+    def Building18658(): Unit = { // Name: GW_Ceryshen_N Type: hst GUID: 34, MapID: 18658
       LocalBuilding(34, 18658, FoundationBuilder(WarpGate.Structure(Vector3(3175.87f, 5324.2f, 232.33f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map07.scala
+++ b/pslogin/src/main/scala/zonemaps/Map07.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map07 {
   // Esamir
   val ZoneMap = new ZoneMap("map07") {
+    Checksum = 1564014762L
 
     Building8()
 
@@ -1243,13 +1244,13 @@ object Map07 {
 
     Building21321()
 
-    def Building21321(): Unit = { // Name: "GW_Esamir_S" Type: hst GUID: 41, MapID: 21321
+    def Building21321(): Unit = { // Name: GW_Esamir_S Type: hst GUID: 41, MapID: 21321
       LocalBuilding(41, 21321, FoundationBuilder(WarpGate.Structure(Vector3(3761.83f, 2214.34f, 65.95f), hst)))
     }
 
     Building21322()
 
-    def Building21322(): Unit = { // Name: "GW_Esamir_N" Type: hst GUID: 42, MapID: 21322
+    def Building21322(): Unit = { // Name: GW_Esamir_N Type: hst GUID: 42, MapID: 21322
       LocalBuilding(42, 21322, FoundationBuilder(WarpGate.Structure(Vector3(6302.94f, 4799.63f, 86.05f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map08.scala
+++ b/pslogin/src/main/scala/zonemaps/Map08.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map08 {
   // Oshur Prime
   val ZoneMap = new ZoneMap("map08") {
+    Checksum = 0L
 
     Building10()
 
@@ -892,13 +893,13 @@ object Map08 {
 
     Building24811()
 
-    def Building24811(): Unit = { // Name: "GW_Oshur_N" Type: hst GUID: 32, MapID: 24811
+    def Building24811(): Unit = { // Name: GW_Oshur_N Type: hst GUID: 32, MapID: 24811
       LocalBuilding(32, 24811, FoundationBuilder(WarpGate.Structure(Vector3(4033.39f, 5379.88f, 46.13f), hst)))
     }
 
     Building24815()
 
-    def Building24815(): Unit = { // Name: "GW_Oshur_S" Type: hst GUID: 33, MapID: 24815
+    def Building24815(): Unit = { // Name: GW_Oshur_S Type: hst GUID: 33, MapID: 24815
       LocalBuilding(33, 24815, FoundationBuilder(WarpGate.Structure(Vector3(6068.59f, 3165.49f, 31.65f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map09.scala
+++ b/pslogin/src/main/scala/zonemaps/Map09.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map09 {
   // Searhus
   val ZoneMap = new ZoneMap("map09") {
+    Checksum = 1380643455L
 
     Building14()
 
@@ -1502,13 +1503,13 @@ object Map09 {
 
     Building23717()
 
-    def Building23717(): Unit = { // Name: "GW_Searhus_S" Type: hst GUID: 47, MapID: 23717
+    def Building23717(): Unit = { // Name: GW_Searhus_S Type: hst GUID: 47, MapID: 23717
       LocalBuilding(47, 23717, FoundationBuilder(WarpGate.Structure(Vector3(3773.85f, 1132.25f, 46.53f), hst)))
     }
 
     Building23718()
 
-    def Building23718(): Unit = { // Name: "GW_Searhus_N" Type: hst GUID: 48, MapID: 23718
+    def Building23718(): Unit = { // Name: GW_Searhus_N Type: hst GUID: 48, MapID: 23718
       LocalBuilding(48, 23718, FoundationBuilder(WarpGate.Structure(Vector3(7131.17f, 5593.67f, 43.53f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map10.scala
+++ b/pslogin/src/main/scala/zonemaps/Map10.scala
@@ -17,6 +17,7 @@ import net.psforever.types.Vector3
 object Map10 {
   // Amerish
   val ZoneMap = new ZoneMap("map10") {
+    Checksum = 230810349L
 
     Building13()
 
@@ -1253,13 +1254,13 @@ object Map10 {
 
     Building20900()
 
-    def Building20900(): Unit = { // Name: "GW_Amerish_N" Type: hst GUID: 40, MapID: 20900
+    def Building20900(): Unit = { // Name: GW_Amerish_N Type: hst GUID: 40, MapID: 20900
       LocalBuilding(40, 20900, FoundationBuilder(WarpGate.Structure(Vector3(3570.37f, 6924.31f, 40.74f), hst)))
     }
 
     Building20902()
 
-    def Building20902(): Unit = { // Name: "GW_Amerish_S" Type: hst GUID: 41, MapID: 20902
+    def Building20902(): Unit = { // Name: GW_Amerish_S Type: hst GUID: 41, MapID: 20902
       LocalBuilding(41, 20902, FoundationBuilder(WarpGate.Structure(Vector3(3723.31f, 3311.24f, 41.48f), hst)))
     }
 

--- a/pslogin/src/main/scala/zonemaps/Map11.scala
+++ b/pslogin/src/main/scala/zonemaps/Map11.scala
@@ -16,6 +16,7 @@ import net.psforever.types.Vector3
 object Map11 {
   // HOME1 (NEW CONGLOMORATE SANCTUARY)
   val ZoneMap = new ZoneMap("map11") {
+    Checksum = 4129515529L
 
     Building37()
 

--- a/pslogin/src/main/scala/zonemaps/Map12.scala
+++ b/pslogin/src/main/scala/zonemaps/Map12.scala
@@ -16,6 +16,7 @@ import net.psforever.types.Vector3
 object Map12 {
   // HOME2 (TERRAN REPUBLIC SANCTUARY)
   val ZoneMap = new ZoneMap("map12") {
+    Checksum = 962888126L
 
     Building4()
 

--- a/pslogin/src/main/scala/zonemaps/Map13.scala
+++ b/pslogin/src/main/scala/zonemaps/Map13.scala
@@ -16,6 +16,7 @@ import net.psforever.types.Vector3
 object Map13 {
   // HOME3 (VANU SOVREIGNTY SANCTUARY)
   val ZoneMap = new ZoneMap("map13") {
+    Checksum = 3904659548L
 
     Building22()
 

--- a/pslogin/src/main/scala/zonemaps/Map96.scala
+++ b/pslogin/src/main/scala/zonemaps/Map96.scala
@@ -17,6 +17,7 @@ object Map96 {
   // Nexus
   val ZoneMap = new ZoneMap("map96") {
     Scale = MapScale.Dim4096
+    Checksum = 846603446L
 
     Building1()
 
@@ -153,7 +154,7 @@ object Map96 {
 
     Building10000()
 
-    def Building10000(): Unit = { // Name: "Map96_Gate_Three" Type: hst GUID: 4, MapID: 10000
+    def Building10000(): Unit = { // Name: Map96_Gate_Three Type: hst GUID: 4, MapID: 10000
       LocalBuilding(4, 10000, FoundationBuilder(WarpGate.Structure(Vector3(1387.16f, 1639.74f, 48.78f), hst)))
     }
 
@@ -329,13 +330,13 @@ object Map96 {
 
     Building10001()
 
-    def Building10001(): Unit = { // Name: "Map96_Gate_Two" Type: warpgate_small GUID: 10, MapID: 10001
+    def Building10001(): Unit = { // Name: Map96_Gate_Two Type: warpgate_small GUID: 10, MapID: 10001
       LocalBuilding(10, 10001, FoundationBuilder(WarpGate.Structure(Vector3(2407.71f, 2727.84f, 35.71f))))
     }
 
     Building10002()
 
-    def Building10002(): Unit = { // Name: "Map96_Gate_One" Type: warpgate_small GUID: 11, MapID: 10002
+    def Building10002(): Unit = { // Name: Map96_Gate_One Type: warpgate_small GUID: 11, MapID: 10002
       LocalBuilding(11, 10002, FoundationBuilder(WarpGate.Structure(Vector3(2784.82f, 1348.42f, 33.91f))))
     }
   }

--- a/pslogin/src/main/scala/zonemaps/Map97.scala
+++ b/pslogin/src/main/scala/zonemaps/Map97.scala
@@ -17,6 +17,7 @@ object Map97 {
   // Desolation
   val ZoneMap = new ZoneMap("map97") {
     Scale = MapScale.Dim4096
+    Checksum = 2810790213L
 
     Building11()
 
@@ -645,19 +646,19 @@ object Map97 {
 
     Building10001()
 
-    def Building10001(): Unit = { // Name: "Map97_Gate_Two" Type: warpgate_small GUID: 20, MapID: 10001
+    def Building10001(): Unit = { // Name: Map97_Gate_Two Type: warpgate_small GUID: 20, MapID: 10001
       LocalBuilding(20, 10001, FoundationBuilder(WarpGate.Structure(Vector3(1173.69f, 2615.84f, 30.79f))))
     }
 
     Building10003()
 
-    def Building10003(): Unit = { // Name: "Map97_Gate_Three" Type: warpgate_small GUID: 21, MapID: 10003
+    def Building10003(): Unit = { // Name: Map97_Gate_Three Type: warpgate_small GUID: 21, MapID: 10003
       LocalBuilding(21, 10003, FoundationBuilder(WarpGate.Structure(Vector3(2830.98f, 1170.55f, 30.79f))))
     }
 
     Building10002()
 
-    def Building10002(): Unit = { // Name: "Map97_Gate_One" Type: warpgate_small GUID: 22, MapID: 10002
+    def Building10002(): Unit = { // Name: Map97_Gate_One Type: warpgate_small GUID: 22, MapID: 10002
       LocalBuilding(22, 10002, FoundationBuilder(WarpGate.Structure(Vector3(2933.49f, 2963.42f, 30.79f))))
     }
   }

--- a/pslogin/src/main/scala/zonemaps/Map98.scala
+++ b/pslogin/src/main/scala/zonemaps/Map98.scala
@@ -18,6 +18,7 @@ object Map98 {
   // Ascension
   val ZoneMap = new ZoneMap("map98") {
     Scale = MapScale.Dim4096
+    Checksum = 3654267088L
 
     Building39()
 
@@ -995,19 +996,19 @@ object Map98 {
 
     Building10000()
 
-    def Building10000(): Unit = { // Name: "Map98_Gate_One" Type: warpgate_small GUID: 46, MapID: 10000
+    def Building10000(): Unit = { // Name: Map98_Gate_One Type: warpgate_small GUID: 46, MapID: 10000
       LocalBuilding(46, 10000, FoundationBuilder(WarpGate.Structure(Vector3(1298.27f, 1352.5f, 12.09f))))
     }
 
     Building10001()
 
-    def Building10001(): Unit = { // Name: "Map98_Gate_Three" Type: warpgate_small GUID: 47, MapID: 10001
+    def Building10001(): Unit = { // Name: Map98_Gate_Three Type: warpgate_small GUID: 47, MapID: 10001
       LocalBuilding(47, 10001, FoundationBuilder(WarpGate.Structure(Vector3(2481.78f, 2616.39f, 12.09f))))
     }
 
     Building10002()
 
-    def Building10002(): Unit = { // Name: "Map98_Gate_Two" Type: warpgate_small GUID: 48, MapID: 10002
+    def Building10002(): Unit = { // Name: Map98_Gate_Two Type: warpgate_small GUID: 48, MapID: 10002
       LocalBuilding(48, 10002, FoundationBuilder(WarpGate.Structure(Vector3(2679.7f, 1434.86f, 12.09f))))
     }
   }

--- a/pslogin/src/main/scala/zonemaps/Map99.scala
+++ b/pslogin/src/main/scala/zonemaps/Map99.scala
@@ -18,6 +18,7 @@ object Map99 {
   // Extinction
   val ZoneMap = new ZoneMap("map99") {
     Scale = MapScale.Dim4096
+    Checksum = 3770866186L
 
     Building7()
 
@@ -793,19 +794,19 @@ object Map99 {
 
     Building10461()
 
-    def Building10461(): Unit = { // Name: "Map99_Gate_One" Type: warpgate_small GUID: 30, MapID: 10461
+    def Building10461(): Unit = { // Name: Map99_Gate_One Type: warpgate_small GUID: 30, MapID: 10461
       LocalBuilding(30, 10461, FoundationBuilder(WarpGate.Structure(Vector3(1198.85f, 2094.78f, 66.32f))))
     }
 
     Building10462()
 
-    def Building10462(): Unit = { // Name: "Map99_Gate_Two" Type: warpgate_small GUID: 31, MapID: 10462
+    def Building10462(): Unit = { // Name: Map99_Gate_Two Type: warpgate_small GUID: 31, MapID: 10462
       LocalBuilding(31, 10462, FoundationBuilder(WarpGate.Structure(Vector3(2491.85f, 2848.95f, 62.31f))))
     }
 
     Building10464()
 
-    def Building10464(): Unit = { // Name: "Map99_Gate_Three" Type: warpgate_small GUID: 32, MapID: 10464
+    def Building10464(): Unit = { // Name: Map99_Gate_Three Type: warpgate_small GUID: 32, MapID: 10464
       LocalBuilding(32, 10464, FoundationBuilder(WarpGate.Structure(Vector3(2547.98f, 1237.04f, 89.09f))))
     }
   }


### PR DESCRIPTION
Pretty simple fix in the end, just have to pass the correct checksum when loading a map.

How those checksums are calculated is still a mystery, but they're unlikely to change for a long while so this will do for now to cut down on people asking how to update their client.

Also a quick fix for double quoted object names from .lst files