### PR TITLE
Enable quiet tests using SBT config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ dist: trusty
 scala:
   - 2.11.8
 env:
-  - SBT_COMMAND="test:compile test packArchiveZip"
-  - SBT_COMMAND="coverage test:compile test coverageReport"
+  - SBT_COMMAND="test:compile quiet:test packArchiveZip"
+  - SBT_COMMAND="coverage test:compile quiet:test coverageReport"
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,12 @@ lazy val commonSettings = Seq(
   testOptions in QuietTest += Tests.Argument(TestFrameworks.Specs2, "xonly"),
   // http://www.scalatest.org/user_guide/using_the_runner
   testOptions in QuietTest += Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRMI"),
-
+  // TODO: remove when upgraded to SBT 1.0+ https://github.com/sbt/sbt/pull/2747/files
+  ivyLoggingLevel := {
+    // This will suppress "Resolving..." logs on Jenkins and Travis.
+    if (sys.env.get("BUILD_NUMBER").isDefined || sys.env.get("CI").isDefined) UpdateLogging.Quiet
+    else UpdateLogging.Default
+  },
   // Trick taken from https://groups.google.com/d/msg/scala-user/mxV9ok7J_Eg/kt-LnsrD0bkJ
   // scaladoc flags: https://github.com/scala/scala/blob/2.11.x/src/scaladoc/scala/tools/nsc/doc/Settings.scala
   scalacOptions in (Compile,doc) <<= baseDirectory map {

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val commonSettings = Seq(
   // Quiet test options
   testOptions in QuietTest += Tests.Argument(TestFrameworks.Specs2, "xonly"),
   // http://www.scalatest.org/user_guide/using_the_runner
-  testOptions in QuietTest += Tests.Argument(TestFrameworks.ScalaTest, "-oNCXELOPQRMI"),
+  testOptions in QuietTest += Tests.Argument(TestFrameworks.ScalaTest, "-oCEHILMNOPQRX"),
   // TODO: remove when upgraded to SBT 1.0+ https://github.com/sbt/sbt/pull/2747/files
   ivyLoggingLevel := {
     // This will suppress "Resolving..." logs on Jenkins and Travis.

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,9 @@ lazy val commonSettings = Seq(
   scalacOptions := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8", "-language:postfixOps"),
 
   // Quiet test options
-  testOptions in QuietTest += Tests.Argument(TestFrameworks.Specs2, "xonly"),
+  // https://github.com/etorreborre/specs2/blob/8305db76c5084e4b3ce5827ce23117f6fb6beee4/common/shared/src/main/scala/org/specs2/main/Report.scala#L94
+  // https://etorreborre.github.io/specs2/guide/SPECS2-2.4.17/org.specs2.guide.Runners.html
+  testOptions in QuietTest += Tests.Argument(TestFrameworks.Specs2, "showOnly", "x!"),
   // http://www.scalatest.org/user_guide/using_the_runner
   testOptions in QuietTest += Tests.Argument(TestFrameworks.ScalaTest, "-oCEHILMNOPQRX"),
   // TODO: remove when upgraded to SBT 1.0+ https://github.com/sbt/sbt/pull/2747/files

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pslogin/src/test/resources/logback-test.xml
+++ b/pslogin/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This should make TravisCI failing tests be *much* easier to identify as we only show the failing tests for both Specs2 and ScalaTest.