### PR TITLE
Fix VNLWorldStatusMessage for multiple worlds

### DIFF
--- a/common/src/main/scala/net/psforever/newcodecs/PrefixedVectorCodec.scala
+++ b/common/src/main/scala/net/psforever/newcodecs/PrefixedVectorCodec.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 PSForever
+package net.psforever.newcodecs
+
+import scodec._
+import scodec.bits.BitVector
+
+final class PrefixedVectorCodec[A](firstCodec: Codec[A], codec: Codec[A], limit: Option[Int] = None) extends Codec[Vector[A]] {
+
+  def sizeBound = limit match {
+    case None => SizeBound.unknown
+    case Some(lim) => codec.sizeBound * lim.toLong
+  }
+
+  def encode(vector: Vector[A]) = Encoder.encodeSeq(firstCodec)(vector.slice(0,1)).map { bits =>
+      if (vector.length > 1)
+        bits ++ (Encoder.encodeSeq(codec)(vector.tail) getOrElse BitVector.empty)
+      else
+        bits
+  }
+
+  def decode(buffer: BitVector) : scodec.Attempt[scodec.DecodeResult[Vector[A]]] = {
+      Decoder.decodeCollect[Vector, A](firstCodec,  Some(1))(buffer) match {
+        case Attempt.Successful(firstValue) =>
+          Decoder.decodeCollect[Vector, A](codec, limit map { _ - 1 })(firstValue.remainder) match {
+            case Attempt.Successful(secondValue) =>
+              Attempt.successful(DecodeResult(firstValue.value ++ secondValue.value, secondValue.remainder))
+            case Attempt.Failure(e) => Attempt.failure(e)
+          }
+        case Attempt.Failure(e) => Attempt.failure(e)
+      }
+  }
+
+  override def toString = s"vector($codec)"
+}

--- a/common/src/main/scala/net/psforever/newcodecs/package.scala
+++ b/common/src/main/scala/net/psforever/newcodecs/package.scala
@@ -3,14 +3,22 @@ package net.psforever.newcodecs
 
 import scodec.Attempt
 import scodec.Attempt.{Failure, Successful}
-import scodec.Codec
+import scodec._
+import scodec.bits.BitVector
 
 package object newcodecs {
-
   def q_double(min: Double, max: Double, bits: Int): Codec[Double] = new QuantizedDoubleCodec(min, max, bits)
 
   def q_float(min : Double, max : Double, bits : Int): Codec[Float] = q_double(min, max, bits).narrow(v => Attempt.successful(v.toFloat), _.toDouble)
 
   def binary_choice[A](choice: Boolean, codec_true: => Codec[A], codec_false: => Codec[A]): Codec[A] = new BinaryChoiceCodec(choice, codec_true, codec_false)
 
+  def prefixedVectorOfN[A](countCodec: Codec[Int], firstValueCodec: Codec[A], valueCodec: Codec[A]): Codec[Vector[A]] =
+    countCodec.
+      flatZip { count => new PrefixedVectorCodec(firstValueCodec, valueCodec, Some(count)) }.
+      narrow[Vector[A]]({ case (cnt, xs) =>
+        if (xs.size == cnt) Attempt.successful(xs)
+        else Attempt.failure(Err(s"Insufficient number of elements: decoded ${xs.size} but should have decoded $cnt"))
+      }, xs => (xs.size, xs)).
+      withToString(s"vectorOfN($countCodec, $valueCodec)")
 }

--- a/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
+++ b/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
@@ -71,37 +71,30 @@ class VNLWorldStatusMessageTest extends Specification {
   }
 
   "encode and decode multiple worlds" in {
-    var string = hex" 0597570065006c0063006f006d006500200074006f00200050006c0061006e0065007400530069006400650021002000028941424344414243443101000300006240414243444142434432000002020000"
+    var string = hex"0597570065006c0063006f006d006500200074006f00200050006c0061006e0065007400530069006400650021002000048941424344414243443101000300006240414243444142434432000002020022404142434441424344330000010100a2404142434441424344340500040000c0"
 
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
-      Vector(
-      WorldInformation("ABCDABCD1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
-        WorldInformation("ABCDABCD2", WorldStatus.Down, ServerType.Beta, Vector(), PlanetSideEmpire.TR)
-      ))
+    val worlds = Vector(
+        WorldInformation("ABCDABCD1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
+        WorldInformation("ABCDABCD2", WorldStatus.Down, ServerType.Beta, Vector(), PlanetSideEmpire.TR),
+        WorldInformation("ABCDABCD3", WorldStatus.Locked, ServerType.Development, Vector(), PlanetSideEmpire.VS),
+        WorldInformation("ABCDABCD4", WorldStatus.Full, ServerType.Released_Gemini, Vector(), PlanetSideEmpire.NEUTRAL)
+    )
 
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", worlds) 
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string
 
-    string = hex" 0597570065006c0063006f006d006500200074006f00200050006c0061006e0065007400530069006400650021002000028941424344414243443101000300006240414243444142434432000002020000"
-
     PacketCoding.DecodePacket(string).require match {
-      case VNLWorldStatusMessage(message, worlds) =>
+      case VNLWorldStatusMessage(message, pkt_worlds) =>
         message mustEqual "Welcome to PlanetSide! "
 
-        worlds.length mustEqual 2
+        pkt_worlds.length mustEqual worlds.length
 
-        worlds(0).name mustEqual "ABCDABCD1"
-        worlds(0).empireNeed mustEqual PlanetSideEmpire.NC
-        worlds(0).status mustEqual WorldStatus.Up
-        worlds(0).serverType mustEqual ServerType.Released
-        worlds(0).connections.length mustEqual 0
+        for (i <- 0 to pkt_worlds.length-1)
+          pkt_worlds(i) mustEqual worlds(i)
 
-        worlds(1).name mustEqual "ABCDABCD2"
-        worlds(1).empireNeed mustEqual PlanetSideEmpire.TR
-        worlds(1).status mustEqual WorldStatus.Down
-        worlds(1).serverType mustEqual ServerType.Beta
-        worlds(1).connections.length mustEqual 0
+        ok
       case _ =>
         ko
     }

--- a/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
+++ b/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
@@ -16,12 +16,9 @@ class VNLWorldStatusMessageTest extends Specification {
 
   "decode" in {
     PacketCoding.DecodePacket(string).require match {
-      case VNLWorldStatusMessage(message, worlds) =>
-        worlds.length mustEqual 1
+      case VNLWorldStatusMessage(message, _, world, extra_worlds) =>
+        extra_worlds.length mustEqual 0
         message mustEqual "Welcome to PlanetSide! "
-        val world = worlds {
-          0
-        }
         world.name mustEqual "gemini"
         world.empireNeed mustEqual PlanetSideEmpire.NC
         world.status mustEqual WorldStatus.Up
@@ -39,13 +36,11 @@ class VNLWorldStatusMessageTest extends Specification {
   }
 
   "encode" in {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
-      Vector(
-        WorldInformation("gemini", WorldStatus.Up, ServerType.Released,
-          Vector(
-            WorldConnectionInfo(new InetSocketAddress(InetAddress.getByName("64.37.158.69"), 30007))
-          ), PlanetSideEmpire.NC
-        )
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 1,
+      WorldInformation("gemini", WorldStatus.Up, ServerType.Released,
+        Vector(
+          WorldConnectionInfo(new InetSocketAddress(InetAddress.getByName("64.37.158.69"), 30007))
+        ), PlanetSideEmpire.NC
       )
     )
     //0100 04 00 01459e2540377540
@@ -56,15 +51,15 @@ class VNLWorldStatusMessageTest extends Specification {
   }
 
   "encode and decode multiple worlds" in {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 2,
+      WorldInformation("ABCDABCD1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
       Vector(
-        WorldInformation("PSForever1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
-        WorldInformation("PSForever2", WorldStatus.Down, ServerType.Beta, Vector(), PlanetSideEmpire.TR)
+        WorldInformation("ABCDABCD2", WorldStatus.Down, ServerType.Beta, Vector(), PlanetSideEmpire.TR)
       ))
 
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-    //println(pkt)
+    println(pkt)
 
     // TODO: actually test something
     ok

--- a/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
+++ b/common/src/test/scala/game/VNLWorldStatusMessageTest.scala
@@ -16,9 +16,12 @@ class VNLWorldStatusMessageTest extends Specification {
 
   "decode" in {
     PacketCoding.DecodePacket(string).require match {
-      case VNLWorldStatusMessage(message, _, world, extra_worlds) =>
-        extra_worlds.length mustEqual 0
+      case VNLWorldStatusMessage(message, worlds) =>
         message mustEqual "Welcome to PlanetSide! "
+
+        worlds.length mustEqual 1
+
+        val world = worlds(0)
         world.name mustEqual "gemini"
         world.empireNeed mustEqual PlanetSideEmpire.NC
         world.status mustEqual WorldStatus.Up
@@ -36,13 +39,14 @@ class VNLWorldStatusMessageTest extends Specification {
   }
 
   "encode" in {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 1,
-      WorldInformation("gemini", WorldStatus.Up, ServerType.Released,
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
+      Vector(WorldInformation("gemini", WorldStatus.Up, ServerType.Released,
         Vector(
           WorldConnectionInfo(new InetSocketAddress(InetAddress.getByName("64.37.158.69"), 30007))
         ), PlanetSideEmpire.NC
-      )
+      ))
     )
+
     //0100 04 00 01459e2540377540
 
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
@@ -50,18 +54,56 @@ class VNLWorldStatusMessageTest extends Specification {
     pkt mustEqual string
   }
 
+  "encode and decode empty messages" in {
+    val string = hex"0584410041004100410000"
+    val empty_msg = VNLWorldStatusMessage("AAAA", Vector())
+    val empty_pkt = PacketCoding.EncodePacket(empty_msg).require.toByteVector
+
+    empty_pkt mustEqual string
+
+    PacketCoding.DecodePacket(string).require match {
+      case VNLWorldStatusMessage(message, worlds) =>
+        message mustEqual "AAAA"
+        worlds.length mustEqual 0
+      case _ =>
+        ko
+    }
+  }
+
   "encode and decode multiple worlds" in {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 2,
-      WorldInformation("ABCDABCD1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
+    var string = hex" 0597570065006c0063006f006d006500200074006f00200050006c0061006e0065007400530069006400650021002000028941424344414243443101000300006240414243444142434432000002020000"
+
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
       Vector(
+      WorldInformation("ABCDABCD1", WorldStatus.Up, ServerType.Released, Vector(), PlanetSideEmpire.NC),
         WorldInformation("ABCDABCD2", WorldStatus.Down, ServerType.Beta, Vector(), PlanetSideEmpire.TR)
       ))
 
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
-    println(pkt)
+    pkt mustEqual string
 
-    // TODO: actually test something
-    ok
+    string = hex" 0597570065006c0063006f006d006500200074006f00200050006c0061006e0065007400530069006400650021002000028941424344414243443101000300006240414243444142434432000002020000"
+
+    PacketCoding.DecodePacket(string).require match {
+      case VNLWorldStatusMessage(message, worlds) =>
+        message mustEqual "Welcome to PlanetSide! "
+
+        worlds.length mustEqual 2
+
+        worlds(0).name mustEqual "ABCDABCD1"
+        worlds(0).empireNeed mustEqual PlanetSideEmpire.NC
+        worlds(0).status mustEqual WorldStatus.Up
+        worlds(0).serverType mustEqual ServerType.Released
+        worlds(0).connections.length mustEqual 0
+
+        worlds(1).name mustEqual "ABCDABCD2"
+        worlds(1).empireNeed mustEqual PlanetSideEmpire.TR
+        worlds(1).status mustEqual WorldStatus.Down
+        worlds(1).serverType mustEqual ServerType.Beta
+        worlds(1).connections.length mustEqual 0
+      case _ =>
+        ko
+    }
   }
 }

--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -164,13 +164,10 @@ class LoginSessionActor extends Actor with MDCContextAware {
   }
 
   def updateServerList() = {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 2,
-      WorldInformation(
-        serverName, WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.VS
-      ),
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
       Vector(
         WorldInformation(
-          serverName + "A", WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.TR
+          serverName, WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.VS
         )
       )
     )

--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -164,10 +164,13 @@ class LoginSessionActor extends Actor with MDCContextAware {
   }
 
   def updateServerList() = {
-    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ",
+    val msg = VNLWorldStatusMessage("Welcome to PlanetSide! ", 2,
+      WorldInformation(
+        serverName, WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.VS
+      ),
       Vector(
         WorldInformation(
-          serverName, WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.VS
+          serverName + "A", WorldStatus.Up, ServerType.Beta, Vector(WorldConnectionInfo(serverAddress)), PlanetSideEmpire.TR
         )
       )
     )


### PR DESCRIPTION
Having multiple worlds will enable a ton of great things! The fix ended up requiring a new codec as the main issue was that `encodedString` in the PlanetSide client will perform a BYTE alignment AFTER the size byte is decoded. Normally if the stream is byte aligned already all is well, but at the end of the WorldInformation structure is PlanetSideEmpire, which is ONLY 2 bits. This causes the next world in the vectorOfN to be encoded/decoded misaligned, which causes the client to crash upon reception.