### PR TITLE
Database Login Errors

### DIFF
--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -110,6 +110,9 @@ class LoginSessionActor extends Actor with MDCContextAware {
         val serverTick = Math.abs(System.nanoTime().toInt) // limit the size to prevent encoding error
         sendResponse(PacketCoding.CreateControlPacket(ControlSyncResp(diff, serverTick, fa, fb, fb, fa)))
 
+      case TeardownConnection(_) =>
+        sendResponse(DropSession(sessionId, "client requested session termination"))
+
       case default =>
         log.error(s"Unhandled ControlPacket $default")
     }


### PR DESCRIPTION
Are these messages useful?

I would think so.  Without two specific database messages being visible (anywhere, let alone in the log), I would not have been able to determine how to properly GRANT privileges to progress through first account creation and then character creation.  One might argue, "at least only once, if even that;" but, that would mean they were still useful that one time.