### PR TITLE
Cancel jacking if a vehicle is moving

### DIFF
--- a/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
@@ -21,7 +21,7 @@ object HackState extends Enumeration {
   val
   Unknown0,
   Start,
-  Unknown2,
+  Cancelled,
   Ongoing,
   Finished,
   Unknown5,

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3452,7 +3452,6 @@ class WorldSessionActor extends Actor with MDCContextAware {
       avatar.Certifications += ReinforcedExoSuit
       avatar.Certifications += ATV
       avatar.Certifications += Harasser
-      //
       avatar.Certifications += InfiltrationSuit
       avatar.Certifications += Sniping
       avatar.Certifications += AntiVehicular
@@ -3479,6 +3478,9 @@ class WorldSessionActor extends Actor with MDCContextAware {
       avatar.Certifications += AssaultEngineering
       avatar.Certifications += Hacking
       avatar.Certifications += AdvancedHacking
+      avatar.Certifications += ElectronicsExpert
+      avatar.Certifications += Medical
+      avatar.Certifications += AdvancedMedical
       avatar.CEP = 6000001
       this.avatar = avatar
 


### PR DESCRIPTION
There is a small amount of leeway to allow for vehicles such as magriders, which will almost always have a small amount of velocity due to rotation