### PR TITLE
Object "Staleness"

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Deployables.scala
+++ b/common/src/main/scala/net/psforever/objects/Deployables.scala
@@ -3,7 +3,8 @@ package net.psforever.objects
 
 import net.psforever.objects.ce.{Deployable, DeployedItem}
 import net.psforever.objects.serverobject.PlanetSideServerObject
-import net.psforever.packet.game.{DeployableInfo, DeploymentAction, PlanetSideGUID}
+import net.psforever.packet.game.{DeployableInfo, DeploymentAction}
+import net.psforever.types.PlanetSideGUID
 import services.RemoverActor
 import services.local.{LocalAction, LocalServiceMessage}
 

--- a/common/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
@@ -9,8 +9,7 @@ import net.psforever.objects.definition.converter.SmallDeployableConverter
 import net.psforever.objects.equipment.JammableUnit
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.vital.{StandardResolutions, Vitality}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.local.{LocalAction, LocalServiceMessage}
 

--- a/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
+++ b/common/src/main/scala/net/psforever/objects/OwnableByPlayer.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 PSForever
 package net.psforever.objects
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 trait OwnableByPlayer {
   private var owner : Option[PlanetSideGUID] = None

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -10,9 +10,8 @@ import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.vital.resistance.ResistanceProfile
 import net.psforever.objects.vital.{DamageResistanceModel, Vitality}
 import net.psforever.objects.zones.ZoneAware
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{Cosmetics, DetailedCharacterData, PersonalStyle}
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 
 import scala.annotation.tailrec
 import scala.util.{Success, Try}

--- a/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
@@ -11,7 +11,7 @@ import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.vital.{StandardResolutions, Vitality}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.local.{LocalAction, LocalServiceMessage}

--- a/common/src/main/scala/net/psforever/objects/ShieldGeneratorDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ShieldGeneratorDeployable.scala
@@ -11,7 +11,7 @@ import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.Service
 import services.vehicle.{VehicleAction, VehicleServiceMessage}

--- a/common/src/main/scala/net/psforever/objects/SpawnPoint.scala
+++ b/common/src/main/scala/net/psforever/objects/SpawnPoint.scala
@@ -3,8 +3,7 @@ package net.psforever.objects
 
 import net.psforever.objects.definition.{ObjectDefinition, VehicleDefinition}
 import net.psforever.objects.serverobject.PlanetSideServerObject
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 
 import scala.collection.mutable
 

--- a/common/src/main/scala/net/psforever/objects/TurretDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/TurretDeployable.scala
@@ -14,7 +14,7 @@ import net.psforever.objects.serverobject.mount.MountableBehavior
 import net.psforever.objects.serverobject.turret.{TurretDefinition, WeaponTurret}
 import net.psforever.objects.vital.{StandardResolutions, StandardVehicleDamage, StandardVehicleResistance, Vitality}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -12,8 +12,7 @@ import net.psforever.objects.serverobject.deploy.Deployment
 import net.psforever.objects.serverobject.structures.AmenityOwner
 import net.psforever.objects.vehicles._
 import net.psforever.objects.vital.{DamageResistanceModel, StandardResistanceProfile, Vitality}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.annotation.tailrec
 

--- a/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/DeployableToolbox.scala
@@ -3,8 +3,7 @@ package net.psforever.objects.avatar
 
 import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.ce.{Deployable, DeployableCategory, DeployedItem}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 
 import scala.collection.mutable
 

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.objects.vehicles.Utility
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 trait TelepadLike {
   private var router : Option[PlanetSideGUID] = None

--- a/common/src/main/scala/net/psforever/objects/definition/converter/ACEConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/ACEConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.ConstructionItem
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedConstructionToolData, HandheldData}
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/AmmoBoxConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/AmmoBoxConverter.scala
@@ -2,9 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.AmmoBox
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedAmmoBoxData}
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
@@ -3,9 +3,8 @@ package net.psforever.objects.definition.converter
 
 import net.psforever.objects.Player
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{ExoSuitType, GrenadeState, ImplantType}
+import net.psforever.types.{ExoSuitType, GrenadeState, ImplantType, PlanetSideGUID}
 
 import scala.annotation.tailrec
 import scala.util.{Success, Try}

--- a/common/src/main/scala/net/psforever/objects/definition/converter/BoomerTriggerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/BoomerTriggerConverter.scala
@@ -2,9 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.SimpleItem
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedConstructionToolData, HandheldData}
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
@@ -3,9 +3,8 @@ package net.psforever.objects.definition.converter
 
 import net.psforever.objects.{Player, Tool}
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/common/src/main/scala/net/psforever/objects/definition/converter/CommandDetonaterConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/CommandDetonaterConverter.scala
@@ -2,9 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.SimpleItem
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedCommandDetonaterData, HandheldData}
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
@@ -3,9 +3,8 @@ package net.psforever.objects.definition.converter
 
 import net.psforever.objects.Player
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/common/src/main/scala/net/psforever/objects/definition/converter/FieldTurretConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/FieldTurretConverter.scala
@@ -4,8 +4,8 @@ package net.psforever.objects.definition.converter
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.serverobject.turret.WeaponTurret
 import net.psforever.objects.TurretDeployable
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/InternalTelepadDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/InternalTelepadDeployableConverter.scala
@@ -3,9 +3,8 @@ package net.psforever.objects.definition.converter
 
 import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.ce.TelepadLike
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
@@ -4,9 +4,8 @@ package net.psforever.objects.definition.converter
 import net.psforever.objects.LockerContainer
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.GridInventory
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/ProjectileConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/ProjectileConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.ballistics.Projectile
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, CommonFieldDataWithPlacement, FlightPhysics, PlacementData, RemoteProjectileData}
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/REKConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/REKConverter.scala
@@ -2,9 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.SimpleItem
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedREKData, REKData}
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/ShieldGeneratorConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/ShieldGeneratorConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.ShieldGeneratorDeployable
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/SmallDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/SmallDeployableConverter.scala
@@ -4,8 +4,8 @@ package net.psforever.objects.definition.converter
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.equipment.JammableUnit
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/SmallTurretConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/SmallTurretConverter.scala
@@ -4,8 +4,8 @@ package net.psforever.objects.definition.converter
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.TurretDeployable
 import net.psforever.objects.serverobject.turret.WeaponTurret
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TRAPConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TRAPConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.TrapDeployable
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.Telepad
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedConstructionToolData, HandheldData}
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/TelepadDeployableConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.TelepadDeployable
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/ToolConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/ToolConverter.scala
@@ -2,8 +2,8 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.Tool
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{CommonFieldData, DetailedWeaponData, InternalSlot, WeaponData}
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
@@ -3,9 +3,8 @@ package net.psforever.objects.definition.converter
 
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.Vehicle
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.DriveState
+import net.psforever.types.{DriveState, PlanetSideGUID}
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/entity/GUIDException.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/GUIDException.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2017-2020 PSForever
+package net.psforever.objects.entity
+
+import net.psforever.types.PlanetSideGUID
+
+/**
+  * The base for all complaints that can be raised regarding the management of global unique identifier numbers.
+  * @param message the message string
+  * @param cause the cause of this error
+  * @param obj the entity being manipulated when the complaint arose
+  * @param guid the identifier number being manipulated when the ciomplaint arose
+  */
+abstract class GUIDException(message : String, cause : Throwable, obj : IdentifiableEntity, guid : PlanetSideGUID)
+  extends RuntimeException(message, cause) {
+  private val entity : IdentifiableEntity = obj
+  def getEntity : IdentifiableEntity = entity
+
+  private val entityGUID : PlanetSideGUID = guid
+  def getGUID : PlanetSideGUID = entityGUID
+}
+
+/**
+  * The specific complaint for an instance where an entity does not possess a global unique identifier number
+  * but the said number is requested.
+  * In general, this `Exception` is only thrown if the entity has never been registered,
+  * or provided the bare minimum or registration benefits.
+  * @param message the message string
+  * @param obj the entity being manipulated when the complaint arose
+  * @param cause the cause of this error
+  */
+class NoGUIDException(message : String,
+                      obj : IdentifiableEntity = None.orNull,
+                      cause : Throwable = None.orNull
+                     ) extends GUIDException(message, cause, obj, null)
+
+object NoGUIDException {
+  def unapply(e : NoGUIDException): Option[(String, IdentifiableEntity, Throwable)] = Some((e.getMessage, e.getEntity, e.getCause))
+}
+
+/**
+  * The general complaint for an instance where an entity can not be assigned the given global unique identifier number.
+  * @param message the message string
+  * @param obj the entity being manipulated when the complaint arose
+  * @param guid the identifier number being manipulated when the ciomplaint arose
+  * @param cause the cause of this error
+  */
+class AssigningGUIDException(message : String,
+                             obj : IdentifiableEntity,
+                             guid : PlanetSideGUID,
+                             cause : Throwable = None.orNull
+                            ) extends GUIDException(message, cause, obj, guid)
+
+object AssigningGUIDException {
+  def unapply(e : AssigningGUIDException): Option[(String, Throwable, IdentifiableEntity, PlanetSideGUID)] = Some((e.getMessage, e.getCause, e.getEntity, e.getGUID))
+}

--- a/common/src/main/scala/net/psforever/objects/entity/Identifiable.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/Identifiable.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.entity
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * Identifiable represents anything that has its own globally unique identifier (GUID).

--- a/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
@@ -1,104 +1,110 @@
-// Copyright (c) 2017 PSForever
+// Copyright (c) 2017-2019 PSForever
 package net.psforever.objects.entity
 
-import net.psforever.types.PlanetSideGUID
+import net.psforever.types.{PlanetSideGUID, StalePlanetSideGUID}
 
 /**
-  * Represent any entity that must have its own globally unique identifier (GUID) to be functional.<br>
+  * Represent any entity that must have its own valid global unique identifier (GUID) to be functional.<br>
   * <br>
-  * "Testing" the object refers to the act of acquiring a reference to the GUID the object is using.
-  * This object starts with a container class that represents a unprepared GUID state and raises an `Exception` when tested.
-  * Setting a proper `PlanetSideGUID` replaces that container class with a container class that returns the GUID when tested.
-  * The object can be invalidated, retaining the previous identifier number, but marking that object as being "stale."
-  * "Staleness" is a property indicating whether or not the number can be used as a valid representation of the object.
+  * The basic design philosophy of the workflow of a GUID at this stage is a deterministic state machine.
+  * At the start, an `Exception` will be thrown while the default conditions of the accessor and mutator are maintained.
+  * ("The ability to set a new valid GUID".)
+  * Only a valid GUID may be set and, once it does, that changes the conditions of the accessor and mutator
+  * to one where it will return the valid GUID and one where it will no longer accept a new GUID (valid or invalid).
+  * That GUID will continue being the GUID reported by the object, even if another valid GUID tries to be set.
+  * (No error or exception will be thrown.)
+  * To set a new GUID, the current one must be invalidated with the appropriate function,
+  * and this turns both the object and any object reference that can be acquired from the object "stale."
+  * Doing this prior to setting the initial valid GUID is fruitless
+  * as it restores the object to its default mutation option ("the ability to set a new valid GUID").
+  * Access to the GUID is retained.
+  * This can be done as many times as is necessary by following the same order of actions.<br>
+  * <br>
+  * The "staleness" of the object and the "staleness" of the GUID are related.
+  * The condition in general indicates that the object has somehow become externally disconnected from its GUID reference
+  * though the two still share something similar to their prior relationship internally.
+  * Do not expect a "stale" GUID to refer to the same object through some mapping mechanism.
+  * Do not expect a "stale" object to give you a GUID that will map back to itself.
   * @throws `NoGUIDException` if a GUID has not yet been assigned
   */
 abstract class IdentifiableEntity extends Identifiable {
+  /** storage for the GUID information; starts as a `StalePlanetSideGUID` */
+  private var current : PlanetSideGUID = StalePlanetSideGUID(0)
   /** indicate the validity of the current GUID */
-  private var stale : Boolean = true
-  /** storage for the active GUID */
-  private val container : GUIDContainable = GUIDContainer()
-  /** the handle for the active GUID; starts as exception-throwing */
-  private var current : GUIDContainable = IdentifiableEntity.noGUIDContainer
+  private var guidValid : Boolean = false
+  /** the current accessor; can be re-assigned */
+  private var guidAccessor : IdentifiableEntity=>PlanetSideGUID = IdentifiableEntity.noGuidGet
+  /** the current mutator; can be re-assigned */
+  private var guidMutator : (IdentifiableEntity, PlanetSideGUID)=>PlanetSideGUID = IdentifiableEntity.noGuidSet
+
+  def GUID : PlanetSideGUID = guidAccessor(this)
+
+  /** Always intercept `StalePlanetSideGUID` references when attempting to mutate the GUID value. */
+  def GUID_=(guid : StalePlanetSideGUID) : PlanetSideGUID = guidAccessor(this)
+
+  def GUID_=(guid : PlanetSideGUID) : PlanetSideGUID = guidMutator(this, guid)
 
   /**
-    * The object will not originally having a valid GUID,
-    * so "stale" will be used to expressed "not initialized."
-    * After being set and then properly invalidated, then it will indicate proper staleness.
+    * Flag when the object has no GUID (initial condition) or is considered stale.
     * @return whether the value of the GUID is a valid representation for this object
     */
-  def HasGUID : Boolean = !stale
-
-  def GUID : PlanetSideGUID = current.GUID
-
-  def GUID_=(guid : PlanetSideGUID) : PlanetSideGUID = {
-    stale = false
-    current = container
-    current.GUID = guid
-    GUID
-  }
+  def HasGUID : Boolean = guidValid
 
   /**
-    * Set the staleness to indicate whether the GUID has ever been set
-    * or that the set GUID is not a proper representation of the object.
-    * It is always set to `true`.
+    * Indicate that the current GUID is no longer a valid representation of the object.
+    * Transforms whatever the current GUID is into a `StalePlanetSideGUID` entity with the same value.
+    * Doing this restores the object to its default mutation option ("the ability to set a new valid GUID").
+    * The current GUID will still be accessed as if it were valid, but it will be wrapped in the new stale object.
     */
   def Invalidate() : Unit = {
-    stale = true
+    guidValid = false
+    current = StalePlanetSideGUID(current.guid)
+    guidMutator = IdentifiableEntity.noGuidSet
   }
 }
 
 object IdentifiableEntity {
-  private val noGUIDContainer : GUIDContainable = new NoGUIDContainer
-}
-
-/**
-  * Mask the `Identifiable` `trait`.
-  */
-sealed trait GUIDContainable extends Identifiable
-
-/**
-  * Hidden container that represents an object that is not ready to be used by the game.
-  */
-private case class NoGUIDContainer() extends GUIDContainable {
   /**
-    * Raise an `Exception` because we have no GUID to give.
+    * Raise an `Exception` because the entity is never considered having a GUID to give.
+    * @param o the any entity with a GUID
     * @throws `NoGUIDException` always
     * @return never returns
     */
-  def GUID : PlanetSideGUID = {
-    throw NoGUIDException(s"object $this has not initialized a global identifier")
+  def noGuidGet(o : IdentifiableEntity) : PlanetSideGUID = {
+    throw NoGUIDException(s"did not initialize this object $o with a valid global identifier")
   }
 
   /**
-    * Normally, this should never be called.
-    * @param toGuid the globally unique identifier
-    * @return never returns
-    */
-  def GUID_=(toGuid : PlanetSideGUID) : PlanetSideGUID = {
-    throw NoGUIDException("can not initialize a global identifier with this object")
-  }
-}
-
-/**
-  * Hidden container that represents an object that has a working GUID and is ready to be used by the game.
-  * @param guid the object's globally unique identifier;
-  *             defaults to a GUID equal to 0
-  */
-private case class GUIDContainer(private var guid : PlanetSideGUID = PlanetSideGUID(0)) extends GUIDContainable {
-  /**
-    * Provide the GUID used to initialize this object.
+    * Provide the entity with a valid GUID replacing an invalid GUID.
+    * Modify the accessor and mutator function literals to ensure the entity will remain stable.
+    * It will not be mutated by a new valid value without the existing valid value having to first be invalidated.
+    * Its access is made standard.
+    * @param o the any entity with a GUID
+    * @param guid the valid GUID to assign
     * @return the GUID
     */
-  def GUID : PlanetSideGUID = guid
+  def noGuidSet(o : IdentifiableEntity, guid : PlanetSideGUID) : PlanetSideGUID = {
+    o.current = guid
+    o.guidValid = true
+    o.guidAccessor = guidGet
+    o.guidMutator = guidSet
+    guid
+  }
 
   /**
-    * Exchange the previous GUID for a new one, re-using this container.
-    * @param toGuid the globally unique identifier
-    * @return the GUID
+    * The entity should have a valid GUID that can be provided.
+    * @param o the entity
+    * @return the entity's GUID
     */
-  def GUID_=(toGuid : PlanetSideGUID) : PlanetSideGUID = {
-    guid = toGuid
-    GUID
-  }
+  def guidGet(o : IdentifiableEntity) : PlanetSideGUID = o.current
+
+  /**
+    * The entity is in a condition where it can not be assigned the new valid GUID.
+    * This state establishes itself after setting the very first valid GUID and
+    * will persist to the end of the entity's life.
+    * @param o the any entity with a GUID
+    * @param guid the valid GUID to assign
+    * @return the entity's GUID
+    */
+  def guidSet(o : IdentifiableEntity, guid : PlanetSideGUID) : PlanetSideGUID = o.current
 }

--- a/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
@@ -9,25 +9,42 @@ import net.psforever.packet.game.PlanetSideGUID
   * "Testing" the object refers to the act of acquiring a reference to the GUID the object is using.
   * This object starts with a container class that represents a unprepared GUID state and raises an `Exception` when tested.
   * Setting a proper `PlanetSideGUID` replaces that container class with a container class that returns the GUID when tested.
-  * The object can be invalidated, restoring the previous `Exception`-raising condition.
-  * @throws `NoGUIDException` if there is no GUID to give
+  * The object can be invalidated, retaining the previous identifier number, but marking that object as being "stale."
+  * "Staleness" is a property indicating whether or not the number can be used as a valid representation of the object.
+  * @throws `NoGUIDException` if a GUID has not yet been assigned
   */
 abstract class IdentifiableEntity extends Identifiable {
+  /** indicate the validity of the current GUID */
+  private var stale : Boolean = true
+  /** storage for the active GUID */
   private val container : GUIDContainable = GUIDContainer()
+  /** the handle for the active GUID; starts as exception-throwing */
   private var current : GUIDContainable = IdentifiableEntity.noGUIDContainer
 
-  def HasGUID : Boolean = current ne IdentifiableEntity.noGUIDContainer
+  /**
+    * The object will not originally having a valid GUID,
+    * so "stale" will be used to expressed "not initialized."
+    * After being set and then properly invalidated, then it will indicate proper staleness.
+    * @return whether the value of the GUID is a valid representation for this object
+    */
+  def HasGUID : Boolean = !stale
 
   def GUID : PlanetSideGUID = current.GUID
 
   def GUID_=(guid : PlanetSideGUID) : PlanetSideGUID = {
+    stale = false
     current = container
     current.GUID = guid
     GUID
   }
 
+  /**
+    * Set the staleness to indicate whether the GUID has ever been set
+    * or that the set GUID is not a proper representation of the object.
+    * It is always set to `true`.
+    */
   def Invalidate() : Unit = {
-    current = IdentifiableEntity.noGUIDContainer
+    stale = true
   }
 }
 
@@ -50,7 +67,7 @@ private case class NoGUIDContainer() extends GUIDContainable {
     * @return never returns
     */
   def GUID : PlanetSideGUID = {
-    throw NoGUIDException("object has not initialized a global identifier")
+    throw NoGUIDException(s"object $this has not initialized a global identifier")
   }
 
   /**

--- a/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/IdentifiableEntity.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.entity
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * Represent any entity that must have its own globally unique identifier (GUID) to be functional.<br>

--- a/common/src/main/scala/net/psforever/objects/entity/NoGUIDException.scala
+++ b/common/src/main/scala/net/psforever/objects/entity/NoGUIDException.scala
@@ -1,6 +1,0 @@
-// Copyright (c) 2017 PSForever
-package net.psforever.objects.entity
-
-case class NoGUIDException(private val message: String = "",
-                           private val cause: Throwable = None.orNull
-                          ) extends RuntimeException(message, cause)

--- a/common/src/main/scala/net/psforever/objects/equipment/RemoteUnit.scala
+++ b/common/src/main/scala/net/psforever/objects/equipment/RemoteUnit.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.equipment
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 trait RemoteUnit {
   private var companion : Option[PlanetSideGUID] = None

--- a/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
@@ -285,7 +285,7 @@ class NumberPoolHub(private val source : NumberSource) {
       case Success(key) =>
         Success(key)
       case Failure(_) =>
-        throw NoGUIDException(s"a pool gave us a number $number that is actually unavailable") //stop the show; this is terrible!
+        throw new NoGUIDException(s"a pool gave us a number $number that is actually unavailable") //stop the show; this is terrible!
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/NumberPoolHub.scala
@@ -5,7 +5,7 @@ import net.psforever.objects.entity.{IdentifiableEntity, NoGUIDException}
 import net.psforever.objects.guid.key.LoanedKey
 import net.psforever.objects.guid.pool.{ExclusivePool, GenericPool, NumberPool}
 import net.psforever.objects.guid.source.NumberSource
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.{Failure, Success, Try}
 

--- a/common/src/main/scala/net/psforever/objects/guid/key/LoanedKey.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/key/LoanedKey.scala
@@ -36,7 +36,7 @@ class LoanedKey(private val guid : Int, private val key : Monitor) {
       }
       key.Object = obj
       if(obj.isDefined) {
-        import net.psforever.packet.game.PlanetSideGUID
+        import net.psforever.types.PlanetSideGUID
         obj.get.GUID = PlanetSideGUID(guid)
       }
     }

--- a/common/src/main/scala/net/psforever/objects/inventory/Container.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/Container.scala
@@ -3,7 +3,7 @@ package net.psforever.objects.inventory
 
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
 import net.psforever.objects.OffhandEquipmentSlot
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 import scala.util.Try
 

--- a/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -4,7 +4,7 @@ package net.psforever.objects.inventory
 import java.util.concurrent.atomic.AtomicInteger
 
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/common/src/main/scala/net/psforever/objects/inventory/InventoryItem.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/InventoryItem.scala
@@ -2,7 +2,7 @@
 package net.psforever.objects.inventory
 
 import net.psforever.objects.equipment.Equipment
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * Represent the image placard that is used to visually and spatially manipulate an item placed into the grid-like inventory.

--- a/common/src/main/scala/net/psforever/objects/serverobject/hackable/Hackable.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/hackable/Hackable.scala
@@ -2,8 +2,8 @@ package net.psforever.objects.serverobject.hackable
 
 import net.psforever.objects.Player
 import net.psforever.objects.serverobject.affinity.FactionAffinity
-import net.psforever.packet.game.{PlanetSideGUID, TriggeredSound}
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.TriggeredSound
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 trait Hackable extends FactionAffinity {
   import Hackable._

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
@@ -3,7 +3,7 @@ package net.psforever.objects.serverobject.pad
 
 import net.psforever.objects.{Player, Vehicle}
 import net.psforever.objects.serverobject.structures.Amenity
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * A structure-owned server object that is a "spawn pad" for vehicles.<br>

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
@@ -2,8 +2,7 @@
 package net.psforever.objects.serverobject.pad.process
 
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/common/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -13,7 +13,7 @@ import net.psforever.objects.serverobject.terminals.CaptureTerminal
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import scalax.collection.{Graph, GraphEdge}
 
 class Building(private val name: String,

--- a/common/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}

--- a/common/src/main/scala/net/psforever/objects/serverobject/turret/WeaponTurret.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/turret/WeaponTurret.scala
@@ -24,7 +24,9 @@ trait WeaponTurret extends FactionAffinity
   /** may or may not have inaccessible inventory space
     * see `ReserveAmmunition` in the definition */
   protected val inventory : GridInventory = new GridInventory() {
-    import net.psforever.packet.game.PlanetSideGUID
+
+    import net.psforever.types.PlanetSideGUID
+
     override def Remove(index : Int) : Boolean = false
     override def Remove(guid : PlanetSideGUID) : Boolean = false
   }

--- a/common/src/main/scala/net/psforever/objects/teamwork/Squad.scala
+++ b/common/src/main/scala/net/psforever/objects/teamwork/Squad.scala
@@ -2,8 +2,7 @@
 package net.psforever.objects.teamwork
 
 import net.psforever.objects.entity.IdentifiableEntity
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CertificationType, PlanetSideEmpire}
+import net.psforever.types.{CertificationType, PlanetSideEmpire, PlanetSideGUID}
 
 class Squad(squadId : PlanetSideGUID, alignment : PlanetSideEmpire.Value) extends IdentifiableEntity {
   super.GUID_=(squadId)

--- a/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/Utility.scala
@@ -8,8 +8,8 @@ import net.psforever.objects.ce.TelepadLike
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.objects.serverobject.terminals._
 import net.psforever.objects.serverobject.tube.{SpawnTube, SpawnTubeDefinition}
-import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
-import net.psforever.types.Vector3
+import net.psforever.packet.game.ItemTransactionMessage
+import net.psforever.types.{PlanetSideGUID, Vector3}
 
 /**
   * An `Enumeration` of the available vehicular utilities.<br>

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -10,8 +10,7 @@ import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffi
 import net.psforever.objects.serverobject.deploy.{Deployment, DeploymentBehavior}
 import net.psforever.objects.vital.{VehicleShieldCharge, Vitality}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{DriveState, ExoSuitType, Vector3}
+import net.psforever.types.{DriveState, ExoSuitType, PlanetSideGUID, Vector3}
 import services.{RemoverActor, Service}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.local.{LocalAction, LocalServiceMessage}

--- a/common/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -17,8 +17,7 @@ import net.psforever.objects.serverobject.painbox.{Painbox, PainboxDefinition}
 import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Amenity, Building, WarpGate}
 import net.psforever.objects.serverobject.turret.FacilityTurret
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.avatar.AvatarService
 import services.local.LocalService
 import services.vehicle.VehicleService

--- a/common/src/main/scala/net/psforever/objects/zones/ZoneGroundActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZoneGroundActor.scala
@@ -3,7 +3,7 @@ package net.psforever.objects.zones
 
 import akka.actor.Actor
 import net.psforever.objects.equipment.Equipment
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer

--- a/common/src/main/scala/net/psforever/packet/game/ActionCancelMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ActionCancelMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ArmorChangedMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.ExoSuitType
+import net.psforever.types.{ExoSuitType, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/AvatarFirstTimeEventMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarFirstTimeEventMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarGrenadeStateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.GrenadeState
+import net.psforever.types.{GrenadeState, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarImplantMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/AvatarSearchCriteriaMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarSearchCriteriaMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/AvatarVehicleTimerMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/AvatarVehicleTimerMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/BattleExperienceMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/BattleExperienceMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/CargoMountPointStatusMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/CargoMountPointStatusMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.CargoStatus
+import net.psforever.types.{CargoStatus, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ChangeAmmoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeAmmoMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ChangeFireModeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeFireModeMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ChangeFireStateMessage_Start.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeFireStateMessage_Start.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ChangeFireStateMessage_Stop.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeFireStateMessage_Stop.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChangeShortcutBankMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/CharacterInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/CharacterInfoMessage.scala
@@ -2,20 +2,14 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
-
 
 case class PlanetSideZoneID(zoneId : Long)
 
 object PlanetSideZoneID {
   implicit val codec = uint32L.as[PlanetSideZoneID]
-}
-
-case class PlanetSideGUID(guid : Int)
-
-object PlanetSideGUID {
-  implicit val codec = uint16L.as[PlanetSideGUID]
 }
 
 /**

--- a/common/src/main/scala/net/psforever/packet/game/CharacterKnowledgeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/CharacterKnowledgeMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ChildObjectStateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Angular
+import net.psforever.types.{Angular, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/CreateShortcutMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/CreateShortcutMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DamageFeedbackMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DamageFeedbackMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/DamageMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DamageMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Angular
+import net.psforever.types.{Angular, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DelayedPathMountMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DelayedPathMountMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DeployObjectMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployObjectMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployRequestMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{DriveState, Vector3}
+import net.psforever.types.{DriveState, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DeployableObjectsInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DeployableObjectsInfoMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DestroyMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DestroyMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountBuildingMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DismountVehicleCargoMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountVehicleCargoMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/DismountVehicleMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DismountVehicleMsg.scala
@@ -4,7 +4,7 @@ package net.psforever.packet.game
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
 import scodec.Codec
 import scodec.codecs._
-import net.psforever.types.BailType
+import net.psforever.types.{BailType, PlanetSideGUID}
 
 /**
   * Dispatched by the client when the player wishes to get out of a vehicle.

--- a/common/src/main/scala/net/psforever/packet/game/DisplayedAwardMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DisplayedAwardMessage.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game
 
-import net.psforever.types.MeritCommendation
+import net.psforever.types.{MeritCommendation, PlanetSideGUID}
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
 import scodec.Codec
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/game/DropItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/DropItemMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/EmoteMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/EmoteMsg.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.EmoteType
+import net.psforever.types.{EmoteType, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/FacilityBenefitShieldChargeRequestMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FacilityBenefitShieldChargeRequestMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/FavoritesMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FavoritesMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.LoadoutType
+import net.psforever.types.{LoadoutType, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/FavoritesRequest.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FavoritesRequest.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.LoadoutType
+import net.psforever.types.{LoadoutType, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/FireHintMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/FireHintMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericCollisionMsg.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec}
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/game/GenericObjectStateMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericObjectStateMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HackMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/HitHint.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HitHint.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/HitMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/HitMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/InventoryStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/InventoryStateMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ItemTransactionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ItemTransactionMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.TransactionType
+import net.psforever.types.{PlanetSideGUID, TransactionType}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ItemTransactionResultMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ItemTransactionResultMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.TransactionType
+import net.psforever.types.{PlanetSideGUID, TransactionType}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/LashMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/LashMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/LootItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/LootItemMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/MountVehicleCargoMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/MountVehicleCargoMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/MountVehicleMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/MountVehicleMsg.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/MoveItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/MoveItemMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ObjectAttachMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectAttachMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ObjectCreateDetailedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectCreateDetailedMessage.scala
@@ -3,6 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.packet.game.objectcreate.{ConstructorData, ObjectClass, ObjectCreateBase, ObjectCreateMessageParent}
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, Err}
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ObjectCreateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectCreateMessage.scala
@@ -3,6 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
 import net.psforever.packet.game.objectcreate.{ObjectCreateBase, _}
+import net.psforever.types.PlanetSideGUID
 import scodec.{Attempt, Codec, Err}
 import scodec.bits.BitVector
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ObjectDeleteMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectDeleteMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ObjectDetachMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectDetachMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ObjectDetectedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectDetectedMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ObjectHeldMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ObjectHeldMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/OrbitalStrikeWaypointMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/OrbitalStrikeWaypointMessage.scala
@@ -3,6 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/OxygenStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/OxygenStateMessage.scala
@@ -3,6 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.{Attempt, Codec}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/PickupItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PickupItemMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/PlanetsideStringAttributeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlanetsideStringAttributeMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/PlayerStasisMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlayerStasisMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/PlayerStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlayerStateMessage.scala
@@ -3,7 +3,7 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/PlayerStateMessageUpstream.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlayerStateMessageUpstream.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ProjectileStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ProjectileStateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/ProximityTerminalUseMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ProximityTerminalUseMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/QuantityDeltaUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/QuantityDeltaUpdateMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/QuantityUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/QuantityUpdateMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ReloadMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReloadMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/RepairMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/RepairMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -3,9 +3,10 @@ package net.psforever.packet.game
 
 import net.psforever.newcodecs.newcodecs
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
-import shapeless.HNil //DO NOT IMPORT shapeless.:: HERE; it interferes with required scala.collection.immutable.::
+import shapeless.HNil
 
 import scala.annotation.tailrec
 

--- a/common/src/main/scala/net/psforever/packet/game/RequestDestroyMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/RequestDestroyMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/RespawnAMSInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/RespawnAMSInfoMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/SetCurrentAvatarMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SetCurrentAvatarMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/SetEmpireMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SetEmpireMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/SplashHitMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SplashHitMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/SquadDefinitionActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SquadDefinitionActionMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/game/SquadDetailDefinitionUpdateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SquadDetailDefinitionUpdateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.HNil

--- a/common/src/main/scala/net/psforever/packet/game/SquadInvitationRequestMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SquadInvitationRequestMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/SquadState.scala
+++ b/common/src/main/scala/net/psforever/packet/game/SquadState.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/TargetingImplantRequest.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TargetingImplantRequest.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TargetingInfoMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/TrainingZoneMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TrainingZoneMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/TriggerEffectMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TriggerEffectMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/TriggerEnvironmentalDamageMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/TriggerEnvironmentalDamageMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/UnuseItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/UnuseItemMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/UseItemMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/UseItemMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{Angular, Vector3}
+import net.psforever.types.{Angular, PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/VehicleSubStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VehicleSubStateMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/VoiceHostInfo.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VoiceHostInfo.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/game/VoiceHostRequest.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VoiceHostRequest.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._

--- a/common/src/main/scala/net/psforever/packet/game/WarpgateRequest.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WarpgateRequest.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/WeaponDelayFireMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WeaponDelayFireMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/WeaponDryFireMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WeaponDryFireMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/WeaponFireMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WeaponFireMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/WeaponJammedMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WeaponJammedMessage.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/WeaponLazeTargetPositionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/WeaponLazeTargetPositionMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/AmmoBoxData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/AmmoBoxData.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * A representation of ammunition that can be created using `ObjectCreateMessage` packet data.

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/CharacterAppearanceData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/CharacterAppearanceData.scala
@@ -1,9 +1,8 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.{Marshallable, PacketHelpers}
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldDataWithPlacement.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldDataWithPlacement.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.Codec
 import scodec.codecs._
 

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedAmmoBoxData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedAmmoBoxData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedLockerContainerData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedLockerContainerData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedWeaponData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/DetailedWeaponData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/InternalSlot.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/InternalSlot.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.PacketHelpers
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/InventoryItemData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/InventoryItemData.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 
 /**

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/MountItem.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/MountItem.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 
 /**

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectCreateBase.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/ObjectCreateBase.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.PacketHelpers
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import scodec.{Attempt, Codec, Err}
 import scodec.bits.BitVector
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/OneMannedFieldTurretData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/OneMannedFieldTurretData.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/Prefab.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/Prefab.scala
@@ -1,8 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{DriveState, PlanetSideEmpire}
+import net.psforever.types.{DriveState, PlanetSideEmpire, PlanetSideGUID}
 
 /**
   * A compilation of the common `*Data` objects that would be used for stock game objects.

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/SmallTurretData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/SmallTurretData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/TerminalData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/TerminalData.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 /**
   * A representation of an object that can be interacted with when using a variety of terminals.

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
@@ -1,13 +1,12 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.packet.game.objectcreate
 
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.{Marshallable, PacketHelpers}
 import scodec.Attempt.{Failure, Successful}
 import scodec.{Attempt, Codec, Err}
-import shapeless.HNil //note: do not import shapeless.:: here; it messes up List's :: functionality
+import shapeless.HNil
 import scodec.codecs._
-import net.psforever.types.DriveState
+import net.psforever.types.{DriveState, PlanetSideGUID}
 
 import scala.collection.mutable.ListBuffer
 

--- a/common/src/main/scala/net/psforever/packet/game/objectcreate/WeaponData.scala
+++ b/common/src/main/scala/net/psforever/packet/game/objectcreate/WeaponData.scala
@@ -2,8 +2,7 @@
 package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.Marshallable
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}

--- a/common/src/main/scala/net/psforever/types/PlanetSideGUID.scala
+++ b/common/src/main/scala/net/psforever/types/PlanetSideGUID.scala
@@ -1,9 +1,40 @@
+// Copyright (c) 2017-2019 PSForever
 package net.psforever.types
 
 import scodec.codecs.uint16L
 
-case class PlanetSideGUID(guid : Int)
+abstract class PlanetSideGUID {
+  def guid : Int
+
+  /* overriding equals and hashCode to benefit the case class subclasses through inheritance;
+   * essentially, if not for these overrides, each case class would implement its own equivalence methods
+   * */
+  /**
+    * All subclasses of `PlanetSideGUID` are equivalent through being subclasses of `PlanetSideGUID`.
+    * @param o an entity
+    * @return whether that entity is a `PlanetSideGUID` object
+    */
+  def canEqual(o : Any) : Boolean = o.isInstanceOf[PlanetSideGUID]
+
+  override def equals(o : Any) : Boolean =  o match {
+    case that : PlanetSideGUID => that.canEqual(this) && that.guid == this.guid
+    case _ => false
+  }
+
+  override def hashCode: Int = java.util.Objects.hashCode(guid)
+}
+
+final case class ValidPlanetSideGUID(guid : Int) extends PlanetSideGUID
+
+final case class StalePlanetSideGUID(guid : Int) extends PlanetSideGUID
 
 object PlanetSideGUID {
-  implicit val codec = uint16L.as[PlanetSideGUID]
+  def apply(guid : Int) : PlanetSideGUID = ValidPlanetSideGUID(guid)
+
+  def unapply(n : PlanetSideGUID) : Option[Int] = Some(n.guid)
+
+  implicit val codec = uint16L.xmap[PlanetSideGUID] (
+    n => PlanetSideGUID(n),
+    n => n.guid
+  )
 }

--- a/common/src/main/scala/net/psforever/types/PlanetSideGUID.scala
+++ b/common/src/main/scala/net/psforever/types/PlanetSideGUID.scala
@@ -1,0 +1,9 @@
+package net.psforever.types
+
+import scodec.codecs.uint16L
+
+case class PlanetSideGUID(guid : Int)
+
+object PlanetSideGUID {
+  implicit val codec = uint16L.as[PlanetSideGUID]
+}

--- a/common/src/main/scala/services/Service.scala
+++ b/common/src/main/scala/services/Service.scala
@@ -3,7 +3,7 @@ package services
 
 import akka.event.{ActorEventBus, SubchannelClassification}
 import akka.util.Subclassification
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 object Service {
   final val defaultPlayerGUID : PlanetSideGUID = PlanetSideGUID(0)

--- a/common/src/main/scala/services/avatar/AvatarService.scala
+++ b/common/src/main/scala/services/avatar/AvatarService.scala
@@ -3,8 +3,9 @@ package services.avatar
 
 import akka.actor.{Actor, ActorRef, Props}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate.{DroppedItemData, ObjectCreateMessageParent, PlacementData}
+import net.psforever.types.PlanetSideGUID
 import services.avatar.support.{CorpseRemovalActor, DroppedItemRemover}
 import services.{GenericEventBus, RemoverActor, Service}
 

--- a/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
@@ -9,9 +9,8 @@ import net.psforever.objects.inventory.Container
 import net.psforever.objects.vital.resolution.ResolutionCalculations
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.PlanetSideGamePacket
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{ConstructorData, ObjectCreateMessageParent}
-import net.psforever.types.{ExoSuitType, PlanetSideEmpire, Vector3}
+import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
@@ -7,8 +7,8 @@ import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.vital.resolution.ResolutionCalculations
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
-import net.psforever.types.{ExoSuitType, PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.ObjectCreateMessage
+import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.GenericEventBusMsg
 
 final case class AvatarServiceResponse(toChannel : String,

--- a/common/src/main/scala/services/chat/ChatAction.scala
+++ b/common/src/main/scala/services/chat/ChatAction.scala
@@ -2,8 +2,8 @@
 package services.chat
 
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{ChatMsg, PlanetSideGUID}
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.ChatMsg
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 object ChatAction {
   sealed trait Action

--- a/common/src/main/scala/services/chat/ChatResponse.scala
+++ b/common/src/main/scala/services/chat/ChatResponse.scala
@@ -1,8 +1,7 @@
 // Copyright (c) 2017 PSForever
 package services.chat
 
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.ChatMessageType
+import net.psforever.types.{ChatMessageType, PlanetSideGUID}
 
 object ChatResponse {
   sealed trait Response

--- a/common/src/main/scala/services/chat/ChatService.scala
+++ b/common/src/main/scala/services/chat/ChatService.scala
@@ -3,7 +3,7 @@ package services.chat
 
 import akka.actor.Actor
 import net.psforever.objects.LivePlayerList
-import net.psforever.packet.game.{ChatMsg, PlanetSideGUID}
+import net.psforever.packet.game.ChatMsg
 import net.psforever.types.ChatMessageType
 import services.{GenericEventBus, Service}
 

--- a/common/src/main/scala/services/chat/ChatServiceResponse.scala
+++ b/common/src/main/scala/services/chat/ChatServiceResponse.scala
@@ -2,8 +2,8 @@
 package services.chat
 
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{ChatMsg, PlanetSideGUID}
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.ChatMsg
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.GenericEventBusMsg
 
 final case class ChatServiceResponse(toChannel : String,

--- a/common/src/main/scala/services/galaxy/GalaxyServiceMessage.scala
+++ b/common/src/main/scala/services/galaxy/GalaxyServiceMessage.scala
@@ -2,7 +2,8 @@
 package services.galaxy
 
 import net.psforever.objects.Vehicle
-import net.psforever.packet.game.{BuildingInfoUpdateMessage, PlanetSideGUID}
+import net.psforever.packet.game.BuildingInfoUpdateMessage
+import net.psforever.types.PlanetSideGUID
 
 final case class GalaxyServiceMessage(forChannel : String, actionMessage : GalaxyAction.Action)
 

--- a/common/src/main/scala/services/galaxy/GalaxyServiceResponse.scala
+++ b/common/src/main/scala/services/galaxy/GalaxyServiceResponse.scala
@@ -3,7 +3,8 @@ package services.galaxy
 
 import net.psforever.objects.Vehicle
 import net.psforever.objects.zones.HotSpotInfo
-import net.psforever.packet.game.{BuildingInfoUpdateMessage, PlanetSideGUID}
+import net.psforever.packet.game.BuildingInfoUpdateMessage
+import net.psforever.types.PlanetSideGUID
 import services.GenericEventBusMsg
 
 final case class GalaxyServiceResponse(toChannel : String,

--- a/common/src/main/scala/services/local/LocalService.scala
+++ b/common/src/main/scala/services/local/LocalService.scala
@@ -7,9 +7,9 @@ import net.psforever.objects.serverobject.structures.{Amenity, Building}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, Terminal}
 import net.psforever.objects.zones.Zone
 import net.psforever.objects._
-import net.psforever.packet.game.{PlanetSideGUID, TriggeredEffect, TriggeredEffectLocation}
+import net.psforever.packet.game.{TriggeredEffect, TriggeredEffectLocation}
 import net.psforever.objects.vital.Vitality
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import services.local.support._
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 import services.{GenericEventBus, RemoverActor, Service}

--- a/common/src/main/scala/services/local/LocalServiceMessage.scala
+++ b/common/src/main/scala/services/local/LocalServiceMessage.scala
@@ -9,8 +9,8 @@ import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.serverobject.terminals.CaptureTerminal
 import net.psforever.objects.vehicles.Utility
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{DeployableInfo, DeploymentAction, PlanetSideGUID, TriggeredSound}
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.{DeployableInfo, DeploymentAction, TriggeredSound}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 final case class LocalServiceMessage(forChannel : String, actionMessage : LocalAction.Action)
 

--- a/common/src/main/scala/services/local/LocalServiceResponse.scala
+++ b/common/src/main/scala/services/local/LocalServiceResponse.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.ce.Deployable
 import net.psforever.objects.serverobject.terminals.{ProximityUnit, Terminal}
 import net.psforever.objects.vehicles.Utility
 import net.psforever.packet.game._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.GenericEventBusMsg
 
 final case class LocalServiceResponse(toChannel : String,

--- a/common/src/main/scala/services/local/support/DeployableRemover.scala
+++ b/common/src/main/scala/services/local/support/DeployableRemover.scala
@@ -5,8 +5,7 @@ import net.psforever.objects.ce.Deployable
 import net.psforever.objects.guid.{GUIDTask, TaskResolver}
 import net.psforever.objects.zones.Zone
 import net.psforever.objects.{BoomerDeployable, PlanetSideGameObject, TurretDeployable}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import services.RemoverActor
 
 import scala.concurrent.duration._

--- a/common/src/main/scala/services/local/support/DoorCloseActor.scala
+++ b/common/src/main/scala/services/local/support/DoorCloseActor.scala
@@ -5,8 +5,7 @@ import akka.actor.{Actor, Cancellable}
 import net.psforever.objects.DefaultCancellable
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._

--- a/common/src/main/scala/services/local/support/HackCaptureActor.scala
+++ b/common/src/main/scala/services/local/support/HackCaptureActor.scala
@@ -7,8 +7,7 @@ import net.psforever.objects.serverobject.structures.Building
 import net.psforever.objects.serverobject.terminals.CaptureTerminal
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.concurrent.duration.{FiniteDuration, _}
 

--- a/common/src/main/scala/services/local/support/HackClearActor.scala
+++ b/common/src/main/scala/services/local/support/HackClearActor.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.DefaultCancellable
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._

--- a/common/src/main/scala/services/teamwork/SquadServiceMessage.scala
+++ b/common/src/main/scala/services/teamwork/SquadServiceMessage.scala
@@ -3,8 +3,8 @@ package services.teamwork
 
 import net.psforever.objects.Player
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{PlanetSideGUID, SquadAction => PacketSquadAction, WaypointEventAction, WaypointInfo}
-import net.psforever.types.{SquadRequestType, SquadWaypoints, Vector3}
+import net.psforever.packet.game.{WaypointEventAction, WaypointInfo, SquadAction => PacketSquadAction}
+import net.psforever.types.{PlanetSideGUID, SquadRequestType, SquadWaypoints, Vector3}
 
 final case class SquadServiceMessage(tplayer : Player, zone : Zone, actionMessage : Any)
 

--- a/common/src/main/scala/services/teamwork/SquadServiceResponse.scala
+++ b/common/src/main/scala/services/teamwork/SquadServiceResponse.scala
@@ -3,7 +3,7 @@ package services.teamwork
 
 import net.psforever.objects.teamwork.Squad
 import net.psforever.packet.game._
-import net.psforever.types.{SquadResponseType, SquadWaypoints}
+import net.psforever.types.{PlanetSideGUID, SquadResponseType, SquadWaypoints}
 import services.GenericEventBusMsg
 
 final case class SquadServiceResponse(toChannel : String, exclude : Iterable[Long], response : SquadResponse.Response) extends GenericEventBusMsg

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -9,10 +9,10 @@ import net.psforever.objects.serverobject.terminals.{MedicalTerminalDefinition, 
 import net.psforever.objects.vehicles.{Utility, UtilityType}
 import net.psforever.objects.vital.RepairFromTerm
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate.ObjectCreateMessageParent
 import services.vehicle.support.{TurretUpgrader, VehicleRemover}
-import net.psforever.types.DriveState
+import net.psforever.types.{DriveState, PlanetSideGUID}
 import services.local.LocalServiceMessage
 import services.{GenericEventBus, RemoverActor, Service}
 

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -5,9 +5,8 @@ import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.PlanetSideGamePacket
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.types.{BailType, DriveState, Vector3}
+import net.psforever.types.{BailType, DriveState, PlanetSideGUID, Vector3}
 
 final case class VehicleServiceMessage(forChannel : String, actionMessage : VehicleAction.Action)
 

--- a/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
@@ -7,8 +7,8 @@ import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
-import net.psforever.types.{BailType, DriveState, Vector3}
+import net.psforever.packet.game.ObjectCreateMessage
+import net.psforever.types.{BailType, DriveState, PlanetSideGUID, Vector3}
 import services.GenericEventBusMsg
 
 final case class VehicleServiceResponse(toChannel : String,

--- a/common/src/main/scala/services/vehicle/support/TurretUpgrader.scala
+++ b/common/src/main/scala/services/vehicle/support/TurretUpgrader.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
 import net.psforever.objects.serverobject.turret.{FacilityTurret, TurretUpgrade}
 import net.psforever.objects.vehicles.MountedWeapons
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.support.{SimilarityComparator, SupportActor, SupportActorCaseConversions}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 import services.{Service, ServiceManager}

--- a/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
+++ b/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
@@ -4,8 +4,7 @@ package services.vehicle.support
 import net.psforever.objects.Vehicle
 import net.psforever.objects.guid.{GUIDTask, TaskResolver}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.DriveState
+import net.psforever.types.{DriveState, PlanetSideGUID}
 import services.{RemoverActor, Service}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 

--- a/common/src/test/scala/control/MultiPacketCollectorTest.scala
+++ b/common/src/test/scala/control/MultiPacketCollectorTest.scala
@@ -4,7 +4,8 @@ package control
 import org.specs2.mutable._
 import net.psforever.packet.control.{ControlSync, MultiPacketBundle, MultiPacketCollector}
 import net.psforever.packet.crypto.{ClientFinished, ServerFinished}
-import net.psforever.packet.game.{ObjectDeleteMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectDeleteMessage
+import net.psforever.types.PlanetSideGUID
 
 class MultiPacketCollectorTest extends Specification {
   val packet1 = ObjectDeleteMessage(PlanetSideGUID(1103), 2)

--- a/common/src/test/scala/game/ActionCancelMessageTest.scala
+++ b/common/src/test/scala/game/ActionCancelMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ActionCancelMessageTest extends Specification {

--- a/common/src/test/scala/game/ArmorChangedMessageTest.scala
+++ b/common/src/test/scala/game/ArmorChangedMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.ExoSuitType
+import net.psforever.types.{ExoSuitType, PlanetSideGUID}
 import scodec.bits._
 
 class ArmorChangedMessageTest extends Specification {

--- a/common/src/test/scala/game/AvatarFirstTimeEventMessageTest.scala
+++ b/common/src/test/scala/game/AvatarFirstTimeEventMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class AvatarFirstTimeEventMessageTest extends Specification {

--- a/common/src/test/scala/game/AvatarGrenadeStateMessageTest.scala
+++ b/common/src/test/scala/game/AvatarGrenadeStateMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.GrenadeState
+import net.psforever.types.{GrenadeState, PlanetSideGUID}
 import scodec.bits._
 
 class AvatarGrenadeStateMessageTest extends Specification {

--- a/common/src/test/scala/game/AvatarImplantMessageTest.scala
+++ b/common/src/test/scala/game/AvatarImplantMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class AvatarImplantMessageTest extends Specification {

--- a/common/src/test/scala/game/AvatarSearchCriteriaMessageTest.scala
+++ b/common/src/test/scala/game/AvatarSearchCriteriaMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class AvatarSearchCriteriaMessageTest extends Specification {

--- a/common/src/test/scala/game/AvatarVehicleTimerMessageTest.scala
+++ b/common/src/test/scala/game/AvatarVehicleTimerMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class AvatarVehicleTimerMessageTest extends Specification {

--- a/common/src/test/scala/game/BattleExperienceMessageTest.scala
+++ b/common/src/test/scala/game/BattleExperienceMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class BattleExperienceMessageTest extends Specification {

--- a/common/src/test/scala/game/ChangeAmmoMessageTest.scala
+++ b/common/src/test/scala/game/ChangeAmmoMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChangeAmmoMessageTest extends Specification {

--- a/common/src/test/scala/game/ChangeFireModeMessageTest.scala
+++ b/common/src/test/scala/game/ChangeFireModeMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChangeFireModeMessageTest extends Specification {

--- a/common/src/test/scala/game/ChangeFireStateMessage_StartTest.scala
+++ b/common/src/test/scala/game/ChangeFireStateMessage_StartTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChangeFireStateMessage_StartTest extends Specification {

--- a/common/src/test/scala/game/ChangeFireStateMessage_StopTest.scala
+++ b/common/src/test/scala/game/ChangeFireStateMessage_StopTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChangeFireStateMessage_StopTest extends Specification {

--- a/common/src/test/scala/game/ChangeShortcutBankMessageTest.scala
+++ b/common/src/test/scala/game/ChangeShortcutBankMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChangeShortcutBankMessageTest extends Specification {

--- a/common/src/test/scala/game/CharacterInfoMessageTest.scala
+++ b/common/src/test/scala/game/CharacterInfoMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class CharacterInfoMessageTest extends Specification {

--- a/common/src/test/scala/game/CharacterKnowledgeMessageTest.scala
+++ b/common/src/test/scala/game/CharacterKnowledgeMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import scodec.bits._
 
 class CharacterKnowledgeMessageTest extends Specification {

--- a/common/src/test/scala/game/ChildObjectStateMessageTest.scala
+++ b/common/src/test/scala/game/ChildObjectStateMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ChildObjectStateMessageTest extends Specification {

--- a/common/src/test/scala/game/CreateShortcutMessageTest.scala
+++ b/common/src/test/scala/game/CreateShortcutMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class CreateShortcutMessageTest extends Specification {

--- a/common/src/test/scala/game/DamageFeedbackMessageTest.scala
+++ b/common/src/test/scala/game/DamageFeedbackMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DamageFeedbackMessageTest extends Specification {

--- a/common/src/test/scala/game/DamageMessageTest.scala
+++ b/common/src/test/scala/game/DamageMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DamageMessageTest extends Specification {

--- a/common/src/test/scala/game/DelayedPathMountMsgTest.scala
+++ b/common/src/test/scala/game/DelayedPathMountMsgTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DelayedPathMountMsgTest extends Specification {

--- a/common/src/test/scala/game/DeployObjectMessageTest.scala
+++ b/common/src/test/scala/game/DeployObjectMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class DeployObjectMessageTest extends Specification {

--- a/common/src/test/scala/game/DeployRequestMessageTest.scala
+++ b/common/src/test/scala/game/DeployRequestMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.{DriveState, Vector3}
+import net.psforever.types.{DriveState, PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class DeployRequestMessageTest extends Specification {

--- a/common/src/test/scala/game/DeployableObjectsInfoMessageTest.scala
+++ b/common/src/test/scala/game/DeployableObjectsInfoMessageTest.scala
@@ -3,8 +3,8 @@ package game
 
 import org.specs2.mutable._
 import net.psforever.packet._
-import net.psforever.packet.game.{PlanetSideGUID, DeploymentAction, DeployableIcon, DeployableInfo, DeployableObjectsInfoMessage}
-import net.psforever.types.Vector3
+import net.psforever.packet.game.{DeployableIcon, DeployableInfo, DeployableObjectsInfoMessage, DeploymentAction}
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class DeployableObjectsInfoMessageTest extends Specification {

--- a/common/src/test/scala/game/DestroyMessageTest.scala
+++ b/common/src/test/scala/game/DestroyMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class DestroyMessageTest extends Specification {

--- a/common/src/test/scala/game/DismountBuildingMsgTest.scala
+++ b/common/src/test/scala/game/DismountBuildingMsgTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DismountBuildingMsgTest extends Specification {

--- a/common/src/test/scala/game/DismountVehicleMsgTest.scala
+++ b/common/src/test/scala/game/DismountVehicleMsgTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
 import scodec.bits._
-import net.psforever.types.BailType
+import net.psforever.types.{BailType, PlanetSideGUID}
 
 class DismountVehicleMsgTest extends Specification {
   val string = hex"0F C609 00"

--- a/common/src/test/scala/game/DisplayedAwardMessageTest.scala
+++ b/common/src/test/scala/game/DisplayedAwardMessageTest.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package game
 
-import net.psforever.types.MeritCommendation
+import net.psforever.types.{MeritCommendation, PlanetSideGUID}
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._

--- a/common/src/test/scala/game/DropItemMessageTest.scala
+++ b/common/src/test/scala/game/DropItemMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DropItemMessageTest extends Specification {

--- a/common/src/test/scala/game/EmoteMsgTest.scala
+++ b/common/src/test/scala/game/EmoteMsgTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.EmoteType
+import net.psforever.types.{EmoteType, PlanetSideGUID}
 import scodec.bits._
 
 class EmoteMsgTest extends Specification {

--- a/common/src/test/scala/game/FacilityBenefitShieldChargeRequestMessageTest.scala
+++ b/common/src/test/scala/game/FacilityBenefitShieldChargeRequestMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class FacilityBenefitShieldChargeRequestMessageTest extends Specification {

--- a/common/src/test/scala/game/FavoritesMessageTest.scala
+++ b/common/src/test/scala/game/FavoritesMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.LoadoutType
+import net.psforever.types.{LoadoutType, PlanetSideGUID}
 import scodec.bits._
 
 class FavoritesMessageTest extends Specification {

--- a/common/src/test/scala/game/FavoritesRequestTest.scala
+++ b/common/src/test/scala/game/FavoritesRequestTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.LoadoutType
+import net.psforever.types.{LoadoutType, PlanetSideGUID}
 import scodec.bits._
 
 class FavoritesRequestTest extends Specification {

--- a/common/src/test/scala/game/FireHintMessageTest.scala
+++ b/common/src/test/scala/game/FireHintMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class FireHintMessageTest extends Specification {

--- a/common/src/test/scala/game/GenericCollisionMsgTest.scala
+++ b/common/src/test/scala/game/GenericCollisionMsgTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class GenericCollisionMsgTest extends Specification {

--- a/common/src/test/scala/game/GenericObjectActionMessageTest.scala
+++ b/common/src/test/scala/game/GenericObjectActionMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class GenericObjectActionMessageTest extends Specification {

--- a/common/src/test/scala/game/GenericObjectStateMsgTest.scala
+++ b/common/src/test/scala/game/GenericObjectStateMsgTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class GenericObjectStateMsgTest extends Specification {

--- a/common/src/test/scala/game/HackMessageTest.scala
+++ b/common/src/test/scala/game/HackMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class HackMessageTest extends Specification {

--- a/common/src/test/scala/game/HitHintTest.scala
+++ b/common/src/test/scala/game/HitHintTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class HitHintTest extends Specification {

--- a/common/src/test/scala/game/HitMessageTest.scala
+++ b/common/src/test/scala/game/HitMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class HitMessageTest extends Specification {

--- a/common/src/test/scala/game/InventoryStateMessageTest.scala
+++ b/common/src/test/scala/game/InventoryStateMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class InventoryStateMessageTest extends Specification {

--- a/common/src/test/scala/game/ItemTransactionMessageTest.scala
+++ b/common/src/test/scala/game/ItemTransactionMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.TransactionType
+import net.psforever.types.{PlanetSideGUID, TransactionType}
 import scodec.bits._
 
 class ItemTransactionMessageTest extends Specification {

--- a/common/src/test/scala/game/ItemTransactionResultMessageTest.scala
+++ b/common/src/test/scala/game/ItemTransactionResultMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.TransactionType
+import net.psforever.types.{PlanetSideGUID, TransactionType}
 import scodec.bits._
 
 class ItemTransactionResultMessageTest extends Specification {

--- a/common/src/test/scala/game/LashMessageTest.scala
+++ b/common/src/test/scala/game/LashMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class LashMessageTest extends Specification {

--- a/common/src/test/scala/game/LootItemMessageTest.scala
+++ b/common/src/test/scala/game/LootItemMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class LootItemMessageTest extends Specification {

--- a/common/src/test/scala/game/MountVehicleMsgTest.scala
+++ b/common/src/test/scala/game/MountVehicleMsgTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class MountVehicleMsgTest extends Specification {

--- a/common/src/test/scala/game/MoveItemMessageTest.scala
+++ b/common/src/test/scala/game/MoveItemMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class MoveItemMessageTest extends Specification {

--- a/common/src/test/scala/game/ObjectAttachMessageTest.scala
+++ b/common/src/test/scala/game/ObjectAttachMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ObjectAttachMessageTest extends Specification {

--- a/common/src/test/scala/game/ObjectDeleteMessageTest.scala
+++ b/common/src/test/scala/game/ObjectDeleteMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ObjectDeleteMessageTest extends Specification {

--- a/common/src/test/scala/game/ObjectDetachMessageTest.scala
+++ b/common/src/test/scala/game/ObjectDetachMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class ObjectDetachMessageTest extends Specification {

--- a/common/src/test/scala/game/ObjectDetectedMessageTest.scala
+++ b/common/src/test/scala/game/ObjectDetectedMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ObjectDetectedMessageTest extends Specification {

--- a/common/src/test/scala/game/ObjectHeldMessageTest.scala
+++ b/common/src/test/scala/game/ObjectHeldMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ObjectHeldMessageTest extends Specification {

--- a/common/src/test/scala/game/OrbitalStrikeWaypointMessageTest.scala
+++ b/common/src/test/scala/game/OrbitalStrikeWaypointMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class OrbitalStrikeWaypointMessageTest extends Specification {

--- a/common/src/test/scala/game/OxygenStateMessageTest.scala
+++ b/common/src/test/scala/game/OxygenStateMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class OxygenStateMessageTest extends Specification {

--- a/common/src/test/scala/game/PickupItemMessageTest.scala
+++ b/common/src/test/scala/game/PickupItemMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class PickupItemMessageTest extends Specification {

--- a/common/src/test/scala/game/PlanetsideAttributeMessageTest.scala
+++ b/common/src/test/scala/game/PlanetsideAttributeMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable.Specification
 import net.psforever.packet.PacketCoding
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class PlanetsideAttributeMessageTest extends Specification {

--- a/common/src/test/scala/game/PlanetsideStringAttributeMessageTest.scala
+++ b/common/src/test/scala/game/PlanetsideStringAttributeMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable.Specification
 import net.psforever.packet.PacketCoding
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class PlanetsideStringAttributeMessageTest extends Specification {

--- a/common/src/test/scala/game/PlayerStasisMessageTest.scala
+++ b/common/src/test/scala/game/PlayerStasisMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class PlayerStasisMessageTest extends Specification {

--- a/common/src/test/scala/game/PlayerStateMessageUpstreamTest.scala
+++ b/common/src/test/scala/game/PlayerStateMessageUpstreamTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class PlayerStateMessageUpstreamTest extends Specification {

--- a/common/src/test/scala/game/ProjectileStateMessageTest.scala
+++ b/common/src/test/scala/game/ProjectileStateMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class ProjectileStateMessageTest extends Specification {

--- a/common/src/test/scala/game/ProximityTerminalUseMessageTest.scala
+++ b/common/src/test/scala/game/ProximityTerminalUseMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ProximityTerminalUseMessageTest extends Specification {

--- a/common/src/test/scala/game/QuantityDeltaUpdateMessageTest.scala
+++ b/common/src/test/scala/game/QuantityDeltaUpdateMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class QuantityDeltaUpdateMessageTest extends Specification {

--- a/common/src/test/scala/game/QuantityUpdateMessageTest.scala
+++ b/common/src/test/scala/game/QuantityUpdateMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class QuantityUpdateMessageTest extends Specification {

--- a/common/src/test/scala/game/ReloadMessageTest.scala
+++ b/common/src/test/scala/game/ReloadMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ReloadMessageTest extends Specification {

--- a/common/src/test/scala/game/RepairMessageTest.scala
+++ b/common/src/test/scala/game/RepairMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class RepairMessageTest extends Specification {

--- a/common/src/test/scala/game/ReplicationStreamMessageTest.scala
+++ b/common/src/test/scala/game/ReplicationStreamMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class ReplicationStreamMessageTest extends Specification {

--- a/common/src/test/scala/game/RequestDestroyMessageTest.scala
+++ b/common/src/test/scala/game/RequestDestroyMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class RequestDestroyMessageTest extends Specification {

--- a/common/src/test/scala/game/SetEmpireMessageTest.scala
+++ b/common/src/test/scala/game/SetEmpireMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.bits._
 
 class SetEmpireMessageTest extends Specification {

--- a/common/src/test/scala/game/SplashHitMessageTest.scala
+++ b/common/src/test/scala/game/SplashHitMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class SplashHitMessageTest extends Specification {

--- a/common/src/test/scala/game/SquadDefinitionActionMessageTest.scala
+++ b/common/src/test/scala/game/SquadDefinitionActionMessageTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.SquadAction._
 import net.psforever.packet.game._
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import scodec.bits._
 
 class SquadDefinitionActionMessageTest extends Specification {

--- a/common/src/test/scala/game/SquadDetailDefinitionUpdateMessageTest.scala
+++ b/common/src/test/scala/game/SquadDetailDefinitionUpdateMessageTest.scala
@@ -3,7 +3,7 @@ package game
 
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/SquadStateTest.scala
+++ b/common/src/test/scala/game/SquadStateTest.scala
@@ -3,7 +3,7 @@ package game
 
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/TargetingImplantRequestTest.scala
+++ b/common/src/test/scala/game/TargetingImplantRequestTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class TargetingImplantRequestTest extends Specification {

--- a/common/src/test/scala/game/TargetingInfoMessageTest.scala
+++ b/common/src/test/scala/game/TargetingInfoMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class TargetingInfoMessageTest extends Specification {

--- a/common/src/test/scala/game/TrainingZoneMessageTest.scala
+++ b/common/src/test/scala/game/TrainingZoneMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class TrainingZoneMessageTest extends Specification {

--- a/common/src/test/scala/game/TriggerEffectMessageTest.scala
+++ b/common/src/test/scala/game/TriggerEffectMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class TriggerEffectMessageTest extends Specification {

--- a/common/src/test/scala/game/TriggerEnvironmentalDamageMessageTest.scala
+++ b/common/src/test/scala/game/TriggerEnvironmentalDamageMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class TriggerEnvironmentalDamageMessageTest extends Specification {

--- a/common/src/test/scala/game/UnuseItemMessageTest.scala
+++ b/common/src/test/scala/game/UnuseItemMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class UnuseItemMessageTest extends Specification {

--- a/common/src/test/scala/game/UseItemMessageTest.scala
+++ b/common/src/test/scala/game/UseItemMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class UseItemMessageTest extends Specification {

--- a/common/src/test/scala/game/VehicleStateMessageTest.scala
+++ b/common/src/test/scala/game/VehicleStateMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class VehicleStateMessageTest extends Specification {

--- a/common/src/test/scala/game/VehicleSubStateMessageTest.scala
+++ b/common/src/test/scala/game/VehicleSubStateMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class VehicleSubStateMessageTest extends Specification {

--- a/common/src/test/scala/game/VoiceHostInfoTest.scala
+++ b/common/src/test/scala/game/VoiceHostInfoTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class VoiceHostInfoTest extends Specification {

--- a/common/src/test/scala/game/VoiceHostRequestTest.scala
+++ b/common/src/test/scala/game/VoiceHostRequestTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class VoiceHostRequestTest extends Specification {

--- a/common/src/test/scala/game/WarpgateRequestTest.scala
+++ b/common/src/test/scala/game/WarpgateRequestTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class WarpgateRequestTest extends Specification {

--- a/common/src/test/scala/game/WeaponDelayFireMessageTest.scala
+++ b/common/src/test/scala/game/WeaponDelayFireMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class WeaponDelayFireMessageTest extends Specification {

--- a/common/src/test/scala/game/WeaponDryFireMessageTest.scala
+++ b/common/src/test/scala/game/WeaponDryFireMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class WeaponDryFireMessageTest extends Specification {

--- a/common/src/test/scala/game/WeaponFireMessageTest.scala
+++ b/common/src/test/scala/game/WeaponFireMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class WeaponFireMessageTest extends Specification {

--- a/common/src/test/scala/game/WeaponJammedMessageTest.scala
+++ b/common/src/test/scala/game/WeaponJammedMessageTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class WeaponJammedMessageTest extends Specification {

--- a/common/src/test/scala/game/WeaponLazeTargetPositionMessageTest.scala
+++ b/common/src/test/scala/game/WeaponLazeTargetPositionMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class WeaponLazeTargetPositionMessageTest extends Specification {

--- a/common/src/test/scala/game/ZipLineMessageTest.scala
+++ b/common/src/test/scala/game/ZipLineMessageTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import scodec.bits._
 
 class ZipLineMessageTest extends Specification {

--- a/common/src/test/scala/game/objectcreate/AegisShieldGeneratorDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/AegisShieldGeneratorDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/CaptureFlagDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/CaptureFlagDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/CharacterDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/CharacterDataTest.scala
@@ -2,7 +2,7 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
 import net.psforever.types._
 import org.specs2.mutable._

--- a/common/src/test/scala/game/objectcreate/CommonFieldDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/CommonFieldDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable.Specification
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/CommonFieldDataWithPlacementTest.scala
+++ b/common/src/test/scala/game/objectcreate/CommonFieldDataWithPlacementTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/HandheldDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/HandheldDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/LockerContainerDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/LockerContainerDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/OneMannedFieldTurretDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/OneMannedFieldTurretDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/REKDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/REKDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/RemoteProjectileDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/RemoteProjectileDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/SmallTurretDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/SmallTurretDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/TRAPDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/TRAPDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/TelepadDeployableDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/TelepadDeployableDataTest.scala
@@ -4,7 +4,7 @@ package game.objectcreate
 import net.psforever.packet._
 import net.psforever.packet.game._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreate/WeaponDataTest.scala
+++ b/common/src/test/scala/game/objectcreate/WeaponDataTest.scala
@@ -2,9 +2,9 @@
 package game.objectcreate
 
 import net.psforever.packet.PacketCoding
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedAmmoBoxDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedAmmoBoxDataTest.scala
@@ -5,6 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.{ObjectCreateDetailedMessage, _}
 import net.psforever.packet.game.objectcreate._
+import net.psforever.types.PlanetSideGUID
 import scodec.bits._
 
 class DetailedAmmoBoxDataTest extends Specification {

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedCommandDetonaterDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedCommandDetonaterDataTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.{ObjectCreateDetailedMessage, _}
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.bits._
 
 class DetailedCommandDetonaterDataTest extends Specification {

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedConstructionToolDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedConstructionToolDataTest.scala
@@ -4,7 +4,7 @@ package game.objectcreatedetailed
 import net.psforever.packet._
 import net.psforever.packet.game._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedREKDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedREKDataTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.{ObjectCreateDetailedMessage, _}
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.bits._
 
 class DetailedREKDataTest extends Specification {

--- a/common/src/test/scala/game/objectcreatedetailed/DetailedWeaponDataTest.scala
+++ b/common/src/test/scala/game/objectcreatedetailed/DetailedWeaponDataTest.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.{ObjectCreateDetailedMessage, _}
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import scodec.bits._
 
 class DetailedWeaponDataTest extends Specification {

--- a/common/src/test/scala/game/objectcreatevehicle/DestroyedVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/DestroyedVehiclesTest.scala
@@ -3,7 +3,8 @@ package game.objectcreatevehicle
 
 import net.psforever.packet._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
 import scodec.bits._
 

--- a/common/src/test/scala/game/objectcreatevehicle/MountedVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/MountedVehiclesTest.scala
@@ -3,7 +3,7 @@ package game.objectcreatevehicle
 
 import net.psforever.packet._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.types._
 import org.specs2.mutable._
 import scodec.bits._

--- a/common/src/test/scala/game/objectcreatevehicle/NonstandardVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/NonstandardVehiclesTest.scala
@@ -3,7 +3,7 @@ package game.objectcreatevehicle
 
 import net.psforever.packet._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.types._
 import org.specs2.mutable._
 import scodec.bits._

--- a/common/src/test/scala/game/objectcreatevehicle/NormalVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/NormalVehiclesTest.scala
@@ -3,7 +3,7 @@ package game.objectcreatevehicle
 
 import net.psforever.packet._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.types._
 import org.specs2.mutable._
 import scodec.bits._

--- a/common/src/test/scala/game/objectcreatevehicle/UtilityVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/UtilityVehiclesTest.scala
@@ -3,7 +3,7 @@ package game.objectcreatevehicle
 
 import net.psforever.packet._
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.types._
 import org.specs2.mutable._
 import scodec.bits._

--- a/common/src/test/scala/game/objectcreatevehicle/VariantVehiclesTest.scala
+++ b/common/src/test/scala/game/objectcreatevehicle/VariantVehiclesTest.scala
@@ -2,7 +2,7 @@
 package game.objectcreatevehicle
 
 import net.psforever.packet._
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID}
+import net.psforever.packet.game.ObjectCreateMessage
 import net.psforever.packet.game.objectcreate._
 import net.psforever.types._
 import org.specs2.mutable._

--- a/common/src/test/scala/objects/BuildingTest.scala
+++ b/common/src/test/scala/objects/BuildingTest.scala
@@ -9,8 +9,7 @@ import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.serverobject.doors.{Door, DoorControl}
 import net.psforever.objects.serverobject.structures._
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.PlanetSideEmpire
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable.Specification
 import services.ServiceManager
 import services.galaxy.GalaxyService

--- a/common/src/test/scala/objects/ContainerTest.scala
+++ b/common/src/test/scala/objects/ContainerTest.scala
@@ -4,7 +4,7 @@ package objects
 import net.psforever.objects.equipment.{EquipmentSize, EquipmentSlot}
 import net.psforever.objects.inventory.{Container, GridInventory, InventoryEquipmentSlot}
 import net.psforever.objects.{GlobalDefinitions, OffhandEquipmentSlot, Tool}
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
 
 import scala.util.Success

--- a/common/src/test/scala/objects/ConverterTest.scala
+++ b/common/src/test/scala/objects/ConverterTest.scala
@@ -9,9 +9,8 @@ import net.psforever.objects.inventory.InventoryTile
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects.vehicles.UtilityType
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate._
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+import net.psforever.types._
 import org.specs2.mutable.Specification
 
 import scala.util.{Failure, Success}

--- a/common/src/test/scala/objects/DeployableTest.scala
+++ b/common/src/test/scala/objects/DeployableTest.scala
@@ -6,8 +6,7 @@ import base.ActorTest
 import net.psforever.objects.ce.DeployedItem
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.{TurretDeployable, _}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable.Specification
 
 import scala.concurrent.duration._

--- a/common/src/test/scala/objects/DeployableTest.scala
+++ b/common/src/test/scala/objects/DeployableTest.scala
@@ -15,16 +15,16 @@ class DeployableTest extends Specification {
   "Deployable" should {
     "know its owner by GUID" in {
       val obj = new ExplosiveDeployable(GlobalDefinitions.he_mine)
-      obj.Owner mustEqual None
+      obj.Owner.isEmpty mustEqual true
       obj.Owner = PlanetSideGUID(10)
-      obj.Owner mustEqual Some(PlanetSideGUID(10))
+      obj.Owner.contains(PlanetSideGUID(10)) mustEqual true
     }
 
     "know its owner by GUID" in {
       val obj = new ExplosiveDeployable(GlobalDefinitions.he_mine)
-      obj.OwnerName mustEqual None
+      obj.OwnerName.isEmpty mustEqual true
       obj.OwnerName = "TestCharacter"
-      obj.OwnerName mustEqual Some("TestCharacter")
+      obj.OwnerName.contains("TestCharacter") mustEqual true
     }
 
     "know its faction allegiance" in {
@@ -66,7 +66,7 @@ class BoomerDeployableTest extends Specification {
     "construct" in {
       val obj = new BoomerDeployable(GlobalDefinitions.boomer)
       obj.Exploded mustEqual false
-      obj.Trigger mustEqual None
+      obj.Trigger.isEmpty mustEqual true
     }
 
     "explode" in {
@@ -78,14 +78,14 @@ class BoomerDeployableTest extends Specification {
 
     "manage its trigger" in {
       val obj = new BoomerDeployable(GlobalDefinitions.boomer)
-      obj.Trigger mustEqual None
+      obj.Trigger.isEmpty mustEqual true
 
       val trigger = new BoomerTrigger
       obj.Trigger = trigger
-      obj.Trigger mustEqual Some(trigger)
+      obj.Trigger.contains(trigger) mustEqual true
 
       obj.Trigger = None
-      obj.Trigger mustEqual None
+      obj.Trigger.isEmpty mustEqual true
     }
   }
 }
@@ -322,7 +322,7 @@ class TelepadDeployableTest extends Specification {
     "construct" in {
       val obj = new Telepad(GlobalDefinitions.router_telepad)
       obj.Active mustEqual false
-      obj.Router mustEqual None
+      obj.Router.isEmpty mustEqual true
     }
 
     "activate and deactivate" in {
@@ -336,15 +336,15 @@ class TelepadDeployableTest extends Specification {
 
     "keep track of a Router" in {
       val obj = new Telepad(GlobalDefinitions.router_telepad)
-      obj.Router mustEqual None
+      obj.Router.isEmpty mustEqual true
       obj.Router = PlanetSideGUID(1)
-      obj.Router mustEqual Some(PlanetSideGUID(1))
+      obj.Router.contains(PlanetSideGUID(1)) mustEqual true
       obj.Router = None
-      obj.Router mustEqual None
+      obj.Router.isEmpty mustEqual true
       obj.Router = PlanetSideGUID(1)
-      obj.Router mustEqual Some(PlanetSideGUID(1))
+      obj.Router.contains(PlanetSideGUID(1)) mustEqual true
       obj.Router = PlanetSideGUID(0)
-      obj.Router mustEqual None
+      obj.Router.isEmpty mustEqual true
     }
   }
 }

--- a/common/src/test/scala/objects/DeployableToolboxTest.scala
+++ b/common/src/test/scala/objects/DeployableToolboxTest.scala
@@ -4,8 +4,8 @@ package objects
 import net.psforever.objects._
 import net.psforever.objects.avatar.DeployableToolbox
 import net.psforever.objects.ce.{DeployableCategory, DeployedItem}
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.types.CertificationType._
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable.Specification
 
 class DeployableToolboxTest extends Specification {

--- a/common/src/test/scala/objects/DoorTest.scala
+++ b/common/src/test/scala/objects/DoorTest.scala
@@ -7,8 +7,8 @@ import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
 import net.psforever.objects.serverobject.doors.{Door, DoorControl}
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{PlanetSideGUID, UseItemMessage}
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.UseItemMessage
+import net.psforever.types._
 import org.specs2.mutable.Specification
 
 import scala.concurrent.duration.Duration

--- a/common/src/test/scala/objects/EntityTest.scala
+++ b/common/src/test/scala/objects/EntityTest.scala
@@ -4,8 +4,7 @@ package objects
 import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.definition.ObjectDefinition
 import net.psforever.objects.entity.NoGUIDException
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 import org.specs2.mutable._
 
 class EntityTest extends Specification {

--- a/common/src/test/scala/objects/EntityTest.scala
+++ b/common/src/test/scala/objects/EntityTest.scala
@@ -106,14 +106,16 @@ class EntityTest extends Specification {
       ok
     }
 
-    "error while unset" in {
+    "error while not set" in {
       val obj : EntityTestClass = new EntityTestClass
+      obj.HasGUID mustEqual false
       obj.GUID must throwA[NoGUIDException]
     }
 
     "work after mutation" in {
       val obj : EntityTestClass = new EntityTestClass
       obj.GUID = PlanetSideGUID(1051)
+      obj.HasGUID mustEqual true
       obj.GUID mustEqual PlanetSideGUID(1051)
     }
 
@@ -127,12 +129,43 @@ class EntityTest extends Specification {
       obj.GUID mustEqual PlanetSideGUID(62)
     }
 
-    "invalidate and resume error" in {
+    "invalidate and report as not having a GUID, but continue to work" in {
       val obj : EntityTestClass = new EntityTestClass
       obj.GUID = PlanetSideGUID(1051)
+      obj.HasGUID mustEqual true
       obj.GUID mustEqual PlanetSideGUID(1051)
       obj.Invalidate()
-      obj.GUID must throwA[NoGUIDException]
+      obj.HasGUID mustEqual false
+      obj.GUID mustEqual PlanetSideGUID(1051)
+    }
+
+    "assign a new GUID after invalidation and continue to work" in {
+      val obj : EntityTestClass = new EntityTestClass
+      obj.GUID = PlanetSideGUID(1051)
+      obj.HasGUID mustEqual true
+      obj.GUID mustEqual PlanetSideGUID(1051)
+      obj.Invalidate()
+      obj.GUID mustEqual PlanetSideGUID(1051)
+      obj.HasGUID mustEqual false
+
+      obj.GUID = PlanetSideGUID(1052)
+      obj.HasGUID mustEqual true
+      obj.GUID mustEqual PlanetSideGUID(1052)
+    }
+
+    "assignthe same GUID after invalidation and continue to work" in {
+      val obj : EntityTestClass = new EntityTestClass
+      val guid = new PlanetSideGUID(1051)
+      obj.GUID = guid
+      obj.HasGUID mustEqual true
+      obj.GUID mustEqual guid
+      obj.Invalidate()
+      obj.GUID mustEqual guid
+      obj.HasGUID mustEqual false
+
+      obj.GUID = guid
+      obj.HasGUID mustEqual true
+      obj.GUID mustEqual guid
     }
   }
 }

--- a/common/src/test/scala/objects/EquipmentTest.scala
+++ b/common/src/test/scala/objects/EquipmentTest.scala
@@ -7,8 +7,7 @@ import net.psforever.objects.inventory.InventoryTile
 import net.psforever.objects.GlobalDefinitions._
 import net.psforever.objects.ce.{DeployedItem, TelepadLike}
 import net.psforever.objects.definition._
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.CertificationType
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import org.specs2.mutable._
 
 class EquipmentTest extends Specification {

--- a/common/src/test/scala/objects/FacilityTurretTest.scala
+++ b/common/src/test/scala/objects/FacilityTurretTest.scala
@@ -9,8 +9,7 @@ import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.serverobject.turret._
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable.Specification
 
 import scala.collection.mutable

--- a/common/src/test/scala/objects/IFFLockTest.scala
+++ b/common/src/test/scala/objects/IFFLockTest.scala
@@ -8,8 +8,7 @@ import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
 import net.psforever.objects.serverobject.locks.{IFFLock, IFFLockControl}
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+import net.psforever.types._
 import org.specs2.mutable.Specification
 
 class IFFLockTest extends Specification {

--- a/common/src/test/scala/objects/InventoryTest.scala
+++ b/common/src/test/scala/objects/InventoryTest.scala
@@ -5,7 +5,7 @@ import net.psforever.objects.{AmmoBox, SimpleItem}
 import net.psforever.objects.definition.SimpleItemDefinition
 import net.psforever.objects.inventory.{GridInventory, InventoryItem, InventoryTile}
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
 
 import scala.collection.mutable.ListBuffer

--- a/common/src/test/scala/objects/MountableTest.scala
+++ b/common/src/test/scala/objects/MountableTest.scala
@@ -8,8 +8,7 @@ import net.psforever.objects.definition.{ObjectDefinition, SeatDefinition}
 import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.vehicles.Seat
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, PlanetSideGUID}
 
 import scala.concurrent.duration.Duration
 

--- a/common/src/test/scala/objects/PlayerTest.scala
+++ b/common/src/test/scala/objects/PlayerTest.scala
@@ -5,9 +5,8 @@ import net.psforever.objects.GlobalDefinitions._
 import net.psforever.objects._
 import net.psforever.objects.definition.{ImplantDefinition, SimpleItemDefinition, SpecialExoSuitDefinition}
 import net.psforever.objects.equipment.EquipmentSize
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.packet.game.objectcreate.{Cosmetics, PersonalStyle}
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import org.specs2.mutable._
 
 import scala.util.Success

--- a/common/src/test/scala/objects/ProjectileTest.scala
+++ b/common/src/test/scala/objects/ProjectileTest.scala
@@ -6,8 +6,7 @@ import net.psforever.objects.ballistics._
 import net.psforever.objects.definition.ProjectileDefinition
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.vital.DamageType
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import org.specs2.mutable.Specification
 
 class ProjectileTest extends Specification {

--- a/common/src/test/scala/objects/ResourceSiloTest.scala
+++ b/common/src/test/scala/objects/ResourceSiloTest.scala
@@ -10,8 +10,8 @@ import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
 import net.psforever.objects.serverobject.resourcesilo.{ResourceSilo, ResourceSiloControl, ResourceSiloDefinition}
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.zones.{Zone, ZoneMap}
-import net.psforever.packet.game.{PlanetSideGUID, UseItemMessage}
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+import net.psforever.packet.game.UseItemMessage
+import net.psforever.types._
 import org.specs2.mutable.Specification
 import services.ServiceManager
 import services.avatar.{AvatarAction, AvatarServiceMessage}
@@ -72,7 +72,6 @@ class ResourceSiloControlStartupTest extends ActorTest {
       expectNoMsg(500 milliseconds)
       system.actorOf(Props(classOf[ResourceSiloControl], obj), "test-silo")
       expectNoMsg(1 seconds)
-      assert(true)
     }
   }
 }

--- a/common/src/test/scala/objects/ServerObjectBuilderTest.scala
+++ b/common/src/test/scala/objects/ServerObjectBuilderTest.scala
@@ -5,12 +5,11 @@ import akka.actor.{Actor, ActorContext, Props}
 import base.ActorTest
 import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.guid.NumberPoolHub
-import net.psforever.packet.game.PlanetSideGUID
 import net.psforever.objects.serverobject.ServerObjectBuilder
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.ProximityTerminal
 import net.psforever.objects.zones.Zone
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 
 import scala.concurrent.duration.Duration
 

--- a/common/src/test/scala/objects/UtilityTest.scala
+++ b/common/src/test/scala/objects/UtilityTest.scala
@@ -6,7 +6,7 @@ import base.ActorTest
 import net.psforever.objects._
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.vehicles._
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
 
 import scala.concurrent.duration.Duration

--- a/common/src/test/scala/objects/VehicleTest.scala
+++ b/common/src/test/scala/objects/VehicleTest.scala
@@ -11,8 +11,7 @@ import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.vehicles._
 import net.psforever.objects.vital.{VehicleShieldCharge, Vitality}
 import net.psforever.objects.zones.{Zone, ZoneMap}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import org.specs2.mutable._
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 

--- a/common/src/test/scala/objects/ZoneTest.scala
+++ b/common/src/test/scala/objects/ZoneTest.scala
@@ -12,8 +12,7 @@ import net.psforever.objects.guid.source.LimitedNumberSource
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects._
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+import net.psforever.types._
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType}
 import net.psforever.objects.zones.{Zone, ZoneActor, ZoneMap}
 import net.psforever.objects.Vehicle

--- a/common/src/test/scala/objects/number/NumberPoolActorTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolActorTest.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package objects.number
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.Props
 import base.ActorTest
 import net.psforever.objects.guid.actor.NumberPoolActor
 import net.psforever.objects.guid.pool.ExclusivePool

--- a/common/src/test/scala/objects/number/NumberPoolHubTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolHubTest.scala
@@ -5,7 +5,7 @@ import net.psforever.objects.entity.IdentifiableEntity
 import net.psforever.objects.guid.NumberPoolHub
 import net.psforever.objects.guid.selector.RandomSelector
 import net.psforever.objects.guid.source.LimitedNumberSource
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable.Specification
 
 import scala.util.Success

--- a/common/src/test/scala/objects/number/NumberPoolHubTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolHubTest.scala
@@ -55,7 +55,7 @@ class NumberPoolHubTest extends Specification {
       obj.Numbers.toSet.equals(numberList.toSet) mustEqual true
       obj.RemovePool("fibonacci").toSet.equals(numberList.toSet) mustEqual true
       obj.Numbers.isEmpty mustEqual true
-      obj.GetPool("fibonacci") mustEqual None
+      obj.GetPool("fibonacci").isEmpty mustEqual true
     }
 
     "block removing the default 'generic' pool" in {
@@ -101,7 +101,7 @@ class NumberPoolHubTest extends Specification {
       hub.register(obj, "fibonacci") match {
         case Success(number) =>
           val objFromNumber = hub(number)
-          objFromNumber mustEqual Some(obj)
+          objFromNumber.contains(obj) mustEqual true
         case _ =>
           ko
       }
@@ -111,7 +111,7 @@ class NumberPoolHubTest extends Specification {
       val hub = new NumberPoolHub(new LimitedNumberSource(51))
       hub.AddPool("fibonacci1", numberList1)
       hub.AddPool("fibonacci2", numberList2)
-      hub.WhichPool(13) mustEqual Some("fibonacci2")
+      hub.WhichPool(13).contains("fibonacci2") mustEqual true
     }
 
     "lookup the pool of a registered object" in {
@@ -119,7 +119,7 @@ class NumberPoolHubTest extends Specification {
       hub.AddPool("fibonacci", numberList1)
       val obj = new EntityTestClass()
       hub.register(obj, "fibonacci")
-      hub.WhichPool(obj) mustEqual Some("fibonacci")
+      hub.WhichPool(obj).contains("fibonacci") mustEqual true
     }
 
     "register an object to a specific, unused number; it is assigned to pool 'generic'" in {
@@ -130,7 +130,7 @@ class NumberPoolHubTest extends Specification {
       hub.register(obj, 44) match {
         case Success(number) =>
           obj.GUID mustEqual PlanetSideGUID(number)
-          hub.WhichPool(obj) mustEqual Some("generic")
+          hub.WhichPool(obj).contains("generic") mustEqual true
         case _ =>
           ko
       }
@@ -145,8 +145,8 @@ class NumberPoolHubTest extends Specification {
       hub.register(obj, 5) match {
         case Success(number) =>
           obj.GUID mustEqual PlanetSideGUID(number)
-          hub.WhichPool(obj) mustEqual Some("fibonacci")
-          src.Available(5) mustEqual None
+          hub.WhichPool(obj).contains("fibonacci") mustEqual true
+          src.Available(5).isEmpty mustEqual true
         case _ =>
           ko
       }
@@ -161,8 +161,8 @@ class NumberPoolHubTest extends Specification {
       hub.register(obj, 13) match {
         case Success(number) =>
           obj.GUID mustEqual PlanetSideGUID(number)
-          hub.WhichPool(obj) mustEqual Some("fibonacci")
-          src.Available(13) mustEqual None
+          hub.WhichPool(obj).contains("fibonacci") mustEqual true
+          src.Available(13).isEmpty mustEqual true
         case _ =>
           ko
       }
@@ -172,20 +172,21 @@ class NumberPoolHubTest extends Specification {
       val hub = new NumberPoolHub(new LimitedNumberSource(51))
       val obj = new EntityTestClass()
       hub.register(obj)
-      hub.WhichPool(obj) mustEqual Some("generic")
+      hub.WhichPool(obj).contains("generic") mustEqual true
     }
 
     "unregister an object" in {
       val hub = new NumberPoolHub(new LimitedNumberSource(51))
       hub.AddPool("fibonacci", numberList)
       val obj = new EntityTestClass()
+      obj.HasGUID mustEqual false
       hub.register(obj, "fibonacci")
-      hub.WhichPool(obj) mustEqual Some("fibonacci")
-      try { obj.GUID } catch { case _ : Exception => ko } //passes
+      hub.WhichPool(obj).contains("fibonacci") mustEqual true
+      obj.HasGUID mustEqual true
 
       hub.unregister(obj)
-      hub.WhichPool(obj) mustEqual None
-      obj.GUID must throwA[Exception] //fails
+      obj.HasGUID mustEqual false
+      hub.WhichPool(obj).isEmpty mustEqual true
     }
 
     "not register an object to a different pool" in {
@@ -247,14 +248,15 @@ class NumberPoolHubTest extends Specification {
       hub.register(13) match {
         case Success(key) =>
           key.Object = obj
+          obj.HasGUID mustEqual true
         case _ =>
           ko
       }
-      hub.WhichPool(obj) mustEqual Some("fibonacci")
+      hub.WhichPool(obj).contains("fibonacci") mustEqual true
       hub.unregister(13) match {
         case Success(thing) =>
-          thing mustEqual Some(obj)
-          thing.get.GUID must throwA[Exception]
+          thing.contains(obj) mustEqual true
+          thing.get.HasGUID mustEqual false
         case _ =>
           ko
       }

--- a/common/src/test/scala/objects/number/NumberPoolTest.scala
+++ b/common/src/test/scala/objects/number/NumberPoolTest.scala
@@ -158,10 +158,10 @@ class NumberPoolTest extends Specification {
       val obj = new GenericPool(map, 11)
       obj.Selector.asInstanceOf[SpecificSelector].SelectionIndex = 5
       obj.Get()
-      map.get(5) mustEqual Some("generic")
+      map.get(5).contains("generic") mustEqual true
       obj.Numbers.contains(5) mustEqual true
       obj.Return(5) mustEqual true
-      map.get(5) mustEqual None
+      map.get(5).isEmpty mustEqual true
       obj.Numbers.isEmpty mustEqual true
     }
 

--- a/common/src/test/scala/objects/number/NumberSourceTest.scala
+++ b/common/src/test/scala/objects/number/NumberSourceTest.scala
@@ -106,11 +106,12 @@ class NumberSourceTest extends Specification {
     "return a secure key" in {
       val obj = LimitedNumberSource(25)
       val test = new TestClass()
+
       val result1 : Option[LoanedKey] = obj.Available(5)
       result1.get.Object = test
-      test.GUID = PlanetSideGUID(5)
-      val result2 : Option[SecureKey] = obj.Get(5)
+      test.GUID mustEqual PlanetSideGUID(5)
 
+      val result2 : Option[SecureKey] = obj.Get(5)
       obj.Return(result2.get).contains(test) mustEqual true
     }
 
@@ -180,18 +181,20 @@ class NumberSourceTest extends Specification {
       val obj = LimitedNumberSource(25)
       val test1 = new TestClass()
       val test2 = new TestClass()
+      val test3 = new TestClass()
       obj.Available(5) //no assignment
       obj.Available(10).get.Object = test1
       obj.Available(15).get.Object = test2
       obj.Restrict(15)
-      obj.Restrict(20).get.Object = test1
+      obj.Restrict(20).get.Object = test3
       obj.CountUsed mustEqual 4
 
       val list : List[IdentifiableEntity] = obj.Clear()
       obj.CountUsed mustEqual 0
       list.size mustEqual 3
-      list.count(obj => obj == test1) mustEqual 2
+      list.count(obj => obj == test1) mustEqual 1
       list.count(obj => obj == test2) mustEqual 1
+      list.count(obj => obj == test3) mustEqual 1
     }
   }
 }

--- a/common/src/test/scala/objects/number/NumberSourceTest.scala
+++ b/common/src/test/scala/objects/number/NumberSourceTest.scala
@@ -25,7 +25,7 @@ class NumberSourceTest extends Specification {
       result.isDefined mustEqual true
       result.get.GUID mustEqual 5
       result.get.Policy mustEqual AvailabilityPolicy.Leased
-      result.get.Object mustEqual None
+      result.get.Object.isEmpty mustEqual true
       obj.Size mustEqual 26
       obj.CountAvailable mustEqual 25
       obj.CountUsed mustEqual 1
@@ -46,7 +46,7 @@ class NumberSourceTest extends Specification {
       result.get.GUID mustEqual 5
       obj.CountUsed mustEqual 1
       val ret = obj.Return(result.get)
-      ret mustEqual None
+      ret.isEmpty mustEqual true
       obj.CountUsed mustEqual 0
     }
 
@@ -59,7 +59,7 @@ class NumberSourceTest extends Specification {
       result.get.Object = test
       obj.CountUsed mustEqual 1
       val ret = obj.Return(result.get)
-      ret mustEqual Some(test)
+      ret.contains(test) mustEqual true
       obj.CountUsed mustEqual 0
     }
 
@@ -69,7 +69,7 @@ class NumberSourceTest extends Specification {
       result.isDefined mustEqual true
       result.get.GUID mustEqual 5
       result.get.Policy mustEqual AvailabilityPolicy.Restricted
-      result.get.Object mustEqual None
+      result.get.Object.isEmpty mustEqual true
     }
 
     "restrict a number (assigned + multiple assignments)" in {
@@ -79,13 +79,13 @@ class NumberSourceTest extends Specification {
       val result : Option[LoanedKey] = obj.Restrict(5)
       result.get.GUID mustEqual 5
       result.get.Policy mustEqual AvailabilityPolicy.Restricted
-      result.get.Object mustEqual None
+      result.get.Object.isEmpty mustEqual true
       result.get.Object = None //assignment 1
-      result.get.Object mustEqual None //still unassigned
+      result.get.Object.isEmpty mustEqual true //still unassigned
       result.get.Object = test1 //assignment 2
-      result.get.Object mustEqual Some(test1)
+      result.get.Object.contains(test1) mustEqual true
       result.get.Object = test2 //assignment 3
-      result.get.Object mustEqual Some(test1) //same as above
+      result.get.Object.contains(test1) mustEqual true //same as above
     }
 
     "return a restricted number (correctly fail)" in {
@@ -100,7 +100,7 @@ class NumberSourceTest extends Specification {
       val result2 : Option[SecureKey] = obj.Get(5)
       result2.get.GUID mustEqual 5
       result2.get.Policy mustEqual AvailabilityPolicy.Restricted
-      result2.get.Object mustEqual Some(test)
+      result2.get.Object.contains(test) mustEqual true
     }
 
     "return a secure key" in {
@@ -111,7 +111,7 @@ class NumberSourceTest extends Specification {
       test.GUID = PlanetSideGUID(5)
       val result2 : Option[SecureKey] = obj.Get(5)
 
-      obj.Return(result2.get) mustEqual Some(test)
+      obj.Return(result2.get).contains(test) mustEqual true
     }
 
     "restrict a previously-assigned number" in {
@@ -124,7 +124,7 @@ class NumberSourceTest extends Specification {
       val result2 : Option[LoanedKey] = obj.Restrict(5)
       result2.isDefined mustEqual true
       result2.get.Policy mustEqual AvailabilityPolicy.Restricted
-      result2.get.Object mustEqual Some(test)
+      result2.get.Object.contains(test) mustEqual true
     }
 
     "check a number (not previously gotten)" in {
@@ -132,7 +132,7 @@ class NumberSourceTest extends Specification {
       val result2 : Option[SecureKey] = obj.Get(5)
       result2.get.GUID mustEqual 5
       result2.get.Policy mustEqual AvailabilityPolicy.Available
-      result2.get.Object mustEqual None
+      result2.get.Object.isEmpty mustEqual true
     }
 
     "check a number (previously gotten)" in {
@@ -141,11 +141,11 @@ class NumberSourceTest extends Specification {
       result.isDefined mustEqual true
       result.get.GUID mustEqual 5
       result.get.Policy mustEqual AvailabilityPolicy.Leased
-      result.get.Object mustEqual None
+      result.get.Object.isEmpty mustEqual true
       val result2 : Option[SecureKey] = obj.Get(5)
       result2.get.GUID mustEqual 5
       result2.get.Policy mustEqual AvailabilityPolicy.Leased
-      result2.get.Object mustEqual None
+      result2.get.Object.isEmpty mustEqual true
     }
 
     "check a number (assigned)" in {
@@ -170,10 +170,10 @@ class NumberSourceTest extends Specification {
       val result2 : Option[SecureKey] = obj.Get(5)
       result2.get.Policy mustEqual AvailabilityPolicy.Leased
       result2.get.Object.get mustEqual test
-      obj.Return(5) mustEqual Some(test)
+      obj.Return(5).contains(test) mustEqual true
       val result3 : Option[SecureKey] = obj.Get(5)
       result3.get.Policy mustEqual AvailabilityPolicy.Available
-      result3.get.Object mustEqual None
+      result3.get.Object.isEmpty mustEqual true
     }
 
     "clear" in {

--- a/common/src/test/scala/objects/number/NumberSourceTest.scala
+++ b/common/src/test/scala/objects/number/NumberSourceTest.scala
@@ -3,7 +3,7 @@ package objects.number
 
 import net.psforever.objects.guid.AvailabilityPolicy
 import net.psforever.objects.guid.key.{LoanedKey, SecureKey}
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable.Specification
 
 class NumberSourceTest extends Specification {

--- a/common/src/test/scala/objects/number/RegisterTest.scala
+++ b/common/src/test/scala/objects/number/RegisterTest.scala
@@ -12,49 +12,49 @@ class RegisterTest extends Specification {
     "construct (object)" in {
       val reg = Register(obj)
       reg.obj mustEqual obj
-      reg.number mustEqual None
-      reg.name mustEqual None
-      reg.callback mustEqual None
+      reg.number.isEmpty mustEqual true
+      reg.name.isEmpty mustEqual true
+      reg.callback.isEmpty mustEqual true
     }
 
     "construct (object, callback)" in {
       val reg = Register(obj, Actor.noSender)
       reg.obj mustEqual obj
-      reg.number mustEqual None
-      reg.name mustEqual None
-      reg.callback mustEqual Some(Actor.noSender)
+      reg.number.isEmpty mustEqual true
+      reg.name.isEmpty mustEqual true
+      reg.callback.contains(Actor.noSender) mustEqual true
     }
 
     "construct (object, suggested number)" in {
       val reg = Register(obj, 5)
       reg.obj mustEqual obj
-      reg.number mustEqual Some(5)
-      reg.name mustEqual None
-      reg.callback mustEqual None
+      reg.number.contains(5) mustEqual true
+      reg.name.isEmpty mustEqual true
+      reg.callback.isEmpty mustEqual true
     }
 
     "construct (object, suggested number, callback)" in {
       val reg = Register(obj, 5, Actor.noSender)
       reg.obj mustEqual obj
-      reg.number mustEqual Some(5)
-      reg.name mustEqual None
-      reg.callback mustEqual Some(Actor.noSender)
+      reg.number.contains(5) mustEqual true
+      reg.name.isEmpty mustEqual true
+      reg.callback.contains(Actor.noSender) mustEqual true
     }
 
     "construct (object, pool name)" in {
       val reg = Register(obj, "pool")
       reg.obj mustEqual obj
-      reg.number mustEqual None
-      reg.name mustEqual Some("pool")
-      reg.callback mustEqual None
+      reg.number.isEmpty mustEqual true
+      reg.name.contains("pool") mustEqual true
+      reg.callback.isEmpty mustEqual true
     }
 
     "construct (object, pool name, callback)" in {
       val reg = Register(obj, "pool", Actor.noSender)
       reg.obj mustEqual obj
-      reg.number mustEqual None
-      reg.name mustEqual Some("pool")
-      reg.callback mustEqual Some(Actor.noSender)
+      reg.number.isEmpty mustEqual true
+      reg.name.contains("pool") mustEqual true
+      reg.callback.contains(Actor.noSender) mustEqual true
     }
   }
 }

--- a/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
+++ b/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
@@ -341,7 +341,7 @@ object UniqueNumberSystemTest {
     * @see `UniqueNumberSystem.AllocateNumberPoolActors(NumberPoolHub)(implicit ActorContext)`
     */
   def AllocateNumberPoolActors(poolSource : NumberPoolHub)(implicit system : ActorSystem) : Map[String, ActorRef] = {
-    poolSource.Pools.map({ case ((pname, pool)) =>
+    poolSource.Pools.map({ case (pname, pool) =>
       pname -> system.actorOf(Props(classOf[NumberPoolActor], pool), pname)
     }).toMap
   }

--- a/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
+++ b/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
@@ -8,6 +8,8 @@ import net.psforever.objects.guid.NumberPoolHub
 import net.psforever.objects.guid.actor.{NumberPoolActor, Register, UniqueNumberSystem, Unregister}
 import net.psforever.objects.guid.selector.RandomSelector
 import net.psforever.objects.guid.source.LimitedNumberSource
+import net.psforever.types
+import net.psforever.types.PlanetSideGUID
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -237,7 +239,7 @@ class UniqueNumberSystemTest7 extends ActorTest() {
       guid.AddPool("pool3", (5001 to 6000).toList).Selector = new RandomSelector
       val uns = system.actorOf(Props(classOf[UniqueNumberSystem], guid, UniqueNumberSystemTest.AllocateNumberPoolActors(guid)), "uns")
       val testObj = new EntityTestClass()
-      testObj.GUID = net.psforever.packet.game.PlanetSideGUID(6001) //fake registering; number too high
+      testObj.GUID = types.PlanetSideGUID(6001) //fake registering; number too high
       assert(testObj.HasGUID)
       assert(src.CountUsed == 0)
 
@@ -262,7 +264,7 @@ class UniqueNumberSystemTest8 extends ActorTest() {
       guid.AddPool("pool3", (5001 to 6000).toList).Selector = new RandomSelector
       val uns = system.actorOf(Props(classOf[UniqueNumberSystem], guid, UniqueNumberSystemTest.AllocateNumberPoolActors(guid)), "uns")
       val testObj = new EntityTestClass()
-      testObj.GUID = net.psforever.packet.game.PlanetSideGUID(3500) //fake registering
+      testObj.GUID = PlanetSideGUID(3500) //fake registering
       assert(testObj.HasGUID)
       assert(src.CountUsed == 0)
 

--- a/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
+++ b/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
@@ -8,7 +8,6 @@ import net.psforever.objects.guid.NumberPoolHub
 import net.psforever.objects.guid.actor.{NumberPoolActor, Register, UniqueNumberSystem, Unregister}
 import net.psforever.objects.guid.selector.RandomSelector
 import net.psforever.objects.guid.source.LimitedNumberSource
-import net.psforever.types
 import net.psforever.types.PlanetSideGUID
 
 import scala.concurrent.duration._
@@ -239,7 +238,7 @@ class UniqueNumberSystemTest7 extends ActorTest() {
       guid.AddPool("pool3", (5001 to 6000).toList).Selector = new RandomSelector
       val uns = system.actorOf(Props(classOf[UniqueNumberSystem], guid, UniqueNumberSystemTest.AllocateNumberPoolActors(guid)), "uns")
       val testObj = new EntityTestClass()
-      testObj.GUID = types.PlanetSideGUID(6001) //fake registering; number too high
+      testObj.GUID =PlanetSideGUID(6001) //fake registering; number too high
       assert(testObj.HasGUID)
       assert(src.CountUsed == 0)
 

--- a/common/src/test/scala/objects/terminal/ImplantTerminalMechTest.scala
+++ b/common/src/test/scala/objects/terminal/ImplantTerminalMechTest.scala
@@ -157,8 +157,7 @@ object ImplantTerminalMechTest {
   def SetUpAgents(faction : PlanetSideEmpire.Value)(implicit system : ActorSystem) : (Player, ImplantTerminalMech) = {
     import net.psforever.objects.serverobject.structures.Building
     import net.psforever.objects.zones.Zone
-    import net.psforever.packet.game.PlanetSideGUID
-
+    import net.psforever.types.PlanetSideGUID
     val terminal = ImplantTerminalMech(GlobalDefinitions.implant_terminal_mech)
     terminal.Actor = system.actorOf(Props(classOf[ImplantTerminalMechControl], terminal), "mech")
     terminal.Owner = new Building("Building", building_guid = 0, map_id = 0, Zone.Nowhere, StructureType.Building, GlobalDefinitions.building)

--- a/common/src/test/scala/objects/terminal/MatrixTerminalTest.scala
+++ b/common/src/test/scala/objects/terminal/MatrixTerminalTest.scala
@@ -3,7 +3,7 @@ package objects.terminal
 
 import net.psforever.objects.serverobject.terminals.{MatrixTerminalDefinition, Terminal}
 import net.psforever.objects.{Avatar, GlobalDefinitions, Player, Vehicle}
-import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
+import net.psforever.packet.game.ItemTransactionMessage
 import net.psforever.types._
 import org.specs2.mutable.Specification
 

--- a/common/src/test/scala/objects/terminal/OrderTerminalTest.scala
+++ b/common/src/test/scala/objects/terminal/OrderTerminalTest.scala
@@ -5,7 +5,7 @@ import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.zones.Zone
 import net.psforever.objects._
-import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
+import net.psforever.packet.game.ItemTransactionMessage
 import net.psforever.types._
 import org.specs2.mutable.Specification
 

--- a/common/src/test/scala/objects/terminal/ProximityTest.scala
+++ b/common/src/test/scala/objects/terminal/ProximityTest.scala
@@ -9,8 +9,7 @@ import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{ProximityTerminal, ProximityTerminalControl, ProximityUnit, Terminal}
 import net.psforever.objects.zones.{Zone, ZoneActor, ZoneMap}
 import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, PlanetSideGUID}
 import org.specs2.mutable.Specification
 import services.Service
 import services.local.LocalService

--- a/common/src/test/scala/objects/terminal/ProximityTest.scala
+++ b/common/src/test/scala/objects/terminal/ProximityTest.scala
@@ -157,7 +157,7 @@ class ProximityTerminalControlTwoUsersTest extends ActorTest {
     avatar2.Health = 50
 
     avatar.GUID = PlanetSideGUID(1)
-    avatar.GUID = PlanetSideGUID(2)
+    avatar2.GUID = PlanetSideGUID(2)
     terminal.GUID = PlanetSideGUID(3)
     terminal.Actor ! Service.Startup()
     expectNoMsg(500 milliseconds) //spacer
@@ -252,7 +252,7 @@ class ProximityTerminalControlNotStopTest extends ActorTest {
     avatar2.Health = 50
 
     avatar.GUID = PlanetSideGUID(1)
-    avatar.GUID = PlanetSideGUID(2)
+    avatar2.GUID = PlanetSideGUID(2)
     terminal.GUID = PlanetSideGUID(3)
     terminal.Actor ! Service.Startup()
     expectNoMsg(500 milliseconds) //spacer

--- a/common/src/test/scala/objects/terminal/TerminalControlTest.scala
+++ b/common/src/test/scala/objects/terminal/TerminalControlTest.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{Terminal, TerminalControl, TerminalDefinition}
 import net.psforever.objects.zones.Zone
 import net.psforever.objects.{Avatar, GlobalDefinitions, Player}
-import net.psforever.packet.game.{ItemTransactionMessage, PlanetSideGUID}
+import net.psforever.packet.game.ItemTransactionMessage
 import net.psforever.types._
 
 import scala.concurrent.duration.Duration

--- a/common/src/test/scala/service/LocalServiceTest.scala
+++ b/common/src/test/scala/service/LocalServiceTest.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.terminals.{ProximityTerminal, Terminal}
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game._
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.{Service, ServiceManager}
 import services.local._
 

--- a/common/src/test/scala/service/RemoverActorTest.scala
+++ b/common/src/test/scala/service/RemoverActorTest.scala
@@ -10,7 +10,7 @@ import net.psforever.objects.definition.{EquipmentDefinition, ObjectDefinition}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.guid.TaskResolver
 import net.psforever.objects.zones.{Zone, ZoneMap}
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.{RemoverActor, ServiceManager}
 
 import scala.concurrent.duration._

--- a/common/src/test/scala/service/RouterTelepadActivationTest.scala
+++ b/common/src/test/scala/service/RouterTelepadActivationTest.scala
@@ -5,7 +5,7 @@ import akka.actor.Props
 import base.ActorTest
 import net.psforever.objects._
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
+import net.psforever.types.PlanetSideGUID
 import services.local.support.RouterTelepadActivation
 import services.support.SupportActor
 

--- a/common/src/test/scala/service/VehicleServiceTest.scala
+++ b/common/src/test/scala/service/VehicleServiceTest.scala
@@ -5,8 +5,7 @@ import akka.actor.Props
 import base.ActorTest
 import net.psforever.objects._
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import services.{Service, ServiceManager}
 import services.vehicle._
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -170,7 +170,6 @@ class WorldSessionActor extends Actor
   var antChargingTick : Cancellable = DefaultCancellable.obj
   var antDischargingTick : Cancellable = DefaultCancellable.obj
 
-
   /**
     * Convert a boolean value into an integer value.
     * Use: `true:Int` or `false:Int`
@@ -1131,7 +1130,7 @@ class WorldSessionActor extends Actor
       log.warn(s"Vital target ${target.Definition.Name} damage resolution not supported using this method")
 
     case ResponseToSelf(pkt) =>
-      log.info(s"Received a direct message: $pkt")
+      //log.info(s"Received a direct message: $pkt")
       sendResponse(pkt)
 
     case LoadedRemoteProjectile(projectile_guid, Some(projectile)) =>

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -46,7 +46,7 @@ import net.psforever.objects.vital._
 import net.psforever.objects.zones.{InterstellarCluster, Zone, ZoneHotSpotProjector}
 import net.psforever.packet.game.objectcreate._
 import net.psforever.packet.game.{HotSpotInfo => PacketHotSpotInfo}
-import net.psforever.types.{PlanetSideGUID, _}
+import net.psforever.types._
 import services.{RemoverActor, vehicle, _}
 import services.avatar.{AvatarAction, AvatarResponse, AvatarServiceMessage, AvatarServiceResponse}
 import services.galaxy.{GalaxyAction, GalaxyResponse, GalaxyServiceMessage, GalaxyServiceResponse}
@@ -410,7 +410,7 @@ class WorldSessionActor extends Actor
       if(!excluded.exists(_ == avatar.CharId)) {
         response match {
           case SquadResponse.ListSquadFavorite(line, task) =>
-            sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), line, SquadAction.ListSquadFavorite(task)))
+            sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), line, SquadAction.ListSquadFavorite(task)))
 
           case SquadResponse.InitList(infos) =>
             sendResponse(ReplicationStreamMessage(infos))
@@ -512,7 +512,7 @@ class WorldSessionActor extends Actor
             }
             StopBundlingPackets()
             //send an initial dummy update for map icon(s)
-            sendResponse(SquadState(types.PlanetSideGUID(squad_supplement_id),
+            sendResponse(SquadState(PlanetSideGUID(squad_supplement_id),
               membershipPositions
                 .filterNot { case (member, _) => member.CharId == avatar.CharId }
                 .map{ case (member, _) => SquadStateInfo(member.CharId, member.Health, member.Armor, member.Position, 2,2, false, 429, None,None) }
@@ -538,7 +538,7 @@ class WorldSessionActor extends Actor
                 sendResponse(PlanetsideAttributeMessage(playerGuid, 34, 4294967295L)) //unknown, perhaps unrelated?
                 lfsm = false
                 //a finalization? what does this do?
-                sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
+                sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
                 squad_supplement_id = 0
                 squadUpdateCounter = 0
                 updateSquad = NoSquadUpdates
@@ -604,7 +604,7 @@ class WorldSessionActor extends Actor
             if(updatedEntries.nonEmpty) {
               sendResponse(
                 SquadState(
-                  types.PlanetSideGUID(squad_supplement_id),
+                  PlanetSideGUID(squad_supplement_id),
                   updatedEntries.map { entry => SquadStateInfo(entry.char_id, entry.health, entry.armor, entry.pos, 2,2, false, 429, None,None)}
                 )
               )
@@ -612,7 +612,7 @@ class WorldSessionActor extends Actor
 
           case SquadResponse.SquadSearchResults() =>
             //I don't actually know how to return search results
-            sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.NoSquadSearchResults()))
+            sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.NoSquadSearchResults()))
 
           case SquadResponse.InitWaypoints(char_id, waypoints) =>
             StartBundlingPackets()
@@ -719,8 +719,8 @@ class WorldSessionActor extends Actor
       }
       sendResponse(CharacterInfoMessage(15, PlanetSideZoneID(10000), avatar.CharId, player.GUID, false, 6404428))
       RemoveCharacterSelectScreenGUID(player)
-      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, types.PlanetSideGUID(0), true, 0))
-      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, types.PlanetSideGUID(0), true, 0))
+      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, PlanetSideGUID(0), true, 0))
+      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, PlanetSideGUID(0), true, 0))
 
     case VehicleLoaded(_ /*vehicle*/) => ;
     //currently being handled by VehicleSpawnPad.LoadVehicle during testing phase
@@ -822,7 +822,7 @@ class WorldSessionActor extends Actor
           continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(obj, continent))
           sendResponse(SetEmpireMessage(guid, PlanetSideEmpire.NEUTRAL))
           continent.AvatarEvents ! AvatarServiceMessage(factionChannel, AvatarAction.SetEmpire(playerGUID, guid, PlanetSideEmpire.NEUTRAL))
-          val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, types.PlanetSideGUID(0))
+          val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, PlanetSideGUID(0))
           sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Dismiss, info))
           continent.LocalEvents ! LocalServiceMessage(factionChannel, LocalAction.DeployableMapIcon(playerGUID, DeploymentAction.Dismiss, info))
           PutItemOnGround(item, pos, orient)
@@ -830,7 +830,7 @@ class WorldSessionActor extends Actor
           //pointless trigger
           val guid = item.GUID
           continent.Ground ! Zone.Ground.RemoveItem(guid) //undo; no callback
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), guid))
+          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
           taskResolver ! GUIDTask.UnregisterObjectTask(item)(continent.GUID)
       }
 
@@ -1031,7 +1031,7 @@ class WorldSessionActor extends Actor
       LivePlayerList.Add(sessionId, avatar)
       traveler = new Traveler(self, continent.Id)
       //PropertyOverrideMessage
-      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 112, 0)) // disable festive backpacks
+      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
       sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
       sendResponse(FriendsResponse(FriendAction.InitializeFriendList, 0, true, true, Nil))
       sendResponse(FriendsResponse(FriendAction.InitializeIgnoreList, 0, true, true, Nil))
@@ -1170,7 +1170,7 @@ class WorldSessionActor extends Actor
     */
   def HandleAvatarServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : AvatarResponse.Response) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else types.PlanetSideGUID(0)
+    else PlanetSideGUID(0)
     reply match {
       case AvatarResponse.SendResponse(msg) =>
         sendResponse(msg)
@@ -1431,7 +1431,7 @@ class WorldSessionActor extends Actor
         }
 
       case AvatarResponse.ProjectileExplodes(projectile_guid, projectile) =>
-        sendResponse(ProjectileStateMessage(projectile_guid, projectile.Position, Vector3.Zero, projectile.Orientation, 0, true, types.PlanetSideGUID(0)))
+        sendResponse(ProjectileStateMessage(projectile_guid, projectile.Position, Vector3.Zero, projectile.Orientation, 0, true, PlanetSideGUID(0)))
         sendResponse(ObjectDeleteMessage(projectile_guid, 2))
 
       case AvatarResponse.ProjectileAutoLockAwareness(mode) =>
@@ -1519,7 +1519,7 @@ class WorldSessionActor extends Actor
     */
   def HandleLocalServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : LocalResponse.Response) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else types.PlanetSideGUID(0)
+    else PlanetSideGUID(0)
     reply match {
       case LocalResponse.AlertDestroyDeployable(obj) =>
         //the (former) owner (obj.OwnerName) should process this message
@@ -1662,10 +1662,10 @@ class WorldSessionActor extends Actor
         }
 
       case LocalResponse.ProximityTerminalEffect(object_guid, true) =>
-        sendResponse(ProximityTerminalUseMessage(types.PlanetSideGUID(0), object_guid, true))
+        sendResponse(ProximityTerminalUseMessage(PlanetSideGUID(0), object_guid, true))
 
       case LocalResponse.ProximityTerminalEffect(object_guid, false) =>
-        sendResponse(ProximityTerminalUseMessage(types.PlanetSideGUID(0), object_guid, false))
+        sendResponse(ProximityTerminalUseMessage(PlanetSideGUID(0), object_guid, false))
         ForgetAllProximityTerminals(object_guid)
 
       case LocalResponse.RouterTelepadMessage(msg) =>
@@ -1701,7 +1701,7 @@ class WorldSessionActor extends Actor
     */
   def HandleChatServiceResponse(toChannel : String, avatar_guid : PlanetSideGUID, avatar_name : String, cont : Zone, avatar_pos : Vector3, avatar_faction : PlanetSideEmpire.Value, target : Int, reply : ChatMsg) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else types.PlanetSideGUID(0)
+    else PlanetSideGUID(0)
     target match {
       case 0 => // for other(s) user(s)
         if (player.GUID != avatar_guid) {
@@ -1725,7 +1725,7 @@ class WorldSessionActor extends Actor
                 if(!player.silenced) {
                   sendResponse(ChatMsg(ChatMessageType.UNK_71, reply.wideContents, reply.recipient, "@silence_on", reply.note))
                   player.silenced = true
-                  context.system.scheduler.scheduleOnce(silence_time minutes, chatService, ChatServiceMessage("gm", ChatAction.GM(types.PlanetSideGUID(0), player.Name, ChatMsg(ChatMessageType.CMT_SILENCE, true, "", player.Name, None))))
+                  context.system.scheduler.scheduleOnce(silence_time minutes, chatService, ChatServiceMessage("gm", ChatAction.GM(PlanetSideGUID(0), player.Name, ChatMsg(ChatMessageType.CMT_SILENCE, true, "", player.Name, None))))
                 }
                 else {
                   sendResponse(ChatMsg(ChatMessageType.UNK_71, reply.wideContents, reply.recipient, "@silence_off", reply.note))
@@ -2218,7 +2218,7 @@ class WorldSessionActor extends Actor
                   val existingBox = existingWeapon.AmmoSlots(index).Box
                   existingBox.Capacity = savedWeapon.AmmoSlots(index).Box.Capacity
                   //use VehicleAction.InventoryState2; VehicleAction.InventoryState temporarily glitches ammo count in ui
-                  continent.VehicleEvents ! VehicleServiceMessage(channel, VehicleAction.InventoryState2(types.PlanetSideGUID(0), existingBox.GUID, existingWeapon.GUID, existingBox.Capacity))
+                  continent.VehicleEvents ! VehicleServiceMessage(channel, VehicleAction.InventoryState2(PlanetSideGUID(0), existingBox.GUID, existingWeapon.GUID, existingBox.Capacity))
                 })
               })
               afterInventory
@@ -2433,7 +2433,7 @@ class WorldSessionActor extends Actor
     * @param reply     na
     */
   def HandleVehicleServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : VehicleResponse.Response) : Unit = {
-    val tplayer_guid = if(player.HasGUID) player.GUID else types.PlanetSideGUID(0)
+    val tplayer_guid = if(player.HasGUID) player.GUID else PlanetSideGUID(0)
 
     reply match {
       case VehicleResponse.AttachToRails(vehicle_guid, pad_guid) =>
@@ -2689,7 +2689,7 @@ class WorldSessionActor extends Actor
             continent.Id,
             VehicleAction.SendResponse(
               player.GUID,
-              CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
             )
           )
           //sending packet to the cargo vehicle's client results in player locking himself in his vehicle
@@ -2760,8 +2760,8 @@ class WorldSessionActor extends Actor
           cargo.MountedIn = carrierGUID
           hold.Occupant = cargo
           cargo.Velocity = None
-          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
-          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
+          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
+          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
           StartBundlingPackets()
           val (attachMsg, mountPointMsg) = CargoMountBehaviorForAll(carrier, cargo, mountPoint)
           StopBundlingPackets()
@@ -2775,7 +2775,7 @@ class WorldSessionActor extends Actor
             continent.Id,
             VehicleAction.SendResponse(
               player.GUID,
-              CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
             )
           )
           //sending packet to the cargo vehicle's client results in player locking himself in his vehicle
@@ -2828,7 +2828,7 @@ class WorldSessionActor extends Actor
   def CargoMountMessages(carrierGUID : PlanetSideGUID, cargoGUID : PlanetSideGUID, mountPoint : Int, orientation : Int) : (ObjectAttachMessage, CargoMountPointStatusMessage) = {
     (
       ObjectAttachMessage(carrierGUID, cargoGUID, mountPoint),
-      CargoMountPointStatusMessage(carrierGUID, cargoGUID, cargoGUID, types.PlanetSideGUID(0), mountPoint, CargoStatus.Occupied, orientation)
+      CargoMountPointStatusMessage(carrierGUID, cargoGUID, cargoGUID, PlanetSideGUID(0), mountPoint, CargoStatus.Occupied, orientation)
     )
   }
 
@@ -3073,7 +3073,7 @@ class WorldSessionActor extends Actor
     val guid = tplayer.GUID
     StartBundlingPackets()
     InitializeDeployableUIElements(avatar)
-    sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 75, 0))
+    sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 75, 0))
     sendResponse(SetCurrentAvatarMessage(guid, 0, 0))
     sendResponse(ChatMsg(ChatMessageType.CMT_EXPANSIONS, true, "", "1 on", None)) //CC on //TODO once per respawn?
     sendResponse(PlayerStateShiftMessage(ShiftState(1, shiftPosition.getOrElse(tplayer.Position), tplayer.Orientation.z)))
@@ -3086,7 +3086,7 @@ class WorldSessionActor extends Actor
       sendResponse(AvatarImplantMessage(guid, ImplantAction.Activation, slot, 0)) //deactivate implant
       //TODO if this implant is Installed but does not have shortcut, add to a free slot or write over slot 61/62/63
     })
-    sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 82, 0))
+    sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 82, 0))
     //TODO if Medkit does not have shortcut, add to a free slot or write over slot 64
     sendResponse(CreateShortcutMessage(guid, 1, 0, true, Shortcut.MEDKIT))
     sendResponse(ChangeShortcutBankMessage(guid, 0))
@@ -3111,7 +3111,7 @@ class WorldSessionActor extends Actor
     sendResponse(AvatarSearchCriteriaMessage(guid, List(0, 0, 0, 0, 0, 0)))
     (1 to 73).foreach(i => {
       // not all GUID's are set, and not all of the set ones will always be zero; what does this section do?
-      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(i), 67, 0))
+      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(i), 67, 0))
     })
     (0 to 30).foreach(i => {
       //TODO 30 for a new character only?
@@ -3170,16 +3170,16 @@ class WorldSessionActor extends Actor
   def FirstTimeSquadSetup() : Unit = {
     sendResponse(SquadDetailDefinitionUpdateMessage.Init)
     sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
-    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(6)))
+    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(6)))
     //only need to load these once - they persist between zone transfers and respawns
     avatar.SquadLoadouts.Loadouts.foreach {
       case (index, loadout : SquadLoadout) =>
-        sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), index, SquadAction.ListSquadFavorite(loadout.task)))
+        sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), index, SquadAction.ListSquadFavorite(loadout.task)))
     }
     //non-squad GUID-0 counts as the settings when not joined with a squad
-    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.AssociateWithSquad()))
-    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.SetListSquad()))
-    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
+    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.AssociateWithSquad()))
+    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.SetListSquad()))
+    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
     squadService ! SquadServiceMessage(player, continent, SquadServiceAction.InitSquadList())
     squadService ! SquadServiceMessage(player, continent, SquadServiceAction.InitCharId())
     squadSetup = RespawnSquadSetup
@@ -3369,7 +3369,7 @@ class WorldSessionActor extends Actor
         case (Some(_ : Vehicle), Some(carrier : Vehicle)) =>
           carrier.Definition.Cargo.headOption match {
             case Some((mountPoint, _)) => //begin the mount process - open the cargo door
-              val reply = CargoMountPointStatusMessage(cargo_vehicle_guid, types.PlanetSideGUID(0), vehicle_guid, types.PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
+              val reply = CargoMountPointStatusMessage(cargo_vehicle_guid, PlanetSideGUID(0), vehicle_guid, PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
               log.debug(reply.toString)
               continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.SendResponse(player.GUID, reply))
               sendResponse(reply)
@@ -3435,7 +3435,7 @@ class WorldSessionActor extends Actor
       //custom
       sendResponse(ContinentalLockUpdateMessage(13, PlanetSideEmpire.VS)) // "The VS have captured the VS Sanctuary."
       sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
-      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 112, 0)) // disable festive backpacks
+      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
       //(0 to 255).foreach(i => { sendResponse(SetEmpireMessage(PlanetSideGUID(i), PlanetSideEmpire.VS)) })
 
       //find and reclaim own deployables, if any
@@ -3497,7 +3497,7 @@ class WorldSessionActor extends Actor
       continent.DeployableList
         .filter(obj => obj.Faction == faction && obj.Health > 0)
         .foreach(obj => {
-          val deployInfo = DeployableInfo(obj.GUID, Deployable.Icon(obj.Definition.Item), obj.Position, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
+          val deployInfo = DeployableInfo(obj.GUID, Deployable.Icon(obj.Definition.Item), obj.Position, obj.Owner.getOrElse(PlanetSideGUID(0)))
           sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Build, deployInfo))
         })
       //render Equipment that was dropped into zone before the player arrived
@@ -3611,14 +3611,14 @@ class WorldSessionActor extends Actor
 
       //implant terminals
       continent.Map.TerminalToInterface.foreach({ case ((terminal_guid, interface_guid)) =>
-        val parent_guid = types.PlanetSideGUID(terminal_guid)
+        val parent_guid = PlanetSideGUID(terminal_guid)
         continent.GUID(interface_guid) match {
           case Some(obj : Terminal) =>
             val objDef = obj.Definition
             sendResponse(
               ObjectCreateMessage(
                 objDef.ObjectId,
-                types.PlanetSideGUID(interface_guid),
+                PlanetSideGUID(interface_guid),
                 ObjectCreateMessageParent(parent_guid, 1),
                 objDef.Packet.ConstructorData(obj).get
               )
@@ -4016,7 +4016,7 @@ class WorldSessionActor extends Actor
           case Some(turret : FacilityTurret) if turret.isUpgrading =>
             FinishUpgradingMannedTurret(turret, TurretUpgrade.None)
           case _ =>
-            self ! PacketCoding.CreateGamePacket(0, RequestDestroyMessage(types.PlanetSideGUID(guid)))
+            self ! PacketCoding.CreateGamePacket(0, RequestDestroyMessage(PlanetSideGUID(guid)))
         }
       }
       if(messagetype == ChatMessageType.CMT_VOICE) {
@@ -4423,7 +4423,7 @@ class WorldSessionActor extends Actor
                   log.warn(s"RequestDestroy: boomer_trigger@$guid has been found but it seems to be orphaned")
                 case _ => ;
               }
-              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), guid))
+              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
               GUIDTask.UnregisterObjectTask(trigger)(continent.GUID)
 
             case None => ;
@@ -4561,7 +4561,7 @@ class WorldSessionActor extends Actor
           if (avatar.Implant(slot).id == 3) timeDL = 0
           if (avatar.Implant(slot).id == 9) timeSurge = 0
         }
-        sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid),action,slot,status))
+        sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid),action,slot,status))
       }
 
     case msg @ UseItemMessage(avatar_guid, item_used_guid, object_guid, unk2, unk3, unk4, unk5, unk6, unk7, unk8, itemType) =>
@@ -5011,7 +5011,7 @@ class WorldSessionActor extends Actor
                 //explicit request
                 terminal.Actor ! Terminal.Request(
                   player,
-                  ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "router_telepad", 0, types.PlanetSideGUID(0))
+                  ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "router_telepad", 0, PlanetSideGUID(0))
                 )
               }
               else if (!ownerIsHacked || (ownerIsHacked && terminal.HackedBy.isDefined)) {
@@ -5030,7 +5030,7 @@ class WorldSessionActor extends Actor
             }
           }
         case Some(obj : SpawnTube) =>
-          if(item_used_guid == types.PlanetSideGUID(0)) { // Ensure that we're not trying to use a tool on the spawn tube, e.g. medical applicator
+          if(item_used_guid == PlanetSideGUID(0)) { // Ensure that we're not trying to use a tool on the spawn tube, e.g. medical applicator
             //deconstruction
             PlayerActionsToCancel()
             CancelAllProximityUnits()
@@ -6251,7 +6251,7 @@ class WorldSessionActor extends Actor
     tplayer.Holsters().foreach(holster => {
       SetCharacterSelectScreenGUID_SelectEquipment(holster.Equipment, gen)
     })
-    tplayer.GUID = types.PlanetSideGUID(gen.getAndIncrement)
+    tplayer.GUID = PlanetSideGUID(gen.getAndIncrement)
   }
 
   /**
@@ -6264,10 +6264,10 @@ class WorldSessionActor extends Actor
   private def SetCharacterSelectScreenGUID_SelectEquipment(item : Option[Equipment], gen : AtomicInteger) : Unit = {
     item match {
       case Some(tool : Tool) =>
-        tool.AmmoSlots.foreach(slot => { slot.Box.GUID = types.PlanetSideGUID(gen.getAndIncrement) })
-        tool.GUID = types.PlanetSideGUID(gen.getAndIncrement)
+        tool.AmmoSlots.foreach(slot => { slot.Box.GUID = PlanetSideGUID(gen.getAndIncrement) })
+        tool.GUID = PlanetSideGUID(gen.getAndIncrement)
       case Some(item : Equipment) =>
-        item.GUID = types.PlanetSideGUID(gen.getAndIncrement)
+        item.GUID = PlanetSideGUID(gen.getAndIncrement)
       case None => ;
     }
   }
@@ -6549,7 +6549,7 @@ class WorldSessionActor extends Actor
     if(vehicle.Owner.contains(pguid)) {
       vehicle.AssignOwnership(None)
       val factionChannel = s"${vehicle.Faction}"
-      continent.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.Ownership(pguid, types.PlanetSideGUID(0)))
+      continent.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.Ownership(pguid, PlanetSideGUID(0)))
       val vguid = vehicle.GUID
       val empire = VehicleLockState.Empire.id
       (0 to 2).foreach(group => {
@@ -7423,7 +7423,7 @@ class WorldSessionActor extends Actor
               }
             case DriveState.Deployed =>
               //let the timer do all the work
-              continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(types.PlanetSideGUID(0), vehicle, TelepadLike.AppraiseTeleportationSystem(vehicle, continent)))
+              continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(PlanetSideGUID(0), vehicle, TelepadLike.AppraiseTeleportationSystem(vehicle, continent)))
             case DriveState.Undeploying =>
               //deactivate internal router before trying to reset the system
               vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
@@ -7436,7 +7436,7 @@ class WorldSessionActor extends Actor
                     case Some(_) | None => ;
                   }
                   util.Active = false
-                  continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(types.PlanetSideGUID(0), vehicle, None))
+                  continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(PlanetSideGUID(0), vehicle, None))
                 case _ =>
                   log.warn(s"DeploymentActivities: could not find internal telepad in router@${vehicle.GUID.guid} while $state")
               }
@@ -7612,10 +7612,10 @@ class WorldSessionActor extends Actor
           if(hackable.HackedBy.isDefined) {
             amenity.Definition match {
               case GlobalDefinitions.capture_terminal =>
-                self ! LocalServiceResponse("", types.PlanetSideGUID(0), LocalResponse.HackCaptureTerminal(amenity.GUID, 0L, 0L, false))
+                self ! LocalServiceResponse("", PlanetSideGUID(0), LocalResponse.HackCaptureTerminal(amenity.GUID, 0L, 0L, false))
               case _ =>
                 // Generic hackable object
-                self ! LocalServiceResponse("", types.PlanetSideGUID(0), LocalResponse.HackObject(amenity.GUID, 1114636288L, 8L))
+                self ! LocalServiceResponse("", PlanetSideGUID(0), LocalResponse.HackObject(amenity.GUID, 1114636288L, 8L))
             }
           }
         }
@@ -7662,7 +7662,7 @@ class WorldSessionActor extends Actor
     sendResponse(PlanetsideAttributeMessage(player_guid, 0, 0))
     sendResponse(PlanetsideAttributeMessage(player_guid, 2, 0))
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player_guid, 0, 0))
-    sendResponse(DestroyMessage(player_guid, player_guid, types.PlanetSideGUID(0), pos)) //how many players get this message?
+    sendResponse(DestroyMessage(player_guid, player_guid, PlanetSideGUID(0), pos)) //how many players get this message?
     sendResponse(AvatarDeadStateMessage(DeadState.Dead, respawnTimer, respawnTimer, pos, player.Faction, true))
     if(tplayer.VehicleSeated.nonEmpty) {
       continent.GUID(tplayer.VehicleSeated.get) match {
@@ -8542,7 +8542,7 @@ class WorldSessionActor extends Actor
     *             second pair is maximum quantity
     */
   def UpdateDeployableUIElements(list : List[(Int,Int,Int,Int)]) : Unit = {
-    val guid = types.PlanetSideGUID(0)
+    val guid = PlanetSideGUID(0)
     list.foreach({ case((currElem, curr, maxElem, max)) =>
       //fields must update in ordered pairs: max, curr
       sendResponse(PlanetsideAttributeMessage(guid, maxElem, max))
@@ -8743,7 +8743,7 @@ class WorldSessionActor extends Actor
     sendResponse(ObjectCreateMessage(definition.ObjectId, guid, definition.Packet.ConstructorData(obj).get))
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DeployItem(player.GUID, obj))
     //map icon
-    val deployInfo = DeployableInfo(guid, Deployable.Icon(item), obj.Position, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
+    val deployInfo = DeployableInfo(guid, Deployable.Icon(item), obj.Position, obj.Owner.getOrElse(PlanetSideGUID(0)))
     sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Build, deployInfo))
     continent.LocalEvents ! LocalServiceMessage(s"${player.Faction}", LocalAction.DeployableMapIcon(player.GUID, DeploymentAction.Build, deployInfo))
   }
@@ -8917,7 +8917,7 @@ class WorldSessionActor extends Actor
           obj.Position = Vector3.Zero
           continent.Ground ! Zone.Ground.RemoveItem(object_guid)
           continent.AvatarEvents ! AvatarServiceMessage.Ground(RemoverActor.ClearSpecific(List(obj), continent))
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), object_guid))
+          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), object_guid))
           log.info(s"RequestDestroy: equipment $obj on ground")
           true
         }
@@ -8942,7 +8942,7 @@ class WorldSessionActor extends Actor
       sendResponse(
         DeployableObjectsInfoMessage(
           DeploymentAction.Dismiss,
-          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
+          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(PlanetSideGUID(0)))
         )
       )
     }
@@ -8967,7 +8967,7 @@ class WorldSessionActor extends Actor
       sendResponse(
         DeployableObjectsInfoMessage(
           DeploymentAction.Dismiss,
-          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
+          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(PlanetSideGUID(0)))
         )
       )
     }
@@ -9000,13 +9000,13 @@ class WorldSessionActor extends Actor
     target.OwnerName match {
       case Some(owner) =>
         target.OwnerName = None
-        continent.LocalEvents ! LocalServiceMessage(owner, LocalAction.AlertDestroyDeployable(types.PlanetSideGUID(0), target))
+        continent.LocalEvents ! LocalServiceMessage(owner, LocalAction.AlertDestroyDeployable(PlanetSideGUID(0), target))
       case None => ;
     }
     continent.LocalEvents ! LocalServiceMessage(s"${target.Faction}", LocalAction.DeployableMapIcon(
-      types.PlanetSideGUID(0),
+      PlanetSideGUID(0),
       DeploymentAction.Dismiss,
-      DeployableInfo(target.GUID, Deployable.Icon(target.Definition.Item), target.Position, types.PlanetSideGUID(0)))
+      DeployableInfo(target.GUID, Deployable.Icon(target.Definition.Item), target.Position, PlanetSideGUID(0)))
     )
     continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.ClearSpecific(List(target), continent))
     continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(target, continent, time))
@@ -9269,7 +9269,7 @@ class WorldSessionActor extends Actor
       player.Continent = zone_id //forward-set the continent id to perform a test
       interstellarFerryTopLevelGUID = (if(vehicle.Seats.values.count(_.isOccupied) == 1 && occupiedCargoHolds.size == 0) {
         //do not delete if vehicle has passengers or cargo
-        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(types.PlanetSideGUID(0))
+        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(PlanetSideGUID(0))
         continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.UnloadVehicle(pguid, continent, vehicle, vehicleToDelete))
         None
       }
@@ -9331,7 +9331,7 @@ class WorldSessionActor extends Actor
       val continentId = continent.Id
       if(NoVehicleOccupantsInZone(vehicle, continentId)) {
         //do not dispatch delete action if any hierarchical occupant has not gotten this far through the summoning process
-        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(types.PlanetSideGUID(0))
+        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(PlanetSideGUID(0))
         continent.VehicleEvents ! VehicleServiceMessage(continentId, VehicleAction.UnloadVehicle(player.GUID, continent, vehicle, vehicleToDelete))
       }
       interstellarFerryTopLevelGUID = None
@@ -9439,7 +9439,7 @@ class WorldSessionActor extends Actor
         sendResponse(ActionResultMessage.Pass)
         player.GUID //we're dropping the item; don't need to see it dropped again
       case None =>
-        types.PlanetSideGUID(0) //item is being introduced into the world upon drop
+        PlanetSideGUID(0) //item is being introduced into the world upon drop
     }
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DropItem(exclusionId, item, continent))
   }
@@ -9696,18 +9696,18 @@ class WorldSessionActor extends Actor
           carrier.Position
         }
         StartBundlingPackets()
-        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
-        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
+        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
+        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
         if(carrier.Flying) {
           //the carrier vehicle is flying; eject the cargo vehicle
-          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.InProgress, 0)
+          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.InProgress, 0)
           val detachCargoMsg = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition - Vector3.z(1), rotation)
-          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
           sendResponse(ejectCargoMsg) //dismount vehicle on UI and disable "shield" effect on lodestar
           sendResponse(detachCargoMsg)
           continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(player_guid, ejectCargoMsg))
           continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(player_guid, detachCargoMsg))
-          continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(types.PlanetSideGUID(0), resetCargoMsg)) //lazy
+          continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
           log.debug(ejectCargoMsg.toString)
           log.debug(detachCargoMsg.toString)
           if(driverOpt.isEmpty) {
@@ -9718,7 +9718,7 @@ class WorldSessionActor extends Actor
         }
         else {
           //the carrier vehicle is not flying; just open the door and let the cargo vehicle back out; force it out if necessary
-          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), cargoGUID, types.PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
+          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), cargoGUID, PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
           val cargoDetachMessage = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition + Vector3.z(1f), rotation)
           sendResponse(cargoStatusMessage)
           sendResponse(cargoDetachMessage)
@@ -9734,8 +9734,8 @@ class WorldSessionActor extends Actor
               cargoDismountTimer.cancel
               cargoDismountTimer = context.system.scheduler.scheduleOnce(250 milliseconds, self, CheckCargoDismount(cargoGUID, carrierGUID, mountPoint, iteration = 0))
             case None =>
-              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
-              continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(types.PlanetSideGUID(0), resetCargoMsg)) //lazy
+              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
               //TODO cargo should back out like normal; until then, deconstruct it
               continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(cargo), continent))
               continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(cargo, continent, Some(0 seconds)))
@@ -9895,7 +9895,7 @@ class WorldSessionActor extends Actor
         sendResponse(SquadMemberEvent.Add(id, fromCharId, fromIndex, toElem.name, toElem.zone, unk7 = 0))
         sendResponse(
           SquadState(
-            types.PlanetSideGUID(id),
+            PlanetSideGUID(id),
             List(
               SquadStateInfo(fromCharId, toElem.health, toElem.armor, toElem.position, 2, 2, false, 429, None, None),
               SquadStateInfo(toCharId, fromElem.health, fromElem.armor, fromElem.position, 2, 2, false, 429, None, None)
@@ -9911,7 +9911,7 @@ class WorldSessionActor extends Actor
         sendResponse(SquadMemberEvent.Add(id, fromCharId, toIndex, elem.name, elem.zone, unk7 = 0))
         sendResponse(
           SquadState(
-            types.PlanetSideGUID(id),
+            PlanetSideGUID(id),
             List(SquadStateInfo(fromCharId, elem.health, elem.armor, elem.position, 2, 2, false, 429, None, None))
           )
         )
@@ -10099,7 +10099,7 @@ class WorldSessionActor extends Actor
     if(avatar.Implants(0).Active) {
       avatar.Implants(0).Active = false
       continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player.GUID, 28, avatar.Implant(0).id * 2))
-      sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 0, 0))
+      sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 0, 0))
       timeDL = 0
     }
   }
@@ -10112,7 +10112,7 @@ class WorldSessionActor extends Actor
     if(avatar.Implants(1).Active) {
       avatar.Implants(1).Active = false
       continent.AvatarEvents  ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player.GUID, 28, avatar.Implant(1).id * 2))
-      sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 1, 0))
+      sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 1, 0))
       timeSurge = 0
     }
   }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -46,7 +46,7 @@ import net.psforever.objects.vital._
 import net.psforever.objects.zones.{InterstellarCluster, Zone, ZoneHotSpotProjector}
 import net.psforever.packet.game.objectcreate._
 import net.psforever.packet.game.{HotSpotInfo => PacketHotSpotInfo}
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import services.{RemoverActor, vehicle, _}
 import services.avatar.{AvatarAction, AvatarResponse, AvatarServiceMessage, AvatarServiceResponse}
 import services.galaxy.{GalaxyAction, GalaxyResponse, GalaxyServiceMessage, GalaxyServiceResponse}
@@ -67,6 +67,7 @@ import scala.util.Success
 import akka.pattern.ask
 import net.psforever.objects.entity.{SimpleWorldEntity, WorldEntity}
 import net.psforever.objects.vehicles.Utility.InternalTelepad
+import net.psforever.types
 import services.local.support.{HackCaptureActor, RouterTelepadActivation}
 import services.support.SupportActor
 
@@ -409,7 +410,7 @@ class WorldSessionActor extends Actor
       if(!excluded.exists(_ == avatar.CharId)) {
         response match {
           case SquadResponse.ListSquadFavorite(line, task) =>
-            sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), line, SquadAction.ListSquadFavorite(task)))
+            sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), line, SquadAction.ListSquadFavorite(task)))
 
           case SquadResponse.InitList(infos) =>
             sendResponse(ReplicationStreamMessage(infos))
@@ -511,7 +512,7 @@ class WorldSessionActor extends Actor
             }
             StopBundlingPackets()
             //send an initial dummy update for map icon(s)
-            sendResponse(SquadState(PlanetSideGUID(squad_supplement_id),
+            sendResponse(SquadState(types.PlanetSideGUID(squad_supplement_id),
               membershipPositions
                 .filterNot { case (member, _) => member.CharId == avatar.CharId }
                 .map{ case (member, _) => SquadStateInfo(member.CharId, member.Health, member.Armor, member.Position, 2,2, false, 429, None,None) }
@@ -537,7 +538,7 @@ class WorldSessionActor extends Actor
                 sendResponse(PlanetsideAttributeMessage(playerGuid, 34, 4294967295L)) //unknown, perhaps unrelated?
                 lfsm = false
                 //a finalization? what does this do?
-                sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
+                sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
                 squad_supplement_id = 0
                 squadUpdateCounter = 0
                 updateSquad = NoSquadUpdates
@@ -603,7 +604,7 @@ class WorldSessionActor extends Actor
             if(updatedEntries.nonEmpty) {
               sendResponse(
                 SquadState(
-                  PlanetSideGUID(squad_supplement_id),
+                  types.PlanetSideGUID(squad_supplement_id),
                   updatedEntries.map { entry => SquadStateInfo(entry.char_id, entry.health, entry.armor, entry.pos, 2,2, false, 429, None,None)}
                 )
               )
@@ -611,7 +612,7 @@ class WorldSessionActor extends Actor
 
           case SquadResponse.SquadSearchResults() =>
             //I don't actually know how to return search results
-            sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.NoSquadSearchResults()))
+            sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.NoSquadSearchResults()))
 
           case SquadResponse.InitWaypoints(char_id, waypoints) =>
             StartBundlingPackets()
@@ -718,8 +719,8 @@ class WorldSessionActor extends Actor
       }
       sendResponse(CharacterInfoMessage(15, PlanetSideZoneID(10000), avatar.CharId, player.GUID, false, 6404428))
       RemoveCharacterSelectScreenGUID(player)
-      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, PlanetSideGUID(0), true, 0))
-      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, PlanetSideGUID(0), true, 0))
+      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, types.PlanetSideGUID(0), true, 0))
+      sendResponse(CharacterInfoMessage(0, PlanetSideZoneID(1), 0, types.PlanetSideGUID(0), true, 0))
 
     case VehicleLoaded(_ /*vehicle*/) => ;
     //currently being handled by VehicleSpawnPad.LoadVehicle during testing phase
@@ -821,7 +822,7 @@ class WorldSessionActor extends Actor
           continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(obj, continent))
           sendResponse(SetEmpireMessage(guid, PlanetSideEmpire.NEUTRAL))
           continent.AvatarEvents ! AvatarServiceMessage(factionChannel, AvatarAction.SetEmpire(playerGUID, guid, PlanetSideEmpire.NEUTRAL))
-          val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, PlanetSideGUID(0))
+          val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, types.PlanetSideGUID(0))
           sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Dismiss, info))
           continent.LocalEvents ! LocalServiceMessage(factionChannel, LocalAction.DeployableMapIcon(playerGUID, DeploymentAction.Dismiss, info))
           PutItemOnGround(item, pos, orient)
@@ -829,7 +830,7 @@ class WorldSessionActor extends Actor
           //pointless trigger
           val guid = item.GUID
           continent.Ground ! Zone.Ground.RemoveItem(guid) //undo; no callback
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
+          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), guid))
           taskResolver ! GUIDTask.UnregisterObjectTask(item)(continent.GUID)
       }
 
@@ -1030,7 +1031,7 @@ class WorldSessionActor extends Actor
       LivePlayerList.Add(sessionId, avatar)
       traveler = new Traveler(self, continent.Id)
       //PropertyOverrideMessage
-      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
+      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 112, 0)) // disable festive backpacks
       sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
       sendResponse(FriendsResponse(FriendAction.InitializeFriendList, 0, true, true, Nil))
       sendResponse(FriendsResponse(FriendAction.InitializeIgnoreList, 0, true, true, Nil))
@@ -1169,7 +1170,7 @@ class WorldSessionActor extends Actor
     */
   def HandleAvatarServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : AvatarResponse.Response) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else PlanetSideGUID(0)
+    else types.PlanetSideGUID(0)
     reply match {
       case AvatarResponse.SendResponse(msg) =>
         sendResponse(msg)
@@ -1430,7 +1431,7 @@ class WorldSessionActor extends Actor
         }
 
       case AvatarResponse.ProjectileExplodes(projectile_guid, projectile) =>
-        sendResponse(ProjectileStateMessage(projectile_guid, projectile.Position, Vector3.Zero, projectile.Orientation, 0, true, PlanetSideGUID(0)))
+        sendResponse(ProjectileStateMessage(projectile_guid, projectile.Position, Vector3.Zero, projectile.Orientation, 0, true, types.PlanetSideGUID(0)))
         sendResponse(ObjectDeleteMessage(projectile_guid, 2))
 
       case AvatarResponse.ProjectileAutoLockAwareness(mode) =>
@@ -1518,7 +1519,7 @@ class WorldSessionActor extends Actor
     */
   def HandleLocalServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : LocalResponse.Response) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else PlanetSideGUID(0)
+    else types.PlanetSideGUID(0)
     reply match {
       case LocalResponse.AlertDestroyDeployable(obj) =>
         //the (former) owner (obj.OwnerName) should process this message
@@ -1661,10 +1662,10 @@ class WorldSessionActor extends Actor
         }
 
       case LocalResponse.ProximityTerminalEffect(object_guid, true) =>
-        sendResponse(ProximityTerminalUseMessage(PlanetSideGUID(0), object_guid, true))
+        sendResponse(ProximityTerminalUseMessage(types.PlanetSideGUID(0), object_guid, true))
 
       case LocalResponse.ProximityTerminalEffect(object_guid, false) =>
-        sendResponse(ProximityTerminalUseMessage(PlanetSideGUID(0), object_guid, false))
+        sendResponse(ProximityTerminalUseMessage(types.PlanetSideGUID(0), object_guid, false))
         ForgetAllProximityTerminals(object_guid)
 
       case LocalResponse.RouterTelepadMessage(msg) =>
@@ -1700,7 +1701,7 @@ class WorldSessionActor extends Actor
     */
   def HandleChatServiceResponse(toChannel : String, avatar_guid : PlanetSideGUID, avatar_name : String, cont : Zone, avatar_pos : Vector3, avatar_faction : PlanetSideEmpire.Value, target : Int, reply : ChatMsg) : Unit = {
     val tplayer_guid = if(player.HasGUID) player.GUID
-    else PlanetSideGUID(0)
+    else types.PlanetSideGUID(0)
     target match {
       case 0 => // for other(s) user(s)
         if (player.GUID != avatar_guid) {
@@ -1724,7 +1725,7 @@ class WorldSessionActor extends Actor
                 if(!player.silenced) {
                   sendResponse(ChatMsg(ChatMessageType.UNK_71, reply.wideContents, reply.recipient, "@silence_on", reply.note))
                   player.silenced = true
-                  context.system.scheduler.scheduleOnce(silence_time minutes, chatService, ChatServiceMessage("gm", ChatAction.GM(PlanetSideGUID(0), player.Name, ChatMsg(ChatMessageType.CMT_SILENCE, true, "", player.Name, None))))
+                  context.system.scheduler.scheduleOnce(silence_time minutes, chatService, ChatServiceMessage("gm", ChatAction.GM(types.PlanetSideGUID(0), player.Name, ChatMsg(ChatMessageType.CMT_SILENCE, true, "", player.Name, None))))
                 }
                 else {
                   sendResponse(ChatMsg(ChatMessageType.UNK_71, reply.wideContents, reply.recipient, "@silence_off", reply.note))
@@ -2217,7 +2218,7 @@ class WorldSessionActor extends Actor
                   val existingBox = existingWeapon.AmmoSlots(index).Box
                   existingBox.Capacity = savedWeapon.AmmoSlots(index).Box.Capacity
                   //use VehicleAction.InventoryState2; VehicleAction.InventoryState temporarily glitches ammo count in ui
-                  continent.VehicleEvents ! VehicleServiceMessage(channel, VehicleAction.InventoryState2(PlanetSideGUID(0), existingBox.GUID, existingWeapon.GUID, existingBox.Capacity))
+                  continent.VehicleEvents ! VehicleServiceMessage(channel, VehicleAction.InventoryState2(types.PlanetSideGUID(0), existingBox.GUID, existingWeapon.GUID, existingBox.Capacity))
                 })
               })
               afterInventory
@@ -2432,7 +2433,7 @@ class WorldSessionActor extends Actor
     * @param reply     na
     */
   def HandleVehicleServiceResponse(toChannel : String, guid : PlanetSideGUID, reply : VehicleResponse.Response) : Unit = {
-    val tplayer_guid = if(player.HasGUID) player.GUID else PlanetSideGUID(0)
+    val tplayer_guid = if(player.HasGUID) player.GUID else types.PlanetSideGUID(0)
 
     reply match {
       case VehicleResponse.AttachToRails(vehicle_guid, pad_guid) =>
@@ -2688,7 +2689,7 @@ class WorldSessionActor extends Actor
             continent.Id,
             VehicleAction.SendResponse(
               player.GUID,
-              CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
             )
           )
           //sending packet to the cargo vehicle's client results in player locking himself in his vehicle
@@ -2759,8 +2760,8 @@ class WorldSessionActor extends Actor
           cargo.MountedIn = carrierGUID
           hold.Occupant = cargo
           cargo.Velocity = None
-          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
-          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
+          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
+          continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
           StartBundlingPackets()
           val (attachMsg, mountPointMsg) = CargoMountBehaviorForAll(carrier, cargo, mountPoint)
           StopBundlingPackets()
@@ -2774,7 +2775,7 @@ class WorldSessionActor extends Actor
             continent.Id,
             VehicleAction.SendResponse(
               player.GUID,
-              CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
             )
           )
           //sending packet to the cargo vehicle's client results in player locking himself in his vehicle
@@ -2827,7 +2828,7 @@ class WorldSessionActor extends Actor
   def CargoMountMessages(carrierGUID : PlanetSideGUID, cargoGUID : PlanetSideGUID, mountPoint : Int, orientation : Int) : (ObjectAttachMessage, CargoMountPointStatusMessage) = {
     (
       ObjectAttachMessage(carrierGUID, cargoGUID, mountPoint),
-      CargoMountPointStatusMessage(carrierGUID, cargoGUID, cargoGUID, PlanetSideGUID(0), mountPoint, CargoStatus.Occupied, orientation)
+      CargoMountPointStatusMessage(carrierGUID, cargoGUID, cargoGUID, types.PlanetSideGUID(0), mountPoint, CargoStatus.Occupied, orientation)
     )
   }
 
@@ -3072,7 +3073,7 @@ class WorldSessionActor extends Actor
     val guid = tplayer.GUID
     StartBundlingPackets()
     InitializeDeployableUIElements(avatar)
-    sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 75, 0))
+    sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 75, 0))
     sendResponse(SetCurrentAvatarMessage(guid, 0, 0))
     sendResponse(ChatMsg(ChatMessageType.CMT_EXPANSIONS, true, "", "1 on", None)) //CC on //TODO once per respawn?
     sendResponse(PlayerStateShiftMessage(ShiftState(1, shiftPosition.getOrElse(tplayer.Position), tplayer.Orientation.z)))
@@ -3085,7 +3086,7 @@ class WorldSessionActor extends Actor
       sendResponse(AvatarImplantMessage(guid, ImplantAction.Activation, slot, 0)) //deactivate implant
       //TODO if this implant is Installed but does not have shortcut, add to a free slot or write over slot 61/62/63
     })
-    sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 82, 0))
+    sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 82, 0))
     //TODO if Medkit does not have shortcut, add to a free slot or write over slot 64
     sendResponse(CreateShortcutMessage(guid, 1, 0, true, Shortcut.MEDKIT))
     sendResponse(ChangeShortcutBankMessage(guid, 0))
@@ -3110,7 +3111,7 @@ class WorldSessionActor extends Actor
     sendResponse(AvatarSearchCriteriaMessage(guid, List(0, 0, 0, 0, 0, 0)))
     (1 to 73).foreach(i => {
       // not all GUID's are set, and not all of the set ones will always be zero; what does this section do?
-      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(i), 67, 0))
+      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(i), 67, 0))
     })
     (0 to 30).foreach(i => {
       //TODO 30 for a new character only?
@@ -3169,16 +3170,16 @@ class WorldSessionActor extends Actor
   def FirstTimeSquadSetup() : Unit = {
     sendResponse(SquadDetailDefinitionUpdateMessage.Init)
     sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
-    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(6)))
+    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(6)))
     //only need to load these once - they persist between zone transfers and respawns
     avatar.SquadLoadouts.Loadouts.foreach {
       case (index, loadout : SquadLoadout) =>
-        sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), index, SquadAction.ListSquadFavorite(loadout.task)))
+        sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), index, SquadAction.ListSquadFavorite(loadout.task)))
     }
     //non-squad GUID-0 counts as the settings when not joined with a squad
-    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.AssociateWithSquad()))
-    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.SetListSquad()))
-    sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
+    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.AssociateWithSquad()))
+    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.SetListSquad()))
+    sendResponse(SquadDefinitionActionMessage(types.PlanetSideGUID(0), 0, SquadAction.Unknown(18)))
     squadService ! SquadServiceMessage(player, continent, SquadServiceAction.InitSquadList())
     squadService ! SquadServiceMessage(player, continent, SquadServiceAction.InitCharId())
     squadSetup = RespawnSquadSetup
@@ -3368,7 +3369,7 @@ class WorldSessionActor extends Actor
         case (Some(_ : Vehicle), Some(carrier : Vehicle)) =>
           carrier.Definition.Cargo.headOption match {
             case Some((mountPoint, _)) => //begin the mount process - open the cargo door
-              val reply = CargoMountPointStatusMessage(cargo_vehicle_guid, PlanetSideGUID(0), vehicle_guid, PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
+              val reply = CargoMountPointStatusMessage(cargo_vehicle_guid, types.PlanetSideGUID(0), vehicle_guid, types.PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
               log.debug(reply.toString)
               continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.SendResponse(player.GUID, reply))
               sendResponse(reply)
@@ -3434,7 +3435,7 @@ class WorldSessionActor extends Actor
       //custom
       sendResponse(ContinentalLockUpdateMessage(13, PlanetSideEmpire.VS)) // "The VS have captured the VS Sanctuary."
       sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
-      sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
+      sendResponse(PlanetsideAttributeMessage(types.PlanetSideGUID(0), 112, 0)) // disable festive backpacks
       //(0 to 255).foreach(i => { sendResponse(SetEmpireMessage(PlanetSideGUID(i), PlanetSideEmpire.VS)) })
 
       //find and reclaim own deployables, if any
@@ -3496,7 +3497,7 @@ class WorldSessionActor extends Actor
       continent.DeployableList
         .filter(obj => obj.Faction == faction && obj.Health > 0)
         .foreach(obj => {
-          val deployInfo = DeployableInfo(obj.GUID, Deployable.Icon(obj.Definition.Item), obj.Position, obj.Owner.getOrElse(PlanetSideGUID(0)))
+          val deployInfo = DeployableInfo(obj.GUID, Deployable.Icon(obj.Definition.Item), obj.Position, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
           sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Build, deployInfo))
         })
       //render Equipment that was dropped into zone before the player arrived
@@ -3610,14 +3611,14 @@ class WorldSessionActor extends Actor
 
       //implant terminals
       continent.Map.TerminalToInterface.foreach({ case ((terminal_guid, interface_guid)) =>
-        val parent_guid = PlanetSideGUID(terminal_guid)
+        val parent_guid = types.PlanetSideGUID(terminal_guid)
         continent.GUID(interface_guid) match {
           case Some(obj : Terminal) =>
             val objDef = obj.Definition
             sendResponse(
               ObjectCreateMessage(
                 objDef.ObjectId,
-                PlanetSideGUID(interface_guid),
+                types.PlanetSideGUID(interface_guid),
                 ObjectCreateMessageParent(parent_guid, 1),
                 objDef.Packet.ConstructorData(obj).get
               )
@@ -4015,7 +4016,7 @@ class WorldSessionActor extends Actor
           case Some(turret : FacilityTurret) if turret.isUpgrading =>
             FinishUpgradingMannedTurret(turret, TurretUpgrade.None)
           case _ =>
-            self ! PacketCoding.CreateGamePacket(0, RequestDestroyMessage(PlanetSideGUID(guid)))
+            self ! PacketCoding.CreateGamePacket(0, RequestDestroyMessage(types.PlanetSideGUID(guid)))
         }
       }
       if(messagetype == ChatMessageType.CMT_VOICE) {
@@ -4422,7 +4423,7 @@ class WorldSessionActor extends Actor
                   log.warn(s"RequestDestroy: boomer_trigger@$guid has been found but it seems to be orphaned")
                 case _ => ;
               }
-              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
+              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), guid))
               GUIDTask.UnregisterObjectTask(trigger)(continent.GUID)
 
             case None => ;
@@ -4560,7 +4561,7 @@ class WorldSessionActor extends Actor
           if (avatar.Implant(slot).id == 3) timeDL = 0
           if (avatar.Implant(slot).id == 9) timeSurge = 0
         }
-        sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid),action,slot,status))
+        sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid),action,slot,status))
       }
 
     case msg @ UseItemMessage(avatar_guid, item_used_guid, object_guid, unk2, unk3, unk4, unk5, unk6, unk7, unk8, itemType) =>
@@ -5010,7 +5011,7 @@ class WorldSessionActor extends Actor
                 //explicit request
                 terminal.Actor ! Terminal.Request(
                   player,
-                  ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "router_telepad", 0, PlanetSideGUID(0))
+                  ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "router_telepad", 0, types.PlanetSideGUID(0))
                 )
               }
               else if (!ownerIsHacked || (ownerIsHacked && terminal.HackedBy.isDefined)) {
@@ -5029,7 +5030,7 @@ class WorldSessionActor extends Actor
             }
           }
         case Some(obj : SpawnTube) =>
-          if(item_used_guid == PlanetSideGUID(0)) { // Ensure that we're not trying to use a tool on the spawn tube, e.g. medical applicator
+          if(item_used_guid == types.PlanetSideGUID(0)) { // Ensure that we're not trying to use a tool on the spawn tube, e.g. medical applicator
             //deconstruction
             PlayerActionsToCancel()
             CancelAllProximityUnits()
@@ -6250,7 +6251,7 @@ class WorldSessionActor extends Actor
     tplayer.Holsters().foreach(holster => {
       SetCharacterSelectScreenGUID_SelectEquipment(holster.Equipment, gen)
     })
-    tplayer.GUID = PlanetSideGUID(gen.getAndIncrement)
+    tplayer.GUID = types.PlanetSideGUID(gen.getAndIncrement)
   }
 
   /**
@@ -6263,10 +6264,10 @@ class WorldSessionActor extends Actor
   private def SetCharacterSelectScreenGUID_SelectEquipment(item : Option[Equipment], gen : AtomicInteger) : Unit = {
     item match {
       case Some(tool : Tool) =>
-        tool.AmmoSlots.foreach(slot => { slot.Box.GUID = PlanetSideGUID(gen.getAndIncrement) })
-        tool.GUID = PlanetSideGUID(gen.getAndIncrement)
+        tool.AmmoSlots.foreach(slot => { slot.Box.GUID = types.PlanetSideGUID(gen.getAndIncrement) })
+        tool.GUID = types.PlanetSideGUID(gen.getAndIncrement)
       case Some(item : Equipment) =>
-        item.GUID = PlanetSideGUID(gen.getAndIncrement)
+        item.GUID = types.PlanetSideGUID(gen.getAndIncrement)
       case None => ;
     }
   }
@@ -6548,7 +6549,7 @@ class WorldSessionActor extends Actor
     if(vehicle.Owner.contains(pguid)) {
       vehicle.AssignOwnership(None)
       val factionChannel = s"${vehicle.Faction}"
-      continent.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.Ownership(pguid, PlanetSideGUID(0)))
+      continent.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.Ownership(pguid, types.PlanetSideGUID(0)))
       val vguid = vehicle.GUID
       val empire = VehicleLockState.Empire.id
       (0 to 2).foreach(group => {
@@ -7422,7 +7423,7 @@ class WorldSessionActor extends Actor
               }
             case DriveState.Deployed =>
               //let the timer do all the work
-              continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(PlanetSideGUID(0), vehicle, TelepadLike.AppraiseTeleportationSystem(vehicle, continent)))
+              continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(types.PlanetSideGUID(0), vehicle, TelepadLike.AppraiseTeleportationSystem(vehicle, continent)))
             case DriveState.Undeploying =>
               //deactivate internal router before trying to reset the system
               vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
@@ -7435,7 +7436,7 @@ class WorldSessionActor extends Actor
                     case Some(_) | None => ;
                   }
                   util.Active = false
-                  continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(PlanetSideGUID(0), vehicle, None))
+                  continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.ToggleTeleportSystem(types.PlanetSideGUID(0), vehicle, None))
                 case _ =>
                   log.warn(s"DeploymentActivities: could not find internal telepad in router@${vehicle.GUID.guid} while $state")
               }
@@ -7611,10 +7612,10 @@ class WorldSessionActor extends Actor
           if(hackable.HackedBy.isDefined) {
             amenity.Definition match {
               case GlobalDefinitions.capture_terminal =>
-                self ! LocalServiceResponse("", PlanetSideGUID(0), LocalResponse.HackCaptureTerminal(amenity.GUID, 0L, 0L, false))
+                self ! LocalServiceResponse("", types.PlanetSideGUID(0), LocalResponse.HackCaptureTerminal(amenity.GUID, 0L, 0L, false))
               case _ =>
                 // Generic hackable object
-                self ! LocalServiceResponse("", PlanetSideGUID(0), LocalResponse.HackObject(amenity.GUID, 1114636288L, 8L))
+                self ! LocalServiceResponse("", types.PlanetSideGUID(0), LocalResponse.HackObject(amenity.GUID, 1114636288L, 8L))
             }
           }
         }
@@ -7661,7 +7662,7 @@ class WorldSessionActor extends Actor
     sendResponse(PlanetsideAttributeMessage(player_guid, 0, 0))
     sendResponse(PlanetsideAttributeMessage(player_guid, 2, 0))
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player_guid, 0, 0))
-    sendResponse(DestroyMessage(player_guid, player_guid, PlanetSideGUID(0), pos)) //how many players get this message?
+    sendResponse(DestroyMessage(player_guid, player_guid, types.PlanetSideGUID(0), pos)) //how many players get this message?
     sendResponse(AvatarDeadStateMessage(DeadState.Dead, respawnTimer, respawnTimer, pos, player.Faction, true))
     if(tplayer.VehicleSeated.nonEmpty) {
       continent.GUID(tplayer.VehicleSeated.get) match {
@@ -8541,7 +8542,7 @@ class WorldSessionActor extends Actor
     *             second pair is maximum quantity
     */
   def UpdateDeployableUIElements(list : List[(Int,Int,Int,Int)]) : Unit = {
-    val guid = PlanetSideGUID(0)
+    val guid = types.PlanetSideGUID(0)
     list.foreach({ case((currElem, curr, maxElem, max)) =>
       //fields must update in ordered pairs: max, curr
       sendResponse(PlanetsideAttributeMessage(guid, maxElem, max))
@@ -8742,7 +8743,7 @@ class WorldSessionActor extends Actor
     sendResponse(ObjectCreateMessage(definition.ObjectId, guid, definition.Packet.ConstructorData(obj).get))
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DeployItem(player.GUID, obj))
     //map icon
-    val deployInfo = DeployableInfo(guid, Deployable.Icon(item), obj.Position, obj.Owner.getOrElse(PlanetSideGUID(0)))
+    val deployInfo = DeployableInfo(guid, Deployable.Icon(item), obj.Position, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
     sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Build, deployInfo))
     continent.LocalEvents ! LocalServiceMessage(s"${player.Faction}", LocalAction.DeployableMapIcon(player.GUID, DeploymentAction.Build, deployInfo))
   }
@@ -8916,7 +8917,7 @@ class WorldSessionActor extends Actor
           obj.Position = Vector3.Zero
           continent.Ground ! Zone.Ground.RemoveItem(object_guid)
           continent.AvatarEvents ! AvatarServiceMessage.Ground(RemoverActor.ClearSpecific(List(obj), continent))
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), object_guid))
+          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(types.PlanetSideGUID(0), object_guid))
           log.info(s"RequestDestroy: equipment $obj on ground")
           true
         }
@@ -8941,7 +8942,7 @@ class WorldSessionActor extends Actor
       sendResponse(
         DeployableObjectsInfoMessage(
           DeploymentAction.Dismiss,
-          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(PlanetSideGUID(0)))
+          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
         )
       )
     }
@@ -8966,7 +8967,7 @@ class WorldSessionActor extends Actor
       sendResponse(
         DeployableObjectsInfoMessage(
           DeploymentAction.Dismiss,
-          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(PlanetSideGUID(0)))
+          DeployableInfo(guid, Deployable.Icon(obj.Definition.Item), pos, obj.Owner.getOrElse(types.PlanetSideGUID(0)))
         )
       )
     }
@@ -8999,13 +9000,13 @@ class WorldSessionActor extends Actor
     target.OwnerName match {
       case Some(owner) =>
         target.OwnerName = None
-        continent.LocalEvents ! LocalServiceMessage(owner, LocalAction.AlertDestroyDeployable(PlanetSideGUID(0), target))
+        continent.LocalEvents ! LocalServiceMessage(owner, LocalAction.AlertDestroyDeployable(types.PlanetSideGUID(0), target))
       case None => ;
     }
     continent.LocalEvents ! LocalServiceMessage(s"${target.Faction}", LocalAction.DeployableMapIcon(
-      PlanetSideGUID(0),
+      types.PlanetSideGUID(0),
       DeploymentAction.Dismiss,
-      DeployableInfo(target.GUID, Deployable.Icon(target.Definition.Item), target.Position, PlanetSideGUID(0)))
+      DeployableInfo(target.GUID, Deployable.Icon(target.Definition.Item), target.Position, types.PlanetSideGUID(0)))
     )
     continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.ClearSpecific(List(target), continent))
     continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(target, continent, time))
@@ -9268,7 +9269,7 @@ class WorldSessionActor extends Actor
       player.Continent = zone_id //forward-set the continent id to perform a test
       interstellarFerryTopLevelGUID = (if(vehicle.Seats.values.count(_.isOccupied) == 1 && occupiedCargoHolds.size == 0) {
         //do not delete if vehicle has passengers or cargo
-        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(PlanetSideGUID(0))
+        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(types.PlanetSideGUID(0))
         continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.UnloadVehicle(pguid, continent, vehicle, vehicleToDelete))
         None
       }
@@ -9330,7 +9331,7 @@ class WorldSessionActor extends Actor
       val continentId = continent.Id
       if(NoVehicleOccupantsInZone(vehicle, continentId)) {
         //do not dispatch delete action if any hierarchical occupant has not gotten this far through the summoning process
-        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(PlanetSideGUID(0))
+        val vehicleToDelete = interstellarFerryTopLevelGUID.orElse(player.VehicleSeated).getOrElse(types.PlanetSideGUID(0))
         continent.VehicleEvents ! VehicleServiceMessage(continentId, VehicleAction.UnloadVehicle(player.GUID, continent, vehicle, vehicleToDelete))
       }
       interstellarFerryTopLevelGUID = None
@@ -9438,7 +9439,7 @@ class WorldSessionActor extends Actor
         sendResponse(ActionResultMessage.Pass)
         player.GUID //we're dropping the item; don't need to see it dropped again
       case None =>
-        PlanetSideGUID(0) //item is being introduced into the world upon drop
+        types.PlanetSideGUID(0) //item is being introduced into the world upon drop
     }
     continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DropItem(exclusionId, item, continent))
   }
@@ -9695,18 +9696,18 @@ class WorldSessionActor extends Actor
           carrier.Position
         }
         StartBundlingPackets()
-        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
-        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
+        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
+        continent.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(types.PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
         if(carrier.Flying) {
           //the carrier vehicle is flying; eject the cargo vehicle
-          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.InProgress, 0)
+          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.InProgress, 0)
           val detachCargoMsg = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition - Vector3.z(1), rotation)
-          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
           sendResponse(ejectCargoMsg) //dismount vehicle on UI and disable "shield" effect on lodestar
           sendResponse(detachCargoMsg)
           continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(player_guid, ejectCargoMsg))
           continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(player_guid, detachCargoMsg))
-          continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
+          continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(types.PlanetSideGUID(0), resetCargoMsg)) //lazy
           log.debug(ejectCargoMsg.toString)
           log.debug(detachCargoMsg.toString)
           if(driverOpt.isEmpty) {
@@ -9717,7 +9718,7 @@ class WorldSessionActor extends Actor
         }
         else {
           //the carrier vehicle is not flying; just open the door and let the cargo vehicle back out; force it out if necessary
-          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), cargoGUID, PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
+          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), cargoGUID, types.PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
           val cargoDetachMessage = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition + Vector3.z(1f), rotation)
           sendResponse(cargoStatusMessage)
           sendResponse(cargoDetachMessage)
@@ -9733,8 +9734,8 @@ class WorldSessionActor extends Actor
               cargoDismountTimer.cancel
               cargoDismountTimer = context.system.scheduler.scheduleOnce(250 milliseconds, self, CheckCargoDismount(cargoGUID, carrierGUID, mountPoint, iteration = 0))
             case None =>
-              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
-              continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
+              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, types.PlanetSideGUID(0), types.PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              continent.VehicleEvents ! VehicleServiceMessage(continent.Id, VehicleAction.SendResponse(types.PlanetSideGUID(0), resetCargoMsg)) //lazy
               //TODO cargo should back out like normal; until then, deconstruct it
               continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(cargo), continent))
               continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(cargo, continent, Some(0 seconds)))
@@ -9894,7 +9895,7 @@ class WorldSessionActor extends Actor
         sendResponse(SquadMemberEvent.Add(id, fromCharId, fromIndex, toElem.name, toElem.zone, unk7 = 0))
         sendResponse(
           SquadState(
-            PlanetSideGUID(id),
+            types.PlanetSideGUID(id),
             List(
               SquadStateInfo(fromCharId, toElem.health, toElem.armor, toElem.position, 2, 2, false, 429, None, None),
               SquadStateInfo(toCharId, fromElem.health, fromElem.armor, fromElem.position, 2, 2, false, 429, None, None)
@@ -9910,7 +9911,7 @@ class WorldSessionActor extends Actor
         sendResponse(SquadMemberEvent.Add(id, fromCharId, toIndex, elem.name, elem.zone, unk7 = 0))
         sendResponse(
           SquadState(
-            PlanetSideGUID(id),
+            types.PlanetSideGUID(id),
             List(SquadStateInfo(fromCharId, elem.health, elem.armor, elem.position, 2, 2, false, 429, None, None))
           )
         )
@@ -10098,7 +10099,7 @@ class WorldSessionActor extends Actor
     if(avatar.Implants(0).Active) {
       avatar.Implants(0).Active = false
       continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player.GUID, 28, avatar.Implant(0).id * 2))
-      sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 0, 0))
+      sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 0, 0))
       timeDL = 0
     }
   }
@@ -10111,7 +10112,7 @@ class WorldSessionActor extends Actor
     if(avatar.Implants(1).Active) {
       avatar.Implants(1).Active = false
       continent.AvatarEvents  ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player.GUID, 28, avatar.Implant(1).id * 2))
-      sendResponse(AvatarImplantMessage(PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 1, 0))
+      sendResponse(AvatarImplantMessage(types.PlanetSideGUID(player.GUID.guid), ImplantAction.Activation, 1, 0))
       timeSurge = 0
     }
   }

--- a/pslogin/src/test/scala/PacketCodingActorTest.scala
+++ b/pslogin/src/test/scala/PacketCodingActorTest.scala
@@ -6,7 +6,6 @@ import net.psforever.packet.control.{ControlSync, MultiPacketBundle, SlottedMeta
 import net.psforever.packet.{ControlPacket, GamePacket, GamePacketOpcode, PacketCoding}
 import net.psforever.packet.game._
 import net.psforever.packet.game.objectcreate.ObjectClass
-import net.psforever.types
 import net.psforever.types._
 import scodec.bits._
 
@@ -52,7 +51,7 @@ class PacketCodingActor3Test extends ActorTest {
 
 class PacketCodingActor4Test extends ActorTest {
   val string_hex = RawPacket(hex"2A 9F05 D405 86")
-  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "translate r-originating game packet into l-facing hexadecimal data" in {
@@ -73,7 +72,7 @@ class PacketCodingActor4Test extends ActorTest {
 
 class PacketCodingActor5Test extends ActorTest {
   val string_hex = RawPacket(hex"2A 9F05 D405 86")
-  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "translate l-originating hexadecimal data into r-facing game packet" in {
@@ -96,7 +95,7 @@ class PacketCodingActor5Test extends ActorTest {
 }
 
 class PacketCodingActor6Test extends ActorTest {
-  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "permit l-originating game packet to pass through as an r-facing game packet" in {
@@ -370,8 +369,8 @@ class PacketCodingActorETest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into multiple r-facing packets (MultiPacket -> 2 PlayerStateMessageUpstream)" in {
       val string_hex = RawPacket(hex"00 03 18 BD E8 04 5C 02  60 E3 F9 19 0E C1 41 27  00 04 02 60 20 0C 58 0B  20 00 00 18 BD E8 04 86  02 62 13 F9 19 0E D8 40  4D 00 04 02 60 20 0C 78  0A 80 00 00")
-      val string_obj1 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(types.PlanetSideGUID(1256),Vector3(3076.7188f,4734.1094f,56.390625f),Some(Vector3(4.0625f,4.59375f,0.0f)),36.5625f,-2.8125f,0.0f,866,0,false,false,false,false,178,0))
-      val string_obj2 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(types.PlanetSideGUID(1256),Vector3(3077.0469f,4734.258f,56.390625f),Some(Vector3(5.5f,1.1875f,0.0f)),36.5625f,-2.8125f,0.0f,867,0,false,false,false,false,168,0))
+      val string_obj1 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(PlanetSideGUID(1256),Vector3(3076.7188f,4734.1094f,56.390625f),Some(Vector3(4.0625f,4.59375f,0.0f)),36.5625f,-2.8125f,0.0f,866,0,false,false,false,false,178,0))
+      val string_obj2 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(PlanetSideGUID(1256),Vector3(3077.0469f,4734.258f,56.390625f),Some(Vector3(5.5f,1.1875f,0.0f)),36.5625f,-2.8125f,0.0f,867,0,false,false,false,false,168,0))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -392,7 +391,7 @@ class PacketCodingActorFTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into an r-facing packet (MultiPacket -> RelatedB + GenericObjectStateMsg)" in {
       val string_hex = RawPacket(hex"00 03 04 00 15 02 98 0B  00 09 0C 0A 1D F2 00 10 00 00 00")
-      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(types.PlanetSideGUID(242), 16))
+      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(PlanetSideGUID(242), 16))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -413,7 +412,7 @@ class PacketCodingActorGTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into an r-facing packet (MultiPacketEx -> RelatedA + GenericObjectStateMsg)" in {
       val string_hex = RawPacket(hex"00 19 04 00 11 02 98 0B  00 09 0C 0A 1D F2 00 10 00 00 00")
-      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(types.PlanetSideGUID(242), 16))
+      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(PlanetSideGUID(242), 16))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -434,8 +433,8 @@ class PacketCodingActorHTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into two r-facing packets (SlottedMetaPacket/MultiPacketEx -> 2 ObjectDeleteMessage)" in {
       val string_hex = RawPacket(hex"00 09 0A E1 00 19 04 19  4F 04 40 04 19 51 04 40")
-      val string_obj1 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(types.PlanetSideGUID(1103), 2))
-      val string_obj2 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(types.PlanetSideGUID(1105), 2))
+      val string_obj1 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(PlanetSideGUID(1103), 2))
+      val string_obj2 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(PlanetSideGUID(1105), 2))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -486,7 +485,7 @@ class PacketCodingActorITest extends ActorTest {
   )
   val obj = DetailedPlayerData(pos, app, char, InventoryData(Nil), DrawnSlot.None)
   //println(s"${PacketCoding.EncodePacket(ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj))}")
-  val pkt = MultiPacketBundle(List(ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(75), obj)))
+  val pkt = MultiPacketBundle(List(ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj)))
   val string_hex = hex"00090000186c060000bc84b000000000000000000002040000097049006c006c006c004900490049006c006c006c0049006c0049006c006c0049006c006c006c0049006c006c00490084524000000000000000000000000000000020000007f00703fffffffffffffffffffffffffffffffc000000000000000000000000000000000000000190019000640000000000c800c80000000000000000000000000000000000000001c00042c54686c7000000000000000000000000000000000000000000000000000000000000100000000400e0"
 
   "PacketCodingActor" should {
@@ -521,7 +520,7 @@ class PacketCodingActorJTest extends ActorTest {
   "PacketCodingActor" should {
     "bundle r-originating packets into a number of MTU-acceptable l-facing byte streams (1 packets into 1)" in {
       val pkt = MultiPacketBundle(
-        List(ObjectDeleteMessage(types.PlanetSideGUID(1103), 2), ObjectDeleteMessage(types.PlanetSideGUID(1105), 2), ObjectDeleteMessage(types.PlanetSideGUID(1107), 2))
+        List(ObjectDeleteMessage(PlanetSideGUID(1103), 2), ObjectDeleteMessage(PlanetSideGUID(1105), 2), ObjectDeleteMessage(PlanetSideGUID(1107), 2))
       )
       val string_hex = hex"00090000001904194f044004195104400419530440"
 
@@ -565,7 +564,7 @@ class PacketCodingActorKTest extends ActorTest {
       false,
       None,
       None,
-      types.PlanetSideGUID(0)
+      PlanetSideGUID(0)
     ),
     ExoSuitType.Standard,
     0,
@@ -641,12 +640,12 @@ class PacketCodingActorKTest extends ActorTest {
     (pad_length : Option[Int]) => DetailedCharacterData(ba, bb(ba.bep, pad_length))(pad_length)
   val obj = DetailedPlayerData(pos, app, char, InventoryData(Nil), DrawnSlot.None)
   val list = List(
-    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(75), obj),
-    ObjectDeleteMessage(types.PlanetSideGUID(1103), 2),
-    ObjectDeleteMessage(types.PlanetSideGUID(1105), 2),
-    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(175), obj),
-    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(275), obj),
-    ObjectDeleteMessage(types.PlanetSideGUID(1107), 2)
+    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj),
+    ObjectDeleteMessage(PlanetSideGUID(1103), 2),
+    ObjectDeleteMessage(PlanetSideGUID(1105), 2),
+    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(175), obj),
+    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(275), obj),
+    ObjectDeleteMessage(PlanetSideGUID(1107), 2)
   )
 
   "PacketCodingActor" should {

--- a/pslogin/src/test/scala/PacketCodingActorTest.scala
+++ b/pslogin/src/test/scala/PacketCodingActorTest.scala
@@ -6,6 +6,7 @@ import net.psforever.packet.control.{ControlSync, MultiPacketBundle, SlottedMeta
 import net.psforever.packet.{ControlPacket, GamePacket, GamePacketOpcode, PacketCoding}
 import net.psforever.packet.game._
 import net.psforever.packet.game.objectcreate.ObjectClass
+import net.psforever.types
 import net.psforever.types._
 import scodec.bits._
 
@@ -51,7 +52,7 @@ class PacketCodingActor3Test extends ActorTest {
 
 class PacketCodingActor4Test extends ActorTest {
   val string_hex = RawPacket(hex"2A 9F05 D405 86")
-  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "translate r-originating game packet into l-facing hexadecimal data" in {
@@ -72,7 +73,7 @@ class PacketCodingActor4Test extends ActorTest {
 
 class PacketCodingActor5Test extends ActorTest {
   val string_hex = RawPacket(hex"2A 9F05 D405 86")
-  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "translate l-originating hexadecimal data into r-facing game packet" in {
@@ -95,7 +96,7 @@ class PacketCodingActor5Test extends ActorTest {
 }
 
 class PacketCodingActor6Test extends ActorTest {
-  val string_obj = ObjectAttachMessage(PlanetSideGUID(1439), PlanetSideGUID(1492), 6)
+  val string_obj = ObjectAttachMessage(types.PlanetSideGUID(1439), types.PlanetSideGUID(1492), 6)
 
   "PacketCodingActor" should {
     "permit l-originating game packet to pass through as an r-facing game packet" in {
@@ -369,8 +370,8 @@ class PacketCodingActorETest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into multiple r-facing packets (MultiPacket -> 2 PlayerStateMessageUpstream)" in {
       val string_hex = RawPacket(hex"00 03 18 BD E8 04 5C 02  60 E3 F9 19 0E C1 41 27  00 04 02 60 20 0C 58 0B  20 00 00 18 BD E8 04 86  02 62 13 F9 19 0E D8 40  4D 00 04 02 60 20 0C 78  0A 80 00 00")
-      val string_obj1 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(PlanetSideGUID(1256),Vector3(3076.7188f,4734.1094f,56.390625f),Some(Vector3(4.0625f,4.59375f,0.0f)),36.5625f,-2.8125f,0.0f,866,0,false,false,false,false,178,0))
-      val string_obj2 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(PlanetSideGUID(1256),Vector3(3077.0469f,4734.258f,56.390625f),Some(Vector3(5.5f,1.1875f,0.0f)),36.5625f,-2.8125f,0.0f,867,0,false,false,false,false,168,0))
+      val string_obj1 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(types.PlanetSideGUID(1256),Vector3(3076.7188f,4734.1094f,56.390625f),Some(Vector3(4.0625f,4.59375f,0.0f)),36.5625f,-2.8125f,0.0f,866,0,false,false,false,false,178,0))
+      val string_obj2 = GamePacket(GamePacketOpcode.PlayerStateMessageUpstream, 0, PlayerStateMessageUpstream(types.PlanetSideGUID(1256),Vector3(3077.0469f,4734.258f,56.390625f),Some(Vector3(5.5f,1.1875f,0.0f)),36.5625f,-2.8125f,0.0f,867,0,false,false,false,false,168,0))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -391,7 +392,7 @@ class PacketCodingActorFTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into an r-facing packet (MultiPacket -> RelatedB + GenericObjectStateMsg)" in {
       val string_hex = RawPacket(hex"00 03 04 00 15 02 98 0B  00 09 0C 0A 1D F2 00 10 00 00 00")
-      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(PlanetSideGUID(242), 16))
+      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(types.PlanetSideGUID(242), 16))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -412,7 +413,7 @@ class PacketCodingActorGTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into an r-facing packet (MultiPacketEx -> RelatedA + GenericObjectStateMsg)" in {
       val string_hex = RawPacket(hex"00 19 04 00 11 02 98 0B  00 09 0C 0A 1D F2 00 10 00 00 00")
-      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(PlanetSideGUID(242), 16))
+      val string_obj = GamePacket(GamePacketOpcode.GenericObjectStateMsg, 0, GenericObjectStateMsg(types.PlanetSideGUID(242), 16))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -433,8 +434,8 @@ class PacketCodingActorHTest extends ActorTest {
   "PacketCodingActor" should {
     "unwind l-originating hexadecimal data into two r-facing packets (SlottedMetaPacket/MultiPacketEx -> 2 ObjectDeleteMessage)" in {
       val string_hex = RawPacket(hex"00 09 0A E1 00 19 04 19  4F 04 40 04 19 51 04 40")
-      val string_obj1 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(PlanetSideGUID(1103), 2))
-      val string_obj2 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(PlanetSideGUID(1105), 2))
+      val string_obj1 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(types.PlanetSideGUID(1103), 2))
+      val string_obj2 = GamePacket(GamePacketOpcode.ObjectDeleteMessage, 0, ObjectDeleteMessage(types.PlanetSideGUID(1105), 2))
 
       val probe1 = TestProbe()
       val probe2 = system.actorOf(Props(classOf[MDCTestProbe], probe1), "mdc-probe")
@@ -485,7 +486,7 @@ class PacketCodingActorITest extends ActorTest {
   )
   val obj = DetailedPlayerData(pos, app, char, InventoryData(Nil), DrawnSlot.None)
   //println(s"${PacketCoding.EncodePacket(ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj))}")
-  val pkt = MultiPacketBundle(List(ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj)))
+  val pkt = MultiPacketBundle(List(ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(75), obj)))
   val string_hex = hex"00090000186c060000bc84b000000000000000000002040000097049006c006c006c004900490049006c006c006c0049006c0049006c006c0049006c006c006c0049006c006c00490084524000000000000000000000000000000020000007f00703fffffffffffffffffffffffffffffffc000000000000000000000000000000000000000190019000640000000000c800c80000000000000000000000000000000000000001c00042c54686c7000000000000000000000000000000000000000000000000000000000000100000000400e0"
 
   "PacketCodingActor" should {
@@ -520,7 +521,7 @@ class PacketCodingActorJTest extends ActorTest {
   "PacketCodingActor" should {
     "bundle r-originating packets into a number of MTU-acceptable l-facing byte streams (1 packets into 1)" in {
       val pkt = MultiPacketBundle(
-        List(ObjectDeleteMessage(PlanetSideGUID(1103), 2), ObjectDeleteMessage(PlanetSideGUID(1105), 2), ObjectDeleteMessage(PlanetSideGUID(1107), 2))
+        List(ObjectDeleteMessage(types.PlanetSideGUID(1103), 2), ObjectDeleteMessage(types.PlanetSideGUID(1105), 2), ObjectDeleteMessage(types.PlanetSideGUID(1107), 2))
       )
       val string_hex = hex"00090000001904194f044004195104400419530440"
 
@@ -564,7 +565,7 @@ class PacketCodingActorKTest extends ActorTest {
       false,
       None,
       None,
-      PlanetSideGUID(0)
+      types.PlanetSideGUID(0)
     ),
     ExoSuitType.Standard,
     0,
@@ -640,12 +641,12 @@ class PacketCodingActorKTest extends ActorTest {
     (pad_length : Option[Int]) => DetailedCharacterData(ba, bb(ba.bep, pad_length))(pad_length)
   val obj = DetailedPlayerData(pos, app, char, InventoryData(Nil), DrawnSlot.None)
   val list = List(
-    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(75), obj),
-    ObjectDeleteMessage(PlanetSideGUID(1103), 2),
-    ObjectDeleteMessage(PlanetSideGUID(1105), 2),
-    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(175), obj),
-    ObjectCreateDetailedMessage(0x79, PlanetSideGUID(275), obj),
-    ObjectDeleteMessage(PlanetSideGUID(1107), 2)
+    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(75), obj),
+    ObjectDeleteMessage(types.PlanetSideGUID(1103), 2),
+    ObjectDeleteMessage(types.PlanetSideGUID(1105), 2),
+    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(175), obj),
+    ObjectCreateDetailedMessage(0x79, types.PlanetSideGUID(275), obj),
+    ObjectDeleteMessage(types.PlanetSideGUID(1107), 2)
   )
 
   "PacketCodingActor" should {

--- a/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
+++ b/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
@@ -8,8 +8,7 @@ import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawn
 import net.psforever.objects.serverobject.structures.StructureType
 import net.psforever.objects.{Avatar, GlobalDefinitions, Player, Vehicle}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.PlanetSideGUID
-import net.psforever.types._
+import net.psforever.types.{PlanetSideGUID, _}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.concurrent.duration._

--- a/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
+++ b/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
@@ -9,7 +9,7 @@ import net.psforever.objects.ballistics.ResolvedProjectile
 import net.psforever.objects.guid.{GUIDTask, TaskResolver}
 import net.psforever.objects.zones.{Zone, ZoneActor, ZoneMap}
 import net.psforever.packet.game.objectcreate.{DroppedItemData, ObjectClass, ObjectCreateMessageParent, PlacementData}
-import net.psforever.packet.game.{ObjectCreateMessage, PlanetSideGUID, PlayerStateMessageUpstream}
+import net.psforever.packet.game.{ObjectCreateMessage, PlayerStateMessageUpstream}
 import net.psforever.types._
 import services.{RemoverActor, Service, ServiceManager}
 import services.avatar._


### PR DESCRIPTION
After a long hard discussion with my rubber ducky, I have decided that unregistered objects should no longer lose the globally unique identifier they have been assigned by the server during registration.

Same as before, if the same unique identifier number is checked against the zone-wide collection of objects mapped to numbers, it will still not point to that entity anymore.  That is a basic requirement of unregistration that must remain fulfilled.  This is not a fair test to constantly have to make, however, so two methods of determining when an entity is outside of its expected scope have been instituted.  This degree of "staleness" is internalized by an entity itself in two ways.  The first is a pre-existing condition called "`HasGUID`" which merely flags whether a valid unique identifier number has ever been applied to the entity.  The second is an explicit distinction in "valid" and "stale" unique identifier containers that are expressed by the object when it is requested, the former for registration and the latter for the default condition and for unregistration,  By linking the two class/states of the unique dientifier in such a way that removes unnecessary distinction between the classed, all entities will always report an identifier number if one has been initially registered in such a way that it remains useful to the majority of the server.

The primary purpose of reporting like this is to create fields that can be filtered or pattern matched to isolate and detect invalid identifier numbers and invalid objects.  Currently, no functionality is implemented to take advantage of this safeguard.  The more short-term demonstration of this change should be a decline in zone loading failure, specifically the kind of issues that arise due to an entity going out of scope when such the entity's zone is loading for some avatar.  The window for a stale object to exist should be so small that it will realistically never run the possibility of overriding a valid object that has been re-assigned the unique identifier - the runtime of a completed functional call.

Most of the time, no change to server ops should be noticed due to this update.  Fewer crashes due to `NoGUIDException`, maybe.

___Features___
__`PlanetSideGUID`__
The class was moved to `types`, the directory where packet / object cross-over structures are expected to be found.  The class is also no longer just a `case class` but is an `abstract class` with two subclasses that form part of the backbone for staleness implementation - the `case class`es `ValidPlanetSideGUID` and `StalePlanetSideGUID`.  A great massaging of the classes is then applied to ensure that the code does not need massive reviews to deal with this change to such a fundamental building block.

__`IdentifiableEntity`__
The internal mechanisms of this class were completely rewritten, gutting out the old "hidden container" approach in exchange for a re-assigning function literal approach.  The basic impact and handling of the class is exactly the same, save for any changes made pertaining to a demonstration of "staleness", and the change to the fate of the unregistered globally unique identifier number.

__`NoGUIDException`__
~~While no changes were made to the exception itself,~~ the purpose of the exception is now one that raises concern when a globally unique identifier has never been set on an object.  This indicates only the initial registration is unfulfilled.

___Caveat___
The code went crazy when I moved `PlanetSideGUID` from `packet.game.CharacterInfoMessage` to `types`.  That's why 342 files have been changed!  Refactoring might be a powerful IDE tool but it's pretty rubbish when it comes to responsibly handling class import statements.