### PR TITLE
GenericObjectActionMessage Field Change

### DIFF
--- a/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
@@ -11,26 +11,34 @@ import shapeless.{::, HNil}
   * Dispatched by the server to enact an effect on some game object.
   * (Write more some other time.)
   * @param object_guid the target object
-  * @param code the action code
-  *             24 - deconstructs player
-  *             28 - start imprinting process (progress bar + character animation)
-  *             32 - finish imprinting?
-  *             36 - cloak
-  *             40 - uncloak
-  *             82 - hit flinch?
-  *             138 - time till item can be used ?????
-  *             44, 45, 46, 47 - Deploy capital base shield pole with animation and broadcasts "The capitol force dome at X has been activated"
-  *             48, 49, 50, 51 - Stow capital base shield pole with animation and broadcasts "The capitol force dome at X has been deactivated"
-  *             52, 53, 54, 55 - Deploy capital base shield pole (instantly, unless still in the middle of the stow animation)
-  *             60, 61, 62, 63 - Displays "This facility's generator is under attack!"
-  *             64, 65, 66, 67 - Displays "Generator has Overloaded! Evacuate Generator Room Immediately!"
-  *             68, 69, 70, 71 - Displays "This facility's generator is back on line"
-  *             88, 89, 90, 91 - ???? (Has been seen on vehicle pad objects, possibly some sort of reset flag after base faction flip / hack clear?)
-  *             92, 93, 94, 95 - Plays vehicle pad animation moving downwards
-  *             96, 97, 98, 99 - Makes the vehicle bounce slightly. Have seen this in packet captures after taking a vehicle through a warpgate
-  *             200, 201, 202, 203 - For aircraft - client shows "THe bailing mechanism failed! To fix the mechanism, land and repair the vehicle!"
-  *             224 - Sets vehicle or player to be black ops
-  *             228 - Reverts player from black ops
+  * @param code the action code (0-63)
+  *             6 - Deconstructs player
+  *             7 - Start imprinting process (progress bar + character animation)
+  *             8 - Finish imprinting?
+  *             9 - Cloak
+  *             10 - Uncloak
+  *             11 - Deploy capital base shield pole with animation and broadcasts "The capitol force dome at X has been activated"
+  *             12 - Stow capital base shield pole with animation and broadcasts "The capitol force dome at X has been deactivated"
+  *             13 - Deploy capital base shield pole (instantly, unless still in the middle of the stow animation)
+  *             15 - Displays "This facility's generator is under attack!"
+  *             16 - Displays "Generator has Overloaded! Evacuate Generator Room Immediately!"
+  *             17 - Displays "This facility's generator is back on line"
+  *             20 - Hit flinch? (orig, 82->80)
+  *             21 - Reset build cooldown from using an ACE
+  *             22 - ???? (Has been seen on vehicle pad objects, possibly some sort of reset flag after base faction flip / hack clear?)
+  *             23 - Plays vehicle pad animation moving downwards
+  *             24 - Makes the vehicle bounce slightly. Have seen this in packet captures after taking a vehicle through a warpgate
+  *             27 - Activates the router internal telepad for linking
+  *             28 - Activates the router internal telepad for linking
+  *             29 - Activates the telepad deployable (also used on the router's internal telepad)
+  *             30 - Activates the telepad deployable (also used on the router's internal telepad)
+  *             31 - Animation during router teleportation (source)
+  *             32 - Animation during router teleportation (destination)
+  *             34 - Time until item can be used ?????
+  *             50 - For aircraft - client shows "The bailing mechanism failed! To fix the mechanism, land and repair the vehicle!"
+  *             53 - Put down an FDU
+  *             56 - Sets vehicle or player to be black ops
+  *             57 - Reverts player from black ops
   */
 final case class GenericObjectActionMessage(object_guid : PlanetSideGUID,
                                             code : Int)
@@ -43,7 +51,7 @@ final case class GenericObjectActionMessage(object_guid : PlanetSideGUID,
 object GenericObjectActionMessage extends Marshallable[GenericObjectActionMessage] {
   implicit val codec : Codec[GenericObjectActionMessage] = (
     ("object_guid" | PlanetSideGUID.codec) ::
-      ("code" | uint8L) ::
+      ("code" | uint(bits = 6)) ::
       ("ex" | bits) //"code" may extract at odd sizes
     ).exmap[GenericObjectActionMessage] (
     {

--- a/common/src/test/scala/game/GenericObjectActionMessageTest.scala
+++ b/common/src/test/scala/game/GenericObjectActionMessageTest.scala
@@ -13,14 +13,14 @@ class GenericObjectActionMessageTest extends Specification {
     PacketCoding.DecodePacket(string).require match {
       case GenericObjectActionMessage(object_guid, action) =>
         object_guid mustEqual PlanetSideGUID(437)
-        action mustEqual 36
+        action mustEqual 9
       case _ =>
         ko
     }
   }
 
   "encode" in {
-    val msg = GenericObjectActionMessage(PlanetSideGUID(437), 36)
+    val msg = GenericObjectActionMessage(PlanetSideGUID(437), 9)
     val pkt = PacketCoding.EncodePacket(msg).require.toByteVector
 
     pkt mustEqual string

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -888,7 +888,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
           case GlobalDefinitions.ace =>
             continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.TriggerEffectLocation(player.GUID, "spawn_object_effect", obj.Position, obj.Orientation))
           case GlobalDefinitions.advanced_ace =>
-            sendResponse(GenericObjectActionMessage(player.GUID, 212)) //put fdu down; it will be removed from the client's holster
+            sendResponse(GenericObjectActionMessage(player.GUID, 53)) //put fdu down; it will be removed from the client's holster
             continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PutDownFDU(player.GUID))
           case GlobalDefinitions.router_telepad => ;
           case _ =>
@@ -1009,7 +1009,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
       val guid = obj.GUID
       val definition = obj.Definition
       StartBundlingPackets()
-      sendResponse(GenericObjectActionMessage(guid, 84)) //reset build cooldown
+      sendResponse(GenericObjectActionMessage(guid, 21)) //reset build cooldown
       sendResponse(ObjectDeployedMessage.Failure(definition.Name))
       log.warn(s"FinalizeDeployable: deployable ${definition.asInstanceOf[DeployableDefinition].Item}@$guid not handled by specific case")
       log.warn(s"FinalizeDeployable: deployable will be cleaned up, but may not get unregistered properly")
@@ -1243,7 +1243,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
         }
 
       case AvatarResponse.ConcealPlayer() =>
-        sendResponse(GenericObjectActionMessage(guid, 36))
+        sendResponse(GenericObjectActionMessage(guid, 9))
 
       case AvatarResponse.EnvironmentalDamage(target, amount) =>
         if(player.isAlive) {
@@ -1469,7 +1469,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
 
       case AvatarResponse.PutDownFDU(target) =>
         if(tplayer_guid != guid) {
-          sendResponse(GenericObjectActionMessage(target, 212))
+          sendResponse(GenericObjectActionMessage(target, 53))
         }
 
       case AvatarResponse.Release(tplayer) =>
@@ -1592,8 +1592,8 @@ class WorldSessionActor extends Actor with MDCContextAware {
         //if active, deactivate
         if(obj.Active) {
           obj.Active = false
-          sendResponse(GenericObjectActionMessage(guid, 116))
-          sendResponse(GenericObjectActionMessage(guid, 120))
+          sendResponse(GenericObjectActionMessage(guid, 29))
+          sendResponse(GenericObjectActionMessage(guid, 30))
         }
         //determine if no replacement teleport system exists
         continent.GUID(obj.Router) match {
@@ -2457,7 +2457,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
         }
 
       case VehicleResponse.ConcealPlayer(player_guid) =>
-        sendResponse(GenericObjectActionMessage(player_guid, 36))
+        sendResponse(GenericObjectActionMessage(player_guid, 9))
         //sendResponse(PlanetsideAttributeMessage(player_guid, 29, 1))
 
       case VehicleResponse.DismountVehicle(bailType, wasKickedByDriver) =>
@@ -2540,10 +2540,10 @@ class WorldSessionActor extends Actor with MDCContextAware {
         }
 
       case VehicleResponse.ResetSpawnPad(pad_guid) =>
-        sendResponse(GenericObjectActionMessage(pad_guid, 92))
+        sendResponse(GenericObjectActionMessage(pad_guid, 23))
 
       case VehicleResponse.RevealPlayer(player_guid) =>
-        sendResponse(GenericObjectActionMessage(player_guid, 40))
+        sendResponse(GenericObjectActionMessage(player_guid, 10))
 
       case VehicleResponse.SeatPermissions(vehicle_guid, seat_group, permission) =>
         if(tplayer_guid != guid) {
@@ -8933,7 +8933,7 @@ class WorldSessionActor extends Actor with MDCContextAware {
     }
     avatar.Deployables.Add(obj)
     UpdateDeployableUIElements(avatar.Deployables.UpdateUIElement(item))
-    sendResponse(GenericObjectActionMessage(guid, 84)) //reset build cooldown
+    sendResponse(GenericObjectActionMessage(guid, 21)) //reset build cooldown
     sendResponse(ObjectCreateMessage(definition.ObjectId, guid, definition.Packet.ConstructorData(obj).get))
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DeployItem(player.GUID, obj))
     //map icon
@@ -9734,14 +9734,14 @@ class WorldSessionActor extends Actor with MDCContextAware {
         udef.Packet.ConstructorData(internalTelepad).get
       )
     )
-    sendResponse(GenericObjectActionMessage(uguid, 108))
-    sendResponse(GenericObjectActionMessage(uguid, 120))
+    sendResponse(GenericObjectActionMessage(uguid, 27))
+    sendResponse(GenericObjectActionMessage(uguid, 30))
     /*
     the following configurations create the interactive beam underneath the Deployed Router
     normally dispatched after the warm-up timer has completed
      */
-    sendResponse(GenericObjectActionMessage(uguid, 108))
-    sendResponse(GenericObjectActionMessage(uguid, 112))
+    sendResponse(GenericObjectActionMessage(uguid, 27))
+    sendResponse(GenericObjectActionMessage(uguid, 28))
   }
 
   /**
@@ -9749,8 +9749,8 @@ class WorldSessionActor extends Actor with MDCContextAware {
     * @param telepadGUID na
     */
   def LinkRemoteTelepad(telepadGUID: PlanetSideGUID) : Unit = {
-    sendResponse(GenericObjectActionMessage(telepadGUID, 108))
-    sendResponse(GenericObjectActionMessage(telepadGUID, 112))
+    sendResponse(GenericObjectActionMessage(telepadGUID, 27))
+    sendResponse(GenericObjectActionMessage(telepadGUID, 28))
   }
 
   /**
@@ -9790,8 +9790,8 @@ class WorldSessionActor extends Actor with MDCContextAware {
     */
   def UseRouterTelepadEffect(playerGUID : PlanetSideGUID, srcGUID : PlanetSideGUID, destGUID : PlanetSideGUID) : Unit = {
     sendResponse(PlanetsideAttributeMessage(playerGUID, 64, 1)) //what does this do?
-    sendResponse(GenericObjectActionMessage(srcGUID, 124))
-    sendResponse(GenericObjectActionMessage(destGUID, 128))
+    sendResponse(GenericObjectActionMessage(srcGUID, 31))
+    sendResponse(GenericObjectActionMessage(destGUID, 32))
   }
 
   /**


### PR DESCRIPTION
A quick examination of comments in the documentation for this packet asserts that number ranges such as 60, 61, 62, 63 possess the same effect and the next number range 64, 65, 66, 67 all possess a same effect, different from the previous.  And so forth for 68, 69, 70, 71.  Based on that analysis, the numbers that matter are actually 60, 64, 68; divided by two twice they are 15, 16, 17; and, furthermore, that means the fidelity of the field extracted is too high by two bits.  This makes sense for all currently utilized data as they are all divisible by four.

Instead of a domain of possible `8u` numbers 0-255 where most of the purpose of the numbers are currently unknown or undefined, the amended domain is `6u` numbers 0-63 with only about half unattributed.