### PR TITLE
Ziplines, teleporters and caverns

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -923,6 +923,8 @@ object GlobalDefinitions {
 
   val order_terminalb = new OrderTerminalDefinition(614)
 
+  val vanu_equipment_term = new OrderTerminalDefinition(933)
+
   val cert_terminal = new OrderTerminalDefinition(171)
 
   val implant_terminal_mech = new ImplantTerminalMechDefinition
@@ -936,6 +938,10 @@ object GlobalDefinitions {
   val dropship_vehicle_terminal = new OrderTerminalDefinition(263)
 
   val vehicle_terminal_combined = new OrderTerminalDefinition(952)
+
+  val vanu_air_vehicle_term = new OrderTerminalDefinition(928)
+
+  val vanu_vehicle_term = new OrderTerminalDefinition(949)
 
   val bfr_terminal = new OrderTerminalDefinition(143)
 
@@ -967,6 +973,8 @@ object GlobalDefinitions {
 
   val dropship_pad_doors = new VehicleSpawnPadDefinition(261)
 
+  val vanu_vehicle_creation_pad = new VehicleSpawnPadDefinition(947)
+
   val mb_locker = new LockerDefinition
 
   val lock_external = new IFFLockDefinition
@@ -978,6 +986,8 @@ object GlobalDefinitions {
   val capture_terminal = new CaptureTerminalDefinition(158) // Base CC
 
   val secondary_capture = new CaptureTerminalDefinition(751) // Tower CC
+
+  val vanu_control_console = new CaptureTerminalDefinition(930) // Cavern CC
 
   val lodestar_repair_terminal = new MedicalTerminalDefinition(461)
 
@@ -1008,6 +1018,32 @@ object GlobalDefinitions {
   val comm_station : ObjectDefinition = new ObjectDefinition(211) with SphereOfInfluence { Name = "comm_station"; SOIRadius = 300 }
   val comm_station_dsp : ObjectDefinition = new ObjectDefinition(212) with SphereOfInfluence { Name = "comm_station_dsp"; SOIRadius = 300 }
   val cryo_facility : ObjectDefinition = new ObjectDefinition(215) with SphereOfInfluence { Name = "cryo_facility"; SOIRadius = 300 }
+
+  val vanu_core : ObjectDefinition = new ObjectDefinition(932) { Name = "vanu_core" }
+
+  val ground_bldg_a : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_a" } //borrows object id of entity mainbase1
+  val ground_bldg_b : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_b" } //borrows object id of entity mainbase1
+  val ground_bldg_c : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_c" } //borrows object id of entity mainbase1
+  val ground_bldg_d : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_d" } //borrows object id of entity mainbase1
+  val ground_bldg_e : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_e" } //borrows object id of entity mainbase1
+  val ground_bldg_f : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_f" } //borrows object id of entity mainbase1
+  val ground_bldg_g : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_g" } //borrows object id of entity mainbase1
+  val ground_bldg_h : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_h" } //borrows object id of entity mainbase1
+  val ground_bldg_i : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_i" } //borrows object id of entity mainbase1
+  val ground_bldg_j : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_j" } //borrows object id of entity mainbase1
+  val ground_bldg_z : ObjectDefinition = new ObjectDefinition(474) { Name = "ground_bldg_z" } //borrows object id of entity mainbase1
+
+  val ceiling_bldg_a : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_a" } //borrows object id of entity mainbase1
+  val ceiling_bldg_b : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_b" } //borrows object id of entity mainbase1
+  val ceiling_bldg_c : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_c" } //borrows object id of entity mainbase1
+  val ceiling_bldg_d : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_d" } //borrows object id of entity mainbase1
+  val ceiling_bldg_e : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_e" } //borrows object id of entity mainbase1
+  val ceiling_bldg_f : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_f" } //borrows object id of entity mainbase1
+  val ceiling_bldg_g : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_g" } //borrows object id of entity mainbase1
+  val ceiling_bldg_h : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_h" } //borrows object id of entity mainbase1
+  val ceiling_bldg_i : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_i" } //borrows object id of entity mainbase1
+  val ceiling_bldg_j : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_j" } //borrows object id of entity mainbase1
+  val ceiling_bldg_z : ObjectDefinition = new ObjectDefinition(474) { Name = "ceiling_bldg_z" } //borrows object id of entity mainbase1
 
   val hst : ObjectDefinition with SpawnPointDefinition = new ObjectDefinition(402) with SpawnPointDefinition
   hst.Name = "hst"
@@ -6079,6 +6115,14 @@ object GlobalDefinitions {
     order_terminalb.Tab(4).asInstanceOf[OrderTerminalDefinition.InfantryLoadoutPage].Exclude = ExoSuitType.MAX
     order_terminalb.SellEquipmentByDefault = true
 
+    vanu_equipment_term.Name = "vanu_equipment_term"
+    vanu_equipment_term.Tab += 0 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.infantryAmmunition ++ EquipmentTerminalDefinition.infantryWeapons)
+    vanu_equipment_term.Tab += 1 -> OrderTerminalDefinition.ArmorWithAmmoPage(EquipmentTerminalDefinition.suits ++ EquipmentTerminalDefinition.maxSuits, EquipmentTerminalDefinition.maxAmmo)
+    vanu_equipment_term.Tab += 2 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.supportAmmunition ++ EquipmentTerminalDefinition.supportWeapons)
+    vanu_equipment_term.Tab += 3 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.vehicleAmmunition)
+    vanu_equipment_term.Tab += 4 -> OrderTerminalDefinition.InfantryLoadoutPage()
+    vanu_equipment_term.SellEquipmentByDefault = true
+
     cert_terminal.Name = "cert_terminal"
     cert_terminal.Tab += 0 -> OrderTerminalDefinition.CertificationPage(CertTerminalDefinition.certs)
 
@@ -6100,6 +6144,14 @@ object GlobalDefinitions {
     vehicle_terminal_combined.Name = "vehicle_terminal_combined"
     vehicle_terminal_combined.Tab += 46769 -> OrderTerminalDefinition.VehiclePage(VehicleTerminalDefinition.flight1Vehicles ++ VehicleTerminalDefinition.groundVehicles, VehicleTerminalDefinition.trunk)
     vehicle_terminal_combined.Tab += 4 -> OrderTerminalDefinition.VehicleLoadoutPage()
+
+    vanu_air_vehicle_term.Name = "vanu_air_vehicle_term"
+    vanu_air_vehicle_term.Tab += 46769 -> OrderTerminalDefinition.VehiclePage(VehicleTerminalDefinition.flight1Vehicles, VehicleTerminalDefinition.trunk)
+    vanu_air_vehicle_term.Tab += 4 -> OrderTerminalDefinition.VehicleLoadoutPage()
+
+    vanu_vehicle_term.Name = "vanu_vehicle_term"
+    vanu_vehicle_term.Tab += 46769 -> OrderTerminalDefinition.VehiclePage(VehicleTerminalDefinition.groundVehicles, VehicleTerminalDefinition.trunk)
+    vanu_vehicle_term.Tab += 4 -> OrderTerminalDefinition.VehicleLoadoutPage()
 
     bfr_terminal.Name = "bfr_terminal"
     bfr_terminal.Tab += 46769 -> OrderTerminalDefinition.VehiclePage(VehicleTerminalDefinition.bfrVehicles, VehicleTerminalDefinition.trunk)

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1069,13 +1069,13 @@ object GlobalDefinitions {
   val minibase1 : ObjectDefinition = new ObjectDefinition(557) { Name = "minibase1" }
   val minibase2 : ObjectDefinition = new ObjectDefinition(558) { Name = "minibase2" }
   val minibase3 : ObjectDefinition = new ObjectDefinition(559) { Name = "minibase3" }
-  val redoubt : ObjectDefinition = new ObjectDefinition(726) { Name = "redoubt" }
+  val redoubt : ObjectDefinition = new ObjectDefinition(726) with SphereOfInfluence { Name = "redoubt"; SOIRadius = 187 }
   val tech_plant : ObjectDefinition = new ObjectDefinition(852) with SphereOfInfluence { Name = "tech_plant"; SOIRadius = 300 }
   val tower_a : ObjectDefinition = new ObjectDefinition(869) with SphereOfInfluence { Name = "tower_a"; SOIRadius = 50 }
   val tower_b : ObjectDefinition = new ObjectDefinition(870) with SphereOfInfluence { Name = "tower_b"; SOIRadius = 50 }
   val tower_c : ObjectDefinition = new ObjectDefinition(871) with SphereOfInfluence { Name = "tower_c"; SOIRadius = 50 }
-  val vanu_control_point : ObjectDefinition = new ObjectDefinition(931) { Name = "vanu_control_point" }
-  val vanu_vehicle_station : ObjectDefinition = new ObjectDefinition(948) { Name = "vanu_vehicle_station" }
+  val vanu_control_point : ObjectDefinition = new ObjectDefinition(931) with SphereOfInfluence { Name = "vanu_control_point"; SOIRadius = 187 }
+  val vanu_vehicle_station : ObjectDefinition = new ObjectDefinition(948) with SphereOfInfluence { Name = "vanu_vehicle_station"; SOIRadius = 187 }
 
   val warpgate : ObjectDefinition with SpawnPointDefinition = new ObjectDefinition(993) with SpawnPointDefinition
   warpgate.Name = "warpgate"

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -6195,7 +6195,7 @@ object GlobalDefinitions {
     crystals_health_b.Name = "crystals_health_b"
     crystals_health_b.Interval = 500
     crystals_health_b.HealAmount = 4
-    crystals_health_b.UseRadius = 1.3f
+    crystals_health_b.UseRadius = 5
     crystals_health_b.TargetValidation += EffectTarget.Category.Player -> EffectTarget.Validation.HealthCrystal
 
     portable_med_terminal.Name = "portable_med_terminal"

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/CaptureTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/CaptureTerminalDefinition.scala
@@ -3,11 +3,10 @@ package net.psforever.objects.serverobject.terminals
 import net.psforever.objects.definition.ObjectDefinition
 
 class CaptureTerminalDefinition(objectId : Int) extends ObjectDefinition(objectId) {
-  Name = if(objectId == 158) {
-    "capture_terminal"
-  } else if (objectId == 751) {
-    "secondary_capture"
-  } else {
-    throw new IllegalArgumentException("Not a valid capture terminal object id")
+  Name = objectId match {
+    case 158 => "capture_terminal"
+    case 751 => "secondary_capture"
+    case 930 => "vanu_control_console"
+    case _ => throw new IllegalArgumentException("Not a valid capture terminal object id")
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/Terminal.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.definition.VehicleDefinition
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.packet.game.{ItemTransactionMessage, TriggeredSound}
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideGUID, Vector3}
 
 /**
   * A server object that can be accessed for services and other amenities.
@@ -37,7 +37,10 @@ class Terminal(tdef : TerminalDefinition) extends Amenity with Hackable {
 
   /**
     * Process a message (a "request") dispatched by the user.
-    * To be accessible, the terminal must be owned by the same faction by the user or must be compromised.
+    * To be accessible, the terminal must be:
+    *   owned by the same faction by the user
+    *   or must be compromised
+    *   or must be a zone owned object (GUID == 0, e.g. non-facility buildings in caves)
     * @see `FactionAffinity`
     * @see `PlanetSideEmpire`
     * @param player the player
@@ -45,7 +48,7 @@ class Terminal(tdef : TerminalDefinition) extends Amenity with Hackable {
     * @return an actionable message that explains what resulted from interacting with this `Terminal`
     */
   def Request(player : Player, msg : Any) : Terminal.Exchange = {
-    if(Faction == player.Faction || HackedBy.isDefined) {
+    if(Faction == player.Faction || HackedBy.isDefined || Owner.GUID == PlanetSideGUID(0)) {
       tdef.Request(player, msg)
     }
     else {

--- a/common/src/main/scala/net/psforever/objects/serverobject/zipline/ZipLinePath.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/zipline/ZipLinePath.scala
@@ -1,0 +1,9 @@
+package net.psforever.objects.serverobject.zipline
+
+import net.psforever.types.Vector3
+
+class ZipLinePath(private val pathId: Integer, private val isTeleporter: Boolean, private val zipLinePoints: List[Vector3]) {
+  def PathId : Integer = pathId
+  def IsTeleporter : Boolean = isTeleporter
+  def ZipLinePoints : List[Vector3] = zipLinePoints
+}

--- a/common/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
@@ -52,7 +52,9 @@ class SphereOfInfluenceActor(zone: Zone) extends Actor {
   }
 
   def UpdateSOI(): Unit = {
-    sois.foreach { case (facility, radius) => facility.PlayersInSOI = zone.LivePlayers.filter(p => Vector3.DistanceSquared(facility.Position.xy, p.Position.xy) < radius) }
+    sois.foreach { case (facility, radius) =>
+      facility.PlayersInSOI = zone.LivePlayers.filter(p => Vector3.DistanceSquared(facility.Position.xy, p.Position.xy) < radius)
+    }
     populateTick.cancel
     populateTick = context.system.scheduler.scheduleOnce(5 seconds, self, SOI.Populate())
   }

--- a/common/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
@@ -52,7 +52,7 @@ class SphereOfInfluenceActor(zone: Zone) extends Actor {
   }
 
   def UpdateSOI(): Unit = {
-    SOI.Populate(sois.iterator, zone.LivePlayers)
+    sois.foreach { case (facility, radius) => facility.PlayersInSOI = zone.LivePlayers.filter(p => Vector3.DistanceSquared(facility.Position.xy, p.Position.xy) < radius) }
     populateTick.cancel
     populateTick = context.system.scheduler.scheduleOnce(5 seconds, self, SOI.Populate())
   }
@@ -67,20 +67,4 @@ object SOI {
   final case class Start()
   /** Stop sorting players into sois */
   final case class Stop()
-
-  /**
-    * Recursively populate each facility's sphere of influence with players.
-    * @param buildings an iterator of buildings and the radius of its sphere of influence
-    * @param players a list of players to allocate;
-    *                the list gets shorter as each building is allocated
-    */
-  @tailrec
-  def Populate(buildings : Iterator[(Building, Int)], players : List[Player]) : Unit = {
-    if(players.nonEmpty && buildings.hasNext) {
-      val (facility, radius) = buildings.next
-      val (tenants, remainder) = players.partition(p => Vector3.DistanceSquared(facility.Position.xy, p.Position.xy) < radius)
-      facility.PlayersInSOI = tenants
-      Populate(buildings, remainder)
-    }
-  }
 }

--- a/common/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -17,6 +17,7 @@ import net.psforever.objects.serverobject.painbox.{Painbox, PainboxDefinition}
 import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Amenity, Building, WarpGate}
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.serverobject.zipline.ZipLinePath
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 import services.avatar.AvatarService
 import services.local.LocalService
@@ -83,6 +84,8 @@ class Zone(private val zoneId : String, zoneMap : ZoneMap, zoneNumber : Int) {
 
   private var lattice : Graph[Building, UnDiEdge] = Graph()
 
+  private var zipLinePaths : List[ZipLinePath] = List()
+
   /** key - spawn zone id, value - buildings belonging to spawn zone */
   private var spawnGroups : Map[Building, List[SpawnPoint]] = PairMap[Building, List[SpawnPoint]]()
   /** */
@@ -139,6 +142,8 @@ class Zone(private val zoneId : String, zoneMap : ZoneMap, zoneNumber : Int) {
       MakeLattice()
       AssignAmenities()
       CreateSpawnGroups()
+
+      zipLinePaths = Map.ZipLinePaths
     }
   }
 
@@ -350,6 +355,10 @@ class Zone(private val zoneId : String, zoneMap : ZoneMap, zoneNumber : Int) {
 
   def Lattice : Graph[Building, UnDiEdge] = {
     lattice
+  }
+
+  def ZipLinePaths : List[ZipLinePath] = {
+    zipLinePaths
   }
 
   private def BuildLocalObjects(implicit context : ActorContext, guid : NumberPoolHub) : Unit = {

--- a/common/src/main/scala/net/psforever/objects/zones/ZoneMap.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZoneMap.scala
@@ -2,9 +2,8 @@
 package net.psforever.objects.zones
 
 import net.psforever.objects.serverobject.structures.FoundationBuilder
+import net.psforever.objects.serverobject.zipline.ZipLinePath
 import net.psforever.objects.serverobject.{PlanetSideServerObject, ServerObjectBuilder}
-import scalax.collection.Graph
-import scalax.collection.GraphPredef._, scalax.collection.GraphEdge._
 
 /**
   * The fixed instantiation and relation of a series of server objects.<br>
@@ -37,6 +36,7 @@ class ZoneMap(private val name : String) {
   private var buildings : Map[(String, Int, Int), FoundationBuilder] = Map()
   private var lattice: Set[(String, String)] = Set()
   private var checksum : Long = 0
+  private var zipLinePaths : List[ZipLinePath] = List()
 
   def Name : String = name
 
@@ -88,6 +88,13 @@ class ZoneMap(private val name : String) {
       }
     }
     localObjects.size
+  }
+
+  def ZipLinePaths : List[ZipLinePath] = zipLinePaths
+
+  def ZipLinePaths(path: ZipLinePath): Int = {
+    zipLinePaths = zipLinePaths :+ path
+    zipLinePaths.size
   }
 
   def LocalBuildings : Map[(String, Int, Int), FoundationBuilder] = buildings

--- a/common/src/main/scala/net/psforever/packet/game/GenericObjectStateMsg.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericObjectStateMsg.scala
@@ -6,6 +6,13 @@ import net.psforever.types.PlanetSideGUID
 import scodec.Codec
 import scodec.codecs._
 
+/**
+  *
+  * @param object_guid the target object
+  * @param state the state code
+  *              16 - open door
+  *              17 - close door
+  */
 final case class GenericObjectStateMsg(object_guid : PlanetSideGUID,
                                        state : Long)
   extends PlanetSideGamePacket {

--- a/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -145,6 +145,7 @@ import scodec.codecs._
   * -- e.g., 13 = 8 + 4 + 1 = fire and LLU and plasma<br>
   * `55 - "Someone is attempting to Heal you". Value is 1`<br>
   * `56 - "Someone is attempting to Repair you". Value is 1`<br>
+  * `64 - ????? related to using router telepads`
   * `67 - Enables base shields (from cavern module/lock). MUST use base MapId not GUID`<br>
   * `73 - "You are locked into the Core Beam. Charging your Module now.". Value is 1 to active`<br>
   * `77 - Cavern Facility Captures. Value is the number of captures`<br>

--- a/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
@@ -16,16 +16,18 @@ import scodec.codecs._
   * `1 - Arrived at destination`<br>
   * `2 - Forcibly detach from zip line in mid-transit`
   * @param player_guid the player
-  * @param origin_side whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals
+  * @param started_at_origin whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals.
+  *                          It will remain consistent throughout travel across the zipline.
+  *                          For example: Entering at the origin will be true, but when exiting at the end of the zipline path it will still be true
   * @param action how the player interacts with the zip line
-  * @param guid a number that is consistent to a terminus
+  * @param path_id the path id that this zipline belongs to, from the relevant .zpl file
   * @param pos the coordinates of the point where the player is interacting with the zip line;
   *            "optional," in theory
   */
 final case class ZipLineMessage(player_guid : PlanetSideGUID,
-                                origin_side : Boolean,
+                                started_at_origin : Boolean,
                                 action : Int,
-                                guid : Long,
+                                path_id : Long,
                                 pos : Option[Vector3] = None)
   extends PlanetSideGamePacket {
   type Packet = ZipLineMessage
@@ -36,20 +38,23 @@ final case class ZipLineMessage(player_guid : PlanetSideGUID,
 object ZipLineMessage extends Marshallable[ZipLineMessage] {
   /**
     * Alternate constructor for `ZipLineMessage` that requirement for the last field.
-    * @param player_guid the player
-    * @param origin_side whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals
-    * @param action how the player interacts with the zip line
-    * @param guid a number that is consistent to a terminus
-    * @param pos the coordinates of the point where the player is interacting with the zip line
+    *
+    * @param player_guid       the player
+    * @param started_at_origin whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals.
+    *                          It will remain consistent throughout travel across the zipline.
+    *                          For example: Entering at the origin will be true, but when exiting at the end of the zipline path it will still be true
+    * @param action            how the player interacts with the zip line
+    * @param path_id           the path id that this zipline belongs to, from the relevant .zpl file
+    * @param pos               the coordinates of the point where the player is interacting with the zip line
     * @return a `ZipLineMessage` object
     */
-  def apply(player_guid : PlanetSideGUID, origin_side : Boolean, action : Int, guid : Long, pos : Vector3) : ZipLineMessage = {
-    ZipLineMessage(player_guid, origin_side, action, guid, Some(pos))
+  def apply(player_guid : PlanetSideGUID, started_at_origin : Boolean, action : Int, path_id : Long, pos : Vector3) : ZipLineMessage = {
+    ZipLineMessage(player_guid, started_at_origin, action, path_id, Some(pos))
   }
 
   implicit val codec : Codec[ZipLineMessage] = (
     ("player_guid" | PlanetSideGUID.codec) >>:~ { player =>
-      ("origin_side" | bool) ::
+      ("started_at_origin" | bool) ::
         ("action" | uint2) ::
         ("id" | uint32L) ::
         conditional(player.guid > 0, Vector3.codec_float) // !(player.guid == 0)

--- a/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/ZipLineMessage.scala
@@ -16,16 +16,14 @@ import scodec.codecs._
   * `1 - Arrived at destination`<br>
   * `2 - Forcibly detach from zip line in mid-transit`
   * @param player_guid the player
-  * @param started_at_origin whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals.
-  *                          It will remain consistent throughout travel across the zipline.
-  *                          For example: Entering at the origin will be true, but when exiting at the end of the zipline path it will still be true
+  * @param forwards true if the player is travelling in the direction of the light pulses
   * @param action how the player interacts with the zip line
   * @param path_id the path id that this zipline belongs to, from the relevant .zpl file
   * @param pos the coordinates of the point where the player is interacting with the zip line;
   *            "optional," in theory
   */
 final case class ZipLineMessage(player_guid : PlanetSideGUID,
-                                started_at_origin : Boolean,
+                                forwards : Boolean,
                                 action : Int,
                                 path_id : Long,
                                 pos : Option[Vector3] = None)
@@ -40,21 +38,19 @@ object ZipLineMessage extends Marshallable[ZipLineMessage] {
     * Alternate constructor for `ZipLineMessage` that requirement for the last field.
     *
     * @param player_guid       the player
-    * @param started_at_origin whether this corresponds with the "entry" or the "exit" of the zip line, as per the direction of the light pulse visuals.
-    *                          It will remain consistent throughout travel across the zipline.
-    *                          For example: Entering at the origin will be true, but when exiting at the end of the zipline path it will still be true
+    * @param forwards          true if the player is travelling in the direction of the light pulses
     * @param action            how the player interacts with the zip line
     * @param path_id           the path id that this zipline belongs to, from the relevant .zpl file
     * @param pos               the coordinates of the point where the player is interacting with the zip line
     * @return a `ZipLineMessage` object
     */
-  def apply(player_guid : PlanetSideGUID, started_at_origin : Boolean, action : Int, path_id : Long, pos : Vector3) : ZipLineMessage = {
-    ZipLineMessage(player_guid, started_at_origin, action, path_id, Some(pos))
+  def apply(player_guid : PlanetSideGUID, forwards : Boolean, action : Int, path_id : Long, pos : Vector3) : ZipLineMessage = {
+    ZipLineMessage(player_guid, forwards, action, path_id, Some(pos))
   }
 
   implicit val codec : Codec[ZipLineMessage] = (
     ("player_guid" | PlanetSideGUID.codec) >>:~ { player =>
-      ("started_at_origin" | bool) ::
+      ("forwards" | bool) ::
         ("action" | uint2) ::
         ("id" | uint32L) ::
         conditional(player.guid > 0, Vector3.codec_float) // !(player.guid == 0)

--- a/common/src/main/scala/services/local/LocalService.scala
+++ b/common/src/main/scala/services/local/LocalService.scala
@@ -106,6 +106,8 @@ class LocalService(zone : Zone) extends Actor {
               case GlobalDefinitions.secondary_capture =>
                 // Tower CC
                 hackCapturer ! HackCaptureActor.ObjectIsHacked(target, zone, unk1, unk2, duration = 1 nanosecond)
+              case GlobalDefinitions.vanu_control_console =>
+                hackCapturer ! HackCaptureActor.ObjectIsHacked(target, zone, unk1, unk2, duration = 15 minutes)
             }
           }
 

--- a/common/src/main/scala/services/local/LocalService.scala
+++ b/common/src/main/scala/services/local/LocalService.scala
@@ -107,7 +107,7 @@ class LocalService(zone : Zone) extends Actor {
                 // Tower CC
                 hackCapturer ! HackCaptureActor.ObjectIsHacked(target, zone, unk1, unk2, duration = 1 nanosecond)
               case GlobalDefinitions.vanu_control_console =>
-                hackCapturer ! HackCaptureActor.ObjectIsHacked(target, zone, unk1, unk2, duration = 15 minutes)
+                hackCapturer ! HackCaptureActor.ObjectIsHacked(target, zone, unk1, unk2, duration = 10 minutes)
             }
           }
 

--- a/pslogin/src/main/scala/Maps.scala
+++ b/pslogin/src/main/scala/Maps.scala
@@ -4,20 +4,49 @@ import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.zones.ZoneMap
 import zonemaps._
 
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
 object Maps {
-  val map1 = Map01.ZoneMap
-  val map2 = Map02.ZoneMap
-  val map3 = Map03.ZoneMap
-  val map4 = Map04.ZoneMap
-  val map5 = Map05.ZoneMap
-  val map6 = Map06.ZoneMap
-  val map7 = Map07.ZoneMap
-  val map8 = Map08.ZoneMap
-  val map9 = Map09.ZoneMap
-  val map10 = Map10.ZoneMap
-  val map11 = Map11.ZoneMap
-  val map12 = Map12.ZoneMap
-  val map13 = Map13.ZoneMap
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val map1f = Future { Map01.ZoneMap }
+  val map2f = Future { Map02.ZoneMap }
+  val map3f = Future { Map03.ZoneMap }
+  val map4f = Future { Map04.ZoneMap }
+  val map5f = Future { Map05.ZoneMap }
+  val map6f = Future { Map06.ZoneMap }
+  val map7f = Future { Map07.ZoneMap }
+  val map8f = Future { Map08.ZoneMap }
+  val map9f = Future { Map09.ZoneMap }
+  val map10f = Future { Map10.ZoneMap }
+  val map11f = Future { Map11.ZoneMap }
+  val map12f = Future { Map12.ZoneMap }
+  val map13f = Future { Map13.ZoneMap }
+  val ugd01f = Future { Ugd01.ZoneMap }
+  val ugd02f = Future { Ugd02.ZoneMap }
+  val ugd03f = Future { Ugd03.ZoneMap }
+  val ugd04f = Future { Ugd04.ZoneMap }
+  val ugd05f = Future { Ugd05.ZoneMap }
+  val ugd06f = Future { Ugd06.ZoneMap }
+  val map96f = Future { Map96.ZoneMap }
+  val map97f = Future { Map97.ZoneMap }
+  val map98f = Future { Map98.ZoneMap }
+  val map99f = Future { Map99.ZoneMap }
+
+  val map1 = Await.result(map1f, 30 seconds)
+  val map2 = Await.result(map2f, 30 seconds)
+  val map3 = Await.result(map3f, 30 seconds)
+  val map4 = Await.result(map4f, 30 seconds)
+  val map5 = Await.result(map5f, 30 seconds)
+  val map6 = Await.result(map6f, 30 seconds)
+  val map7 = Await.result(map7f, 30 seconds)
+  val map8 = Await.result(map8f, 30 seconds)
+  val map9 = Await.result(map9f, 30 seconds)
+  val map10 = Await.result(map10f, 30 seconds)
+  val map11 = Await.result(map11f, 30 seconds)
+  val map12 = Await.result(map12f, 30 seconds)
+  val map13 = Await.result(map13f, 30 seconds)
 
   Projectiles(map1)
   Projectiles(map2)
@@ -45,12 +74,12 @@ object Maps {
     Projectiles(this)
   }
 
-  val ugd01 = Ugd01.ZoneMap
-  val ugd02 = Ugd02.ZoneMap
-  val ugd03 = Ugd03.ZoneMap
-  val ugd04 = Ugd04.ZoneMap
-  val ugd05 = Ugd05.ZoneMap
-  val ugd06 = Ugd06.ZoneMap
+  val ugd01 = Await.result(ugd01f, 30 seconds)
+  val ugd02 = Await.result(ugd02f, 30 seconds)
+  val ugd03 = Await.result(ugd03f, 30 seconds)
+  val ugd04 = Await.result(ugd04f, 30 seconds)
+  val ugd05 = Await.result(ugd05f, 30 seconds)
+  val ugd06 = Await.result(ugd06f, 30 seconds)
 
   Projectiles(ugd01)
   Projectiles(ugd02)
@@ -59,10 +88,10 @@ object Maps {
   Projectiles(ugd05)
   Projectiles(ugd06)
 
-  val map96 = Map96.ZoneMap
-  val map97 = Map97.ZoneMap
-  val map98 = Map98.ZoneMap
-  val map99 = Map99.ZoneMap
+  val map96 = Await.result(map96f, 30 seconds)
+  val map97 = Await.result(map97f, 30 seconds)
+  val map98 = Await.result(map98f, 30 seconds)
+  val map99 = Await.result(map99f, 30 seconds)
 
   Projectiles(map96)
   Projectiles(map97)

--- a/pslogin/src/main/scala/Maps.scala
+++ b/pslogin/src/main/scala/Maps.scala
@@ -45,29 +45,19 @@ object Maps {
     Projectiles(this)
   }
 
-  val ugd01 = new ZoneMap("ugd01") {
-    Projectiles(this)
-  }
+  val ugd01 = Ugd01.ZoneMap
+  val ugd02 = Ugd02.ZoneMap
+  val ugd03 = Ugd03.ZoneMap
+  val ugd04 = Ugd04.ZoneMap
+  val ugd05 = Ugd05.ZoneMap
+  val ugd06 = Ugd06.ZoneMap
 
-  val ugd02 = new ZoneMap("ugd02") {
-    Projectiles(this)
-  }
-
-  val ugd03 = new ZoneMap("ugd03") {
-    Projectiles(this)
-  }
-
-  val ugd04 = new ZoneMap("ugd04") {
-    Projectiles(this)
-  }
-
-  val ugd05 = new ZoneMap("ugd05") {
-    Projectiles(this)
-  }
-
-  val ugd06 = new ZoneMap("ugd06") {
-    Projectiles(this)
-  }
+  Projectiles(ugd01)
+  Projectiles(ugd02)
+  Projectiles(ugd03)
+  Projectiles(ugd04)
+  Projectiles(ugd05)
+  Projectiles(ugd06)
 
   val map96 = Map96.ZoneMap
   val map97 = Map97.ZoneMap

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -4584,7 +4584,7 @@ class WorldSessionActor extends Actor
       skipStaminaRegenForTurns = 5
       sendResponse(PlanetsideAttributeMessage(player.GUID, 2, player.Stamina))
 
-    case msg @ ZipLineMessage(player_guid,started_at_origin,action,path_id,pos) =>
+    case msg @ ZipLineMessage(player_guid,forwards,action,path_id,pos) =>
       log.info("ZipLineMessage: " + msg)
 
       val (isTeleporter : Boolean, path: Option[ZipLinePath]) = continent.ZipLinePaths.find(x => x.PathId == path_id) match {
@@ -4598,18 +4598,18 @@ class WorldSessionActor extends Actor
         val endPoint = path.get.ZipLinePoints.last
         sendResponse(PlayerStateShiftMessage(ShiftState(0, endPoint, player.Orientation.z, None)))
       } else {
-        (started_at_origin, action) match {
-          case (true, 0) =>
-            //doing this lets you use the zip line in one direction, cant come back
-            sendResponse(ZipLineMessage(player_guid, started_at_origin, action, path_id, pos))
-          case (_, 1) =>
+        action match {
+          case 0 =>
+            // Travel along the zipline in the direction specified
+            sendResponse(ZipLineMessage(player_guid, forwards, action, path_id, pos))
+          case 1 =>
             //disembark from zipline at destination !
-            sendResponse(ZipLineMessage(player_guid, started_at_origin, action, 0, pos))
-          case (_, 2) =>
+            sendResponse(ZipLineMessage(player_guid, forwards, action, 0, pos))
+          case 2 =>
             //get off by force
-            sendResponse(ZipLineMessage(player_guid, started_at_origin, action, 0, pos))
-          case (_, _) =>
-            log.warn(s"Tried to do something with a zipline but can't handle it. started_at_origin: ${started_at_origin} action: ${action} path_id: ${path_id} zone: ${continent.Number} / ${continent.Id}")
+            sendResponse(ZipLineMessage(player_guid, forwards, action, 0, pos))
+          case _ =>
+            log.warn(s"Tried to do something with a zipline but can't handle it. forwards: ${forwards} action: ${action} path_id: ${path_id} zone: ${continent.Number} / ${continent.Id}")
         }
       }
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -4159,15 +4159,18 @@ class WorldSessionActor extends Actor
       var echoContents : String = contents
       val trimContents = contents.trim
       //TODO messy on/off strings may work
-      if(messagetype == ChatMessageType.CMT_FLY) {
-        if(trimContents.equals("on")) {
+      if(messagetype == ChatMessageType.CMT_FLY && admin) {
+        makeReply = false
+        if(!flying) {
           flying = true
-        }
-        else if(trimContents.equals("off")) {
+          sendResponse(ChatMsg(ChatMessageType.CMT_FLY, msg.wideContents, msg.recipient, "on", msg.note))
+        } else {
           flying = false
+          sendResponse(ChatMsg(ChatMessageType.CMT_FLY, msg.wideContents, msg.recipient, "off", msg.note))
         }
       }
-      else if(messagetype == ChatMessageType.CMT_SPEED) {
+      else if(messagetype == ChatMessageType.CMT_SPEED && admin) {
+        makeReply = true
         speed = {
           try {
             trimContents.toFloat
@@ -4179,12 +4182,14 @@ class WorldSessionActor extends Actor
           }
         }
       }
-      else if(messagetype == ChatMessageType.CMT_TOGGLESPECTATORMODE) {
-        if(trimContents.equals("on")) {
+      else if(messagetype == ChatMessageType.CMT_TOGGLESPECTATORMODE && admin) {
+        makeReply = false
+        if(!spectator) {
           spectator = true
-        }
-        else if(contents.trim.equals("off")) {
+          sendResponse(ChatMsg(ChatMessageType.CMT_TOGGLESPECTATORMODE, msg.wideContents, msg.recipient, "on", msg.note))
+        } else {
           spectator = false
+          sendResponse(ChatMsg(ChatMessageType.CMT_TOGGLESPECTATORMODE, msg.wideContents, msg.recipient, "off", msg.note))
         }
       }
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -5263,7 +5263,7 @@ class WorldSessionActor extends Actor
                 log.warn(s"Terminal - isHacked ${terminal.HackedBy.isDefined} ownerIsHacked ${ownerIsHacked}")
               }
             }
-            else if (terminal.HackedBy.isDefined) {
+            else if (terminal.HackedBy.isDefined || terminal.Owner.GUID == PlanetSideGUID(0)) {
               sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, unk2, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
             } else {
               log.warn("Tried to use a terminal that doesn't belong to this faction and isn't hacked")

--- a/pslogin/src/main/scala/zonemaps/Map01.scala
+++ b/pslogin/src/main/scala/zonemaps/Map01.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map01 {
-  // Solsar
+object Map01 { // Solsar
   val ZoneMap = new ZoneMap("map01") {
     Checksum = 2094187456L
 
@@ -2107,5 +2104,6 @@ object Map01 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map02.scala
+++ b/pslogin/src/main/scala/zonemaps/Map02.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map02 {
-  // Hossin
+object Map02 { // Hossin
   val ZoneMap = new ZoneMap("map02") {
     Checksum = 1113780607L
 
@@ -2531,5 +2528,6 @@ object Map02 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map03.scala
+++ b/pslogin/src/main/scala/zonemaps/Map03.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map03 {
-  // Cyssor
+object Map03 { // Cyssor
   val ZoneMap = new ZoneMap("map03") {
     Checksum = 1624200906L
 
@@ -3689,5 +3686,6 @@ object Map03 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map04.scala
+++ b/pslogin/src/main/scala/zonemaps/Map04.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map04 {
-  // Ishundar
+object Map04 { // Ishundar
   val ZoneMap = new ZoneMap("map04") {
     Checksum = 2455050867L
 
@@ -3109,5 +3106,6 @@ object Map04 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map05.scala
+++ b/pslogin/src/main/scala/zonemaps/Map05.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map05 {
-  // Forseral
+object Map05 { // Forseral
   val ZoneMap = new ZoneMap("map05") {
     Checksum = 107922342L
 
@@ -2112,5 +2109,6 @@ object Map05 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map06.scala
+++ b/pslogin/src/main/scala/zonemaps/Map06.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map06 {
-  // Ceryshen
+object Map06 { // Ceryshen
   val ZoneMap = new ZoneMap("map06") {
     Checksum = 579139514L
 
@@ -2486,5 +2483,6 @@ object Map06 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map07.scala
+++ b/pslogin/src/main/scala/zonemaps/Map07.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map07 {
-  // Esamir
+object Map07 { // Esamir
   val ZoneMap = new ZoneMap("map07") {
     Checksum = 1564014762L
 
@@ -2805,5 +2802,6 @@ object Map07 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map08.scala
+++ b/pslogin/src/main/scala/zonemaps/Map08.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map08 {
-  // Oshur Prime
+object Map08 { // Oshur Prime
   val ZoneMap = new ZoneMap("map08") {
     Checksum = 0L
 
@@ -2167,5 +2164,6 @@ object Map08 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map09.scala
+++ b/pslogin/src/main/scala/zonemaps/Map09.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map09 {
-  // Searhus
+object Map09 { // Searhus
   val ZoneMap = new ZoneMap("map09") {
     Checksum = 1380643455L
 
@@ -2881,5 +2878,6 @@ object Map09 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map10.scala
+++ b/pslogin/src/main/scala/zonemaps/Map10.scala
@@ -1,24 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map10 {
-  // Amerish
+object Map10 { // Amerish
   val ZoneMap = new ZoneMap("map10") {
     Checksum = 230810349L
 
@@ -2631,5 +2628,6 @@ object Map10 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map11.scala
+++ b/pslogin/src/main/scala/zonemaps/Map11.scala
@@ -1,9 +1,6 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
@@ -13,12 +10,11 @@ import net.psforever.objects.serverobject.painbox.Painbox
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map11 {
-  // HOME1 (NEW CONGLOMORATE SANCTUARY)
+object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
   val ZoneMap = new ZoneMap("map11") {
     Checksum = 4129515529L
 
@@ -1459,5 +1455,6 @@ object Map11 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map12.scala
+++ b/pslogin/src/main/scala/zonemaps/Map12.scala
@@ -1,9 +1,6 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
@@ -13,12 +10,11 @@ import net.psforever.objects.serverobject.painbox.Painbox
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map12 {
-  // HOME2 (TERRAN REPUBLIC SANCTUARY)
+object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
   val ZoneMap = new ZoneMap("map12") {
     Checksum = 962888126L
 
@@ -1348,5 +1344,6 @@ object Map12 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map13.scala
+++ b/pslogin/src/main/scala/zonemaps/Map13.scala
@@ -1,9 +1,6 @@
 package zonemaps
 
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
@@ -13,12 +10,11 @@ import net.psforever.objects.serverobject.painbox.Painbox
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.ZoneMap
 import net.psforever.types.Vector3
 
-object Map13 {
-  // HOME3 (VANU SOVREIGNTY SANCTUARY)
+object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
   val ZoneMap = new ZoneMap("map13") {
     Checksum = 3904659548L
 
@@ -1348,5 +1344,6 @@ object Map13 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map96.scala
+++ b/pslogin/src/main/scala/zonemaps/Map96.scala
@@ -1,25 +1,20 @@
 package zonemaps
 
-import net.psforever.objects.zones.MapScale
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
-import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.{MapScale, ZoneMap}
 import net.psforever.types.Vector3
 
-object Map96 {
-  // Nexus
+object Map96 { // Nexus
   val ZoneMap = new ZoneMap("map96") {
     Scale = MapScale.Dim4096
     Checksum = 846603446L
@@ -373,5 +368,6 @@ object Map96 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map97.scala
+++ b/pslogin/src/main/scala/zonemaps/Map97.scala
@@ -1,25 +1,20 @@
 package zonemaps
 
-import net.psforever.objects.zones.MapScale
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
-import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.{MapScale, ZoneMap}
 import net.psforever.types.Vector3
 
-object Map97 {
-  // Desolation
+object Map97 { // Desolation
   val ZoneMap = new ZoneMap("map97") {
     Scale = MapScale.Dim4096
     Checksum = 2810790213L
@@ -716,5 +711,6 @@ object Map97 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map98.scala
+++ b/pslogin/src/main/scala/zonemaps/Map98.scala
@@ -1,25 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.MapScale
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.{MapScale, ZoneMap}
 import net.psforever.types.Vector3
 
-object Map98 {
-  // Ascension
+object Map98 { // Ascension
   val ZoneMap = new ZoneMap("map98") {
     Scale = MapScale.Dim4096
     Checksum = 3654267088L
@@ -1080,5 +1076,6 @@ object Map98 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map99.scala
+++ b/pslogin/src/main/scala/zonemaps/Map99.scala
@@ -1,25 +1,21 @@
 package zonemaps
 
-import net.psforever.objects.zones.MapScale
-import net.psforever.objects.zones.ZoneMap
 import net.psforever.objects.GlobalDefinitions._
-import net.psforever.objects.LocalProjectile
-import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.implantmech.ImplantTerminalMech
 import net.psforever.objects.serverobject.locks.IFFLock
 import net.psforever.objects.serverobject.mblocker.Locker
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
 import net.psforever.objects.serverobject.tube.SpawnTube
-import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.turret.FacilityTurret
+import net.psforever.objects.zones.{MapScale, ZoneMap}
 import net.psforever.types.Vector3
 
-object Map99 {
-  // Extinction
+object Map99 { // Extinction
   val ZoneMap = new ZoneMap("map99") {
     Scale = MapScale.Dim4096
     Checksum = 3770866186L
@@ -869,5 +865,6 @@ object Map99 {
     }
 
     Lattice()
+
   }
 }

--- a/pslogin/src/main/scala/zonemaps/Map99.scala
+++ b/pslogin/src/main/scala/zonemaps/Map99.scala
@@ -18,7 +18,7 @@ import net.psforever.types.Vector3
 object Map99 { // Extinction
   val ZoneMap = new ZoneMap("map99") {
     Scale = MapScale.Dim4096
-    Checksum = 3770866186L
+    Checksum = 4113726460L
 
     Building7()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd01.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd01.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd01 { // Supai
   val ZoneMap = new ZoneMap("ugd01") {
     Scale = MapScale.Dim2560
-    Checksum = 0L
+    Checksum = 3405929729L
 
     Building10140()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd01.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd01.scala
@@ -1,0 +1,860 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd01 { // Supai
+  val ZoneMap = new ZoneMap("ugd01") {
+    Scale = MapScale.Dim2560
+    Checksum = 0L
+
+    Building10140()
+
+    def Building10140(): Unit = { // Name: ceiling_bldg_a_10140 Type: ceiling_bldg_a GUID: 1, MapID: 10140
+      LocalBuilding("ceiling_bldg_a_10140", 1, 10140, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(850.56f, 1038.27f, 170.61f), ceiling_bldg_a)))
+      LocalObject(571, Door.Constructor(Vector3(836.576f, 1045.967f, 172.389f)), owning_building_guid = 1)
+      LocalObject(580, Door.Constructor(Vector3(865.815f, 1027.238f, 177.895f)), owning_building_guid = 1)
+      LocalObject(581, Door.Constructor(Vector3(865.815f, 1051.238f, 177.895f)), owning_building_guid = 1)
+      LocalObject(583, Door.Constructor(Vector3(867.315f, 1042.238f, 172.389f)), owning_building_guid = 1)
+    }
+
+    Building10141()
+
+    def Building10141(): Unit = { // Name: ceiling_bldg_b_10141 Type: ceiling_bldg_b GUID: 2, MapID: 10141
+      LocalBuilding("ceiling_bldg_b_10141", 2, 10141, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(950.1f, 921.84f, 163.91f), ceiling_bldg_b)))
+      LocalObject(595, Door.Constructor(Vector3(952.115f, 938.33f, 165.689f)), owning_building_guid = 2)
+      LocalObject(596, Door.Constructor(Vector3(956.116f, 920.83f, 165.689f)), owning_building_guid = 2)
+    }
+
+    Building10138()
+
+    def Building10138(): Unit = { // Name: ceiling_bldg_c_10138 Type: ceiling_bldg_c GUID: 3, MapID: 10138
+      LocalBuilding("ceiling_bldg_c_10138", 3, 10138, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1077.18f, 1115.65f, 154.15f), ceiling_bldg_c)))
+      LocalObject(620, Door.Constructor(Vector3(1033.541f, 1097.152f, 155.929f)), owning_building_guid = 3)
+      LocalObject(623, Door.Constructor(Vector3(1052.197f, 1072.395f, 155.929f)), owning_building_guid = 3)
+      LocalObject(624, Door.Constructor(Vector3(1080.784f, 1113.377f, 155.929f)), owning_building_guid = 3)
+    }
+
+    Building10312()
+
+    def Building10312(): Unit = { // Name: ceiling_bldg_d_10312 Type: ceiling_bldg_d GUID: 4, MapID: 10312
+      LocalBuilding("ceiling_bldg_d_10312", 4, 10312, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(993.7f, 1408.09f, 161.96f), ceiling_bldg_d)))
+      LocalObject(601, Door.Constructor(Vector3(976.21f, 1408.106f, 163.695f)), owning_building_guid = 4)
+      LocalObject(610, Door.Constructor(Vector3(993.716f, 1390.58f, 163.695f)), owning_building_guid = 4)
+      LocalObject(611, Door.Constructor(Vector3(993.716f, 1425.58f, 163.695f)), owning_building_guid = 4)
+      LocalObject(615, Door.Constructor(Vector3(1011.21f, 1408.106f, 163.695f)), owning_building_guid = 4)
+      LocalObject(779, Painbox.Constructor(Vector3(993.6073f, 1407.887f, 170.268f), painbox_continuous), owning_building_guid = 4)
+    }
+
+    Building10139()
+
+    def Building10139(): Unit = { // Name: ceiling_bldg_d_10139 Type: ceiling_bldg_d GUID: 5, MapID: 10139
+      LocalBuilding("ceiling_bldg_d_10139", 5, 10139, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.02f, 1242.45f, 159.65f), ceiling_bldg_d)))
+      LocalObject(643, Door.Constructor(Vector3(1269.53f, 1242.466f, 161.385f)), owning_building_guid = 5)
+      LocalObject(648, Door.Constructor(Vector3(1287.036f, 1224.94f, 161.385f)), owning_building_guid = 5)
+      LocalObject(649, Door.Constructor(Vector3(1287.036f, 1259.94f, 161.385f)), owning_building_guid = 5)
+      LocalObject(651, Door.Constructor(Vector3(1304.53f, 1242.466f, 161.385f)), owning_building_guid = 5)
+      LocalObject(780, Painbox.Constructor(Vector3(1286.927f, 1242.247f, 167.958f), painbox_continuous), owning_building_guid = 5)
+    }
+
+    Building10143()
+
+    def Building10143(): Unit = { // Name: ceiling_bldg_e_10143 Type: ceiling_bldg_e GUID: 6, MapID: 10143
+      LocalBuilding("ceiling_bldg_e_10143", 6, 10143, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1408.75f, 1242.78f, 167.66f), ceiling_bldg_e)))
+      LocalObject(685, Door.Constructor(Vector3(1396.734f, 1241.79f, 169.439f)), owning_building_guid = 6)
+      LocalObject(691, Door.Constructor(Vector3(1412.734f, 1275.29f, 174.939f)), owning_building_guid = 6)
+      LocalObject(693, Door.Constructor(Vector3(1427.76f, 1270.796f, 169.439f)), owning_building_guid = 6)
+      LocalObject(696, Door.Constructor(Vector3(1433.76f, 1250.796f, 174.939f)), owning_building_guid = 6)
+    }
+
+    Building10142()
+
+    def Building10142(): Unit = { // Name: ceiling_bldg_f_10142 Type: ceiling_bldg_f GUID: 7, MapID: 10142
+      LocalBuilding("ceiling_bldg_f_10142", 7, 10142, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1376.58f, 1348.91f, 159.37f), ceiling_bldg_f)))
+      LocalObject(668, Door.Constructor(Vector3(1352.277f, 1329.785f, 161.149f)), owning_building_guid = 7)
+      LocalObject(686, Door.Constructor(Vector3(1404.189f, 1356.455f, 161.149f)), owning_building_guid = 7)
+    }
+
+    Building10145()
+
+    def Building10145(): Unit = { // Name: ceiling_bldg_g_10145 Type: ceiling_bldg_g GUID: 8, MapID: 10145
+      LocalBuilding("ceiling_bldg_g_10145", 8, 10145, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1374.9f, 1025.85f, 162.66f), ceiling_bldg_g)))
+      LocalObject(671, Door.Constructor(Vector3(1363.438f, 1039.06f, 164.439f)), owning_building_guid = 8)
+      LocalObject(676, Door.Constructor(Vector3(1379.706f, 1008.152f, 164.439f)), owning_building_guid = 8)
+    }
+
+    Building10146()
+
+    def Building10146(): Unit = { // Name: ceiling_bldg_h_10146 Type: ceiling_bldg_h GUID: 9, MapID: 10146
+      LocalBuilding("ceiling_bldg_h_10146", 9, 10146, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1311.84f, 904.66f, 161.7f), ceiling_bldg_h)))
+      LocalObject(650, Door.Constructor(Vector3(1295.35f, 900.676f, 163.479f)), owning_building_guid = 9)
+      LocalObject(658, Door.Constructor(Vector3(1315.824f, 921.17f, 163.479f)), owning_building_guid = 9)
+      LocalObject(663, Door.Constructor(Vector3(1322.925f, 893.472f, 165.979f)), owning_building_guid = 9)
+    }
+
+    Building10144()
+
+    def Building10144(): Unit = { // Name: ceiling_bldg_i_10144 Type: ceiling_bldg_i GUID: 10, MapID: 10144
+      LocalBuilding("ceiling_bldg_i_10144", 10, 10144, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1206.94f, 1100.55f, 172.13f), ceiling_bldg_i)))
+      LocalObject(636, Door.Constructor(Vector3(1182.45f, 1104.066f, 173.909f)), owning_building_guid = 10)
+      LocalObject(642, Door.Constructor(Vector3(1232.45f, 1104.066f, 173.909f)), owning_building_guid = 10)
+    }
+
+    Building10311()
+
+    def Building10311(): Unit = { // Name: ceiling_bldg_j_10311 Type: ceiling_bldg_j GUID: 11, MapID: 10311
+      LocalBuilding("ceiling_bldg_j_10311", 11, 10311, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(940.03f, 1345.53f, 162.79f), ceiling_bldg_j)))
+      LocalObject(592, Door.Constructor(Vector3(940.046f, 1333.02f, 164.569f)), owning_building_guid = 11)
+      LocalObject(593, Door.Constructor(Vector3(940.046f, 1358.02f, 164.569f)), owning_building_guid = 11)
+    }
+
+    Building10310()
+
+    def Building10310(): Unit = { // Name: ceiling_bldg_z_10310 Type: ceiling_bldg_z GUID: 12, MapID: 10310
+      LocalBuilding("ceiling_bldg_z_10310", 12, 10310, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.73f, 1181.27f, 165.51f), ceiling_bldg_z)))
+      LocalObject(619, Door.Constructor(Vector3(1032.086f, 1173.73f, 167.289f)), owning_building_guid = 12)
+      LocalObject(625, Door.Constructor(Vector3(1082.873f, 1199.608f, 167.289f)), owning_building_guid = 12)
+    }
+
+    Building10029()
+
+    def Building10029(): Unit = { // Name: ground_bldg_b_10029 Type: ground_bldg_b GUID: 61, MapID: 10029
+      LocalBuilding("ground_bldg_b_10029", 61, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(794.78f, 864.61f, 103.74f), ground_bldg_b)))
+      LocalObject(552, Door.Constructor(Vector3(779.3734f, 870.8243f, 105.519f)), owning_building_guid = 61)
+      LocalObject(554, Door.Constructor(Vector3(795.3158f, 889.8535f, 111.019f)), owning_building_guid = 61)
+      LocalObject(556, Door.Constructor(Vector3(797.3127f, 870.1596f, 105.519f)), owning_building_guid = 61)
+    }
+
+    Building10016()
+
+    def Building10016(): Unit = { // Name: ground_bldg_b_10016 Type: ground_bldg_b GUID: 62, MapID: 10016
+      LocalBuilding("ground_bldg_b_10016", 62, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(865.1f, 916.28f, 85.19f), ground_bldg_b)))
+      LocalObject(573, Door.Constructor(Vector3(848.4634f, 897.2867f, 92.469f)), owning_building_guid = 62)
+      LocalObject(578, Door.Constructor(Vector3(859.5927f, 913.6567f, 86.969f)), owning_building_guid = 62)
+      LocalObject(584, Door.Constructor(Vector3(872.9077f, 901.6165f, 86.969f)), owning_building_guid = 62)
+    }
+
+    Building10077()
+
+    def Building10077(): Unit = { // Name: ground_bldg_b_10077 Type: ground_bldg_b GUID: 63, MapID: 10077
+      LocalBuilding("ground_bldg_b_10077", 63, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(998.78f, 1510.64f, 87.06f), ground_bldg_b)))
+      LocalObject(607, Door.Constructor(Vector3(989.4824f, 1524.407f, 88.839f)), owning_building_guid = 63)
+      LocalObject(614, Door.Constructor(Vector3(1003.983f, 1513.825f, 88.839f)), owning_building_guid = 63)
+      LocalObject(616, Door.Constructor(Vector3(1013.34f, 1531.268f, 94.339f)), owning_building_guid = 63)
+    }
+
+    Building10066()
+
+    def Building10066(): Unit = { // Name: ground_bldg_b_10066 Type: ground_bldg_b GUID: 64, MapID: 10066
+      LocalBuilding("ground_bldg_b_10066", 64, 10066, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1041.45f, 1317.49f, 90.89f), ground_bldg_b)))
+      LocalObject(618, Door.Constructor(Vector3(1025.56f, 1322.338f, 92.669f)), owning_building_guid = 64)
+      LocalObject(621, Door.Constructor(Vector3(1039.784f, 1342.684f, 98.169f)), owning_building_guid = 64)
+      LocalObject(622, Door.Constructor(Vector3(1043.489f, 1323.239f, 92.669f)), owning_building_guid = 64)
+    }
+
+    Building10031()
+
+    def Building10031(): Unit = { // Name: ground_bldg_b_10031 Type: ground_bldg_b GUID: 65, MapID: 10031
+      LocalBuilding("ground_bldg_b_10031", 65, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1384.96f, 1262.28f, 85.22f), ground_bldg_b)))
+      LocalObject(670, Door.Constructor(Vector3(1360.715f, 1269.331f, 92.499f)), owning_building_guid = 65)
+      LocalObject(674, Door.Constructor(Vector3(1374.97f, 1249.007f, 86.999f)), owning_building_guid = 65)
+      LocalObject(677, Door.Constructor(Vector3(1380.255f, 1266.163f, 86.999f)), owning_building_guid = 65)
+    }
+
+    Building10025()
+
+    def Building10025(): Unit = { // Name: ground_bldg_b_10025 Type: ground_bldg_b GUID: 66, MapID: 10025
+      LocalBuilding("ground_bldg_b_10025", 66, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.42f, 1346.97f, 87.93f), ground_bldg_b)))
+      LocalObject(707, Door.Constructor(Vector3(1490.413f, 1341.662f, 89.709f)), owning_building_guid = 66)
+      LocalObject(708, Door.Constructor(Vector3(1490.686f, 1321.869f, 95.209f)), owning_building_guid = 66)
+      LocalObject(714, Door.Constructor(Vector3(1508.226f, 1339.437f, 89.709f)), owning_building_guid = 66)
+    }
+
+    Building10017()
+
+    def Building10017(): Unit = { // Name: ground_bldg_c_10017 Type: ground_bldg_c GUID: 67, MapID: 10017
+      LocalBuilding("ground_bldg_c_10017", 67, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(786.51f, 954.37f, 105.26f), ground_bldg_c)))
+      LocalObject(553, Door.Constructor(Vector3(787.5582f, 958.4996f, 107.039f)), owning_building_guid = 67)
+      LocalObject(562, Door.Constructor(Vector3(817.5875f, 918.5826f, 107.039f)), owning_building_guid = 67)
+      LocalObject(570, Door.Constructor(Vector3(835.3683f, 943.9763f, 107.039f)), owning_building_guid = 67)
+    }
+
+    Building10030()
+
+    def Building10030(): Unit = { // Name: ground_bldg_c_10030 Type: ground_bldg_c GUID: 68, MapID: 10030
+      LocalBuilding("ground_bldg_c_10030", 68, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(857.33f, 852.26f, 107.42f), ground_bldg_c)))
+      LocalObject(560, Door.Constructor(Vector3(813.0717f, 835.2968f, 109.199f)), owning_building_guid = 68)
+      LocalObject(567, Door.Constructor(Vector3(830.8526f, 809.903f, 109.199f)), owning_building_guid = 68)
+      LocalObject(579, Door.Constructor(Vector3(860.8521f, 849.8626f, 109.199f)), owning_building_guid = 68)
+    }
+
+    Building10067()
+
+    def Building10067(): Unit = { // Name: ground_bldg_c_10067 Type: ground_bldg_c GUID: 69, MapID: 10067
+      LocalBuilding("ground_bldg_c_10067", 69, 10067, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.9f, 1275.59f, 108.53f), ground_bldg_c)))
+      LocalObject(597, Door.Constructor(Vector3(966.4615f, 1228.78f, 110.309f)), owning_building_guid = 69)
+      LocalObject(603, Door.Constructor(Vector3(977.7372f, 1277.441f, 110.309f)), owning_building_guid = 69)
+      LocalObject(613, Door.Constructor(Vector3(997.3436f, 1231.481f, 110.309f)), owning_building_guid = 69)
+    }
+
+    Building10305()
+
+    def Building10305(): Unit = { // Name: ground_bldg_c_10305 Type: ground_bldg_c GUID: 70, MapID: 10305
+      LocalBuilding("ground_bldg_c_10305", 70, 10305, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.71f, 996.36f, 107.32f), ground_bldg_c)))
+      LocalObject(644, Door.Constructor(Vector3(1272.394f, 1000.565f, 109.099f)), owning_building_guid = 70)
+      LocalObject(653, Door.Constructor(Vector3(1305.788f, 963.4174f, 109.099f)), owning_building_guid = 70)
+      LocalObject(661, Door.Constructor(Vector3(1321.288f, 990.2642f, 109.099f)), owning_building_guid = 70)
+    }
+
+    Building10022()
+
+    def Building10022(): Unit = { // Name: ground_bldg_c_10022 Type: ground_bldg_c GUID: 71, MapID: 10022
+      LocalBuilding("ground_bldg_c_10022", 71, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1456.97f, 1345.86f, 103.88f), ground_bldg_c)))
+      LocalObject(688, Door.Constructor(Vector3(1409.203f, 1360.472f, 105.659f)), owning_building_guid = 71)
+      LocalObject(694, Door.Constructor(Vector3(1429.13f, 1384.22f, 105.659f)), owning_building_guid = 71)
+      LocalObject(698, Door.Constructor(Vector3(1455.566f, 1341.837f, 105.659f)), owning_building_guid = 71)
+    }
+
+    Building10096()
+
+    def Building10096(): Unit = { // Name: ground_bldg_c_10096 Type: ground_bldg_c GUID: 72, MapID: 10096
+      LocalBuilding("ground_bldg_c_10096", 72, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1481.1f, 1136.17f, 101.01f), ground_bldg_c)))
+      LocalObject(703, Door.Constructor(Vector3(1481.044f, 1140.43f, 102.789f)), owning_building_guid = 72)
+      LocalObject(718, Door.Constructor(Vector3(1520.381f, 1109.646f, 102.789f)), owning_building_guid = 72)
+      LocalObject(719, Door.Constructor(Vector3(1530.984f, 1138.776f, 102.789f)), owning_building_guid = 72)
+    }
+
+    Building10027()
+
+    def Building10027(): Unit = { // Name: ground_bldg_c_10027 Type: ground_bldg_c GUID: 73, MapID: 10027
+      LocalBuilding("ground_bldg_c_10027", 73, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.89f, 1467.82f, 105.26f), ground_bldg_c)))
+      LocalObject(709, Door.Constructor(Vector3(1495.639f, 1471.705f, 107.039f)), owning_building_guid = 73)
+      LocalObject(717, Door.Constructor(Vector3(1518.281f, 1427.18f, 107.039f)), owning_building_guid = 73)
+      LocalObject(720, Door.Constructor(Vector3(1540.201f, 1449.1f, 107.039f)), owning_building_guid = 73)
+    }
+
+    Building10028()
+
+    def Building10028(): Unit = { // Name: ground_bldg_d_10028 Type: ground_bldg_d GUID: 74, MapID: 10028
+      LocalBuilding("ground_bldg_d_10028", 74, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(748.19f, 914.57f, 104.86f), ground_bldg_d)))
+      LocalObject(547, Door.Constructor(Vector3(733.8558f, 904.5135f, 106.595f)), owning_building_guid = 74)
+      LocalObject(548, Door.Constructor(Vector3(738.1335f, 928.9042f, 106.595f)), owning_building_guid = 74)
+      LocalObject(550, Door.Constructor(Vector3(758.2087f, 900.2339f, 106.595f)), owning_building_guid = 74)
+      LocalObject(551, Door.Constructor(Vector3(762.5261f, 924.5887f, 106.595f)), owning_building_guid = 74)
+    }
+
+    Building10074()
+
+    def Building10074(): Unit = { // Name: ground_bldg_d_10074 Type: ground_bldg_d GUID: 75, MapID: 10074
+      LocalBuilding("ground_bldg_d_10074", 75, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.93f, 1166.25f, 99.66f), ground_bldg_d)))
+      LocalObject(565, Door.Constructor(Vector3(824.5775f, 1176.28f, 101.395f)), owning_building_guid = 75)
+      LocalObject(566, Door.Constructor(Vector3(828.8998f, 1151.897f, 101.395f)), owning_building_guid = 75)
+      LocalObject(574, Door.Constructor(Vector3(848.975f, 1180.568f, 101.395f)), owning_building_guid = 75)
+      LocalObject(575, Door.Constructor(Vector3(853.2478f, 1156.205f, 101.395f)), owning_building_guid = 75)
+    }
+
+    Building10018()
+
+    def Building10018(): Unit = { // Name: ground_bldg_d_10018 Type: ground_bldg_d GUID: 76, MapID: 10018
+      LocalBuilding("ground_bldg_d_10018", 76, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.98f, 1013.84f, 90.81f), ground_bldg_d)))
+      LocalObject(564, Door.Constructor(Vector3(822.5205f, 1019.814f, 92.545f)), owning_building_guid = 76)
+      LocalObject(568, Door.Constructor(Vector3(832.983f, 997.4103f, 92.545f)), owning_building_guid = 76)
+      LocalObject(572, Door.Constructor(Vector3(844.9537f, 1030.3f, 92.545f)), owning_building_guid = 76)
+      LocalObject(576, Door.Constructor(Vector3(855.4097f, 1007.843f, 92.545f)), owning_building_guid = 76)
+    }
+
+    Building10078()
+
+    def Building10078(): Unit = { // Name: ground_bldg_d_10078 Type: ground_bldg_d GUID: 77, MapID: 10078
+      LocalBuilding("ground_bldg_d_10078", 77, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1107.02f, 1332.16f, 95.93f), ground_bldg_d)))
+      LocalObject(626, Door.Constructor(Vector3(1093.795f, 1343.635f, 97.665f)), owning_building_guid = 77)
+      LocalObject(627, Door.Constructor(Vector3(1095.545f, 1318.935f, 97.665f)), owning_building_guid = 77)
+      LocalObject(629, Door.Constructor(Vector3(1118.507f, 1345.349f, 97.665f)), owning_building_guid = 77)
+      LocalObject(630, Door.Constructor(Vector3(1120.209f, 1320.673f, 97.665f)), owning_building_guid = 77)
+    }
+
+    Building10093()
+
+    def Building10093(): Unit = { // Name: ground_bldg_d_10093 Type: ground_bldg_d GUID: 78, MapID: 10093
+      LocalBuilding("ground_bldg_d_10093", 78, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.91f, 1035.28f, 97.66f), ground_bldg_d)))
+      LocalObject(637, Door.Constructor(Vector3(1185.001f, 1030.733f, 99.395f)), owning_building_guid = 78)
+      LocalObject(638, Door.Constructor(Vector3(1197.399f, 1052.178f, 99.395f)), owning_building_guid = 78)
+      LocalObject(639, Door.Constructor(Vector3(1206.457f, 1018.371f, 99.395f)), owning_building_guid = 78)
+      LocalObject(640, Door.Constructor(Vector3(1218.808f, 1039.791f, 99.395f)), owning_building_guid = 78)
+    }
+
+    Building10023()
+
+    def Building10023(): Unit = { // Name: ground_bldg_d_10023 Type: ground_bldg_d GUID: 79, MapID: 10023
+      LocalBuilding("ground_bldg_d_10023", 79, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1363.37f, 1403.85f, 88.96f), ground_bldg_d)))
+      LocalObject(667, Door.Constructor(Vector3(1348.231f, 1412.609f, 90.695f)), owning_building_guid = 79)
+      LocalObject(669, Door.Constructor(Vector3(1354.611f, 1388.711f, 90.695f)), owning_building_guid = 79)
+      LocalObject(673, Door.Constructor(Vector3(1372.111f, 1419.022f, 90.695f)), owning_building_guid = 79)
+      LocalObject(675, Door.Constructor(Vector3(1378.542f, 1395.109f, 90.695f)), owning_building_guid = 79)
+    }
+
+    Building10094()
+
+    def Building10094(): Unit = { // Name: ground_bldg_d_10094 Type: ground_bldg_d GUID: 80, MapID: 10094
+      LocalBuilding("ground_bldg_d_10094", 80, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1399.93f, 1061.29f, 97.66f), ground_bldg_d)))
+      LocalObject(680, Door.Constructor(Vector3(1387.56f, 1048.897f, 99.395f)), owning_building_guid = 80)
+      LocalObject(681, Door.Constructor(Vector3(1387.537f, 1073.66f, 99.395f)), owning_building_guid = 80)
+      LocalObject(689, Door.Constructor(Vector3(1412.286f, 1048.911f, 99.395f)), owning_building_guid = 80)
+      LocalObject(690, Door.Constructor(Vector3(1412.309f, 1073.646f, 99.395f)), owning_building_guid = 80)
+    }
+
+    Building10026()
+
+    def Building10026(): Unit = { // Name: ground_bldg_d_10026 Type: ground_bldg_d GUID: 81, MapID: 10026
+      LocalBuilding("ground_bldg_d_10026", 81, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1492.58f, 1397.16f, 90.81f), ground_bldg_d)))
+      LocalObject(702, Door.Constructor(Vector3(1477.441f, 1405.919f, 92.545f)), owning_building_guid = 81)
+      LocalObject(705, Door.Constructor(Vector3(1483.821f, 1382.021f, 92.545f)), owning_building_guid = 81)
+      LocalObject(711, Door.Constructor(Vector3(1501.321f, 1412.332f, 92.545f)), owning_building_guid = 81)
+      LocalObject(713, Door.Constructor(Vector3(1507.752f, 1388.419f, 92.545f)), owning_building_guid = 81)
+    }
+
+    Building10020()
+
+    def Building10020(): Unit = { // Name: ground_bldg_i_10020 Type: ground_bldg_i GUID: 82, MapID: 10020
+      LocalBuilding("ground_bldg_i_10020", 82, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(745.29f, 997.76f, 95.81f), ground_bldg_i)))
+      LocalObject(546, Door.Constructor(Vector3(730.0001f, 978.309f, 97.589f)), owning_building_guid = 82)
+      LocalObject(549, Door.Constructor(Vector3(755.0001f, 1021.61f, 97.589f)), owning_building_guid = 82)
+    }
+
+    Building10019()
+
+    def Building10019(): Unit = { // Name: ground_bldg_i_10019 Type: ground_bldg_i GUID: 83, MapID: 10019
+      LocalBuilding("ground_bldg_i_10019", 83, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(906.71f, 986.08f, 94.15f), ground_bldg_i)))
+      LocalObject(586, Door.Constructor(Vector3(883.743f, 976.8799f, 95.929f)), owning_building_guid = 83)
+      LocalObject(591, Door.Constructor(Vector3(927.0443f, 1001.88f, 95.929f)), owning_building_guid = 83)
+    }
+
+    Building10095()
+
+    def Building10095(): Unit = { // Name: ground_bldg_i_10095 Type: ground_bldg_i GUID: 84, MapID: 10095
+      LocalBuilding("ground_bldg_i_10095", 84, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1253.14f, 913.31f, 102.44f), ground_bldg_i)))
+      LocalObject(641, Door.Constructor(Vector3(1229.29f, 923.0201f, 104.219f)), owning_building_guid = 84)
+      LocalObject(645, Door.Constructor(Vector3(1272.591f, 898.0201f, 104.219f)), owning_building_guid = 84)
+    }
+
+    Building10092()
+
+    def Building10092(): Unit = { // Name: ground_bldg_i_10092 Type: ground_bldg_i GUID: 85, MapID: 10092
+      LocalBuilding("ground_bldg_i_10092", 85, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.38f, 1163.11f, 92.1f), ground_bldg_i)))
+      LocalObject(647, Door.Constructor(Vector3(1281.87f, 1159.594f, 93.879f)), owning_building_guid = 85)
+      LocalObject(666, Door.Constructor(Vector3(1331.87f, 1159.594f, 93.879f)), owning_building_guid = 85)
+    }
+
+    Building10024()
+
+    def Building10024(): Unit = { // Name: ground_bldg_i_10024 Type: ground_bldg_i GUID: 86, MapID: 10024
+      LocalBuilding("ground_bldg_i_10024", 86, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1439.95f, 1456.47f, 91.36f), ground_bldg_i)))
+      LocalObject(692, Door.Constructor(Vector3(1419.24f, 1470.006f, 93.139f)), owning_building_guid = 86)
+      LocalObject(700, Door.Constructor(Vector3(1464.556f, 1448.876f, 93.139f)), owning_building_guid = 86)
+    }
+
+    Building10021()
+
+    def Building10021(): Unit = { // Name: ground_bldg_i_10021 Type: ground_bldg_i GUID: 87, MapID: 10021
+      LocalBuilding("ground_bldg_i_10021", 87, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1451.54f, 1274.29f, 94.15f), ground_bldg_i)))
+      LocalObject(695, Door.Constructor(Vector3(1430.52f, 1261.242f, 95.929f)), owning_building_guid = 87)
+      LocalObject(701, Door.Constructor(Vector3(1468.822f, 1293.381f, 95.929f)), owning_building_guid = 87)
+    }
+
+    Building10425()
+
+    def Building10425(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 88, MapID: 10425
+      LocalBuilding("N_Redoubt", 88, 10425, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(882.39f, 1471.4f, 90.88f), redoubt)))
+      LocalObject(832, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 88)
+      LocalObject(582, Door.Constructor(Vector3(866.5455f, 1478.806f, 92.615f)), owning_building_guid = 88)
+      LocalObject(585, Door.Constructor(Vector3(876.3672f, 1487.536f, 102.659f)), owning_building_guid = 88)
+      LocalObject(587, Door.Constructor(Vector3(883.8498f, 1484.043f, 102.639f)), owning_building_guid = 88)
+      LocalObject(588, Door.Constructor(Vector3(891.1319f, 1480.682f, 102.639f)), owning_building_guid = 88)
+      LocalObject(589, Door.Constructor(Vector3(898.2662f, 1464.015f, 92.615f)), owning_building_guid = 88)
+      LocalObject(590, Door.Constructor(Vector3(898.6056f, 1477.203f, 102.659f)), owning_building_guid = 88)
+      LocalObject(844, Terminal.Constructor(Vector3(874.4547f, 1454.679f, 90.8358f), vanu_equipment_term), owning_building_guid = 88)
+      LocalObject(847, Terminal.Constructor(Vector3(890.3133f, 1488.354f, 90.8335f), vanu_equipment_term), owning_building_guid = 88)
+      LocalObject(791, SpawnTube.Constructor(Vector3(882.39f, 1471.4f, 90.88f), Vector3(0, 0, 205)), owning_building_guid = 88)
+      LocalObject(777, Painbox.Constructor(Vector3(882.5502f, 1471.646f, 98.669f), painbox_continuous), owning_building_guid = 88)
+    }
+
+    Building10883()
+
+    def Building10883(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 89, MapID: 10883
+      LocalBuilding("S_Redoubt", 89, 10883, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1399.41f, 850.5f, 91.78f), redoubt)))
+      LocalObject(835, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 89)
+      LocalObject(678, Door.Constructor(Vector3(1384.128f, 842.5555f, 103.559f)), owning_building_guid = 89)
+      LocalObject(679, Door.Constructor(Vector3(1386.684f, 850.4081f, 103.539f)), owning_building_guid = 89)
+      LocalObject(682, Door.Constructor(Vector3(1389.132f, 858.0455f, 103.539f)), owning_building_guid = 89)
+      LocalObject(683, Door.Constructor(Vector3(1391.674f, 865.8876f, 103.559f)), owning_building_guid = 89)
+      LocalObject(684, Door.Constructor(Vector3(1393.99f, 833.871f, 93.515f)), owning_building_guid = 89)
+      LocalObject(687, Door.Constructor(Vector3(1404.806f, 867.158f, 93.515f)), owning_building_guid = 89)
+      LocalObject(873, Terminal.Constructor(Vector3(1381.617f, 856.2981f, 91.7335f), vanu_equipment_term), owning_building_guid = 89)
+      LocalObject(878, Terminal.Constructor(Vector3(1416.974f, 844.6616f, 91.7358f), vanu_equipment_term), owning_building_guid = 89)
+      LocalObject(792, SpawnTube.Constructor(Vector3(1399.41f, 850.5f, 91.78f), Vector3(0, 0, 108)), owning_building_guid = 89)
+      LocalObject(782, Painbox.Constructor(Vector3(1399.146f, 850.6291f, 99.569f), painbox_continuous), owning_building_guid = 89)
+    }
+
+    Building10175()
+
+    def Building10175(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 171, MapID: 10175
+      LocalBuilding("S_Stasis", 171, 10175, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(983.99f, 1034.17f, 94.51f), vanu_control_point)))
+      LocalObject(833, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 171)
+      LocalObject(594, Door.Constructor(Vector3(950.054f, 1050.163f, 96.289f)), owning_building_guid = 171)
+      LocalObject(598, Door.Constructor(Vector3(967.2758f, 983.8116f, 96.289f)), owning_building_guid = 171)
+      LocalObject(599, Door.Constructor(Vector3(968.8129f, 1037.51f, 126.289f)), owning_building_guid = 171)
+      LocalObject(600, Door.Constructor(Vector3(970.6356f, 1029.553f, 101.23f)), owning_building_guid = 171)
+      LocalObject(602, Door.Constructor(Vector3(976.9498f, 1038.902f, 126.269f)), owning_building_guid = 171)
+      LocalObject(604, Door.Constructor(Vector3(980.1362f, 1043.598f, 101.23f)), owning_building_guid = 171)
+      LocalObject(605, Door.Constructor(Vector3(984.6804f, 1020.052f, 101.23f)), owning_building_guid = 171)
+      LocalObject(606, Door.Constructor(Vector3(984.8152f, 1040.464f, 126.269f)), owning_building_guid = 171)
+      LocalObject(608, Door.Constructor(Vector3(991.2167f, 1070.448f, 96.289f)), owning_building_guid = 171)
+      LocalObject(609, Door.Constructor(Vector3(992.8783f, 1042.22f, 126.289f)), owning_building_guid = 171)
+      LocalObject(612, Door.Constructor(Vector3(994.1946f, 1034.132f, 101.23f)), owning_building_guid = 171)
+      LocalObject(617, Door.Constructor(Vector3(1024.07f, 1007.534f, 96.289f)), owning_building_guid = 171)
+      LocalObject(851, Terminal.Constructor(Vector3(972.808f, 1035.897f, 99.523f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(852, Terminal.Constructor(Vector3(975.0327f, 1039.189f, 99.527f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(853, Terminal.Constructor(Vector3(975.1244f, 1024.373f, 99.527f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(854, Terminal.Constructor(Vector3(978.3792f, 1022.209f, 99.523f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(855, Terminal.Constructor(Vector3(986.3745f, 1041.467f, 99.523f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(856, Terminal.Constructor(Vector3(989.6664f, 1039.242f, 99.527f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(857, Terminal.Constructor(Vector3(989.7583f, 1024.426f, 99.527f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(858, Terminal.Constructor(Vector3(991.983f, 1027.718f, 99.523f), vanu_equipment_term), owning_building_guid = 171)
+      LocalObject(897, SpawnTube.Constructor(Vector3(982.4083f, 1031.825f, 99.649f), Vector3(0, 0, 259)), owning_building_guid = 171)
+      LocalObject(778, Painbox.Constructor(Vector3(982.0579f, 1032.05f, 108.8518f), painbox_continuous), owning_building_guid = 171)
+      LocalObject(783, Painbox.Constructor(Vector3(968.9275f, 1029.522f, 103.4f), painbox_door_radius_continuous), owning_building_guid = 171)
+      LocalObject(784, Painbox.Constructor(Vector3(979.7823f, 1045.896f, 102.8f), painbox_door_radius_continuous), owning_building_guid = 171)
+      LocalObject(785, Painbox.Constructor(Vector3(985.6085f, 1017.388f, 103.4f), painbox_door_radius_continuous), owning_building_guid = 171)
+      LocalObject(786, Painbox.Constructor(Vector3(996.1259f, 1034.449f, 103.4f), painbox_door_radius_continuous), owning_building_guid = 171)
+    }
+
+    Building10000()
+
+    def Building10000(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 172, MapID: 10000
+      LocalBuilding("N_Stasis", 172, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1316.27f, 1321.48f, 88.98f), vanu_control_point)))
+      LocalObject(834, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 172)
+      LocalObject(646, Door.Constructor(Vector3(1280.496f, 1312.072f, 90.759f)), owning_building_guid = 172)
+      LocalObject(652, Door.Constructor(Vector3(1305.138f, 1325.94f, 120.759f)), owning_building_guid = 172)
+      LocalObject(654, Door.Constructor(Vector3(1309.486f, 1313.883f, 95.7f)), owning_building_guid = 172)
+      LocalObject(655, Door.Constructor(Vector3(1310.251f, 1319.463f, 120.739f)), owning_building_guid = 172)
+      LocalObject(656, Door.Constructor(Vector3(1311.83f, 1330.668f, 95.7f)), owning_building_guid = 172)
+      LocalObject(657, Door.Constructor(Vector3(1315.104f, 1313.078f, 120.739f)), owning_building_guid = 172)
+      LocalObject(659, Door.Constructor(Vector3(1316.773f, 1283.968f, 90.759f)), owning_building_guid = 172)
+      LocalObject(660, Door.Constructor(Vector3(1319.922f, 1306.375f, 120.759f)), owning_building_guid = 172)
+      LocalObject(662, Door.Constructor(Vector3(1322.64f, 1369.18f, 90.759f)), owning_building_guid = 172)
+      LocalObject(664, Door.Constructor(Vector3(1326.274f, 1311.501f, 95.7f)), owning_building_guid = 172)
+      LocalObject(665, Door.Constructor(Vector3(1328.656f, 1328.289f, 95.7f)), owning_building_guid = 172)
+      LocalObject(672, Door.Constructor(Vector3(1368.859f, 1328.533f, 90.759f)), owning_building_guid = 172)
+      LocalObject(863, Terminal.Constructor(Vector3(1308.666f, 1320.424f, 93.993f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(864, Terminal.Constructor(Vector3(1309.223f, 1324.358f, 93.997f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(865, Terminal.Constructor(Vector3(1315.686f, 1311.229f, 93.997f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(866, Terminal.Constructor(Vector3(1318.565f, 1331.493f, 93.993f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(867, Terminal.Constructor(Vector3(1319.62f, 1310.673f, 93.993f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(868, Terminal.Constructor(Vector3(1322.5f, 1330.936f, 93.997f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(869, Terminal.Constructor(Vector3(1328.962f, 1317.806f, 93.997f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(870, Terminal.Constructor(Vector3(1329.48f, 1321.681f, 93.993f), vanu_equipment_term), owning_building_guid = 172)
+      LocalObject(898, SpawnTube.Constructor(Vector3(1319.071f, 1321.086f, 94.119f), Vector3(0, 0, 143)), owning_building_guid = 172)
+      LocalObject(781, Painbox.Constructor(Vector3(1319.023f, 1320.673f, 103.3218f), painbox_continuous), owning_building_guid = 172)
+      LocalObject(787, Painbox.Constructor(Vector3(1307.576f, 1312.558f, 97.27f), painbox_door_radius_continuous), owning_building_guid = 172)
+      LocalObject(788, Painbox.Constructor(Vector3(1310.699f, 1332.265f, 97.87f), painbox_door_radius_continuous), owning_building_guid = 172)
+      LocalObject(789, Painbox.Constructor(Vector3(1327.051f, 1309.979f, 97.87f), painbox_door_radius_continuous), owning_building_guid = 172)
+      LocalObject(790, Painbox.Constructor(Vector3(1330.644f, 1330.292f, 97.87f), painbox_door_radius_continuous), owning_building_guid = 172)
+    }
+
+    Building10015()
+
+    def Building10015(): Unit = { // Name: Core Type: vanu_core GUID: 173, MapID: 10015
+      LocalBuilding("Core", 173, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1151.45f, 1177.46f, 95.63f), vanu_core)))
+      LocalObject(628, Door.Constructor(Vector3(1118.471f, 1188.026f, 102.418f)), owning_building_guid = 173)
+      LocalObject(631, Door.Constructor(Vector3(1123.351f, 1148.027f, 102.418f)), owning_building_guid = 173)
+      LocalObject(632, Door.Constructor(Vector3(1123.351f, 1148.027f, 107.418f)), owning_building_guid = 173)
+      LocalObject(633, Door.Constructor(Vector3(1158.469f, 1192.906f, 107.418f)), owning_building_guid = 173)
+      LocalObject(634, Door.Constructor(Vector3(1158.469f, 1192.906f, 112.418f)), owning_building_guid = 173)
+      LocalObject(635, Door.Constructor(Vector3(1163.349f, 1152.907f, 112.418f)), owning_building_guid = 173)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 216, MapID: 10001
+      LocalBuilding("N_ATPlant", 216, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(851.77f, 1352.04f, 100.81f), vanu_vehicle_station)))
+      LocalObject(831, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 216)
+      LocalObject(555, Door.Constructor(Vector3(795.9202f, 1354.002f, 132.589f)), owning_building_guid = 216)
+      LocalObject(557, Door.Constructor(Vector3(801.1134f, 1360.407f, 132.569f)), owning_building_guid = 216)
+      LocalObject(558, Door.Constructor(Vector3(806.1349f, 1366.66f, 132.569f)), owning_building_guid = 216)
+      LocalObject(559, Door.Constructor(Vector3(811.3259f, 1373.026f, 132.589f)), owning_building_guid = 216)
+      LocalObject(561, Door.Constructor(Vector3(816.9444f, 1316.404f, 102.589f)), owning_building_guid = 216)
+      LocalObject(563, Door.Constructor(Vector3(821.9714f, 1322.612f, 122.513f)), owning_building_guid = 216)
+      LocalObject(569, Door.Constructor(Vector3(833.7928f, 1375.346f, 122.501f)), owning_building_guid = 216)
+      LocalObject(577, Door.Constructor(Vector3(857.54f, 1366.535f, 102.589f)), owning_building_guid = 216)
+      LocalObject(721, Door.Constructor(Vector3(790.5573f, 1379.225f, 107.443f)), owning_building_guid = 216)
+      LocalObject(826, Terminal.Constructor(Vector3(814.9385f, 1336.645f, 120.727f), vanu_air_vehicle_term), owning_building_guid = 216)
+      LocalObject(900, VehicleSpawnPad.Constructor(Vector3(823.2328f, 1339.834f, 120.726f), vanu_vehicle_creation_pad, Vector3(0, 0, 129)), owning_building_guid = 216, terminal_guid = 826)
+      LocalObject(827, Terminal.Constructor(Vector3(837.2114f, 1364.164f, 120.727f), vanu_air_vehicle_term), owning_building_guid = 216)
+      LocalObject(901, VehicleSpawnPad.Constructor(Vector3(835.8293f, 1355.389f, 120.726f), vanu_vehicle_creation_pad, Vector3(0, 0, 129)), owning_building_guid = 216, terminal_guid = 827)
+      LocalObject(839, Terminal.Constructor(Vector3(813.1694f, 1345.502f, 103.31f), vanu_equipment_term), owning_building_guid = 216)
+      LocalObject(840, Terminal.Constructor(Vector3(828.273f, 1364.154f, 103.31f), vanu_equipment_term), owning_building_guid = 216)
+      LocalObject(905, Terminal.Constructor(Vector3(816.3887f, 1358.16f, 105.81f), vanu_vehicle_term), owning_building_guid = 216)
+      LocalObject(899, VehicleSpawnPad.Constructor(Vector3(804.6929f, 1367.77f, 103.215f), vanu_vehicle_creation_pad, Vector3(0, 0, -51)), owning_building_guid = 216, terminal_guid = 905)
+    }
+
+    Building10314()
+
+    def Building10314(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 217, MapID: 10314
+      LocalBuilding("S_ATPlant", 217, 10314, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1467.03f, 931.27f, 94.78f), vanu_vehicle_station)))
+      LocalObject(836, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 217)
+      LocalObject(697, Door.Constructor(Vector3(1452.924f, 924.604f, 96.559f)), owning_building_guid = 217)
+      LocalObject(699, Door.Constructor(Vector3(1464.283f, 901.9645f, 116.471f)), owning_building_guid = 217)
+      LocalObject(704, Door.Constructor(Vector3(1482.297f, 888.3389f, 126.559f)), owning_building_guid = 217)
+      LocalObject(706, Door.Constructor(Vector3(1490.434f, 889.4543f, 126.539f)), owning_building_guid = 217)
+      LocalObject(710, Door.Constructor(Vector3(1498.372f, 890.6031f, 126.539f)), owning_building_guid = 217)
+      LocalObject(712, Door.Constructor(Vector3(1506.538f, 891.7458f, 126.559f)), owning_building_guid = 217)
+      LocalObject(715, Door.Constructor(Vector3(1508.893f, 932.47f, 116.483f)), owning_building_guid = 217)
+      LocalObject(716, Door.Constructor(Vector3(1516.804f, 933.5817f, 96.559f)), owning_building_guid = 217)
+      LocalObject(722, Door.Constructor(Vector3(1493.258f, 869.6415f, 101.413f)), owning_building_guid = 217)
+      LocalObject(828, Terminal.Constructor(Vector3(1469.409f, 912.4742f, 114.697f), vanu_air_vehicle_term), owning_building_guid = 217)
+      LocalObject(902, VehicleSpawnPad.Constructor(Vector3(1476.404f, 917.949f, 114.696f), vanu_vehicle_creation_pad, Vector3(0, 0, -8)), owning_building_guid = 217, terminal_guid = 828)
+      LocalObject(829, Terminal.Constructor(Vector3(1504.466f, 917.4103f, 114.697f), vanu_air_vehicle_term), owning_building_guid = 217)
+      LocalObject(904, VehicleSpawnPad.Constructor(Vector3(1496.225f, 920.7347f, 114.696f), vanu_vehicle_creation_pad, Vector3(0, 0, -8)), owning_building_guid = 217, terminal_guid = 829)
+      LocalObject(881, Terminal.Constructor(Vector3(1475.953f, 906.3857f, 97.28f), vanu_equipment_term), owning_building_guid = 217)
+      LocalObject(882, Terminal.Constructor(Vector3(1499.719f, 909.7258f, 97.28f), vanu_equipment_term), owning_building_guid = 217)
+      LocalObject(906, Terminal.Constructor(Vector3(1488.732f, 902.664f, 99.78f), vanu_vehicle_term), owning_building_guid = 217)
+      LocalObject(903, VehicleSpawnPad.Constructor(Vector3(1490.732f, 887.6593f, 97.185f), vanu_vehicle_creation_pad, Vector3(0, 0, 172)), owning_building_guid = 217, terminal_guid = 906)
+    }
+
+    Building10230()
+
+    def Building10230(): Unit = { // Name: GW_Cavern1_W Type: warpgate_cavern GUID: 218, MapID: 10230
+      LocalBuilding("GW_Cavern1_W", 218, 10230, FoundationBuilder(WarpGate.Structure(Vector3(157.44f, 1032.63f, 70.89f))))
+    }
+
+    Building10229()
+
+    def Building10229(): Unit = { // Name: GW_Cavern1_S Type: warpgate_cavern GUID: 219, MapID: 10229
+      LocalBuilding("GW_Cavern1_S", 219, 10229, FoundationBuilder(WarpGate.Structure(Vector3(1017.57f, 318.45f, 90.98f))))
+    }
+
+    Building10231()
+
+    def Building10231(): Unit = { // Name: GW_Cavern1_N Type: warpgate_cavern GUID: 220, MapID: 10231
+      LocalBuilding("GW_Cavern1_N", 220, 10231, FoundationBuilder(WarpGate.Structure(Vector3(1030.12f, 2080.82f, 91.42f))))
+    }
+
+    Building10228()
+
+    def Building10228(): Unit = { // Name: GW_Cavern1_E Type: warpgate_cavern GUID: 221, MapID: 10228
+      LocalBuilding("GW_Cavern1_E", 221, 10228, FoundationBuilder(WarpGate.Structure(Vector3(2143.2f, 1401.86f, 91.44f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(837, Terminal.Constructor(Vector3(788.95f, 883.67f, 109.24f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(838, Terminal.Constructor(Vector3(797.79f, 881.34f, 109.24f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(841, Terminal.Constructor(Vector3(835f, 1015.28f, 92.77f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(842, Terminal.Constructor(Vector3(843.21f, 1012.32f, 92.77f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(843, Terminal.Constructor(Vector3(869.22f, 1466.66f, 90.84f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(845, Terminal.Constructor(Vector3(877.77f, 1484.74f, 90.84f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(846, Terminal.Constructor(Vector3(886.94f, 1458.3f, 90.84f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(848, Terminal.Constructor(Vector3(895.74f, 1476.22f, 90.84f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(849, Terminal.Constructor(Vector3(924.69f, 1345.47f, 162.79f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(850, Terminal.Constructor(Vector3(955.27f, 1345.54f, 162.79f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(859, Terminal.Constructor(Vector3(1029.84f, 1332.43f, 96.39f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(860, Terminal.Constructor(Vector3(1042.81f, 1333.65f, 96.39f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(861, Terminal.Constructor(Vector3(1197.72f, 1034.24f, 99.62f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(862, Terminal.Constructor(Vector3(1206.08f, 1036.35f, 99.62f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(871, Terminal.Constructor(Vector3(1369.5f, 1032.42f, 165.16f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(872, Terminal.Constructor(Vector3(1380.5f, 1019.15f, 165.16f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(874, Terminal.Constructor(Vector3(1387.02f, 846.09f, 91.74f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(875, Terminal.Constructor(Vector3(1393.14f, 864.93f, 91.74f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(876, Terminal.Constructor(Vector3(1405.83f, 839.8f, 91.74f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(877, Terminal.Constructor(Vector3(1411.95f, 858.67f, 91.74f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(879, Terminal.Constructor(Vector3(1447.85f, 1272.05f, 94.15f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(880, Terminal.Constructor(Vector3(1451.55f, 1282.54f, 94.15f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(883, Terminal.Constructor(Vector3(1513.39f, 1453.92f, 105.26f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(884, Terminal.Constructor(Vector3(1532.47f, 1434.84f, 105.26f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(13, ProximityTerminal.Constructor(Vector3(1028.75f, 1057.12f, 86.98f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(14, ProximityTerminal.Constructor(Vector3(1228.83f, 1326.29f, 80.38f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(15, ProximityTerminal.Constructor(Vector3(1339.39f, 889.47f, 83.68f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(16, ProximityTerminal.Constructor(Vector3(933.67f, 1249.01f, 80.57f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(17, ProximityTerminal.Constructor(Vector3(1412.5f, 1170.17f, 82.79f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(747, ProximityTerminal.Constructor(Vector3(747.68f, 914.68f, 106.82f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(748, ProximityTerminal.Constructor(Vector3(976.42f, 1227.64f, 108.53f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(749, ProximityTerminal.Constructor(Vector3(1007.68f, 1525.71f, 92.55f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(750, ProximityTerminal.Constructor(Vector3(1318.15f, 980.96f, 107.52f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(751, ProximityTerminal.Constructor(Vector3(1367.72f, 1265.01f, 90.71f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(752, ProximityTerminal.Constructor(Vector3(839.12f, 1165.86f, 101.62f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(753, ProximityTerminal.Constructor(Vector3(854.97f, 902.18f, 90.68f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(754, ProximityTerminal.Constructor(Vector3(965.94f, 927.78f, 169.4f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(755, ProximityTerminal.Constructor(Vector3(1036.99f, 1176.35f, 160.71f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(756, ProximityTerminal.Constructor(Vector3(1202.76f, 1099.57f, 172.13f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(757, ProximityTerminal.Constructor(Vector3(1378.14f, 1364.07f, 159.37f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(758, ProximityTerminal.Constructor(Vector3(1400.04f, 1061.4f, 99.62f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(759, ProximityTerminal.Constructor(Vector3(1493f, 1396.91f, 92.77f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("N_Redoubt", "N_ATPlant")
+      LatticeLink("GW_Cavern1_W", "N_ATPlant")
+      LatticeLink("N_Stasis", "Core")
+      LatticeLink("S_Stasis", "Core")
+      LatticeLink("S_Redoubt", "S_ATPlant")
+      LatticeLink("N_Redoubt", "N_Stasis")
+      LatticeLink("S_Redoubt", "S_Stasis")
+      LatticeLink("S_Stasis", "N_ATPlant")
+      LatticeLink("N_Stasis", "S_ATPlant")
+      LatticeLink("GW_Cavern1_N", "N_Redoubt")
+      LatticeLink("GW_Cavern1_S", "S_Redoubt")
+      LatticeLink("GW_Cavern1_E", "S_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, false, List(Vector3(728.092f, 1006.186f, 106.143f), Vector3(829.164f, 1042.8f, 170.939f), Vector3(830.768f, 1043.381f, 171.46f))))
+      ZipLinePaths(new ZipLinePath(2, false, List(Vector3(734.749f, 961.909f, 109.207f), Vector3(697.971f, 956.655f, 132.489f), Vector3(695.519f, 956.305f, 132.975f))))
+      ZipLinePaths(new ZipLinePath(3, false, List(Vector3(757.247f, 1017.942f, 106.143f), Vector3(848.92f, 1145.895f, 100.51f))))
+      ZipLinePaths(new ZipLinePath(4, false, List(Vector3(778.772f, 817.665f, 111.702f), Vector3(949.992f, 916.26f, 164.246f), Vector3(951.34f, 917.036f, 164.778f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(781.841f, 919.105f, 130.869f), Vector3(830.709f, 1019.833f, 171.021f), Vector3(833.967f, 1026.548f, 171.488f))))
+      ZipLinePaths(new ZipLinePath(6, true, List(Vector3(786.778f, 861.66f, 104.079f), Vector3(786.585f, 860.31f, 109.589f))))
+      ZipLinePaths(new ZipLinePath(7, true, List(Vector3(808.902f, 1324.021f, 103.66f), Vector3(804.094f, 1317.348f, 121.086f))))
+      ZipLinePaths(new ZipLinePath(8, false, List(Vector3(820.334f, 1148.641f, 100.51f), Vector3(734.781f, 1047.986f, 105.623f))))
+      ZipLinePaths(new ZipLinePath(9, true, List(Vector3(851.876f, 1380.436f, 121.086f), Vector3(847.951f, 1372.628f, 103.66f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(876.944f, 1460.559f, 101.73f), Vector3(958.145f, 1415.262f, 162.353f), Vector3(961.393f, 1414.24f, 162.789f))))
+      ZipLinePaths(new ZipLinePath(11, false, List(Vector3(860.918f, 1314.696f, 111.015f), Vector3(900.307f, 1332.997f, 108.401f))))
+      ZipLinePaths(new ZipLinePath(12, true, List(Vector3(873.693f, 913.825f, 85.532f), Vector3(874.142f, 914.083f, 91.039f))))
+      ZipLinePaths(new ZipLinePath(13, false, List(Vector3(874.525f, 1033.849f, 171.461f), Vector3(959.388f, 945.044f, 164.768f))))
+      ZipLinePaths(new ZipLinePath(14, true, List(Vector3(880.884f, 830.239f, 85.076f), Vector3(886.746f, 828.151f, 118.33f))))
+      ZipLinePaths(new ZipLinePath(15, true, List(Vector3(886.448f, 835.152f, 118.33f), Vector3(897.551f, 832.477f, 85.076f))))
+      ZipLinePaths(new ZipLinePath(16, false, List(Vector3(911.301f, 1329.164f, 108.381f), Vector3(970.776f, 1280.269f, 109.38f))))
+      ZipLinePaths(new ZipLinePath(17, false, List(Vector3(932.081f, 1322.242f, 163.637f), Vector3(1051.566f, 1199.372f, 154.901f))))
+      ZipLinePaths(new ZipLinePath(18, false, List(Vector3(938.644f, 941.755f, 164.787f), Vector3(792.952f, 878.137f, 119.212f))))
+      ZipLinePaths(new ZipLinePath(19, true, List(Vector3(944.449f, 928.994f, 164.252f), Vector3(943.808f, 928.722f, 169.759f))))
+      ZipLinePaths(new ZipLinePath(20, false, List(Vector3(960.616f, 1218.649f, 109.291f), Vector3(862.937f, 1157.651f, 100.511f))))
+      ZipLinePaths(new ZipLinePath(21, false, List(Vector3(966.723f, 1345.001f, 163.636f), Vector3(992.911f, 1381.507f, 162.815f))))
+      ZipLinePaths(new ZipLinePath(22, false, List(Vector3(961.889f, 1401.845f, 162.791f), Vector3(939.72f, 1368.197f, 163.637f))))
+      ZipLinePaths(new ZipLinePath(23, false, List(Vector3(980.961f, 925.541f, 164.804f), Vector3(1047.716f, 1064.001f, 155.001f))))
+      ZipLinePaths(new ZipLinePath(24, false, List(Vector3(993.093f, 1516.838f, 107.591f), Vector3(991.266f, 1436.266f, 162.379f), Vector3(991.207f, 1433.667f, 162.803f))))
+      ZipLinePaths(new ZipLinePath(25, false, List(Vector3(1023.794f, 1313.803f, 111.42f), Vector3(1005.777f, 1235.883f, 109.341f))))
+      ZipLinePaths(new ZipLinePath(26, false, List(Vector3(1027.815f, 1097.179f, 155.004f), Vector3(869.866f, 1035.819f, 176.964f))))
+      ZipLinePaths(new ZipLinePath(27, false, List(Vector3(1029.881f, 982.751f, 102.375f), Vector3(1022.505f, 1015.015f, 110.347f), Vector3(1022.013f, 1017.166f, 110.893f))))
+      ZipLinePaths(new ZipLinePath(28, false, List(Vector3(1030.959f, 1102.622f, 155.007f), Vector3(1028.145f, 1165.008f, 166.456f), Vector3(1027.957f, 1169.167f, 166.367f))))
+      ZipLinePaths(new ZipLinePath(29, true, List(Vector3(1064.594f, 1191.324f, 154.4f), Vector3(1077.757f, 1197.047f, 161.06f))))
+      ZipLinePaths(new ZipLinePath(30, false, List(Vector3(1089.529f, 1198.269f, 166.36f), Vector3(1254.864f, 1249.875f, 160.478f))))
+      ZipLinePaths(new ZipLinePath(31, false, List(Vector3(1091.897f, 1357.937f, 122.583f), Vector3(1267.006f, 1337.662f, 109.171f))))
+      ZipLinePaths(new ZipLinePath(32, false, List(Vector3(1095.955f, 1193.434f, 95.453f), Vector3(1106.521f, 1186.623f, 100.976f), Vector3(1107.225f, 1186.169f, 101.502f))))
+      ZipLinePaths(new ZipLinePath(33, false, List(Vector3(1110.201f, 1149.249f, 106.481f), Vector3(1096.384f, 1127.12f, 154.467f), Vector3(1095.463f, 1125.645f, 155.001f))))
+      ZipLinePaths(new ZipLinePath(34, false, List(Vector3(1119.014f, 1123.571f, 91.177f), Vector3(1124.145f, 1135.41f, 100.964f), Vector3(1124.878f, 1137.101f, 101.429f))))
+      ZipLinePaths(new ZipLinePath(35, true, List(Vector3(1119.495f, 1167.509f, 100.98f), Vector3(1119.44f, 1167.508f, 105.98f))))
+      ZipLinePaths(new ZipLinePath(36, true, List(Vector3(1138.384f, 1190.526f, 95.98f), Vector3(1138.423f, 1190.587f, 100.98f))))
+      ZipLinePaths(new ZipLinePath(37, true, List(Vector3(1143.706f, 1149.857f, 95.98f), Vector3(1143.71f, 1149.773f, 100.98f))))
+      ZipLinePaths(new ZipLinePath(38, true, List(Vector3(1162.813f, 1142.615f, 110.912f), Vector3(1166.217f, 1148.317f, 82.567f))))
+      ZipLinePaths(new ZipLinePath(39, true, List(Vector3(1165.452f, 1173.568f, 105.98f), Vector3(1165.372f, 1173.577f, 110.98f))))
+      ZipLinePaths(new ZipLinePath(40, false, List(Vector3(1167.06f, 1111.942f, 172.99f), Vector3(1078.79f, 1081.819f, 152.235f))))
+      ZipLinePaths(new ZipLinePath(41, true, List(Vector3(1168.507f, 1194.822f, 105.993f), Vector3(1183.559f, 1193.418f, 82.467f))))
+      ZipLinePaths(new ZipLinePath(42, false, List(Vector3(1233.414f, 925.048f, 112.774f), Vector3(1039.055f, 975.065f, 102.352f))))
+      ZipLinePaths(new ZipLinePath(43, true, List(Vector3(1234.297f, 1083.106f, 85.33f), Vector3(1239.218f, 1085.932f, 98.231f))))
+      ZipLinePaths(new ZipLinePath(44, true, List(Vector3(1240.283f, 1097.896f, 98.223f), Vector3(1241.528f, 1099.065f, 85.33f))))
+      ZipLinePaths(new ZipLinePath(45, false, List(Vector3(1253.271f, 1236.121f, 160.518f), Vector3(1169.33f, 1195.406f, 111.531f))))
+      ZipLinePaths(new ZipLinePath(46, false, List(Vector3(1271.897f, 1348.201f, 109.172f), Vector3(1315.166f, 1362.907f, 105.351f))))
+      ZipLinePaths(new ZipLinePath(47, false, List(Vector3(1276.015f, 890.527f, 103.291f), Vector3(1358.52f, 878.489f, 98.582f))))
+      ZipLinePaths(new ZipLinePath(48, false, List(Vector3(1286.969f, 885.244f, 162.235f), Vector3(1285.726f, 885.873f, 161.69f), Vector3(1207.434f, 925.508f, 108.171f))))
+      ZipLinePaths(new ZipLinePath(49, false, List(Vector3(1287.639f, 1215.968f, 160.509f), Vector3(1247.467f, 1108.693f, 172.979f))))
+      ZipLinePaths(new ZipLinePath(50, false, List(Vector3(1291.198f, 1238.773f, 104.612f), Vector3(1325.749f, 1230.146f, 85.164f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(1291.852f, 933.318f, 163.861f), Vector3(1377.723f, 1001.816f, 163.51f))))
+      ZipLinePaths(new ZipLinePath(52, false, List(Vector3(1296.924f, 1279.436f, 119.881f), Vector3(1296.11f, 1277.555f, 119.179f), Vector3(1283.903f, 1249.341f, 104.662f))))
+      ZipLinePaths(new ZipLinePath(53, false, List(Vector3(1320.281f, 1238.297f, 160.523f), Vector3(1392.448f, 1236.987f, 168.496f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(1330.534f, 1020.952f, 96.131f), Vector3(1360.046f, 1059.981f, 96.074f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(1333.036f, 990.539f, 108.142f), Vector3(1335.545f, 988.369f, 107.657f), Vector3(1373.179f, 955.828f, 94.447f))))
+      ZipLinePaths(new ZipLinePath(56, false, List(Vector3(1345.506f, 1327.547f, 160.182f), Vector3(1320.126f, 1248.518f, 160.517f))))
+      ZipLinePaths(new ZipLinePath(57, false, List(Vector3(1361.149f, 1322.011f, 160.194f), Vector3(1407.339f, 1279.782f, 174.015f))))
+      ZipLinePaths(new ZipLinePath(58, false, List(Vector3(1369.539f, 1047.413f, 163.51f), Vector3(1405.054f, 1233.856f, 168.561f))))
+      ZipLinePaths(new ZipLinePath(59, false, List(Vector3(1376.224f, 1112.759f, 96.075f), Vector3(1340.386f, 1139.509f, 92.592f))))
+      ZipLinePaths(new ZipLinePath(60, false, List(Vector3(1383.992f, 936.642f, 104.198f), Vector3(1386.949f, 1004.481f, 162.883f), Vector3(1386.996f, 1005.558f, 163.51f))))
+      ZipLinePaths(new ZipLinePath(61, true, List(Vector3(1386.401f, 1253.506f, 85.562f), Vector3(1386.755f, 1253.317f, 91.069f))))
+      ZipLinePaths(new ZipLinePath(62, false, List(Vector3(1387.362f, 814.224f, 97.989f), Vector3(1323.164f, 885.178f, 165.05f))))
+      ZipLinePaths(new ZipLinePath(63, false, List(Vector3(1408.407f, 992.162f, 113.845f), Vector3(1403.502f, 1039.051f, 98.536f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(1418.274f, 1281.224f, 174.016f), Vector3(1403.258f, 1346.119f, 160.196f))))
+      ZipLinePaths(new ZipLinePath(65, true, List(Vector3(1445.963f, 1403.374f, 104.101f), Vector3(1447.786f, 1400.135f, 81.47f))))
+      ZipLinePaths(new ZipLinePath(66, true, List(Vector3(1447.99f, 911.912f, 115.056f), Vector3(1456.023f, 914.153f, 97.63f))))
+      ZipLinePaths(new ZipLinePath(67, false, List(Vector3(1486.297f, 1033.346f, 100.602f), Vector3(1512.289f, 1077.211f, 101.158f), Vector3(1526.559f, 1101.294f, 101.778f))))
+      ZipLinePaths(new ZipLinePath(68, false, List(Vector3(1491.442f, 1308.886f, 94.285f), Vector3(1440.693f, 1249.149f, 173.51f), Vector3(1439.056f, 1247.222f, 174.001f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(1496.411f, 1291.616f, 94.928f), Vector3(1513.727f, 1246.264f, 118.798f), Vector3(1514.286f, 1244.801f, 119.316f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(1510.739f, 1234.732f, 119.268f), Vector3(1477.652f, 1143.291f, 101.868f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(1513.12f, 1102.706f, 101.832f), Vector3(1421.222f, 1075.085f, 98.51f))))
+      ZipLinePaths(new ZipLinePath(72, true, List(Vector3(1518.094f, 922.897f, 97.63f), Vector3(1526.562f, 924.662f, 115.056f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(1521.523f, 1415.007f, 106.059f), Vector3(1413.48f, 1359.402f, 159.712f), Vector3(1409.995f, 1357.609f, 160.249f))))
+      ZipLinePaths(new ZipLinePath(74, false, List(Vector3(1529.09f, 1148.223f, 101.821f), Vector3(1423.234f, 1259.869f, 95f))))
+      ZipLinePaths(new ZipLinePath(75, false, List(Vector3(1575.633f, 1422.701f, 142.971f), Vector3(1573.754f, 1422.279f, 142.448f), Vector3(1455.389f, 1395.726f, 104.616f))))
+      ZipLinePaths(new ZipLinePath(76, true, List(Vector3(1443.656f, 1407.144f, 81.33f), Vector3(1447.871f, 1399.239f, 104.101f))))
+      ZipLinePaths(new ZipLinePath(77, false, List(Vector3(1444.535f, 1293.125f, 104.483f), Vector3(1409.668f, 1349.802f, 159.747f), Vector3(1407.343f, 1353.58f, 160.199f))))
+      ZipLinePaths(new ZipLinePath(78, false, List(Vector3(1460.814f, 1471.557f, 101.716f), Vector3(1404.733f, 1385.491f, 159.076f), Vector3(1402.924f, 1382.714f, 159.607f))))
+      ZipLinePaths(new ZipLinePath(79, false, List(Vector3(1461.855f, 1344.335f, 104.731f), Vector3(1431.469f, 1279.321f, 168.724f), Vector3(1430.489f, 1277.224f, 168.74f))))
+      ZipLinePaths(new ZipLinePath(80, false, List(Vector3(1507.157f, 1349.035f, 109.286f), Vector3(1573.383f, 1404.752f, 142.412f), Vector3(1577.798f, 1408.467f, 142.948f))))
+      ZipLinePaths(new ZipLinePath(81, false, List(Vector3(1341.441f, 1316.326f, 119.836f), Vector3(1294.201f, 1275.704f, 160.11f), Vector3(1287.396f, 1269.586f, 160.499f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(1327.414f, 1137.7f, 99.733f), Vector3(1314.162f, 1035.606f, 96.131f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(1222.673f, 1027.613f, 98.518f), Vector3(1264.198f, 999.281f, 107.7f), Vector3(1266.641f, 997.614f, 108.178f))))
+      ZipLinePaths(new ZipLinePath(84, false, List(Vector3(1202.686f, 1010.169f, 98.51f), Vector3(1181.993f, 958.767f, 96.83f))))
+      ZipLinePaths(new ZipLinePath(85, false, List(Vector3(1163.954f, 1595.853f, 148.196f), Vector3(1159.488f, 1593.995f, 147.755f), Vector3(1021.035f, 1536.395f, 93.444f))))
+      ZipLinePaths(new ZipLinePath(86, false, List(Vector3(1247.125f, 1603.267f, 88.816f), Vector3(1189.521f, 1599.835f, 147.901f), Vector3(1185.681f, 1599.606f, 147.894f))))
+      ZipLinePaths(new ZipLinePath(87, true, List(Vector3(1400.35f, 974.977f, 91.93f), Vector3(1401.252f, 979.522f, 113.331f))))
+      ZipLinePaths(new ZipLinePath(88, true, List(Vector3(1413.085f, 980.32f, 113.34f), Vector3(1396.903f, 981.324f, 91.93f))))
+      ZipLinePaths(new ZipLinePath(89, false, List(Vector3(1199.138f, 1060.892f, 98.515f), Vector3(1174.509f, 1151.691f, 111.554f))))
+      ZipLinePaths(new ZipLinePath(90, false, List(Vector3(1112.192f, 1285.293f, 91.134f), Vector3(1117.61f, 1203.347f, 101.058f), Vector3(1117.971f, 1197.884f, 101.51f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(1366.348f, 897.049f, 101.075f), Vector3(1313.494f, 953.057f, 108.076f))))
+      ZipLinePaths(new ZipLinePath(92, false, List(Vector3(1386.164f, 891.069f, 104.871f), Vector3(1436.442f, 889.065f, 115.11f), Vector3(1453.201f, 888.396f, 115.552f))))
+      ZipLinePaths(new ZipLinePath(93, true, List(Vector3(1287.875f, 1302.571f, 94.329f), Vector3(1343.758f, 1308.594f, 110.937f))))
+      ZipLinePaths(new ZipLinePath(94, true, List(Vector3(1319.908f, 1359.025f, 104.849f), Vector3(1348.35f, 1328.836f, 91.829f))))
+      ZipLinePaths(new ZipLinePath(95, true, List(Vector3(1263.636f, 1349.32f, 82.93f), Vector3(1266.592f, 1341.195f, 108.67f))))
+      ZipLinePaths(new ZipLinePath(96, true, List(Vector3(1273.495f, 1342.655f, 108.67f), Vector3(1269.478f, 1342.713f, 82.93f))))
+      ZipLinePaths(new ZipLinePath(97, false, List(Vector3(1389.222f, 1252.343f, 106.545f), Vector3(1424.476f, 1273.113f, 103.584f))))
+      ZipLinePaths(new ZipLinePath(98, false, List(Vector3(1466.484f, 1291.616f, 104.483f), Vector3(1489.982f, 1325.159f, 104.208f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(1430.153f, 1430.279f, 101.695f), Vector3(1424.616f, 1393.735f, 104.651f))))
+      ZipLinePaths(new ZipLinePath(100, false, List(Vector3(1419.415f, 1441.384f, 102.614f), Vector3(1380.672f, 1422.284f, 89.831f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(1396.405f, 1359.469f, 104.686f), Vector3(1374.748f, 1329.47f, 103.487f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(1455.862f, 1435.587f, 104.393f), Vector3(1509.459f, 1423.314f, 106.078f))))
+      ZipLinePaths(new ZipLinePath(103, false, List(Vector3(1352.319f, 1302.489f, 109.54f), Vector3(1354.026f, 1299.139f, 109.058f), Vector3(1365.971f, 1275.692f, 97.974f))))
+      ZipLinePaths(new ZipLinePath(104, false, List(Vector3(1318.518f, 1147.515f, 103.353f), Vector3(1357.622f, 1045.178f, 163.53f))))
+      ZipLinePaths(new ZipLinePath(105, false, List(Vector3(1180.068f, 1022.799f, 98.55f), Vector3(1282.493f, 911.315f, 162.097f), Vector3(1285.797f, 907.719f, 162.64f))))
+      ZipLinePaths(new ZipLinePath(106, true, List(Vector3(1172.061f, 1007.936f, 90.354f), Vector3(1160.936f, 1016.351f, 116.62f))))
+      ZipLinePaths(new ZipLinePath(107, true, List(Vector3(1164.341f, 1012.921f, 116.62f), Vector3(1171.351f, 1015.839f, 90.354f))))
+      ZipLinePaths(new ZipLinePath(108, true, List(Vector3(1333.537f, 845.263f, 88.13f), Vector3(1331.391f, 854.587f, 118.13f))))
+      ZipLinePaths(new ZipLinePath(109, true, List(Vector3(1339.384f, 853.526f, 118.13f), Vector3(1334.989f, 854.531f, 88.13f))))
+      ZipLinePaths(new ZipLinePath(110, false, List(Vector3(1019.618f, 1006.659f, 110.879f), Vector3(1051.218f, 1057.452f, 154.542f), Vector3(1053.325f, 1060.839f, 155f))))
+      ZipLinePaths(new ZipLinePath(111, true, List(Vector3(975.914f, 1001.793f, 97.359f), Vector3(960.395f, 1014.087f, 116.467f))))
+      ZipLinePaths(new ZipLinePath(112, true, List(Vector3(1011.91f, 1014.587f, 110.379f), Vector3(979.003f, 1067.291f, 99.859f))))
+      ZipLinePaths(new ZipLinePath(113, true, List(Vector3(1044.776f, 974.04f, 84.33f), Vector3(1042.263f, 974.486f, 101.501f), Vector3(1035.728f, 975.644f, 101.851f))))
+      ZipLinePaths(new ZipLinePath(114, true, List(Vector3(1028.874f, 972.119f, 101.843f), Vector3(1033.871f, 975.957f, 84.33f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(950.294f, 1010.662f, 115.049f), Vector3(907.387f, 1011.592f, 104.498f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(932.836f, 983.518f, 107.184f), Vector3(958.721f, 980.339f, 109.018f))))
+      ZipLinePaths(new ZipLinePath(117, false, List(Vector3(859.555f, 856.841f, 108.282f), Vector3(861.234f, 860.752f, 107.928f), Vector3(872.988f, 888.128f, 100.746f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(823.748f, 908.416f, 106.055f), Vector3(829.011f, 907.394f, 105.693f), Vector3(844.8f, 904.328f, 97.942f))))
+      ZipLinePaths(new ZipLinePath(119, false, List(Vector3(847.683f, 942.238f, 106.066f), Vector3(863.593f, 915.671f, 104.714f))))
+      ZipLinePaths(new ZipLinePath(120, false, List(Vector3(880.683f, 916.696f, 107.418f), Vector3(904.488f, 954.484f, 101.787f))))
+      ZipLinePaths(new ZipLinePath(121, false, List(Vector3(879.234f, 989.582f, 103.583f), Vector3(837.231f, 952.58f, 106.075f))))
+      ZipLinePaths(new ZipLinePath(122, false, List(Vector3(871.672f, 905.395f, 105.726f), Vector3(823.879f, 892.325f, 112.638f), Vector3(802.849f, 886.573f, 116.464f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(769.124f, 986.574f, 106.143f), Vector3(781.102f, 955.846f, 106.11f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(725.343f, 990.882f, 107.057f), Vector3(692.244f, 962.514f, 132.431f), Vector3(690.038f, 960.623f, 132.964f))))
+      ZipLinePaths(new ZipLinePath(125, false, List(Vector3(778.287f, 866.552f, 124.271f), Vector3(691.082f, 941.073f, 133.163f))))
+      ZipLinePaths(new ZipLinePath(126, false, List(Vector3(1489.014f, 1467.955f, 106.115f), Vector3(1460.493f, 1455.135f, 101.698f))))
+      ZipLinePaths(new ZipLinePath(127, false, List(Vector3(1483.446f, 1325.031f, 100.653f), Vector3(1458.632f, 1338.057f, 104.735f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(1471.073f, 1301.982f, 95f), Vector3(1485.411f, 1312.821f, 94.284f))))
+      ZipLinePaths(new ZipLinePath(129, false, List(Vector3(755.07f, 1030.528f, 96.662f), Vector3(816.714f, 1025.964f, 91.662f))))
+      ZipLinePaths(new ZipLinePath(130, false, List(Vector3(777.204f, 996.672f, 107.073f), Vector3(820.392f, 1000.457f, 91.69f))))
+      ZipLinePaths(new ZipLinePath(131, true, List(Vector3(790.674f, 923.262f, 103.779f), Vector3(784.461f, 914.388f, 130.332f))))
+      ZipLinePaths(new ZipLinePath(132, true, List(Vector3(782.729f, 908.18f, 130.323f), Vector3(789.14f, 914.457f, 103.779f))))
+      ZipLinePaths(new ZipLinePath(133, true, List(Vector3(910.317f, 1345.869f, 86.23f), Vector3(906.549f, 1335.888f, 107.892f))))
+      ZipLinePaths(new ZipLinePath(134, true, List(Vector3(908.223f, 1341.816f, 107.892f), Vector3(905.648f, 1338.911f, 86.23f))))
+      ZipLinePaths(new ZipLinePath(135, false, List(Vector3(833.232f, 1393.407f, 121.577f), Vector3(915.637f, 1438.261f, 116.831f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(982.46f, 1518.909f, 107.592f), Vector3(917.577f, 1450.059f, 116.832f))))
+      ZipLinePaths(new ZipLinePath(137, true, List(Vector3(924.848f, 1451.53f, 86.33f), Vector3(915.991f, 1444.015f, 116.33f))))
+      ZipLinePaths(new ZipLinePath(138, true, List(Vector3(920.928f, 1445.093f, 116.33f), Vector3(919.855f, 1444.008f, 115.98f), Vector3(916.421f, 1442.794f, 86.33f))))
+      ZipLinePaths(new ZipLinePath(139, true, List(Vector3(828.811f, 1428.899f, 90.331f), Vector3(811.334f, 1398.369f, 121.076f))))
+      ZipLinePaths(new ZipLinePath(140, false, List(Vector3(936.083f, 1393.338f, 95.643f), Vector3(1026.755f, 1400.969f, 95.813f))))
+      ZipLinePaths(new ZipLinePath(141, false, List(Vector3(856.993f, 1184.88f, 100.512f), Vector3(839.109f, 1250.231f, 106.497f))))
+      ZipLinePaths(new ZipLinePath(142, true, List(Vector3(1093.28f, 1376.753f, 90.63f), Vector3(1091.116f, 1365.163f, 122.091f))))
+      ZipLinePaths(new ZipLinePath(143, true, List(Vector3(1096.055f, 1369.18f, 122.091f), Vector3(1093.978f, 1367.448f, 90.63f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(1084.243f, 1366.022f, 122.611f), Vector3(1033.715f, 1403.167f, 162.301f), Vector3(1026.497f, 1408.473f, 162.841f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(956.997f, 1231.56f, 109.347f), Vector3(954.537f, 1320.416f, 163.139f), Vector3(954.457f, 1323.283f, 163.636f))))
+      ZipLinePaths(new ZipLinePath(146, false, List(Vector3(1064.878f, 1173.023f, 154.9f), Vector3(1089.589f, 1126.197f, 155f))))
+      ZipLinePaths(new ZipLinePath(147, false, List(Vector3(1006.476f, 1222.634f, 109.337f), Vector3(1024.688f, 1177.964f, 165.896f), Vector3(1025.902f, 1174.985f, 166.36f))))
+      ZipLinePaths(new ZipLinePath(148, false, List(Vector3(1086.897f, 1315.525f, 96.781f), Vector3(1084.806f, 1209.158f, 166.286f), Vector3(1084.739f, 1205.727f, 166.361f))))
+      ZipLinePaths(new ZipLinePath(149, false, List(Vector3(1305.024f, 1142.624f, 102.434f), Vector3(1251.996f, 1106.28f, 172.469f), Vector3(1248.461f, 1103.857f, 172.979f))))
+      ZipLinePaths(new ZipLinePath(150, false, List(Vector3(1161.901f, 1023.071f, 117.15f), Vector3(1094.77f, 1099.419f, 153.244f))))
+      ZipLinePaths(new ZipLinePath(151, true, List(Vector3(889.775f, 1487.223f, 91.186f), Vector3(869.803f, 1471.874f, 101.23f))))
+      ZipLinePaths(new ZipLinePath(152, true, List(Vector3(889.786f, 1463.643f, 101.23f), Vector3(875.143f, 1455.936f, 91.186f))))
+      ZipLinePaths(new ZipLinePath(153, true, List(Vector3(1415.815f, 847.147f, 92.086f), Vector3(1400.802f, 839.966f, 102.13f))))
+      ZipLinePaths(new ZipLinePath(154, true, List(Vector3(1406.021f, 860.572f, 102.13f), Vector3(1383.189f, 857.817f, 92.086f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(1043.41f, 408.428f, 103.135f), Vector3(1034.259f, 441.256f, 107.824f), Vector3(1003.909f, 461.383f, 108.513f), Vector3(964.41f, 480.238f, 108.113f), Vector3(932.811f, 494.262f, 103.135f))))
+      ZipLinePaths(new ZipLinePath(156, false, List(Vector3(879.653f, 506.603f, 103.138f), Vector3(877.332f, 531.712f, 105.171f), Vector3(877.61f, 556.821f, 91.207f), Vector3(878.967f, 627.04f, 92.694f), Vector3(885.924f, 657.259f, 88.68f), Vector3(904.345f, 693.461f, 83.138f))))
+      ZipLinePaths(new ZipLinePath(157, false, List(Vector3(945.611f, 828.543f, 94.343f), Vector3(969.089f, 916.077f, 164.71f))))
+      ZipLinePaths(new ZipLinePath(158, false, List(Vector3(251.005f, 1006.488f, 83.141f), Vector3(278.893f, 1007.049f, 97.949f), Vector3(317.358f, 1008.267f, 109.649f), Vector3(355.824f, 986.086f, 105.349f), Vector3(376.98f, 977.201f, 103.141f))))
+      ZipLinePaths(new ZipLinePath(159, false, List(Vector3(375.611f, 1014.701f, 103.149f), Vector3(381.423f, 1010.204f, 105.862f), Vector3(447.637f, 1008.626f, 90.749f), Vector3(461.244f, 1020.038f, 83.149f))))
+      ZipLinePaths(new ZipLinePath(160, false, List(Vector3(545.645f, 1102.242f, 83.116f), Vector3(596.275f, 1099.627f, 84.612f), Vector3(644.906f, 1119.313f, 85.692f), Vector3(660.903f, 1127.65f, 83.135f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(902.807f, 1481.246f, 101.73f), Vector3(986.877f, 1529.592f, 102.592f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(814.772f, 1175.312f, 100.51f), Vector3(781.371f, 1305.043f, 103.731f))))
+      ZipLinePaths(new ZipLinePath(163, false, List(Vector3(1420.106f, 1047.818f, 98.511f), Vector3(1478.651f, 956.067f, 104.985f))))
+      ZipLinePaths(new ZipLinePath(164, false, List(Vector3(1177.881f, 1157.518f, 111.616f), Vector3(1274.135f, 1154.874f, 92.959f))))
+      ZipLinePaths(new ZipLinePath(165, true, List(Vector3(1151.406f, 1200.873f, 82.467f), Vector3(1155.773f, 1201.314f, 105.98f))))
+      ZipLinePaths(new ZipLinePath(166, false, List(Vector3(1100.745f, 333.019f, 103.177f), Vector3(1120.674f, 333.769f, 106.796f), Vector3(1180.687f, 333.911f, 91.323f), Vector3(1212.362f, 344.543f, 87.2f), Vector3(1232.066f, 378.678f, 83.094f))))
+      ZipLinePaths(new ZipLinePath(167, false, List(Vector3(1242.328f, 432.765f, 83.142f), Vector3(1257.104f, 433.065f, 86.714f), Vector3(1292.681f, 433.366f, 72.293f), Vector3(1343.033f, 433.967f, 68.738f), Vector3(1367.716f, 434.261f, 63.142f))))
+      ZipLinePaths(new ZipLinePath(168, false, List(Vector3(1424.5f, 440.843f, 63.137f), Vector3(1426.096f, 511.412f, 67.62f), Vector3(1456.893f, 569.707f, 68.225f), Vector3(1459.384f, 625.83f, 79.208f))))
+      ZipLinePaths(new ZipLinePath(169, false, List(Vector3(2056.6f, 1425.645f, 103.14f), Vector3(1983.076f, 1426.488f, 105.286f), Vector3(1957.552f, 1427.33f, 117.037f), Vector3(1931.8f, 1427.768f, 120.163f))))
+      ZipLinePaths(new ZipLinePath(170, false, List(Vector3(1918.56f, 1424.729f, 123.115f), Vector3(1853.468f, 1394.922f, 125.845f), Vector3(1787.707f, 1392.389f, 103.141f))))
+      ZipLinePaths(new ZipLinePath(171, false, List(Vector3(1777.914f, 1349.613f, 103.138f), Vector3(1778.386f, 1335.218f, 106.052f), Vector3(1778.857f, 1283.823f, 87.669f), Vector3(1746.873f, 1217.987f, 86.395f), Vector3(1746.738f, 1162.087f, 83.138f))))
+      ZipLinePaths(new ZipLinePath(172, false, List(Vector3(1701.419f, 1137.503f, 83.135f), Vector3(1651.437f, 1138.699f, 85.328f), Vector3(1645.439f, 1138.843f, 83.135f))))
+      ZipLinePaths(new ZipLinePath(173, false, List(Vector3(1045.419f, 1970.538f, 103.14f), Vector3(1120.109f, 1970.619f, 106.09f), Vector3(1146.398f, 1970.7f, 117.88f), Vector3(1173.128f, 1970.743f, 121.443f))))
+      ZipLinePaths(new ZipLinePath(174, false, List(Vector3(1208.467f, 1895.413f, 123.148f), Vector3(1247.813f, 1870.331f, 125.945f), Vector3(1310.558f, 1869.625f, 109.069f), Vector3(1349.94f, 1869.559f, 95.826f), Vector3(1369.513f, 1870.568f, 84.545f))))
+      ZipLinePaths(new ZipLinePath(175, false, List(Vector3(1421.55f, 1866.085f, 83.138f), Vector3(1458.246f, 1791.885f, 86.285f), Vector3(1457.935f, 1731.766f, 68.567f), Vector3(1459.208f, 1682.72f, 63.138f))))
+      ZipLinePaths(new ZipLinePath(176, false, List(Vector3(948.021f, 2065.12f, 103.188f), Vector3(866.812f, 2065.721f, 128.666f), Vector3(816.304f, 2066.094f, 126.726f), Vector3(809.371f, 2066.146f, 123.14f))))
+      ZipLinePaths(new ZipLinePath(177, false, List(Vector3(785.86f, 2020.291f, 123.141f), Vector3(787.358f, 1953.837f, 126.085f), Vector3(787.114f, 1889.222f, 106.325f), Vector3(755.214f, 1825.132f, 106.961f), Vector3(754.919f, 1770.084f, 85.079f))))
+      ZipLinePaths(new ZipLinePath(178, false, List(Vector3(727.728f, 1734.672f, 83.134f), Vector3(747.409f, 1715.699f, 84.587f), Vector3(770.091f, 1709.127f, 86.541f), Vector3(834.453f, 1676.582f, 85.648f), Vector3(845.365f, 1664.437f, 87.156f), Vector3(845.236f, 1613.224f, 83.135f))))
+      ZipLinePaths(new ZipLinePath(179, false, List(Vector3(1176.424f, 1629.973f, 143.358f), Vector3(1176.427f, 1641.788f, 140.92f), Vector3(1176.43f, 1679.603f, 128.496f), Vector3(1176.434f, 1713.663f, 123.333f))))
+      ZipLinePaths(new ZipLinePath(180, false, List(Vector3(1176.147f, 1746.984f, 132.155f), Vector3(1175.973f, 1795.737f, 117.847f), Vector3(1175.949f, 1802.428f, 113.756f))))
+      ZipLinePaths(new ZipLinePath(181, false, List(Vector3(1199.978f, 1815.422f, 118.22f), Vector3(1205.888f, 1813.125f, 118.397f), Vector3(1213.843f, 1799.985f, 118.398f), Vector3(1243.82f, 1799.915f, 111.399f), Vector3(1258.809f, 1799.88f, 106.563f), Vector3(1273.798f, 1799.845f, 98.843f))))
+      ZipLinePaths(new ZipLinePath(182, false, List(Vector3(1324.259f, 1783.597f, 98.484f), Vector3(1332.029f, 1782.574f, 98.551f), Vector3(1341.288f, 1768.443f, 98.735f), Vector3(1355.698f, 1767.96f, 95.7f), Vector3(1370.107f, 1767.476f, 91.066f), Vector3(1398.927f, 1766.51f, 83.897f), Vector3(1399.036f, 1754.426f, 82.312f), Vector3(1399.146f, 1734.343f, 75.628f), Vector3(1399.255f, 1718.259f, 71.043f), Vector3(1399.365f, 1702.176f, 63.859f))))
+      ZipLinePaths(new ZipLinePath(183, false, List(Vector3(1153.673f, 1816.245f, 108.336f), Vector3(1115.768f, 1816.778f, 98.537f))))
+      ZipLinePaths(new ZipLinePath(184, false, List(Vector3(1096.022f, 1848.979f, 98.955f), Vector3(1097.069f, 1893.221f, 98.075f), Vector3(1134.716f, 1896.163f, 108.395f), Vector3(1171.409f, 1895.447f, 119.434f), Vector3(1177.339f, 1895.326f, 119.74f))))
+      ZipLinePaths(new ZipLinePath(185, false, List(Vector3(1081.349f, 1837.281f, 103.218f), Vector3(1076.7f, 1845.944f, 103.449f), Vector3(1065.451f, 1850.307f, 103.181f), Vector3(1064.126f, 1871.715f, 108.399f), Vector3(1063.133f, 1910.11f, 98.08f), Vector3(1049.936f, 1910.607f, 97.92f), Vector3(1046.238f, 1897.155f, 97.84f), Vector3(1035.789f, 1897.13f, 97.8f), Vector3(1033.74f, 1905.104f, 98.261f))))
+      ZipLinePaths(new ZipLinePath(186, false, List(Vector3(1328.07f, 680.513f, 143.204f), Vector3(1314.583f, 679.882f, 144.113f), Vector3(1301.096f, 679.251f, 143.222f))))
+      ZipLinePaths(new ZipLinePath(187, false, List(Vector3(1298.966f, 663.593f, 143.212f), Vector3(1334.459f, 661.413f, 143.449f), Vector3(1335.652f, 596.233f, 144.186f), Vector3(1335.731f, 589.947f, 143.346f))))
+      ZipLinePaths(new ZipLinePath(188, false, List(Vector3(1325.227f, 568.298f, 148.411f), Vector3(1312.914f, 568.05f, 153.289f), Vector3(1256.247f, 566.409f, 138.091f), Vector3(1256.38f, 556.749f, 137.691f), Vector3(1256.514f, 547.089f, 134.392f), Vector3(1256.78f, 527.769f, 128.209f))))
+      ZipLinePaths(new ZipLinePath(189, false, List(Vector3(1232.488f, 503.972f, 118.271f), Vector3(1177.355f, 503.447f, 103.257f), Vector3(1177.288f, 493.906f, 103.122f), Vector3(1177.221f, 484.365f, 100.387f), Vector3(1177.088f, 465.284f, 94.516f), Vector3(1176.822f, 427.121f, 83.308f))))
+      ZipLinePaths(new ZipLinePath(190, true, List(Vector3(1460.291f, 635.074f, 82.052f), Vector3(1420.606f, 658.542f, 103.255f), Vector3(1348.379f, 701.254f, 155.5f), Vector3(1338.461f, 711.356f, 142.652f))))
+      ZipLinePaths(new ZipLinePath(191, true, List(Vector3(1460.121f, 1669.773f, 62.635f), Vector3(1462.283f, 1665.474f, 65.87f), Vector3(1507.263f, 1576.061f, 93.342f), Vector3(1529.32f, 1532.214f, 107.198f), Vector3(1550.945f, 1489.227f, 120.782f), Vector3(1572.57f, 1446.24f, 134.366f), Vector3(1583.382f, 1424.747f, 142.313f), Vector3(1585.577f, 1418.788f, 142.568f))))
+      ZipLinePaths(new ZipLinePath(192, true, List(Vector3(843.171f, 1604.511f, 82.635f), Vector3(1081.584f, 1606.379f, 130.495f), Vector3(1132.6f, 1606.779f, 140.524f), Vector3(1173.225f, 1605.795f, 147.478f))))
+      ZipLinePaths(new ZipLinePath(193, false, List(Vector3(1614.569f, 1415.707f, 138.328f), Vector3(1626.72f, 1415.726f, 136.133f), Vector3(1638.871f, 1415.745f, 131.063f), Vector3(1663.172f, 1415.782f, 124.323f), Vector3(1711.775f, 1415.857f, 108.883f), Vector3(1721.305f, 1415.871f, 103.923f))))
+      ZipLinePaths(new ZipLinePath(194, false, List(Vector3(1735.537f, 1404.107f, 103.196f), Vector3(1721.896f, 1399.206f, 103.634f), Vector3(1721.852f, 1370.805f, 103.243f))))
+      ZipLinePaths(new ZipLinePath(195, false, List(Vector3(658.194f, 952.284f, 128.38f), Vector3(652.236f, 952.266f, 127.377f), Vector3(646.278f, 952.248f, 125.698f), Vector3(634.363f, 952.212f, 122.04f), Vector3(610.532f, 952.14f, 114.424f), Vector3(562.869f, 951.997f, 99.305f), Vector3(540.468f, 951.929f, 92.103f), Vector3(529.267f, 951.896f, 89.102f), Vector3(518.067f, 951.862f, 83.825f))))
+      ZipLinePaths(new ZipLinePath(196, false, List(Vector3(503.81f, 962.852f, 83.211f), Vector3(518.406f, 970.708f, 83.699f), Vector3(518.408f, 994.66f, 83.232f))))
+      ZipLinePaths(new ZipLinePath(197, false, List(Vector3(492.349f, 1008.389f, 83.135f), Vector3(511.868f, 1054.627f, 86.076f), Vector3(526.104f, 1080.919f, 83.135f))))
+      ZipLinePaths(new ZipLinePath(198, false, List(Vector3(911.833f, 714.846f, 82.993f), Vector3(936.165f, 763.965f, 96.014f), Vector3(954.414f, 800.804f, 98.783f), Vector3(960.497f, 813.084f, 98.139f))))
+      ZipLinePaths(new ZipLinePath(199, false, List(Vector3(676.057f, 1134.606f, 83.178f), Vector3(725.964f, 1144.654f, 93.349f), Vector3(775.871f, 1154.702f, 95.839f), Vector3(805.229f, 1160.613f, 93.832f))))
+      ZipLinePaths(new ZipLinePath(200, false, List(Vector3(1459.819f, 1651.959f, 64.416f), Vector3(1456.288f, 1610.835f, 86.097f), Vector3(1453.64f, 1579.993f, 91.127f), Vector3(1452.757f, 1569.712f, 90.906f))))
+      ZipLinePaths(new ZipLinePath(201, false, List(Vector3(1458.457f, 1545.826f, 90.791f), Vector3(1479.788f, 1501.533f, 100.359f), Vector3(1492.161f, 1475.843f, 106.12f))))
+      ZipLinePaths(new ZipLinePath(202, false, List(Vector3(1444.372f, 1548.139f, 90.82f), Vector3(1432.067f, 1503.254f, 110.53f), Vector3(1419.763f, 1458.368f, 128.818f), Vector3(1407.458f, 1413.483f, 147.106f), Vector3(1399.337f, 1383.859f, 159.624f))))
+      ZipLinePaths(new ZipLinePath(203, false, List(Vector3(1551.372f, 1446.798f, 106.066f), Vector3(1575.322f, 1428.6f, 142.446f), Vector3(1578.744f, 1426.001f, 143.072f))))
+      ZipLinePaths(new ZipLinePath(204, false, List(Vector3(1224.112f, 1046.429f, 98.511f), Vector3(1258.135f, 1084.269f, 96.285f), Vector3(1286.821f, 1116.172f, 92.591f))))
+      ZipLinePaths(new ZipLinePath(205, false, List(Vector3(841.821f, 1278.922f, 97.951f), Vector3(915.183f, 1336.824f, 163.083f), Vector3(917.549f, 1338.692f, 163.636f))))
+      ZipLinePaths(new ZipLinePath(206, false, List(Vector3(878.453f, 1386.561f, 97.851f), Vector3(955.117f, 1405.787f, 162.33f), Vector3(960.228f, 1407.069f, 162.789f))))
+      ZipLinePaths(new ZipLinePath(207, false, List(Vector3(1526.881f, 964.484f, 92.484f), Vector3(1400.135f, 1008.218f, 163.631f), Vector3(1394.22f, 1010.259f, 163.564f))))
+      ZipLinePaths(new ZipLinePath(208, false, List(Vector3(1435.638f, 937.309f, 94.831f), Vector3(1340.67f, 920.751f, 162.022f), Vector3(1334.338f, 919.647f, 162.236f))))
+      ZipLinePaths(new ZipLinePath(209, false, List(Vector3(1043.013f, 1001.463f, 94.331f), Vector3(1059.675f, 1063.189f, 154.808f), Vector3(1060.786f, 1067.304f, 155f))))
+      ZipLinePaths(new ZipLinePath(210, false, List(Vector3(1262.21f, 1329.985f, 87.831f), Vector3(1278.973f, 1277.129f, 159.708f), Vector3(1281.368f, 1269.578f, 160.491f))))
+      ZipLinePaths(new ZipLinePath(211, false, List(Vector3(1310.729f, 1248.042f, 87.731f), Vector3(1351.306f, 1316.913f, 159.718f), Vector3(1352.615f, 1319.135f, 160.182f))))
+      ZipLinePaths(new ZipLinePath(212, false, List(Vector3(922.83f, 1034.618f, 94.431f), Vector3(946.139f, 947.914f, 164.469f), Vector3(946.891f, 945.117f, 164.767f))))
+      ZipLinePaths(new ZipLinePath(213, false, List(Vector3(981.12f, 1104.231f, 94.331f), Vector3(873.547f, 1056.63f, 176.978f), Vector3(870.077f, 1055.095f, 176.961f))))
+      ZipLinePaths(new ZipLinePath(214, false, List(Vector3(1369.892f, 1371.893f, 87.431f), Vector3(1410.201f, 1283.777f, 174.098f), Vector3(1411.501f, 1280.935f, 174.004f))))
+      ZipLinePaths(new ZipLinePath(215, false, List(Vector3(1624.058f, 1140.65f, 82.998f), Vector3(1575.346f, 1141.37f, 98.857f), Vector3(1545.144f, 1141.817f, 101.83f))))
+      ZipLinePaths(new ZipLinePath(216, false, List(Vector3(1514.803f, 1155.469f, 95.704f), Vector3(1441.047f, 1240.007f, 174.127f), Vector3(1438.668f, 1242.734f, 174.386f))))
+      ZipLinePaths(new ZipLinePath(217, false, List(Vector3(1476.13f, 1135.492f, 101.86f), Vector3(1414.559f, 1079.969f, 98.51f))))
+      ZipLinePaths(new ZipLinePath(218, true, List(Vector3(905.255f, 699.031f, 82.635f), Vector3(903.263f, 701.231f, 84.745f), Vector3(858.767f, 750.357f, 93.63f), Vector3(854.782f, 754.756f, 97.496f), Vector3(853.454f, 756.222f, 100.281f), Vector3(818.919f, 794.349f, 107.871f), Vector3(785.049f, 831.744f, 115.315f), Vector3(751.179f, 869.137f, 122.759f), Vector3(717.309f, 906.531f, 130.203f), Vector3(683.438f, 943.925f, 137.646f), Vector3(679.089f, 949.558f, 132.684f))))
+      ZipLinePaths(new ZipLinePath(219, true, List(Vector3(1165.727f, 1602.266f, 147.746f), Vector3(1116.728f, 1601.143f, 139.366f), Vector3(886.441f, 1595.865f, 129.447f), Vector3(843.985f, 1594.922f, 82.706f))))
+      ZipLinePaths(new ZipLinePath(220, false, List(Vector3(1453.183f, 659.325f, 83.215f), Vector3(1437.37f, 707.601f, 91.141f), Vector3(1421.557f, 755.877f, 95.635f), Vector3(1405.744f, 804.154f, 100.129f), Vector3(1395.202f, 836.338f, 102.633f))))
+      ZipLinePaths(new ZipLinePath(221, false, List(Vector3(845.714f, 1588.779f, 82.734f), Vector3(855.47f, 1540.323f, 95.6f), Vector3(865.227f, 1491.868f, 102.057f), Vector3(867.568f, 1480.238f, 101.737f))))
+      ZipLinePaths(new ZipLinePath(222, true, List(Vector3(686.309f, 945.118f, 132.633f), Vector3(720.441f, 907.992f, 125.999f), Vector3(754.573f, 870.865f, 118.411f), Vector3(776.658f, 846.842f, 120.555f), Vector3(811.459f, 808.988f, 112.818f), Vector3(845.591f, 771.862f, 105.23f), Vector3(908.97f, 709.205f, 82.552f))))
+      ZipLinePaths(new ZipLinePath(223, true, List(Vector3(1344.796f, 718.476f, 142.725f), Vector3(1411.682f, 675.619f, 123.587f), Vector3(1450.89f, 650.495f, 102.795f), Vector3(1457.81f, 646.062f, 82.762f))))
+      ZipLinePaths(new ZipLinePath(224, true, List(Vector3(1585.758f, 1426.108f, 142.747f), Vector3(1562.474f, 1469.058f, 129.343f), Vector3(1539.19f, 1512.008f, 114.71f), Vector3(1515.907f, 1554.959f, 100.077f), Vector3(1459.865f, 1658.76f, 63.264f))))
+      ZipLinePaths(new ZipLinePath(225, false, List(Vector3(978.333f, 1281.95f, 109.419f), Vector3(998.278f, 1375.536f, 162.879f), Vector3(999.608f, 1381.775f, 162.859f))))
+      ZipLinePaths(new ZipLinePath(226, false, List(Vector3(1323.318f, 999.538f, 108.132f), Vector3(1352.668f, 1032.694f, 163.149f), Vector3(1354.625f, 1034.905f, 163.51f))))
+      ZipLinePaths(new ZipLinePath(227, false, List(Vector3(1416.023f, 1100.672f, 96.11f), Vector3(1396.498f, 1232.051f, 169.279f), Vector3(1395.869f, 1236.289f, 168.543f))))
+      ZipLinePaths(new ZipLinePath(228, false, List(Vector3(1355.816f, 1040.459f, 163.511f), Vector3(1246.45f, 1095.878f, 172.978f))))
+      ZipLinePaths(new ZipLinePath(229, false, List(Vector3(1363.911f, 1075.694f, 96.074f), Vector3(1252.925f, 1098.509f, 173.077f), Vector3(1249.345f, 1099.245f, 172.98f))))
+      ZipLinePaths(new ZipLinePath(230, false, List(Vector3(1296.075f, 1036.364f, 96.131f), Vector3(1246.252f, 1040.264f, 97.856f), Vector3(1227.319f, 1041.746f, 98.51f))))
+      ZipLinePaths(new ZipLinePath(231, false, List(Vector3(1030.411f, 1318.939f, 111.42f), Vector3(1028.982f, 1397.782f, 161.917f), Vector3(1028.886f, 1403.039f, 162.832f))))
+      ZipLinePaths(new ZipLinePath(232, false, List(Vector3(1346.985f, 726.494f, 143.072f), Vector3(1377.341f, 766.739f, 135.821f), Vector3(1407.697f, 806.984f, 128.102f), Vector3(1438.053f, 847.229f, 120.384f), Vector3(1458.291f, 874.06f, 115.551f))))
+      ZipLinePaths(new ZipLinePath(233, false, List(Vector3(1342.67f, 730.091f, 142.989f), Vector3(1344.678f, 735.667f, 142.661f), Vector3(1374.8f, 819.304f, 99.518f), Vector3(1379.39f, 832.049f, 88.689f))))
+      ZipLinePaths(new ZipLinePath(234, false, List(Vector3(869.078f, 1467.295f, 101.744f), Vector3(840.171f, 1428.178f, 116.211f), Vector3(830.054f, 1414.486f, 120.844f), Vector3(824.996f, 1407.641f, 121.96f), Vector3(819.937f, 1400.795f, 121.59f))))
+    }
+
+    ZipLines()
+
+  }
+}

--- a/pslogin/src/main/scala/zonemaps/Ugd02.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd02.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd02 { // Hunhau
   val ZoneMap = new ZoneMap("ugd02") {
     Scale = MapScale.Dim2560
-    Checksum = 0L
+    Checksum = 2702486449L
 
     Building10093()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd02.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd02.scala
@@ -1,0 +1,1192 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd02 { // Hunhau
+  val ZoneMap = new ZoneMap("ugd02") {
+    Scale = MapScale.Dim2560
+    Checksum = 0L
+
+    Building10093()
+
+    def Building10093(): Unit = { // Name: ceiling_bldg_a_10093 Type: ceiling_bldg_a GUID: 1, MapID: 10093
+      LocalBuilding("ceiling_bldg_a_10093", 1, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(922.89f, 1195.49f, 317.79f), ceiling_bldg_a)))
+      LocalObject(1080, Door.Constructor(Vector3(914.628f, 1209.148f, 319.569f)), owning_building_guid = 1)
+      LocalObject(1092, Door.Constructor(Vector3(930.5852f, 1178.308f, 325.075f)), owning_building_guid = 1)
+      LocalObject(1093, Door.Constructor(Vector3(939.3843f, 1190.549f, 319.569f)), owning_building_guid = 1)
+      LocalObject(1095, Door.Constructor(Vector3(942.5852f, 1199.093f, 325.075f)), owning_building_guid = 1)
+    }
+
+    Building10107()
+
+    def Building10107(): Unit = { // Name: ceiling_bldg_a_10107 Type: ceiling_bldg_a GUID: 2, MapID: 10107
+      LocalBuilding("ceiling_bldg_a_10107", 2, 10107, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(960.11f, 1317.32f, 314.7f), ceiling_bldg_a)))
+      LocalObject(1097, Door.Constructor(Vector3(951.848f, 1330.978f, 316.479f)), owning_building_guid = 2)
+      LocalObject(1102, Door.Constructor(Vector3(967.8052f, 1300.138f, 321.985f)), owning_building_guid = 2)
+      LocalObject(1105, Door.Constructor(Vector3(976.6042f, 1312.379f, 316.479f)), owning_building_guid = 2)
+      LocalObject(1106, Door.Constructor(Vector3(979.8052f, 1320.923f, 321.985f)), owning_building_guid = 2)
+    }
+
+    Building10105()
+
+    def Building10105(): Unit = { // Name: ceiling_bldg_a_10105 Type: ceiling_bldg_a GUID: 3, MapID: 10105
+      LocalBuilding("ceiling_bldg_a_10105", 3, 10105, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1178.77f, 1916.87f, 236.1f), ceiling_bldg_a)))
+      LocalObject(1134, Door.Constructor(Vector3(1170.508f, 1930.528f, 237.879f)), owning_building_guid = 3)
+      LocalObject(1137, Door.Constructor(Vector3(1186.465f, 1899.688f, 243.385f)), owning_building_guid = 3)
+      LocalObject(1141, Door.Constructor(Vector3(1195.264f, 1911.929f, 237.879f)), owning_building_guid = 3)
+      LocalObject(1143, Door.Constructor(Vector3(1198.465f, 1920.473f, 243.385f)), owning_building_guid = 3)
+    }
+
+    Building10084()
+
+    def Building10084(): Unit = { // Name: ceiling_bldg_a_10084 Type: ceiling_bldg_a GUID: 4, MapID: 10084
+      LocalBuilding("ceiling_bldg_a_10084", 4, 10084, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1331.57f, 907.05f, 299.45f), ceiling_bldg_a)))
+      LocalObject(1190, Door.Constructor(Vector3(1317.586f, 914.747f, 301.229f)), owning_building_guid = 4)
+      LocalObject(1194, Door.Constructor(Vector3(1346.825f, 896.018f, 306.735f)), owning_building_guid = 4)
+      LocalObject(1195, Door.Constructor(Vector3(1346.825f, 920.018f, 306.735f)), owning_building_guid = 4)
+      LocalObject(1196, Door.Constructor(Vector3(1348.325f, 911.018f, 301.229f)), owning_building_guid = 4)
+    }
+
+    Building10108()
+
+    def Building10108(): Unit = { // Name: ceiling_bldg_b_10108 Type: ceiling_bldg_b GUID: 5, MapID: 10108
+      LocalBuilding("ceiling_bldg_b_10108", 5, 10108, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(710.38f, 1451.92f, 264.12f), ceiling_bldg_b)))
+      LocalObject(1017, Door.Constructor(Vector3(713.9198f, 1446.952f, 265.899f)), owning_building_guid = 5)
+      LocalObject(1020, Door.Constructor(Vector3(723.465f, 1462.155f, 265.899f)), owning_building_guid = 5)
+    }
+
+    Building10078()
+
+    def Building10078(): Unit = { // Name: ceiling_bldg_b_10078 Type: ceiling_bldg_b GUID: 6, MapID: 10078
+      LocalBuilding("ceiling_bldg_b_10078", 6, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(861.71f, 528.17f, 218.06f), ceiling_bldg_b)))
+      LocalObject(1053, Door.Constructor(Vector3(863.725f, 544.66f, 219.839f)), owning_building_guid = 6)
+      LocalObject(1056, Door.Constructor(Vector3(867.726f, 527.16f, 219.839f)), owning_building_guid = 6)
+    }
+
+    Building10090()
+
+    def Building10090(): Unit = { // Name: ceiling_bldg_b_10090 Type: ceiling_bldg_b GUID: 7, MapID: 10090
+      LocalBuilding("ceiling_bldg_b_10090", 7, 10090, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.1f, 1046.64f, 288.2f), ceiling_bldg_b)))
+      LocalObject(1104, Door.Constructor(Vector3(971.0607f, 1040.891f, 289.979f)), owning_building_guid = 7)
+      LocalObject(1109, Door.Constructor(Vector3(988.9896f, 1041.792f, 289.979f)), owning_building_guid = 7)
+    }
+
+    Building10100()
+
+    def Building10100(): Unit = { // Name: ceiling_bldg_b_10100 Type: ceiling_bldg_b GUID: 8, MapID: 10100
+      LocalBuilding("ceiling_bldg_b_10100", 8, 10100, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1217.11f, 1317.72f, 291.99f), ceiling_bldg_b)))
+      LocalObject(1144, Door.Constructor(Vector3(1200.521f, 1316.841f, 293.769f)), owning_building_guid = 8)
+      LocalObject(1150, Door.Constructor(Vector3(1217.06f, 1323.82f, 293.769f)), owning_building_guid = 8)
+    }
+
+    Building10664()
+
+    def Building10664(): Unit = { // Name: ceiling_bldg_b_10664 Type: ceiling_bldg_b GUID: 9, MapID: 10664
+      LocalBuilding("ceiling_bldg_b_10664", 9, 10664, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.66f, 785.69f, 273.36f), ceiling_bldg_b)))
+      LocalObject(1159, Door.Constructor(Vector3(1263.517f, 801.4866f, 275.139f)), owning_building_guid = 9)
+      LocalObject(1168, Door.Constructor(Vector3(1274.539f, 787.3171f, 275.139f)), owning_building_guid = 9)
+    }
+
+    Building10101()
+
+    def Building10101(): Unit = { // Name: ceiling_bldg_c_10101 Type: ceiling_bldg_c GUID: 10, MapID: 10101
+      LocalBuilding("ceiling_bldg_c_10101", 10, 10101, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(732.43f, 973.16f, 280.28f), ceiling_bldg_c)))
+      LocalObject(1021, Door.Constructor(Vector3(728.5452f, 974.9094f, 282.059f)), owning_building_guid = 10)
+      LocalObject(1024, Door.Constructor(Vector3(751.15f, 1019.471f, 282.059f)), owning_building_guid = 10)
+      LocalObject(1029, Door.Constructor(Vector3(773.0703f, 997.5509f, 282.059f)), owning_building_guid = 10)
+    }
+
+    Building10095()
+
+    def Building10095(): Unit = { // Name: ceiling_bldg_c_10095 Type: ceiling_bldg_c GUID: 11, MapID: 10095
+      LocalBuilding("ceiling_bldg_c_10095", 11, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(834.75f, 1318.05f, 293.22f), ceiling_bldg_c)))
+      LocalObject(1042, Door.Constructor(Vector3(830.5447f, 1318.734f, 294.999f)), owning_building_guid = 11)
+      LocalObject(1045, Door.Constructor(Vector3(840.8458f, 1367.628f, 294.999f)), owning_building_guid = 11)
+      LocalObject(1054, Door.Constructor(Vector3(867.6926f, 1352.128f, 294.999f)), owning_building_guid = 11)
+    }
+
+    Building10091()
+
+    def Building10091(): Unit = { // Name: ceiling_bldg_c_10091 Type: ceiling_bldg_c GUID: 12, MapID: 10091
+      LocalBuilding("ceiling_bldg_c_10091", 12, 10091, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(860.22f, 1024.66f, 306.94f), ceiling_bldg_c)))
+      LocalObject(1049, Door.Constructor(Vector3(856.3351f, 1026.409f, 308.719f)), owning_building_guid = 12)
+      LocalObject(1059, Door.Constructor(Vector3(878.9399f, 1070.971f, 308.719f)), owning_building_guid = 12)
+      LocalObject(1073, Door.Constructor(Vector3(900.8602f, 1049.051f, 308.719f)), owning_building_guid = 12)
+    }
+
+    Building10085()
+
+    def Building10085(): Unit = { // Name: ceiling_bldg_c_10085 Type: ceiling_bldg_c GUID: 13, MapID: 10085
+      LocalBuilding("ceiling_bldg_c_10085", 13, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1463.31f, 980.3f, 265.51f), ceiling_bldg_c)))
+      LocalObject(1209, Door.Constructor(Vector3(1459.18f, 981.3482f, 267.289f)), owning_building_guid = 13)
+      LocalObject(1210, Door.Constructor(Vector3(1473.704f, 1029.158f, 267.289f)), owning_building_guid = 13)
+      LocalObject(1211, Door.Constructor(Vector3(1499.097f, 1011.378f, 267.289f)), owning_building_guid = 13)
+    }
+
+    Building10094()
+
+    def Building10094(): Unit = { // Name: ceiling_bldg_e_10094 Type: ceiling_bldg_e GUID: 14, MapID: 10094
+      LocalBuilding("ceiling_bldg_e_10094", 14, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(697.23f, 1294.78f, 269.71f), ceiling_bldg_e)))
+      LocalObject(1014, Door.Constructor(Vector3(685.214f, 1293.79f, 271.489f)), owning_building_guid = 14)
+      LocalObject(1016, Door.Constructor(Vector3(701.214f, 1327.29f, 276.989f)), owning_building_guid = 14)
+      LocalObject(1018, Door.Constructor(Vector3(716.24f, 1322.796f, 271.489f)), owning_building_guid = 14)
+      LocalObject(1019, Door.Constructor(Vector3(722.24f, 1302.796f, 276.989f)), owning_building_guid = 14)
+    }
+
+    Building10079()
+
+    def Building10079(): Unit = { // Name: ceiling_bldg_e_10079 Type: ceiling_bldg_e GUID: 15, MapID: 10079
+      LocalBuilding("ceiling_bldg_e_10079", 15, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(866.94f, 711.23f, 240.12f), ceiling_bldg_e)))
+      LocalObject(1051, Door.Constructor(Vector3(860.9646f, 721.7018f, 241.899f)), owning_building_guid = 15)
+      LocalObject(1063, Door.Constructor(Vector3(884.7747f, 691.9509f, 247.399f)), owning_building_guid = 15)
+      LocalObject(1070, Door.Constructor(Vector3(898.0878f, 721.3586f, 247.399f)), owning_building_guid = 15)
+      LocalObject(1072, Door.Constructor(Vector3(900.3651f, 705.8411f, 241.899f)), owning_building_guid = 15)
+    }
+
+    Building10096()
+
+    def Building10096(): Unit = { // Name: ceiling_bldg_e_10096 Type: ceiling_bldg_e GUID: 16, MapID: 10096
+      LocalBuilding("ceiling_bldg_e_10096", 16, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(907.97f, 1468.88f, 268.54f), ceiling_bldg_e)))
+      LocalObject(1067, Door.Constructor(Vector3(887.7991f, 1494.685f, 275.819f)), owning_building_guid = 16)
+      LocalObject(1071, Door.Constructor(Vector3(900.1734f, 1459.683f, 270.319f)), owning_building_guid = 16)
+      LocalObject(1074, Door.Constructor(Vector3(901.6017f, 1502.132f, 270.319f)), owning_building_guid = 16)
+      LocalObject(1085, Door.Constructor(Vector3(919.9866f, 1492.233f, 275.819f)), owning_building_guid = 16)
+    }
+
+    Building10102()
+
+    def Building10102(): Unit = { // Name: ceiling_bldg_e_10102 Type: ceiling_bldg_e GUID: 17, MapID: 10102
+      LocalBuilding("ceiling_bldg_e_10102", 17, 10102, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1051.15f, 1568.76f, 271.69f), ceiling_bldg_e)))
+      LocalObject(1112, Door.Constructor(Vector3(1039.134f, 1567.77f, 273.469f)), owning_building_guid = 17)
+      LocalObject(1113, Door.Constructor(Vector3(1055.134f, 1601.27f, 278.969f)), owning_building_guid = 17)
+      LocalObject(1114, Door.Constructor(Vector3(1070.16f, 1596.776f, 273.469f)), owning_building_guid = 17)
+      LocalObject(1115, Door.Constructor(Vector3(1076.16f, 1576.776f, 278.969f)), owning_building_guid = 17)
+    }
+
+    Building10086()
+
+    def Building10086(): Unit = { // Name: ceiling_bldg_e_10086 Type: ceiling_bldg_e GUID: 18, MapID: 10086
+      LocalBuilding("ceiling_bldg_e_10086", 18, 10086, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.98f, 1446.91f, 258.66f), ceiling_bldg_e)))
+      LocalObject(1197, Door.Constructor(Vector3(1352.964f, 1445.92f, 260.439f)), owning_building_guid = 18)
+      LocalObject(1199, Door.Constructor(Vector3(1368.964f, 1479.42f, 265.939f)), owning_building_guid = 18)
+      LocalObject(1202, Door.Constructor(Vector3(1383.99f, 1474.926f, 260.439f)), owning_building_guid = 18)
+      LocalObject(1204, Door.Constructor(Vector3(1389.99f, 1454.926f, 265.939f)), owning_building_guid = 18)
+    }
+
+    Building10092()
+
+    def Building10092(): Unit = { // Name: ceiling_bldg_f_10092 Type: ceiling_bldg_f GUID: 19, MapID: 10092
+      LocalBuilding("ceiling_bldg_f_10092", 19, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(765.59f, 1161.9f, 289.99f), ceiling_bldg_f)))
+      LocalObject(1022, Door.Constructor(Vector3(734.7006f, 1163.41f, 291.769f)), owning_building_guid = 19)
+      LocalObject(1033, Door.Constructor(Vector3(791.3768f, 1149.481f, 291.769f)), owning_building_guid = 19)
+    }
+
+    Building10778()
+
+    def Building10778(): Unit = { // Name: ceiling_bldg_f_10778 Type: ceiling_bldg_f GUID: 20, MapID: 10778
+      LocalBuilding("ceiling_bldg_f_10778", 20, 10778, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(822.13f, 896.66f, 253.11f), ceiling_bldg_f)))
+      LocalObject(1036, Door.Constructor(Vector3(810.3592f, 922.7492f, 254.889f)), owning_building_guid = 20)
+      LocalObject(1047, Door.Constructor(Vector3(844.8219f, 875.6477f, 254.889f)), owning_building_guid = 20)
+    }
+
+    Building10106()
+
+    def Building10106(): Unit = { // Name: ceiling_bldg_f_10106 Type: ceiling_bldg_f GUID: 21, MapID: 10106
+      LocalBuilding("ceiling_bldg_f_10106", 21, 10106, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1198.46f, 1426.56f, 309.72f), ceiling_bldg_f)))
+      LocalObject(1136, Door.Constructor(Vector3(1184.323f, 1454.066f, 311.499f)), owning_building_guid = 21)
+      LocalObject(1145, Door.Constructor(Vector3(1200.598f, 1398.018f, 311.499f)), owning_building_guid = 21)
+    }
+
+    Building10080()
+
+    def Building10080(): Unit = { // Name: ceiling_bldg_g_10080 Type: ceiling_bldg_g GUID: 22, MapID: 10080
+      LocalBuilding("ceiling_bldg_g_10080", 22, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(759.5f, 747.28f, 248.37f), ceiling_bldg_g)))
+      LocalObject(1025, Door.Constructor(Vector3(751.516f, 730.77f, 250.149f)), owning_building_guid = 22)
+      LocalObject(1026, Door.Constructor(Vector3(759.516f, 764.77f, 250.149f)), owning_building_guid = 22)
+    }
+
+    Building10087()
+
+    def Building10087(): Unit = { // Name: ceiling_bldg_g_10087 Type: ceiling_bldg_g GUID: 23, MapID: 10087
+      LocalBuilding("ceiling_bldg_g_10087", 23, 10087, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.94f, 1287.12f, 309.56f), ceiling_bldg_g)))
+      LocalObject(1130, Door.Constructor(Vector3(1151.956f, 1270.61f, 311.339f)), owning_building_guid = 23)
+      LocalObject(1131, Door.Constructor(Vector3(1159.956f, 1304.61f, 311.339f)), owning_building_guid = 23)
+    }
+
+    Building10083()
+
+    def Building10083(): Unit = { // Name: ceiling_bldg_g_10083 Type: ceiling_bldg_g GUID: 24, MapID: 10083
+      LocalBuilding("ceiling_bldg_g_10083", 24, 10083, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1214.34f, 914.27f, 295.15f), ceiling_bldg_g)))
+      LocalObject(1148, Door.Constructor(Vector3(1209.829f, 931.1682f, 296.929f)), owning_building_guid = 24)
+      LocalObject(1149, Door.Constructor(Vector3(1210.901f, 896.2562f, 296.929f)), owning_building_guid = 24)
+    }
+
+    Building10081()
+
+    def Building10081(): Unit = { // Name: ceiling_bldg_h_10081 Type: ceiling_bldg_h GUID: 25, MapID: 10081
+      LocalBuilding("ceiling_bldg_h_10081", 25, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(958.95f, 790.67f, 267.91f), ceiling_bldg_h)))
+      LocalObject(1094, Door.Constructor(Vector3(942.46f, 786.686f, 269.689f)), owning_building_guid = 25)
+      LocalObject(1098, Door.Constructor(Vector3(962.934f, 807.18f, 269.689f)), owning_building_guid = 25)
+      LocalObject(1103, Door.Constructor(Vector3(970.035f, 779.482f, 272.189f)), owning_building_guid = 25)
+    }
+
+    Building10097()
+
+    def Building10097(): Unit = { // Name: ceiling_bldg_h_10097 Type: ceiling_bldg_h GUID: 26, MapID: 10097
+      LocalBuilding("ceiling_bldg_h_10097", 26, 10097, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(979.89f, 1487.96f, 269.47f), ceiling_bldg_h)))
+      LocalObject(1099, Door.Constructor(Vector3(963.2613f, 1491.318f, 271.249f)), owning_building_guid = 26)
+      LocalObject(1107, Door.Constructor(Vector3(985.2082f, 1473.135f, 273.749f)), owning_building_guid = 26)
+      LocalObject(1110, Door.Constructor(Vector3(990.4781f, 1501.239f, 271.249f)), owning_building_guid = 26)
+    }
+
+    Building10082()
+
+    def Building10082(): Unit = { // Name: ceiling_bldg_h_10082 Type: ceiling_bldg_h GUID: 27, MapID: 10082
+      LocalBuilding("ceiling_bldg_h_10082", 27, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1111.54f, 899.56f, 290.68f), ceiling_bldg_h)))
+      LocalObject(1117, Door.Constructor(Vector3(1095.05f, 895.576f, 292.459f)), owning_building_guid = 27)
+      LocalObject(1123, Door.Constructor(Vector3(1115.524f, 916.07f, 292.459f)), owning_building_guid = 27)
+      LocalObject(1125, Door.Constructor(Vector3(1122.625f, 888.372f, 294.959f)), owning_building_guid = 27)
+    }
+
+    Building10088()
+
+    def Building10088(): Unit = { // Name: ceiling_bldg_h_10088 Type: ceiling_bldg_h GUID: 28, MapID: 10088
+      LocalBuilding("ceiling_bldg_h_10088", 28, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1127.33f, 1060.86f, 311.15f), ceiling_bldg_h)))
+      LocalObject(1122, Door.Constructor(Vector3(1110.453f, 1058.957f, 312.929f)), owning_building_guid = 28)
+      LocalObject(1126, Door.Constructor(Vector3(1134.052f, 1075.103f, 315.429f)), owning_building_guid = 28)
+      LocalObject(1128, Door.Constructor(Vector3(1136.714f, 1046.727f, 312.929f)), owning_building_guid = 28)
+    }
+
+    Building10103()
+
+    def Building10103(): Unit = { // Name: ceiling_bldg_h_10103 Type: ceiling_bldg_h GUID: 29, MapID: 10103
+      LocalBuilding("ceiling_bldg_h_10103", 29, 10103, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.59f, 1648.29f, 264.54f), ceiling_bldg_h)))
+      LocalObject(1133, Door.Constructor(Vector3(1170.1f, 1644.306f, 266.319f)), owning_building_guid = 29)
+      LocalObject(1139, Door.Constructor(Vector3(1190.574f, 1664.8f, 266.319f)), owning_building_guid = 29)
+      LocalObject(1142, Door.Constructor(Vector3(1197.675f, 1637.102f, 268.819f)), owning_building_guid = 29)
+    }
+
+    Building10098()
+
+    def Building10098(): Unit = { // Name: ceiling_bldg_h_10098 Type: ceiling_bldg_h GUID: 30, MapID: 10098
+      LocalBuilding("ceiling_bldg_h_10098", 30, 10098, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.22f, 1049.38f, 307.96f), ceiling_bldg_h)))
+      LocalObject(1154, Door.Constructor(Vector3(1251.73f, 1045.396f, 309.739f)), owning_building_guid = 30)
+      LocalObject(1166, Door.Constructor(Vector3(1272.204f, 1065.89f, 309.739f)), owning_building_guid = 30)
+      LocalObject(1173, Door.Constructor(Vector3(1279.305f, 1038.192f, 312.239f)), owning_building_guid = 30)
+    }
+
+    Building10099()
+
+    def Building10099(): Unit = { // Name: ceiling_bldg_i_10099 Type: ceiling_bldg_i GUID: 31, MapID: 10099
+      LocalBuilding("ceiling_bldg_i_10099", 31, 10099, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1303.08f, 1215.7f, 303.15f), ceiling_bldg_i)))
+      LocalObject(1171, Door.Constructor(Vector3(1278.59f, 1219.216f, 304.929f)), owning_building_guid = 31)
+      LocalObject(1192, Door.Constructor(Vector3(1328.59f, 1219.216f, 304.929f)), owning_building_guid = 31)
+    }
+
+    Building10104()
+
+    def Building10104(): Unit = { // Name: ceiling_bldg_j_10104 Type: ceiling_bldg_j GUID: 32, MapID: 10104
+      LocalBuilding("ceiling_bldg_j_10104", 32, 10104, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.96f, 1794.06f, 230.84f), ceiling_bldg_j)))
+      LocalObject(1124, Door.Constructor(Vector3(1117.647f, 1799.353f, 232.619f)), owning_building_guid = 32)
+      LocalObject(1129, Door.Constructor(Vector3(1140.305f, 1788.788f, 232.619f)), owning_building_guid = 32)
+    }
+
+    Building10089()
+
+    def Building10089(): Unit = { // Name: ceiling_bldg_j_10089 Type: ceiling_bldg_j GUID: 33, MapID: 10089
+      LocalBuilding("ceiling_bldg_j_10089", 33, 10089, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1443.23f, 1163.19f, 271.2f), ceiling_bldg_j)))
+      LocalObject(1207, Door.Constructor(Vector3(1433.652f, 1155.174f, 272.979f)), owning_building_guid = 33)
+      LocalObject(1208, Door.Constructor(Vector3(1452.803f, 1171.244f, 272.979f)), owning_building_guid = 33)
+    }
+
+    Building10357()
+
+    def Building10357(): Unit = { // Name: ceiling_bldg_z_10357 Type: ceiling_bldg_z GUID: 34, MapID: 10357
+      LocalBuilding("ceiling_bldg_z_10357", 34, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1366.28f, 1322.62f, 306.75f), ceiling_bldg_z)))
+      LocalObject(1193, Door.Constructor(Vector3(1341.79f, 1326.636f, 308.529f)), owning_building_guid = 34)
+      LocalObject(1206, Door.Constructor(Vector3(1398.79f, 1326.636f, 308.529f)), owning_building_guid = 34)
+    }
+
+    Building10016()
+
+    def Building10016(): Unit = { // Name: ground_bldg_b_10016 Type: ground_bldg_b GUID: 273, MapID: 10016
+      LocalBuilding("ground_bldg_b_10016", 273, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.23f, 1439.35f, 216f), ground_bldg_b)))
+      LocalObject(1028, Door.Constructor(Vector3(772.578f, 1450.504f, 223.279f)), owning_building_guid = 273)
+      LocalObject(1030, Door.Constructor(Vector3(783.0869f, 1428.013f, 217.779f)), owning_building_guid = 273)
+      LocalObject(1032, Door.Constructor(Vector3(791.2707f, 1443.991f, 217.779f)), owning_building_guid = 273)
+    }
+
+    Building10000()
+
+    def Building10000(): Unit = { // Name: ground_bldg_b_10000 Type: ground_bldg_b GUID: 274, MapID: 10000
+      LocalBuilding("ground_bldg_b_10000", 274, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(817.07f, 1033.77f, 211.66f), ground_bldg_b)))
+      LocalObject(1037, Door.Constructor(Vector3(819.085f, 1050.26f, 213.439f)), owning_building_guid = 274)
+      LocalObject(1040, Door.Constructor(Vector3(823.086f, 1032.76f, 213.439f)), owning_building_guid = 274)
+      LocalObject(1046, Door.Constructor(Vector3(841.592f, 1039.786f, 218.939f)), owning_building_guid = 274)
+    }
+
+    Building10021()
+
+    def Building10021(): Unit = { // Name: ground_bldg_b_10021 Type: ground_bldg_b GUID: 275, MapID: 10021
+      LocalBuilding("ground_bldg_b_10021", 275, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.21f, 1419.07f, 224.66f), ground_bldg_b)))
+      LocalObject(1132, Door.Constructor(Vector3(1168.493f, 1413.913f, 231.939f)), owning_building_guid = 275)
+      LocalObject(1138, Door.Constructor(Vector3(1187.233f, 1420.289f, 226.439f)), owning_building_guid = 275)
+      LocalObject(1140, Door.Constructor(Vector3(1190.621f, 1402.66f, 226.439f)), owning_building_guid = 275)
+    }
+
+    Building10030()
+
+    def Building10030(): Unit = { // Name: ground_bldg_b_10030 Type: ground_bldg_b GUID: 276, MapID: 10030
+      LocalBuilding("ground_bldg_b_10030", 276, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.87f, 1038.08f, 216f), ground_bldg_b)))
+      LocalObject(1200, Door.Constructor(Vector3(1369.506f, 1034.116f, 217.779f)), owning_building_guid = 276)
+      LocalObject(1201, Door.Constructor(Vector3(1375.09f, 1051.177f, 217.779f)), owning_building_guid = 276)
+      LocalObject(1203, Door.Constructor(Vector3(1388.988f, 1030.607f, 223.279f)), owning_building_guid = 276)
+    }
+
+    Building10369()
+
+    def Building10369(): Unit = { // Name: ground_bldg_c_10369 Type: ground_bldg_c GUID: 277, MapID: 10369
+      LocalBuilding("ground_bldg_c_10369", 277, 10369, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(915.84f, 988.16f, 228.46f), ground_bldg_c)))
+      LocalObject(1058, Door.Constructor(Vector3(875.1998f, 963.769f, 230.239f)), owning_building_guid = 277)
+      LocalObject(1068, Door.Constructor(Vector3(897.1201f, 941.8487f, 230.239f)), owning_building_guid = 277)
+      LocalObject(1084, Door.Constructor(Vector3(919.7249f, 986.4106f, 230.239f)), owning_building_guid = 277)
+    }
+
+    Building10023()
+
+    def Building10023(): Unit = { // Name: ground_bldg_c_10023 Type: ground_bldg_c GUID: 278, MapID: 10023
+      LocalBuilding("ground_bldg_c_10023", 278, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1266.3f, 1371.91f, 241.56f), ground_bldg_c)))
+      LocalObject(1153, Door.Constructor(Vector3(1239.094f, 1333.098f, 243.339f)), owning_building_guid = 278)
+      LocalObject(1164, Door.Constructor(Vector3(1268.035f, 1321.989f, 243.339f)), owning_building_guid = 278)
+      LocalObject(1165, Door.Constructor(Vector3(1270.561f, 1371.892f, 243.339f)), owning_building_guid = 278)
+    }
+
+    Building10009()
+
+    def Building10009(): Unit = { // Name: ground_bldg_d_10009 Type: ground_bldg_d GUID: 279, MapID: 10009
+      LocalBuilding("ground_bldg_d_10009", 279, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(807.17f, 1205.79f, 216.95f), ground_bldg_d)))
+      LocalObject(1031, Door.Constructor(Vector3(789.7576f, 1203.944f, 218.685f)), owning_building_guid = 279)
+      LocalObject(1034, Door.Constructor(Vector3(805.3238f, 1223.202f, 218.685f)), owning_building_guid = 279)
+      LocalObject(1035, Door.Constructor(Vector3(808.9823f, 1188.394f, 218.685f)), owning_building_guid = 279)
+      LocalObject(1041, Door.Constructor(Vector3(824.5659f, 1207.602f, 218.685f)), owning_building_guid = 279)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: ground_bldg_d_10001 Type: ground_bldg_d GUID: 280, MapID: 10001
+      LocalBuilding("ground_bldg_d_10001", 280, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837f, 990.15f, 218.45f), ground_bldg_d)))
+      LocalObject(1039, Door.Constructor(Vector3(819.51f, 990.166f, 220.185f)), owning_building_guid = 280)
+      LocalObject(1043, Door.Constructor(Vector3(837.016f, 972.64f, 220.185f)), owning_building_guid = 280)
+      LocalObject(1044, Door.Constructor(Vector3(837.016f, 1007.64f, 220.185f)), owning_building_guid = 280)
+      LocalObject(1048, Door.Constructor(Vector3(854.51f, 990.166f, 220.185f)), owning_building_guid = 280)
+    }
+
+    Building10543()
+
+    def Building10543(): Unit = { // Name: ground_bldg_d_10543 Type: ground_bldg_d GUID: 281, MapID: 10543
+      LocalBuilding("ground_bldg_d_10543", 281, 10543, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.03f, 1293.93f, 229f), ground_bldg_d)))
+      LocalObject(1100, Door.Constructor(Vector3(963.8547f, 1304.209f, 230.735f)), owning_building_guid = 281)
+      LocalObject(1101, Door.Constructor(Vector3(967.7367f, 1279.79f, 230.735f)), owning_building_guid = 281)
+      LocalObject(1108, Door.Constructor(Vector3(988.3092f, 1308.105f, 230.735f)), owning_building_guid = 281)
+      LocalObject(1111, Door.Constructor(Vector3(992.1703f, 1283.637f, 230.735f)), owning_building_guid = 281)
+    }
+
+    Building10022()
+
+    def Building10022(): Unit = { // Name: ground_bldg_d_10022 Type: ground_bldg_d GUID: 282, MapID: 10022
+      LocalBuilding("ground_bldg_d_10022", 282, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.5f, 1360.56f, 231.45f), ground_bldg_d)))
+      LocalObject(1135, Door.Constructor(Vector3(1184.01f, 1360.576f, 233.185f)), owning_building_guid = 282)
+      LocalObject(1146, Door.Constructor(Vector3(1201.516f, 1343.05f, 233.185f)), owning_building_guid = 282)
+      LocalObject(1147, Door.Constructor(Vector3(1201.516f, 1378.05f, 233.185f)), owning_building_guid = 282)
+      LocalObject(1151, Door.Constructor(Vector3(1219.01f, 1360.576f, 233.185f)), owning_building_guid = 282)
+    }
+
+    Building10031()
+
+    def Building10031(): Unit = { // Name: ground_bldg_d_10031 Type: ground_bldg_d GUID: 283, MapID: 10031
+      LocalBuilding("ground_bldg_d_10031", 283, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1301.6f, 959.02f, 222f), ground_bldg_d)))
+      LocalObject(1180, Door.Constructor(Vector3(1284.428f, 955.6985f, 223.735f)), owning_building_guid = 283)
+      LocalObject(1184, Door.Constructor(Vector3(1298.278f, 976.1917f, 223.735f)), owning_building_guid = 283)
+      LocalObject(1186, Door.Constructor(Vector3(1304.957f, 941.8348f, 223.735f)), owning_building_guid = 283)
+      LocalObject(1191, Door.Constructor(Vector3(1318.785f, 962.3768f, 223.735f)), owning_building_guid = 283)
+    }
+
+    Building10013()
+
+    def Building10013(): Unit = { // Name: ground_bldg_i_10013 Type: ground_bldg_i GUID: 284, MapID: 10013
+      LocalBuilding("ground_bldg_i_10013", 284, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(715.89f, 1024.55f, 209f), ground_bldg_i)))
+      LocalObject(1015, Door.Constructor(Vector3(695.9173f, 1039.152f, 210.779f)), owning_building_guid = 284)
+      LocalObject(1023, Door.Constructor(Vector3(740.0647f, 1015.678f, 210.779f)), owning_building_guid = 284)
+    }
+
+    Building10018()
+
+    def Building10018(): Unit = { // Name: ground_bldg_i_10018 Type: ground_bldg_i GUID: 285, MapID: 10018
+      LocalBuilding("ground_bldg_i_10018", 285, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.93f, 1513.27f, 225f), ground_bldg_i)))
+      LocalObject(1027, Door.Constructor(Vector3(771.4196f, 1509.899f, 226.779f)), owning_building_guid = 285)
+      LocalObject(1038, Door.Constructor(Vector3(819.4827f, 1523.681f, 226.779f)), owning_building_guid = 285)
+    }
+
+    Building10032()
+
+    def Building10032(): Unit = { // Name: ground_bldg_i_10032 Type: ground_bldg_i GUID: 286, MapID: 10032
+      LocalBuilding("ground_bldg_i_10032", 286, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1375.1f, 964.87f, 225f), ground_bldg_i)))
+      LocalObject(1198, Door.Constructor(Vector3(1353.466f, 950.9024f, 226.779f)), owning_building_guid = 286)
+      LocalObject(1205, Door.Constructor(Vector3(1398.781f, 972.0333f, 226.779f)), owning_building_guid = 286)
+    }
+
+    Building10748()
+
+    def Building10748(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 287, MapID: 10748
+      LocalBuilding("N_Redoubt", 287, 10748, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(870.46f, 1493.53f, 214.4f), redoubt)))
+      LocalObject(1393, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 287)
+      LocalObject(1050, Door.Constructor(Vector3(856.3197f, 1503.823f, 216.135f)), owning_building_guid = 287)
+      LocalObject(1055, Door.Constructor(Vector3(867.6268f, 1510.519f, 226.179f)), owning_building_guid = 287)
+      LocalObject(1057, Door.Constructor(Vector3(874.3053f, 1505.662f, 226.159f)), owning_building_guid = 287)
+      LocalObject(1061, Door.Constructor(Vector3(880.8124f, 1500.974f, 226.159f)), owning_building_guid = 287)
+      LocalObject(1062, Door.Constructor(Vector3(884.6353f, 1483.251f, 216.135f)), owning_building_guid = 287)
+      LocalObject(1066, Door.Constructor(Vector3(887.4849f, 1496.132f, 226.179f)), owning_building_guid = 287)
+      LocalObject(1410, Terminal.Constructor(Vector3(859.4799f, 1478.63f, 214.3558f), vanu_equipment_term), owning_building_guid = 287)
+      LocalObject(1416, Terminal.Constructor(Vector3(881.4727f, 1508.661f, 214.3535f), vanu_equipment_term), owning_building_guid = 287)
+      LocalObject(1340, SpawnTube.Constructor(Vector3(870.46f, 1493.53f, 214.4f), Vector3(0, 0, 216)), owning_building_guid = 287)
+      LocalObject(1328, Painbox.Constructor(Vector3(870.6642f, 1493.741f, 222.189f), painbox_continuous), owning_building_guid = 287)
+    }
+
+    Building10751()
+
+    def Building10751(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 288, MapID: 10751
+      LocalBuilding("S_Redoubt", 288, 10751, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1291.34f, 1131.64f, 216.2f), redoubt)))
+      LocalObject(1397, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 288)
+      LocalObject(1169, Door.Constructor(Vector3(1277.826f, 1142.317f, 227.979f)), owning_building_guid = 288)
+      LocalObject(1172, Door.Constructor(Vector3(1278.836f, 1134.135f, 227.959f)), owning_building_guid = 288)
+      LocalObject(1176, Door.Constructor(Vector3(1279.845f, 1126.178f, 227.959f)), owning_building_guid = 288)
+      LocalObject(1178, Door.Constructor(Vector3(1280.847f, 1117.981f, 227.979f)), owning_building_guid = 288)
+      LocalObject(1182, Door.Constructor(Vector3(1289.19f, 1149.018f, 217.935f)), owning_building_guid = 288)
+      LocalObject(1183, Door.Constructor(Vector3(1293.456f, 1114.278f, 217.935f)), owning_building_guid = 288)
+      LocalObject(1450, Terminal.Constructor(Vector3(1272.764f, 1129.375f, 216.1535f), vanu_equipment_term), owning_building_guid = 288)
+      LocalObject(1459, Terminal.Constructor(Vector3(1309.726f, 1133.771f, 216.1558f), vanu_equipment_term), owning_building_guid = 288)
+      LocalObject(1341, SpawnTube.Constructor(Vector3(1291.34f, 1131.64f, 216.2f), Vector3(0, 0, 83)), owning_building_guid = 288)
+      LocalObject(1331, Painbox.Constructor(Vector3(1291.047f, 1131.646f, 223.989f), painbox_continuous), owning_building_guid = 288)
+    }
+
+    Building10354()
+
+    def Building10354(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 423, MapID: 10354
+      LocalBuilding("S_Stasis", 423, 10354, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(910.38f, 1061.46f, 211.09f), vanu_control_point)))
+      LocalObject(1394, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 423)
+      LocalObject(1052, Door.Constructor(Vector3(862.2756f, 1062.809f, 212.869f)), owning_building_guid = 423)
+      LocalObject(1069, Door.Constructor(Vector3(897.8686f, 1113.024f, 212.869f)), owning_building_guid = 423)
+      LocalObject(1075, Door.Constructor(Vector3(901.7061f, 1056.084f, 217.81f)), owning_building_guid = 423)
+      LocalObject(1076, Door.Constructor(Vector3(902.3132f, 1073.067f, 217.81f)), owning_building_guid = 423)
+      LocalObject(1078, Door.Constructor(Vector3(907.1081f, 1049.923f, 242.869f)), owning_building_guid = 423)
+      LocalObject(1079, Door.Constructor(Vector3(913.0156f, 1055.685f, 242.849f)), owning_building_guid = 423)
+      LocalObject(1081, Door.Constructor(Vector3(918.6442f, 1055.507f, 217.81f)), owning_building_guid = 423)
+      LocalObject(1082, Door.Constructor(Vector3(918.8578f, 1061.178f, 242.849f)), owning_building_guid = 423)
+      LocalObject(1083, Door.Constructor(Vector3(919.2585f, 1072.452f, 217.81f)), owning_building_guid = 423)
+      LocalObject(1087, Door.Constructor(Vector3(923.4755f, 1026.865f, 212.869f)), owning_building_guid = 423)
+      LocalObject(1090, Door.Constructor(Vector3(925.0205f, 1066.671f, 242.869f)), owning_building_guid = 423)
+      LocalObject(1096, Door.Constructor(Vector3(947.6342f, 1065.881f, 212.869f)), owning_building_guid = 423)
+      LocalObject(1420, Terminal.Constructor(Vector3(900.1823f, 1062.696f, 216.103f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1421, Terminal.Constructor(Vector3(900.3245f, 1066.667f, 216.107f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1425, Terminal.Constructor(Vector3(908.254f, 1054.15f, 216.107f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1426, Terminal.Constructor(Vector3(908.7996f, 1074.577f, 216.103f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1427, Terminal.Constructor(Vector3(912.2247f, 1054.008f, 216.103f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1428, Terminal.Constructor(Vector3(912.707f, 1074.466f, 216.107f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1429, Terminal.Constructor(Vector3(920.6359f, 1061.95f, 216.107f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1430, Terminal.Constructor(Vector3(920.7781f, 1065.921f, 216.103f), vanu_equipment_term), owning_building_guid = 423)
+      LocalObject(1481, SpawnTube.Constructor(Vector3(910.4787f, 1064.287f, 216.229f), Vector3(0, 0, 47)), owning_building_guid = 423)
+      LocalObject(1329, Painbox.Constructor(Vector3(910.895f, 1064.282f, 225.4318f), painbox_continuous), owning_building_guid = 423)
+      LocalObject(1332, Painbox.Constructor(Vector3(900.1142f, 1074.834f, 219.98f), painbox_door_radius_continuous), owning_building_guid = 423)
+      LocalObject(1333, Painbox.Constructor(Vector3(900.2362f, 1054.792f, 219.98f), painbox_door_radius_continuous), owning_building_guid = 423)
+      LocalObject(1334, Painbox.Constructor(Vector3(920.1619f, 1053.746f, 219.38f), painbox_door_radius_continuous), owning_building_guid = 423)
+      LocalObject(1335, Painbox.Constructor(Vector3(920.6906f, 1073.384f, 219.98f), painbox_door_radius_continuous), owning_building_guid = 423)
+    }
+
+    Building10020()
+
+    def Building10020(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 424, MapID: 10020
+      LocalBuilding("N_Stasis", 424, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.2f, 1433.74f, 224.19f), vanu_control_point)))
+      LocalObject(1398, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 424)
+      LocalObject(1152, Door.Constructor(Vector3(1223.096f, 1435.089f, 225.969f)), owning_building_guid = 424)
+      LocalObject(1155, Door.Constructor(Vector3(1258.688f, 1485.304f, 225.969f)), owning_building_guid = 424)
+      LocalObject(1156, Door.Constructor(Vector3(1262.526f, 1428.364f, 230.91f)), owning_building_guid = 424)
+      LocalObject(1157, Door.Constructor(Vector3(1263.133f, 1445.347f, 230.91f)), owning_building_guid = 424)
+      LocalObject(1163, Door.Constructor(Vector3(1267.928f, 1422.203f, 255.969f)), owning_building_guid = 424)
+      LocalObject(1167, Door.Constructor(Vector3(1273.836f, 1427.965f, 255.949f)), owning_building_guid = 424)
+      LocalObject(1174, Door.Constructor(Vector3(1279.464f, 1427.787f, 230.91f)), owning_building_guid = 424)
+      LocalObject(1175, Door.Constructor(Vector3(1279.678f, 1433.458f, 255.949f)), owning_building_guid = 424)
+      LocalObject(1177, Door.Constructor(Vector3(1280.078f, 1444.732f, 230.91f)), owning_building_guid = 424)
+      LocalObject(1179, Door.Constructor(Vector3(1284.295f, 1399.145f, 225.969f)), owning_building_guid = 424)
+      LocalObject(1181, Door.Constructor(Vector3(1285.84f, 1438.951f, 255.969f)), owning_building_guid = 424)
+      LocalObject(1189, Door.Constructor(Vector3(1308.454f, 1438.161f, 225.969f)), owning_building_guid = 424)
+      LocalObject(1445, Terminal.Constructor(Vector3(1261.002f, 1434.976f, 229.203f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1446, Terminal.Constructor(Vector3(1261.144f, 1438.947f, 229.207f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1448, Terminal.Constructor(Vector3(1269.074f, 1426.43f, 229.207f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1449, Terminal.Constructor(Vector3(1269.62f, 1446.857f, 229.203f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1451, Terminal.Constructor(Vector3(1273.045f, 1426.288f, 229.203f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1452, Terminal.Constructor(Vector3(1273.527f, 1446.746f, 229.207f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1453, Terminal.Constructor(Vector3(1281.456f, 1434.23f, 229.207f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1454, Terminal.Constructor(Vector3(1281.598f, 1438.201f, 229.203f), vanu_equipment_term), owning_building_guid = 424)
+      LocalObject(1482, SpawnTube.Constructor(Vector3(1271.299f, 1436.567f, 229.329f), Vector3(0, 0, 47)), owning_building_guid = 424)
+      LocalObject(1330, Painbox.Constructor(Vector3(1271.715f, 1436.562f, 238.5318f), painbox_continuous), owning_building_guid = 424)
+      LocalObject(1336, Painbox.Constructor(Vector3(1260.934f, 1447.114f, 233.08f), painbox_door_radius_continuous), owning_building_guid = 424)
+      LocalObject(1337, Painbox.Constructor(Vector3(1261.056f, 1427.072f, 233.08f), painbox_door_radius_continuous), owning_building_guid = 424)
+      LocalObject(1338, Painbox.Constructor(Vector3(1280.982f, 1426.026f, 232.48f), painbox_door_radius_continuous), owning_building_guid = 424)
+      LocalObject(1339, Painbox.Constructor(Vector3(1281.51f, 1445.664f, 233.08f), painbox_door_radius_continuous), owning_building_guid = 424)
+    }
+
+    Building10002()
+
+    def Building10002(): Unit = { // Name: Core Type: vanu_core GUID: 425, MapID: 10002
+      LocalBuilding("Core", 425, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1110.13f, 1216.96f, 266.93f), vanu_core)))
+      LocalObject(1116, Door.Constructor(Vector3(1077.637f, 1204.982f, 273.718f)), owning_building_guid = 425)
+      LocalObject(1118, Door.Constructor(Vector3(1106.108f, 1176.467f, 273.718f)), owning_building_guid = 425)
+      LocalObject(1119, Door.Constructor(Vector3(1106.108f, 1176.467f, 278.718f)), owning_building_guid = 425)
+      LocalObject(1120, Door.Constructor(Vector3(1106.152f, 1233.453f, 278.718f)), owning_building_guid = 425)
+      LocalObject(1121, Door.Constructor(Vector3(1106.152f, 1233.453f, 283.718f)), owning_building_guid = 425)
+      LocalObject(1127, Door.Constructor(Vector3(1134.623f, 1204.938f, 283.718f)), owning_building_guid = 425)
+    }
+
+    Building10015()
+
+    def Building10015(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 472, MapID: 10015
+      LocalBuilding("N_ATPlant", 472, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(877.25f, 1407.81f, 214f), vanu_vehicle_station)))
+      LocalObject(1395, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 472)
+      LocalObject(1060, Door.Constructor(Vector3(880.3055f, 1392.511f, 215.779f)), owning_building_guid = 472)
+      LocalObject(1064, Door.Constructor(Vector3(886.2134f, 1448.72f, 235.703f)), owning_building_guid = 472)
+      LocalObject(1065, Door.Constructor(Vector3(887.0483f, 1456.664f, 215.779f)), owning_building_guid = 472)
+      LocalObject(1077, Door.Constructor(Vector3(905.0204f, 1398.055f, 235.691f)), owning_building_guid = 472)
+      LocalObject(1086, Door.Constructor(Vector3(922.5992f, 1412.237f, 245.779f)), owning_building_guid = 472)
+      LocalObject(1088, Door.Constructor(Vector3(923.4856f, 1420.403f, 245.759f)), owning_building_guid = 472)
+      LocalObject(1089, Door.Constructor(Vector3(924.2911f, 1428.383f, 245.759f)), owning_building_guid = 472)
+      LocalObject(1091, Door.Constructor(Vector3(925.158f, 1436.583f, 245.779f)), owning_building_guid = 472)
+      LocalObject(1212, Door.Constructor(Vector3(943.3931f, 1418.35f, 220.633f)), owning_building_guid = 472)
+      LocalObject(1388, Terminal.Constructor(Vector3(896.063f, 1405.571f, 233.917f), vanu_air_vehicle_term), owning_building_guid = 472)
+      LocalObject(1483, VehicleSpawnPad.Constructor(Vector3(892.4431f, 1413.683f, 233.916f), vanu_vehicle_creation_pad, Vector3(0, 0, -84)), owning_building_guid = 472, terminal_guid = 1388)
+      LocalObject(1389, Terminal.Constructor(Vector3(899.7547f, 1440.781f, 233.917f), vanu_air_vehicle_term), owning_building_guid = 472)
+      LocalObject(1484, VehicleSpawnPad.Constructor(Vector3(894.5354f, 1433.589f, 233.916f), vanu_vehicle_creation_pad, Vector3(0, 0, -84)), owning_building_guid = 472, terminal_guid = 1389)
+      LocalObject(1423, Terminal.Constructor(Vector3(903.5538f, 1410.448f, 216.5f), vanu_equipment_term), owning_building_guid = 472)
+      LocalObject(1424, Terminal.Constructor(Vector3(906.0625f, 1434.317f, 216.5f), vanu_equipment_term), owning_building_guid = 472)
+      LocalObject(1489, Terminal.Constructor(Vector3(910.2566f, 1421.947f, 219f), vanu_vehicle_term), owning_building_guid = 472)
+      LocalObject(1485, VehicleSpawnPad.Constructor(Vector3(925.2994f, 1420.258f, 216.405f), vanu_vehicle_creation_pad, Vector3(0, 0, 96)), owning_building_guid = 472, terminal_guid = 1489)
+    }
+
+    Building10109()
+
+    def Building10109(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 473, MapID: 10109
+      LocalBuilding("S_ATPlant", 473, 10109, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.08f, 1065.9f, 214f), vanu_vehicle_station)))
+      LocalObject(1396, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 473)
+      LocalObject(1158, Door.Constructor(Vector3(1263.409f, 1052.901f, 245.779f)), owning_building_guid = 473)
+      LocalObject(1160, Door.Constructor(Vector3(1264.097f, 1044.716f, 245.759f)), owning_building_guid = 473)
+      LocalObject(1161, Door.Constructor(Vector3(1264.828f, 1036.73f, 245.759f)), owning_building_guid = 473)
+      LocalObject(1162, Door.Constructor(Vector3(1265.542f, 1028.515f, 245.779f)), owning_building_guid = 473)
+      LocalObject(1170, Door.Constructor(Vector3(1277.958f, 1070.177f, 235.691f)), owning_building_guid = 473)
+      LocalObject(1185, Door.Constructor(Vector3(1301.161f, 1080.335f, 215.779f)), owning_building_guid = 473)
+      LocalObject(1187, Door.Constructor(Vector3(1306.087f, 1024.031f, 235.703f)), owning_building_guid = 473)
+      LocalObject(1188, Door.Constructor(Vector3(1306.783f, 1016.074f, 215.779f)), owning_building_guid = 473)
+      LocalObject(1213, Door.Constructor(Vector3(1244.163f, 1042.933f, 220.633f)), owning_building_guid = 473)
+      LocalObject(1390, Terminal.Constructor(Vector3(1288.185f, 1064.508f, 233.917f), vanu_air_vehicle_term), owning_building_guid = 473)
+      LocalObject(1487, VehicleSpawnPad.Constructor(Vector3(1293.287f, 1057.236f, 233.916f), vanu_vehicle_creation_pad, Vector3(0, 0, 85)), owning_building_guid = 473, terminal_guid = 1390)
+      LocalObject(1391, Terminal.Constructor(Vector3(1291.28f, 1029.24f, 233.917f), vanu_air_vehicle_term), owning_building_guid = 473)
+      LocalObject(1488, VehicleSpawnPad.Constructor(Vector3(1295.031f, 1037.296f, 233.916f), vanu_vehicle_creation_pad, Vector3(0, 0, 85)), owning_building_guid = 473, terminal_guid = 1391)
+      LocalObject(1455, Terminal.Constructor(Vector3(1281.763f, 1058.292f, 216.5f), vanu_equipment_term), owning_building_guid = 473)
+      LocalObject(1457, Terminal.Constructor(Vector3(1283.854f, 1034.383f, 216.5f), vanu_equipment_term), owning_building_guid = 473)
+      LocalObject(1490, Terminal.Constructor(Vector3(1277.377f, 1045.724f, 219f), vanu_vehicle_term), owning_building_guid = 473)
+      LocalObject(1486, VehicleSpawnPad.Constructor(Vector3(1262.289f, 1044.513f, 216.405f), vanu_vehicle_creation_pad, Vector3(0, 0, 265)), owning_building_guid = 473, terminal_guid = 1490)
+    }
+
+    Building10112()
+
+    def Building10112(): Unit = { // Name: GW_Cavern2_W Type: warpgate_cavern GUID: 474, MapID: 10112
+      LocalBuilding("GW_Cavern2_W", 474, 10112, FoundationBuilder(WarpGate.Structure(Vector3(227.73f, 1255.27f, 161.35f))))
+    }
+
+    Building10111()
+
+    def Building10111(): Unit = { // Name: GW_Cavern2_N Type: warpgate_cavern GUID: 475, MapID: 10111
+      LocalBuilding("GW_Cavern2_N", 475, 10111, FoundationBuilder(WarpGate.Structure(Vector3(1031.13f, 2429.68f, 231.26f))))
+    }
+
+    Building10583()
+
+    def Building10583(): Unit = { // Name: GW_Cavern2_S Type: warpgate_cavern GUID: 476, MapID: 10583
+      LocalBuilding("GW_Cavern2_S", 476, 10583, FoundationBuilder(WarpGate.Structure(Vector3(1087.96f, 124.96f, 130.92f))))
+    }
+
+    Building10563()
+
+    def Building10563(): Unit = { // Name: GW_Cavern2_E Type: warpgate_cavern GUID: 477, MapID: 10563
+      LocalBuilding("GW_Cavern2_E", 477, 10563, FoundationBuilder(WarpGate.Structure(Vector3(1947.33f, 1306.67f, 181.42f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(1399, Terminal.Constructor(Vector3(698.33f, 1305.7f, 275.21f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1400, Terminal.Constructor(Vector3(698.58f, 1315.74f, 275.19f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1401, Terminal.Constructor(Vector3(708.04f, 1316.01f, 269.6f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1402, Terminal.Constructor(Vector3(712.63f, 1027.1f, 208.95f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1403, Terminal.Constructor(Vector3(780.39f, 1449.89f, 221.48f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1404, Terminal.Constructor(Vector3(781.96f, 1183.78f, 295.04f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1405, Terminal.Constructor(Vector3(793.93f, 893.29f, 258.11f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1406, Terminal.Constructor(Vector3(796.12f, 1214.87f, 216.88f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1407, Terminal.Constructor(Vector3(796.38f, 888.05f, 258.11f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1408, Terminal.Constructor(Vector3(811.1f, 1040.67f, 217.19f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1409, Terminal.Constructor(Vector3(818.56f, 1196.84f, 216.87f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1411, Terminal.Constructor(Vector3(868.14f, 1507.66f, 214.34f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1412, Terminal.Constructor(Vector3(873.05f, 1479.4f, 214.34f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1413, Terminal.Constructor(Vector3(874.34f, 529.76f, 223.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1414, Terminal.Constructor(Vector3(874.43f, 541.76f, 223.6f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1415, Terminal.Constructor(Vector3(878.58f, 714.85f, 245.64f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1417, Terminal.Constructor(Vector3(885.9f, 718.47f, 245.59f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1418, Terminal.Constructor(Vector3(886.9f, 719.18f, 240.1f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1419, Terminal.Constructor(Vector3(892.74f, 1062.22f, 306.95f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1422, Terminal.Constructor(Vector3(901.22f, 968.3f, 228.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1431, Terminal.Constructor(Vector3(960.27f, 1312.18f, 314.7f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1432, Terminal.Constructor(Vector3(960.85f, 1316.61f, 320.2f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1433, Terminal.Constructor(Vector3(992.3f, 1296.21f, 228.93f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1434, Terminal.Constructor(Vector3(1052.35f, 1589.94f, 277.2f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1435, Terminal.Constructor(Vector3(1052.45f, 1579.18f, 277.16f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1436, Terminal.Constructor(Vector3(1061.86f, 1589.88f, 271.7f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1437, Terminal.Constructor(Vector3(1148.93f, 1280.05f, 309.5f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1438, Terminal.Constructor(Vector3(1177.01f, 1655.31f, 264.53f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1439, Terminal.Constructor(Vector3(1179.59f, 1657.89f, 264.54f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1440, Terminal.Constructor(Vector3(1191.35f, 1350.39f, 231.43f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1441, Terminal.Constructor(Vector3(1211.49f, 1310.12f, 297.49f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1442, Terminal.Constructor(Vector3(1211.81f, 1370.72f, 231.41f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1443, Terminal.Constructor(Vector3(1246.72f, 1328.41f, 241.55f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1444, Terminal.Constructor(Vector3(1259.03f, 1323.69f, 241.59f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1447, Terminal.Constructor(Vector3(1261.61f, 1348.42f, 241.57f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1456, Terminal.Constructor(Vector3(1282.61f, 1120.26f, 216.13f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1458, Terminal.Constructor(Vector3(1300.12f, 1143.05f, 216.15f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1460, Terminal.Constructor(Vector3(1332.57f, 907.17f, 304.92f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1461, Terminal.Constructor(Vector3(1334.08f, 903.35f, 299.39f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1462, Terminal.Constructor(Vector3(1360.28f, 1340.27f, 301.92f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1463, Terminal.Constructor(Vector3(1360.38f, 1313.07f, 301.94f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1464, Terminal.Constructor(Vector3(1366.18f, 1468.81f, 264.11f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1465, Terminal.Constructor(Vector3(1366.43f, 1457.77f, 264.13f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1466, Terminal.Constructor(Vector3(1373.3f, 957.15f, 224.99f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1467, Terminal.Constructor(Vector3(1378.62f, 966.06f, 225.05f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1468, Terminal.Constructor(Vector3(1380.3f, 1313.42f, 301.87f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(111, ProximityTerminal.Constructor(Vector3(630.2f, 1322.82f, 188.62f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(112, ProximityTerminal.Constructor(Vector3(630.45f, 1323.4f, 188.57f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(113, ProximityTerminal.Constructor(Vector3(679.73f, 1007f, 196.6f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(114, ProximityTerminal.Constructor(Vector3(763.73f, 705.8f, 185.44f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(115, ProximityTerminal.Constructor(Vector3(764.63f, 705.6f, 185.34f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(116, ProximityTerminal.Constructor(Vector3(812.51f, 989.24f, 208.3f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(117, ProximityTerminal.Constructor(Vector3(858.69f, 1106.27f, 204.05f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(118, ProximityTerminal.Constructor(Vector3(1063.25f, 1071.69f, 214f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(119, ProximityTerminal.Constructor(Vector3(1063.83f, 1071.1f, 213.9f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(120, ProximityTerminal.Constructor(Vector3(1086.51f, 1897.72f, 193.91f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(121, ProximityTerminal.Constructor(Vector3(1135.67f, 1761.38f, 194.24f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(122, ProximityTerminal.Constructor(Vector3(1258.38f, 1481.15f, 237.85f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(123, ProximityTerminal.Constructor(Vector3(1273.92f, 1488.35f, 221.05f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(124, ProximityTerminal.Constructor(Vector3(1276.89f, 1485.76f, 221.15f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(125, ProximityTerminal.Constructor(Vector3(1406.77f, 1537.53f, 192.34f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(126, ProximityTerminal.Constructor(Vector3(691.95f, 1096.04f, 186.74f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(127, ProximityTerminal.Constructor(Vector3(764.38f, 706.85f, 185.44f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(128, ProximityTerminal.Constructor(Vector3(859.73f, 1105.49f, 204.15f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(129, ProximityTerminal.Constructor(Vector3(869.47f, 1368.33f, 212.2f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(130, ProximityTerminal.Constructor(Vector3(911.04f, 1018.53f, 208.5f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(131, ProximityTerminal.Constructor(Vector3(946.53f, 1404.77f, 211.83f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(132, ProximityTerminal.Constructor(Vector3(961.61f, 1447.42f, 200.9f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(133, ProximityTerminal.Constructor(Vector3(983.11f, 1060.58f, 218.9f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(134, ProximityTerminal.Constructor(Vector3(994.01f, 999.99f, 204f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(135, ProximityTerminal.Constructor(Vector3(1073.71f, 1928.76f, 193.51f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(136, ProximityTerminal.Constructor(Vector3(1087.43f, 1898.43f, 194f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(137, ProximityTerminal.Constructor(Vector3(1136.71f, 1761.54f, 194.1f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(138, ProximityTerminal.Constructor(Vector3(1156.21f, 1196.65f, 219.3f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(139, ProximityTerminal.Constructor(Vector3(1234.96f, 1230.91f, 219.5f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(140, ProximityTerminal.Constructor(Vector3(1240.89f, 1398.44f, 219.9f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(141, ProximityTerminal.Constructor(Vector3(1290.83f, 1356.28f, 219.83f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(142, ProximityTerminal.Constructor(Vector3(1431.34f, 1336.17f, 232.1f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1268, ProximityTerminal.Constructor(Vector3(776.85f, 1784.17f, 202.52f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1269, ProximityTerminal.Constructor(Vector3(807.03f, 1498.08f, 224.9f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1270, ProximityTerminal.Constructor(Vector3(807.83f, 1497.78f, 225f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1271, ProximityTerminal.Constructor(Vector3(1082.47f, 500.94f, 167.46f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1272, ProximityTerminal.Constructor(Vector3(1109.76f, 897.5f, 293.08f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1273, ProximityTerminal.Constructor(Vector3(1110.47f, 898.1f, 293.18f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1274, ProximityTerminal.Constructor(Vector3(1110.8f, 897.23f, 292.98f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1275, ProximityTerminal.Constructor(Vector3(1197.16f, 1926.36f, 236.1f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1276, ProximityTerminal.Constructor(Vector3(1197.58f, 1925.73f, 236.27f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1277, ProximityTerminal.Constructor(Vector3(1209.53f, 903.09f, 295.1f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1278, ProximityTerminal.Constructor(Vector3(1209.91f, 903.94f, 295.15f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1279, ProximityTerminal.Constructor(Vector3(1210.24f, 903.12f, 295.1f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1280, ProximityTerminal.Constructor(Vector3(1260.52f, 790.04f, 278.76f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1281, ProximityTerminal.Constructor(Vector3(1359.9f, 1339.75f, 306.85f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1282, ProximityTerminal.Constructor(Vector3(1360.7f, 1339.41f, 306.75f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1283, ProximityTerminal.Constructor(Vector3(1375.04f, 1467.9f, 258.5f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1284, ProximityTerminal.Constructor(Vector3(1375.65f, 1468.45f, 258.65f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1285, ProximityTerminal.Constructor(Vector3(1375.94f, 1467.6f, 258.62f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1286, ProximityTerminal.Constructor(Vector3(1459.76f, 405.36f, 152.45f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1287, ProximityTerminal.Constructor(Vector3(1475.44f, 1004.61f, 265.46f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1288, ProximityTerminal.Constructor(Vector3(1476.42f, 1004.64f, 265.46f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1289, ProximityTerminal.Constructor(Vector3(1476.8f, 1006.25f, 265.51f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1290, ProximityTerminal.Constructor(Vector3(1477.26f, 1005.54f, 265.46f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1291, ProximityTerminal.Constructor(Vector3(1636.75f, 1401.55f, 207.81f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(1292, ProximityTerminal.Constructor(Vector3(501.27f, 1611.08f, 212.58f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1293, ProximityTerminal.Constructor(Vector3(923.12f, 1191.17f, 317.89f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1294, ProximityTerminal.Constructor(Vector3(978.21f, 1293.04f, 230.96f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1295, ProximityTerminal.Constructor(Vector3(1031.55f, 2105f, 247.46f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1296, ProximityTerminal.Constructor(Vector3(1259.36f, 789.96f, 278.86f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1297, ProximityTerminal.Constructor(Vector3(1260.33f, 787.69f, 278.86f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1298, ProximityTerminal.Constructor(Vector3(1261.11f, 788.97f, 278.76f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1299, ProximityTerminal.Constructor(Vector3(1302.33f, 959.25f, 224.16f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1300, ProximityTerminal.Constructor(Vector3(1307.68f, 2054.64f, 197.45f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1301, ProximityTerminal.Constructor(Vector3(1476.08f, 1005.56f, 265.51f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(1302, ProximityTerminal.Constructor(Vector3(1655.04f, 1594.54f, 232.32f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("N_Redoubt", "N_ATPlant")
+      LatticeLink("GW_Cavern2_W", "N_ATPlant")
+      LatticeLink("N_Stasis", "Core")
+      LatticeLink("S_Stasis", "Core")
+      LatticeLink("S_Redoubt", "S_ATPlant")
+      LatticeLink("N_Redoubt", "N_Stasis")
+      LatticeLink("S_Redoubt", "S_Stasis")
+      LatticeLink("S_Stasis", "N_ATPlant")
+      LatticeLink("N_Stasis", "S_ATPlant")
+      LatticeLink("GW_Cavern2_N", "N_Redoubt")
+      LatticeLink("GW_Cavern2_S", "S_Redoubt")
+      LatticeLink("GW_Cavern2_E", "S_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, false, List(Vector3(659.834f, 1494.116f, 209.241f), Vector3(707.787f, 1511.106f, 213.516f), Vector3(745.397f, 1524.431f, 213.52f))))
+      ZipLinePaths(new ZipLinePath(2, true, List(Vector3(675.978f, 1376.759f, 195.646f), Vector3(662.728f, 1365.682f, 211.993f))))
+      ZipLinePaths(new ZipLinePath(3, false, List(Vector3(682.823f, 1290.083f, 270.566f), Vector3(700.533f, 1244.014f, 279.312f), Vector3(718.242f, 1197.945f, 287.32f), Vector3(729.222f, 1169.382f, 290.806f))))
+      ZipLinePaths(new ZipLinePath(4, true, List(Vector3(687.66f, 985.624f, 196.95f), Vector3(687.206f, 988.754f, 231.35f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(689.041f, 994.682f, 231.853f), Vector3(683.022f, 1017.202f, 226.151f), Vector3(677.103f, 1039.422f, 210.753f), Vector3(675.014f, 1047.264f, 199.002f), Vector3(674.625f, 1050.306f, 197.146f))))
+      ZipLinePaths(new ZipLinePath(6, false, List(Vector3(703.28f, 1126.36f, 197.032f), Vector3(699.093f, 1176.999f, 202.114f), Vector3(694.906f, 1227.638f, 206.452f), Vector3(690.72f, 1278.276f, 210.79f), Vector3(687.19f, 1320.972f, 212.492f))))
+      ZipLinePaths(new ZipLinePath(7, true, List(Vector3(705.314f, 1336.125f, 211.992f), Vector3(699.729f, 1323.205f, 270.055f))))
+      ZipLinePaths(new ZipLinePath(8, true, List(Vector3(707.264f, 1106.722f, 194.914f), Vector3(812.54f, 1126.035f, 211.099f))))
+      ZipLinePaths(new ZipLinePath(9, false, List(Vector3(716.802f, 1474.828f, 265.013f), Vector3(755.438f, 1503.938f, 249.574f), Vector3(778.922f, 1521.633f, 236.262f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(718.483f, 1328.007f, 270.791f), Vector3(717.052f, 1377.928f, 269.115f), Vector3(715.62f, 1427.849f, 266.689f), Vector3(715.306f, 1438.831f, 264.931f))))
+      ZipLinePaths(new ZipLinePath(11, true, List(Vector3(723.223f, 1029.31f, 209.35f), Vector3(715.985f, 1022.277f, 221.533f))))
+      ZipLinePaths(new ZipLinePath(12, false, List(Vector3(722.403f, 1012.416f, 275.682f), Vector3(707.86f, 1047.716f, 242.674f), Vector3(693.317f, 1083.015f, 208.861f), Vector3(689.895f, 1091.321f, 198.099f))))
+      ZipLinePaths(new ZipLinePath(13, true, List(Vector3(729.519f, 1441.093f, 264.46f), Vector3(726.664f, 1443.454f, 269.965f))))
+      ZipLinePaths(new ZipLinePath(14, false, List(Vector3(729.274f, 999.606f, 222.057f), Vector3(756.718f, 960.897f, 238.545f), Vector3(784.163f, 922.189f, 254.308f), Vector3(785.81f, 919.866f, 253.346f))))
+      ZipLinePaths(new ZipLinePath(15, true, List(Vector3(732.337f, 1484.986f, 201.35f), Vector3(725.335f, 1474.407f, 212.551f))))
+      ZipLinePaths(new ZipLinePath(16, false, List(Vector3(734.082f, 1235.608f, 221.221f), Vector3(737.893f, 1187.823f, 236.175f), Vector3(741.705f, 1140.039f, 250.411f), Vector3(745.517f, 1092.255f, 264.646f), Vector3(749.328f, 1044.47f, 278.881f), Vector3(750.472f, 1030.135f, 281.149f))))
+      ZipLinePaths(new ZipLinePath(17, true, List(Vector3(734.217f, 1276.157f, 191.504f), Vector3(718.859f, 1278.728f, 195.646f))))
+      ZipLinePaths(new ZipLinePath(18, true, List(Vector3(738.976f, 1350.788f, 201.35f), Vector3(728.212f, 1351.057f, 211.992f))))
+      ZipLinePaths(new ZipLinePath(19, false, List(Vector3(745.07f, 1038.912f, 216.63f), Vector3(776.313f, 1079.198f, 216.124f), Vector3(786.114f, 1091.836f, 214.68f))))
+      ZipLinePaths(new ZipLinePath(20, true, List(Vector3(754.226f, 727.774f, 185.791f), Vector3(759.174f, 746.876f, 251.22f))))
+      ZipLinePaths(new ZipLinePath(21, false, List(Vector3(759.792f, 1153.511f, 286.565f), Vector3(787.783f, 1112.886f, 295.493f), Vector3(815.773f, 1072.261f, 303.632f), Vector3(842.085f, 1034.073f, 307.795f))))
+      ZipLinePaths(new ZipLinePath(22, false, List(Vector3(763.438f, 724.138f, 249.259f), Vector3(780.082f, 707.796f, 246.845f), Vector3(796.727f, 691.454f, 231.971f), Vector3(830.015f, 658.77f, 213.98f), Vector3(863.304f, 626.086f, 195.988f), Vector3(875.288f, 614.319f, 186.049f))))
+      ZipLinePaths(new ZipLinePath(23, false, List(Vector3(763.764f, 1513.528f, 225.857f), Vector3(715.885f, 1501.26f, 219.038f), Vector3(677.697f, 1492.136f, 211.116f))))
+      ZipLinePaths(new ZipLinePath(24, false, List(Vector3(770.787f, 1423.545f, 231.569f), Vector3(755.314f, 1377.756f, 219.472f), Vector3(747.269f, 1353.946f, 211.866f))))
+      ZipLinePaths(new ZipLinePath(25, true, List(Vector3(770.57f, 1226.43f, 209.13f), Vector3(771.447f, 1227.514f, 239.351f))))
+      ZipLinePaths(new ZipLinePath(26, false, List(Vector3(773.819f, 1236.97f, 239.888f), Vector3(747.687f, 1274.476f, 260.853f), Vector3(748.995f, 1290.503f, 274.802f), Vector3(727.303f, 1303.731f, 276.097f))))
+      ZipLinePaths(new ZipLinePath(27, true, List(Vector3(779.487f, 1454.284f, 228.218f), Vector3(766.751f, 1505.627f, 225.35f))))
+      ZipLinePaths(new ZipLinePath(28, true, List(Vector3(774.619f, 1447.611f, 216.34f), Vector3(781.047f, 1442.489f, 221.842f))))
+      ZipLinePaths(new ZipLinePath(29, false, List(Vector3(789.47f, 1333.949f, 221.19f), Vector3(837.145f, 1318.935f, 223.263f), Vector3(884.819f, 1303.92f, 224.578f), Vector3(921.052f, 1292.509f, 224.48f))))
+      ZipLinePaths(new ZipLinePath(30, false, List(Vector3(800.39f, 1230.588f, 217.801f), Vector3(845.704f, 1252.722f, 245.917f), Vector3(881.918f, 1275.956f, 273.294f), Vector3(918.133f, 1299.19f, 300.671f), Vector3(925.074f, 1313.568f, 314.76f), Vector3(938.015f, 1311.946f, 315.545f))))
+      ZipLinePaths(new ZipLinePath(31, false, List(Vector3(801.437f, 1542.691f, 235.379f), Vector3(813.077f, 1552.333f, 236.523f), Vector3(839.518f, 1561.875f, 213.914f), Vector3(846.208f, 1561.9f, 213.489f))))
+      ZipLinePaths(new ZipLinePath(32, true, List(Vector3(805.789f, 1393.447f, 212.85f), Vector3(805.676f, 1395.361f, 246.35f))))
+      ZipLinePaths(new ZipLinePath(33, false, List(Vector3(806.5f, 1182.009f, 217.802f), Vector3(825.037f, 1135.745f, 214.554f), Vector3(842.09f, 1093.181f, 208.952f))))
+      ZipLinePaths(new ZipLinePath(34, false, List(Vector3(806.815f, 1168.614f, 290.224f), Vector3(854.326f, 1180.349f, 305.341f), Vector3(878.081f, 1186.216f, 316.04f), Vector3(899.136f, 1187.584f, 318.661f))))
+      ZipLinePaths(new ZipLinePath(35, false, List(Vector3(807.862f, 497.707f, 223.021f), Vector3(853.713f, 519.793f, 220.513f), Vector3(860.905f, 523.258f, 218.701f))))
+      ZipLinePaths(new ZipLinePath(36, true, List(Vector3(811.458f, 1453.847f, 219.522f), Vector3(798.914f, 1427.003f, 237.724f))))
+      ZipLinePaths(new ZipLinePath(37, false, List(Vector3(812.01f, 1468.508f, 224.2f), Vector3(846.323f, 1483.513f, 225.502f), Vector3(856.965f, 1489.472f, 225.25f))))
+      ZipLinePaths(new ZipLinePath(38, false, List(Vector3(812.402f, 1323.358f, 294.095f), Vector3(795.583f, 1338.858f, 290.07f), Vector3(778.764f, 1354.358f, 276.782f), Vector3(745.525f, 1384.658f, 247.539f), Vector3(712.287f, 1414.958f, 222.697f), Vector3(692.083f, 1433.375f, 206.87f))))
+      ZipLinePaths(new ZipLinePath(39, false, List(Vector3(813.685f, 1399.673f, 246.861f), Vector3(858.609f, 1408.954f, 243.142f))))
+      ZipLinePaths(new ZipLinePath(40, false, List(Vector3(821.339f, 923.858f, 253.949f), Vector3(866.375f, 944.748f, 242.984f), Vector3(871.673f, 947.206f, 238.798f))))
+      ZipLinePaths(new ZipLinePath(41, false, List(Vector3(837.946f, 1377.303f, 294.087f), Vector3(848.543f, 1397.396f, 293.118f), Vector3(859.141f, 1417.489f, 271.666f), Vector3(876.18f, 1449.795f, 248.523f))))
+      ZipLinePaths(new ZipLinePath(42, true, List(Vector3(838.068f, 1040.527f, 212f), Vector3(832.575f, 1040.197f, 217.504f))))
+      ZipLinePaths(new ZipLinePath(43, false, List(Vector3(839.968f, 614.924f, 218.86f), Vector3(821.254f, 568.629f, 222.219f), Vector3(802.541f, 522.334f, 224.818f), Vector3(799.173f, 514.001f, 222.95f))))
+      ZipLinePaths(new ZipLinePath(44, true, List(Vector3(843.115f, 1121.634f, 204.5f), Vector3(844.011f, 1124.97f, 230.35f))))
+      ZipLinePaths(new ZipLinePath(45, false, List(Vector3(844.556f, 1130.363f, 230.85f), Vector3(804.089f, 1161.26f, 228.65f), Vector3(763.623f, 1192.158f, 225.699f), Vector3(760.449f, 1194.581f, 224.701f))))
+      ZipLinePaths(new ZipLinePath(46, false, List(Vector3(847.197f, 1120.008f, 230.85f), Vector3(864.661f, 1084.041f, 230.03f))))
+      ZipLinePaths(new ZipLinePath(47, true, List(Vector3(849.632f, 947.519f, 208.35f), Vector3(849.006f, 948.423f, 242.35f))))
+      ZipLinePaths(new ZipLinePath(48, true, List(Vector3(849.178f, 619.181f, 185.718f), Vector3(848.213f, 618.726f, 218.352f))))
+      ZipLinePaths(new ZipLinePath(49, false, List(Vector3(850.022f, 1063.787f, 302.344f), Vector3(817.191f, 1102.491f, 298.148f), Vector3(784.504f, 1141.537f, 290.814f))))
+      ZipLinePaths(new ZipLinePath(50, false, List(Vector3(850.185f, 548.151f, 218.939f), Vector3(804.066f, 562.931f, 207.212f), Vector3(759.793f, 577.119f, 193.039f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(850.747f, 917.806f, 208.859f), Vector3(839.367f, 893.491f, 210.468f), Vector3(827.988f, 869.176f, 199.585f), Vector3(821.729f, 820.546f, 189.779f), Vector3(819.976f, 806.93f, 186.289f))))
+      ZipLinePaths(new ZipLinePath(52, false, List(Vector3(851.115f, 946.293f, 242.855f), Vector3(874.386f, 901.525f, 251.024f), Vector3(897.657f, 856.756f, 258.449f), Vector3(920.928f, 811.988f, 265.873f), Vector3(931.423f, 791.799f, 268.816f))))
+      ZipLinePaths(new ZipLinePath(53, true, List(Vector3(855.414f, 535.186f, 218.404f), Vector3(855.499f, 535.135f, 223.909f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(872.014f, 1425.892f, 234.776f), Vector3(830.064f, 1452.015f, 234.397f), Vector3(788.115f, 1478.138f, 236.189f), Vector3(770.496f, 1489.11f, 230.217f), Vector3(767.979f, 1490.677f, 225.644f), Vector3(747.004f, 1503.738f, 212.856f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(872.76f, 1078.462f, 307.797f), Vector3(835.192f, 1111.962f, 300.324f), Vector3(797.623f, 1145.462f, 292.117f), Vector3(796.887f, 1146.119f, 290.837f))))
+      ZipLinePaths(new ZipLinePath(56, false, List(Vector3(873.773f, 1379.824f, 290.094f), Vector3(851.7f, 1417.619f, 264.733f), Vector3(829.627f, 1455.415f, 238.56f), Vector3(816.609f, 1477.166f, 222.955f))))
+      ZipLinePaths(new ZipLinePath(57, true, List(Vector3(874.736f, 1018.944f, 208.85f), Vector3(889.984f, 1006.003f, 208.85f))))
+      ZipLinePaths(new ZipLinePath(58, false, List(Vector3(877.022f, 1542.334f, 212.574f), Vector3(918.877f, 1570.679f, 206.656f), Vector3(960.732f, 1599.024f, 199.916f), Vector3(964.835f, 1601.803f, 198.004f))))
+      ZipLinePaths(new ZipLinePath(59, false, List(Vector3(890.368f, 540.934f, 219.08f), Vector3(887.523f, 590.935f, 229.443f), Vector3(884.678f, 640.936f, 242.27f), Vector3(882.279f, 686.093f, 246.469f))))
+      ZipLinePaths(new ZipLinePath(60, false, List(Vector3(898.306f, 1508.067f, 269.626f), Vector3(877.185f, 1514.283f, 268.505f), Vector3(856.064f, 1520.5f, 246.691f), Vector3(825.649f, 1529.452f, 225.853f))))
+      ZipLinePaths(new ZipLinePath(61, false, List(Vector3(899.127f, 727.839f, 246.47f), Vector3(901.011f, 777.946f, 238.043f), Vector3(902.894f, 828.053f, 228.734f), Vector3(904.777f, 878.159f, 219.425f), Vector3(904.35f, 915.319f, 208.86f))))
+      ZipLinePaths(new ZipLinePath(62, false, List(Vector3(906.014f, 938.879f, 229.299f), Vector3(953.394f, 929.472f, 246.524f), Vector3(1000.773f, 920.066f, 262.882f), Vector3(1048.152f, 910.659f, 287.84f), Vector3(1085.768f, 903.512f, 291.607f))))
+      ZipLinePaths(new ZipLinePath(63, false, List(Vector3(915.004f, 908.784f, 208.853f), Vector3(912.459f, 859.095f, 204.635f), Vector3(909.914f, 809.406f, 199.669f), Vector3(908.794f, 787.543f, 196.113f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(915.106f, 1072.529f, 303.834f), Vector3(959.239f, 1089.108f, 285.144f), Vector3(1003.372f, 1105.687f, 265.692f), Vector3(1047.505f, 1122.266f, 246.24f), Vector3(1088.916f, 1137.444f, 225.963f))))
+      ZipLinePaths(new ZipLinePath(65, true, List(Vector3(917.622f, 1395.863f, 247.228f), Vector3(925.782f, 1415.276f, 253.155f))))
+      ZipLinePaths(new ZipLinePath(66, false, List(Vector3(919.772f, 1090.854f, 241.953f), Vector3(901.102f, 1135.904f, 253.824f), Vector3(882.431f, 1180.954f, 264.865f), Vector3(863.76f, 1226.004f, 275.906f), Vector3(845.09f, 1271.054f, 286.947f), Vector3(830.9f, 1305.292f, 293.803f))))
+      ZipLinePaths(new ZipLinePath(67, false, List(Vector3(922.784f, 988.051f, 229.32f), Vector3(972.611f, 991.883f, 219.995f), Vector3(1002.898f, 994.212f, 212.162f))))
+      ZipLinePaths(new ZipLinePath(68, true, List(Vector3(923.81f, 1020.341f, 236.978f), Vector3(922.546f, 982.492f, 238.284f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(928.145f, 1430.927f, 253.696f), Vector3(904.539f, 1456.263f, 269.4f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(928.578f, 1489.868f, 275.282f), Vector3(939.807f, 1485.162f, 274.435f), Vector3(951.236f, 1480.557f, 270.012f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(940.952f, 765.853f, 268.478f), Vector3(924.79f, 748.903f, 265.315f), Vector3(908.628f, 731.954f, 251.685f), Vector3(902.209f, 724.453f, 246.497f))))
+      ZipLinePaths(new ZipLinePath(72, false, List(Vector3(943.605f, 1330.998f, 225.806f), Vector3(942.715f, 1356.015f, 224.659f), Vector3(941.825f, 1381.033f, 216.829f), Vector3(941.755f, 1382.995f, 212.794f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(945.255f, 1187.767f, 318.54f), Vector3(992.83f, 1206.052f, 317.522f), Vector3(1040.406f, 1224.336f, 315.76f), Vector3(1087.982f, 1242.621f, 313.998f), Vector3(1135.558f, 1260.905f, 312.236f), Vector3(1147.685f, 1265.566f, 310.41f))))
+      ZipLinePaths(new ZipLinePath(74, false, List(Vector3(954.358f, 1499.699f, 270.422f), Vector3(947.135f, 1521.815f, 266.047f), Vector3(939.912f, 1543.932f, 251.825f), Vector3(925.465f, 1588.165f, 228.954f), Vector3(913.002f, 1626.326f, 208.144f))))
+      ZipLinePaths(new ZipLinePath(75, false, List(Vector3(955.561f, 817.315f, 268.753f), Vector3(944.748f, 837.827f, 265.663f), Vector3(933.435f, 858.94f, 255.123f), Vector3(910.357f, 902.008f, 240.513f), Vector3(896.329f, 928.187f, 229.295f))))
+      ZipLinePaths(new ZipLinePath(76, false, List(Vector3(959.479f, 1311.02f, 229.35f), Vector3(936.058f, 1315.299f, 238.807f), Vector3(917.137f, 1324.378f, 257.265f), Vector3(878.738f, 1337.899f, 294.48f), Vector3(871.584f, 1345.104f, 294.076f))))
+      ZipLinePaths(new ZipLinePath(77, true, List(Vector3(958.375f, 1463.39f, 196.12f), Vector3(950.221f, 1455.99f, 212.172f))))
+      ZipLinePaths(new ZipLinePath(78, true, List(Vector3(960.543f, 1394.809f, 204.35f), Vector3(955.447f, 1389.008f, 212.281f))))
+      ZipLinePaths(new ZipLinePath(79, false, List(Vector3(962.372f, 1320.909f, 225.715f), Vector3(973.943f, 1364.715f, 248.139f), Vector3(977.513f, 1414.022f, 260.669f), Vector3(981.084f, 1463.329f, 273.198f), Vector3(981.224f, 1465.262f, 272.846f))))
+      ZipLinePaths(new ZipLinePath(80, false, List(Vector3(963.682f, 972.734f, 208.858f), Vector3(982.1f, 963.019f, 212.558f))))
+      ZipLinePaths(new ZipLinePath(81, true, List(Vector3(963.71f, 1377.081f, 212.079f), Vector3(982.598f, 1384.136f, 223.736f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(964.68f, 1283.954f, 322.677f), Vector3(970.913f, 1265.208f, 320.501f), Vector3(978.346f, 1241.462f, 300.857f), Vector3(992.011f, 1198.969f, 278.318f), Vector3(1005.677f, 1156.476f, 255.779f), Vector3(1016.336f, 1123.332f, 233.389f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(966.06f, 1034.152f, 289.043f), Vector3(942.97f, 1039.214f, 293.837f), Vector3(919.481f, 1044.876f, 306.952f), Vector3(912.776f, 1045.47f, 309.571f), Vector3(906.071f, 1046.064f, 307.813f))))
+      ZipLinePaths(new ZipLinePath(84, true, List(Vector3(969.09f, 1626.228f, 197.794f), Vector3(967.362f, 1627.844f, 230.351f))))
+      ZipLinePaths(new ZipLinePath(85, false, List(Vector3(969.733f, 1048.776f, 289.053f), Vector3(969.033f, 1089.005f, 258.458f), Vector3(968.333f, 1129.235f, 227.122f), Vector3(968.25f, 1133.968f, 219.747f))))
+      ZipLinePaths(new ZipLinePath(86, true, List(Vector3(970.108f, 1021.976f, 210.45f), Vector3(971.104f, 1022.424f, 242.351f))))
+      ZipLinePaths(new ZipLinePath(87, false, List(Vector3(970.945f, 1623.276f, 230.839f), Vector3(988.468f, 1603.231f, 238.464f), Vector3(1006.792f, 1599.687f, 261.579f), Vector3(1021.222f, 1590.592f, 283.002f), Vector3(1035.853f, 1581.197f, 285.922f))))
+      ZipLinePaths(new ZipLinePath(88, false, List(Vector3(975.137f, 893.285f, 211.98f), Vector3(928.003f, 888.951f, 228.828f), Vector3(880.869f, 884.618f, 244.946f), Vector3(854.473f, 882.191f, 253.948f))))
+      ZipLinePaths(new ZipLinePath(89, false, List(Vector3(976.142f, 1112.293f, 232.494f), Vector3(933.521f, 1139.785f, 227.909f), Vector3(890.901f, 1167.278f, 222.566f), Vector3(848.281f, 1194.77f, 217.223f), Vector3(844.938f, 1196.926f, 212.254f))))
+      ZipLinePaths(new ZipLinePath(90, false, List(Vector3(977.728f, 813.361f, 268.443f), Vector3(978.126f, 864.072f, 274.605f), Vector3(978.525f, 914.782f, 280.006f), Vector3(978.923f, 965.493f, 285.406f), Vector3(979.314f, 1015.209f, 289.192f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(979.078f, 923.473f, 211.952f), Vector3(948.789f, 940.58f, 208.852f))))
+      ZipLinePaths(new ZipLinePath(92, false, List(Vector3(979.933f, 1302.087f, 315.557f), Vector3(994.753f, 1292.557f, 314.229f), Vector3(1016.774f, 1282.428f, 288.809f), Vector3(1053.614f, 1262.769f, 261.308f), Vector3(1088.982f, 1243.896f, 230.267f))))
+      ZipLinePaths(new ZipLinePath(93, false, List(Vector3(980.715f, 1021.867f, 242.874f), Vector3(1024.608f, 1031.666f, 267.647f), Vector3(1068.499f, 1041.465f, 291.687f), Vector3(1086.971f, 1039f, 310.66f), Vector3(1104.044f, 1049.435f, 311.942f))))
+      ZipLinePaths(new ZipLinePath(94, true, List(Vector3(991.007f, 1141.841f, 214.35f), Vector3(999.178f, 1143.214f, 219.5f))))
+      ZipLinePaths(new ZipLinePath(95, false, List(Vector3(993.009f, 1025.976f, 289.111f), Vector3(1013.284f, 1015.49f, 288.487f), Vector3(1033.56f, 1005.004f, 274.418f), Vector3(1074.112f, 984.032f, 251.628f), Vector3(1115.475f, 962.641f, 222.931f), Vector3(1153.594f, 942.928f, 204.75f))))
+      ZipLinePaths(new ZipLinePath(96, false, List(Vector3(996.021f, 1449.051f, 225.69f), Vector3(1037.859f, 1419.909f, 227.523f), Vector3(1078.055f, 1391.909f, 225.69f))))
+      ZipLinePaths(new ZipLinePath(97, false, List(Vector3(1006.725f, 1501.894f, 270.008f), Vector3(1006.849f, 1523.173f, 267.384f), Vector3(1006.912f, 1533.812f, 256.523f), Vector3(1006.974f, 1544.452f, 242.663f), Vector3(1007.223f, 1587.01f, 209.361f), Vector3(1007.052f, 1593.917f, 209.696f))))
+      ZipLinePaths(new ZipLinePath(98, true, List(Vector3(1021.3f, 1735.504f, 195.26f), Vector3(1028.804f, 1734.83f, 225.08f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(1025.143f, 712.281f, 233.024f), Vector3(1020.116f, 737.102f, 233.165f), Vector3(1015.089f, 761.924f, 227.811f), Vector3(1005.034f, 811.567f, 221.863f), Vector3(994.98f, 861.21f, 215.914f), Vector3(990.84f, 881.651f, 211.953f))))
+      ZipLinePaths(new ZipLinePath(100, false, List(Vector3(1029.198f, 1742.012f, 225.584f), Vector3(1052.55f, 1786.849f, 219.613f), Vector3(1075.902f, 1831.686f, 212.905f), Vector3(1099.254f, 1876.522f, 206.197f), Vector3(1109.328f, 1895.864f, 201.704f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(1031.114f, 1732.901f, 225.593f), Vector3(1022.527f, 1684.799f, 215.719f), Vector3(1013.939f, 1636.698f, 205.102f), Vector3(1009.302f, 1610.723f, 196.964f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(1034.274f, 943.094f, 222.9f), Vector3(1082.772f, 927.34f, 224.31f), Vector3(1131.269f, 911.586f, 224.977f), Vector3(1179.766f, 895.832f, 225.643f), Vector3(1213.247f, 885.838f, 221.1f))))
+      ZipLinePaths(new ZipLinePath(103, false, List(Vector3(1034.409f, 1563.401f, 272.585f), Vector3(1011.925f, 1558.256f, 268.822f), Vector3(989.441f, 1553.111f, 257.502f), Vector3(944.473f, 1542.82f, 234.711f), Vector3(904.002f, 1533.559f, 214.166f))))
+      ZipLinePaths(new ZipLinePath(104, false, List(Vector3(1035.377f, 1080.205f, 262.564f), Vector3(989.509f, 1063.28f, 252.81f), Vector3(955.567f, 1050.755f, 241.954f))))
+      ZipLinePaths(new ZipLinePath(105, true, List(Vector3(1044.219f, 1079.095f, 232.45f), Vector3(1040.901f, 1080.062f, 262.05f))))
+      ZipLinePaths(new ZipLinePath(106, false, List(Vector3(1044.836f, 889.278f, 205.783f), Vector3(1018.74f, 855.748f, 233.598f), Vector3(992.444f, 822.219f, 260.361f), Vector3(987.466f, 815.848f, 268.503f), Vector3(982.289f, 809.377f, 268.435f))))
+      ZipLinePaths(new ZipLinePath(107, false, List(Vector3(1046.498f, 1557.897f, 272.54f), Vector3(1000.009f, 1539.501f, 272.4f), Vector3(953.522f, 1521.105f, 271.521f), Vector3(907.034f, 1502.709f, 269.38f))))
+      ZipLinePaths(new ZipLinePath(108, true, List(Vector3(1050.431f, 901.111f, 198.721f), Vector3(1048.107f, 930.118f, 211.95f))))
+      ZipLinePaths(new ZipLinePath(109, false, List(Vector3(1051.466f, 1522.68f, 211.782f), Vector3(1078.305f, 1479.63f, 217.733f), Vector3(1093.966f, 1452.951f, 220.322f))))
+      ZipLinePaths(new ZipLinePath(110, false, List(Vector3(1055.076f, 1873.539f, 237.931f), Vector3(1079.972f, 1917.996f, 236.679f), Vector3(1103.404f, 1959.838f, 232.911f))))
+      ZipLinePaths(new ZipLinePath(111, false, List(Vector3(1061.645f, 1734.927f, 205.23f), Vector3(1096.745f, 1766.528f, 229.978f), Vector3(1110.51f, 1778.92f, 231.729f))))
+      ZipLinePaths(new ZipLinePath(112, false, List(Vector3(1062.419f, 1853.797f, 238.042f), Vector3(1100.781f, 1820.478f, 234.502f), Vector3(1111.312f, 1811.331f, 231.692f))))
+      ZipLinePaths(new ZipLinePath(113, true, List(Vector3(1071.166f, 1202.403f, 219.85f), Vector3(1069.18f, 1206.548f, 272.258f))))
+      ZipLinePaths(new ZipLinePath(114, false, List(Vector3(1071.354f, 1196.264f, 272.775f), Vector3(1029.289f, 1170.421f, 281.462f), Vector3(987.226f, 1144.579f, 289.413f), Vector3(945.163f, 1118.737f, 297.365f), Vector3(903.101f, 1092.894f, 305.316f), Vector3(882.07f, 1079.973f, 307.796f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(1073.915f, 1593.898f, 272.546f), Vector3(1093.854f, 1581.779f, 270.067f), Vector3(1113.994f, 1567.46f, 260.705f), Vector3(1154.274f, 1538.822f, 248.124f), Vector3(1194.553f, 1510.185f, 235.544f), Vector3(1227.725f, 1486.601f, 222.487f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(1079.887f, 1860.768f, 193.96f), Vector3(1113.7f, 1823.94f, 195.384f), Vector3(1147.514f, 1787.111f, 196.045f), Vector3(1152.247f, 1781.955f, 194.44f))))
+      ZipLinePaths(new ZipLinePath(117, false, List(Vector3(1080.911f, 1572.173f, 278.049f), Vector3(1092.004f, 1550.688f, 276.731f), Vector3(1103.097f, 1529.204f, 265.932f), Vector3(1125.283f, 1486.236f, 253.217f), Vector3(1147.469f, 1443.267f, 240.502f), Vector3(1159.894f, 1419.204f, 231.029f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(1089.579f, 877.305f, 291.235f), Vector3(1069.444f, 833.967f, 276.797f), Vector3(1049.308f, 790.629f, 262.079f), Vector3(1029.173f, 747.291f, 247.36f), Vector3(1011.858f, 710.02f, 233.124f))))
+      ZipLinePaths(new ZipLinePath(119, true, List(Vector3(1091.648f, 1218.925f, 282.28f), Vector3(1120.246f, 1191.143f, 272.28f))))
+      ZipLinePaths(new ZipLinePath(120, true, List(Vector3(1091.707f, 1219.346f, 272.28f), Vector3(1120.248f, 1190.548f, 282.28f))))
+      ZipLinePaths(new ZipLinePath(121, true, List(Vector3(1093.253f, 1192.72f, 267.28f), Vector3(1093.221f, 1193.133f, 272.28f))))
+      ZipLinePaths(new ZipLinePath(122, false, List(Vector3(1093.846f, 1164.617f, 277.782f), Vector3(1061.277f, 1126.854f, 282.223f), Vector3(1028.709f, 1089.092f, 285.924f), Vector3(996.141f, 1051.329f, 289.624f), Vector3(994.838f, 1049.819f, 289.061f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(1098.524f, 1242.661f, 282.779f), Vector3(1062.263f, 1268.949f, 261.253f), Vector3(1026.002f, 1295.237f, 239.025f), Vector3(1010.048f, 1306.804f, 226.202f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(1102.365f, 1079.055f, 311.692f), Vector3(1117.761f, 1118.575f, 284.12f), Vector3(1133.157f, 1158.095f, 255.805f), Vector3(1144.931f, 1188.316f, 231.505f))))
+      ZipLinePaths(new ZipLinePath(125, true, List(Vector3(1102.429f, 1172.438f, 219.85f), Vector3(1105.492f, 1168.703f, 271.778f), Vector3(1105.793f, 1168.336f, 277.28f))))
+      ZipLinePaths(new ZipLinePath(126, false, List(Vector3(1105.881f, 1796.622f, 231.706f), Vector3(1084.406f, 1785.3f, 230.322f), Vector3(1062.931f, 1773.978f, 220.459f), Vector3(1019.981f, 1751.334f, 208.49f), Vector3(1014.827f, 1748.616f, 205.625f))))
+      ZipLinePaths(new ZipLinePath(127, false, List(Vector3(1105.921f, 1241.768f, 277.822f), Vector3(1122.474f, 1286.219f, 259.799f), Vector3(1139.028f, 1330.669f, 241.061f), Vector3(1153.31f, 1369.019f, 221.222f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(1106.815f, 1166.369f, 272.712f), Vector3(1127.341f, 1119.926f, 278.234f), Vector3(1147.866f, 1073.483f, 283.001f), Vector3(1168.392f, 1027.04f, 287.768f), Vector3(1188.918f, 980.598f, 292.536f), Vector3(1207.834f, 937.797f, 296.002f))))
+      ZipLinePaths(new ZipLinePath(129, true, List(Vector3(1107.127f, 1238.536f, 219.7f), Vector3(1100.346f, 1235.501f, 282.273f))))
+      ZipLinePaths(new ZipLinePath(130, false, List(Vector3(1110.596f, 927.637f, 291.518f), Vector3(1101.755f, 947.852f, 288.767f), Vector3(1092.914f, 968.067f, 268.736f), Vector3(1075.232f, 1008.496f, 242.424f), Vector3(1058.258f, 1047.309f, 219.77f))))
+      ZipLinePaths(new ZipLinePath(131, false, List(Vector3(1115.095f, 1244.667f, 282.835f), Vector3(1126.296f, 1264.792f, 280.253f), Vector3(1137.497f, 1284.918f, 268.214f), Vector3(1148.899f, 1304.669f, 253.056f), Vector3(1160.301f, 1324.42f, 237.899f), Vector3(1174.163f, 1348.43f, 221.228f))))
+      ZipLinePaths(new ZipLinePath(132, false, List(Vector3(1117.499f, 1963.794f, 233.051f), Vector3(1159.472f, 1935.007f, 237.142f), Vector3(1164.41f, 1931.62f, 236.951f))))
+      ZipLinePaths(new ZipLinePath(133, true, List(Vector3(1120.295f, 1190.859f, 277.28f), Vector3(1091.482f, 1219.905f, 277.28f))))
+      ZipLinePaths(new ZipLinePath(134, false, List(Vector3(1124.578f, 1549.382f, 212.12f), Vector3(1074.829f, 1544.506f, 214.189f), Vector3(1068.859f, 1543.921f, 211.28f))))
+      ZipLinePaths(new ZipLinePath(135, true, List(Vector3(1130.396f, 1210.112f, 219.65f), Vector3(1137.396f, 1214.411f, 282.362f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(1131.24f, 888.787f, 294.03f), Vector3(1182.184f, 890.508f, 296.375f), Vector3(1208.156f, 891.386f, 296f))))
+      ZipLinePaths(new ZipLinePath(137, false, List(Vector3(1142.54f, 1218.66f, 282.912f), Vector3(1169.204f, 1261.86f, 288.479f), Vector3(1195.868f, 1305.059f, 293.298f), Vector3(1197.437f, 1307.6f, 292.852f))))
+      ZipLinePaths(new ZipLinePath(138, false, List(Vector3(1144.458f, 1193.852f, 282.719f), Vector3(1140.711f, 1145.805f, 296.788f), Vector3(1136.963f, 1097.758f, 310.119f), Vector3(1134.264f, 1081.383f, 314.518f))))
+      ZipLinePaths(new ZipLinePath(139, false, List(Vector3(1149.446f, 1809.731f, 231.685f), Vector3(1167.241f, 1816.872f, 227.954f), Vector3(1190.037f, 1826.814f, 206.722f), Vector3(1205.159f, 1833.178f, 194.758f))))
+      ZipLinePaths(new ZipLinePath(140, false, List(Vector3(1151.375f, 1308.43f, 310.411f), Vector3(1107.283f, 1285.017f, 314.004f), Vector3(1063.191f, 1261.604f, 316.848f), Vector3(1019.099f, 1238.191f, 319.692f), Vector3(975.008f, 1214.777f, 322.536f), Vector3(945.907f, 1199.325f, 324.141f))))
+      ZipLinePaths(new ZipLinePath(141, false, List(Vector3(1151.752f, 1744.783f, 205.193f), Vector3(1170.417f, 1709.389f, 235.92f), Vector3(1180.476f, 1693.4f, 264.353f), Vector3(1188.335f, 1675.411f, 265.287f))))
+      ZipLinePaths(new ZipLinePath(142, false, List(Vector3(1154.103f, 1045.211f, 311.68f), Vector3(1205.072f, 1046.855f, 311.765f), Vector3(1241.05f, 1048.015f, 308.85f))))
+      ZipLinePaths(new ZipLinePath(143, false, List(Vector3(1154.402f, 1908.73f, 236.95f), Vector3(1109.303f, 1887.142f, 238.339f), Vector3(1065.106f, 1865.985f, 237.93f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(1157.948f, 1371.891f, 253.866f), Vector3(1109.132f, 1378.159f, 245.764f), Vector3(1060.317f, 1384.427f, 236.926f), Vector3(1011.501f, 1390.696f, 228.089f), Vector3(981.473f, 1398.468f, 224.307f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(1159.605f, 1452.411f, 220.533f), Vector3(1186.886f, 1495.243f, 216.614f), Vector3(1195.979f, 1509.521f, 213.003f))))
+      ZipLinePaths(new ZipLinePath(146, false, List(Vector3(1164.409f, 1263.605f, 310.411f), Vector3(1211.954f, 1245.315f, 308.766f), Vector3(1259.499f, 1227.024f, 306.377f), Vector3(1265.093f, 1224.872f, 304.001f))))
+      ZipLinePaths(new ZipLinePath(147, true, List(Vector3(1168.129f, 1374.494f, 220.68f), Vector3(1164.962f, 1371.182f, 253.351f))))
+      ZipLinePaths(new ZipLinePath(148, true, List(Vector3(1167.336f, 1311.256f, 214.3f), Vector3(1166.591f, 1298.844f, 219.85f))))
+      ZipLinePaths(new ZipLinePath(149, false, List(Vector3(1169.164f, 1623.147f, 265.079f), Vector3(1191.24f, 1579.293f, 256.342f), Vector3(1213.317f, 1535.44f, 246.87f), Vector3(1235.393f, 1491.586f, 237.399f), Vector3(1238.901f, 1483.6f, 233.64f))))
+      ZipLinePaths(new ZipLinePath(150, true, List(Vector3(1171.102f, 1413.013f, 225.003f), Vector3(1175.787f, 1413.078f, 230.506f))))
+      ZipLinePaths(new ZipLinePath(151, false, List(Vector3(1171.763f, 1889.791f, 240.854f), Vector3(1152.036f, 1844.142f, 236.32f), Vector3(1141.384f, 1819.492f, 231.694f))))
+      ZipLinePaths(new ZipLinePath(152, false, List(Vector3(1173.489f, 1450.182f, 310.544f), Vector3(1126.382f, 1462.615f, 300.085f), Vector3(1079.275f, 1475.048f, 288.844f), Vector3(1032.168f, 1487.481f, 277.603f), Vector3(1010.499f, 1493.2f, 270.014f))))
+      ZipLinePaths(new ZipLinePath(153, true, List(Vector3(1182.916f, 1506.86f, 194.35f), Vector3(1181.854f, 1524.924f, 211.925f))))
+      ZipLinePaths(new ZipLinePath(154, false, List(Vector3(1183.893f, 814.094f, 216.873f), Vector3(1138.422f, 796.348f, 206.755f), Vector3(1092.951f, 778.602f, 195.908f), Vector3(1055.664f, 764.05f, 185.843f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(1188.76f, 862.336f, 212.351f), Vector3(1140.34f, 850.007f, 211.072f), Vector3(1091.921f, 837.678f, 209.034f), Vector3(1077.001f, 833.719f, 206.491f))))
+      ZipLinePaths(new ZipLinePath(156, false, List(Vector3(1191.935f, 1329.688f, 292.852f), Vector3(1142.362f, 1326.045f, 299.044f), Vector3(1092.79f, 1322.401f, 304.504f), Vector3(1043.217f, 1318.757f, 309.964f), Vector3(993.646f, 1315.113f, 315.423f), Vector3(982.741f, 1314.312f, 315.553f))))
+      ZipLinePaths(new ZipLinePath(157, true, List(Vector3(1192.393f, 1929.829f, 196.899f), Vector3(1179.993f, 1912.709f, 236.45f))))
+      ZipLinePaths(new ZipLinePath(158, true, List(Vector3(1194.117f, 818.768f, 185.029f), Vector3(1194.088f, 818.005f, 216.35f))))
+      ZipLinePaths(new ZipLinePath(159, false, List(Vector3(1196.939f, 1341.983f, 293.059f), Vector3(1174.428f, 1331.787f, 290.82f), Vector3(1152.217f, 1323.691f, 277.494f), Vector3(1107.796f, 1307.498f, 261.211f), Vector3(1063.375f, 1291.306f, 244.928f), Vector3(1018.953f, 1275.113f, 228.646f), Vector3(1016.288f, 1274.141f, 226.178f))))
+      ZipLinePaths(new ZipLinePath(160, false, List(Vector3(1198.132f, 1108.054f, 222.911f), Vector3(1148.266f, 1106.413f, 227.001f), Vector3(1098.4f, 1104.771f, 230.337f), Vector3(1048.535f, 1103.129f, 233.672f), Vector3(1041.553f, 1102.899f, 232.951f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(1200.709f, 1913.954f, 236.974f), Vector3(1217.736f, 1928.55f, 233.206f), Vector3(1234.763f, 1946.146f, 217.583f), Vector3(1249.453f, 1960.033f, 207.743f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(1201.001f, 932.287f, 296.001f), Vector3(1151.813f, 923.791f, 293.771f), Vector3(1132.138f, 920.393f, 291.211f))))
+      ZipLinePaths(new ZipLinePath(163, true, List(Vector3(1201.371f, 1448.316f, 253.36f), Vector3(1192.845f, 1447.079f, 310.07f))))
+      ZipLinePaths(new ZipLinePath(164, true, List(Vector3(1201.389f, 1364.36f, 233.756f), Vector3(1201.015f, 1360.354f, 251.467f))))
+      ZipLinePaths(new ZipLinePath(165, false, List(Vector3(1201.803f, 1918.873f, 242.472f), Vector3(1226.809f, 1877.857f, 229.309f), Vector3(1251.815f, 1836.841f, 215.424f), Vector3(1276.821f, 1795.826f, 201.539f), Vector3(1283.823f, 1784.341f, 195.591f))))
+      ZipLinePaths(new ZipLinePath(166, false, List(Vector3(1201.995f, 1390.422f, 310.6f), Vector3(1204.786f, 1368.885f, 306.222f), Vector3(1206.381f, 1358.416f, 295.706f), Vector3(1207.577f, 1347.348f, 292.929f))))
+      ZipLinePaths(new ZipLinePath(167, false, List(Vector3(1204.983f, 964.893f, 219.91f), Vector3(1183.305f, 1011f, 222.92f), Vector3(1161.628f, 1057.107f, 225.178f), Vector3(1139.95f, 1103.214f, 227.436f), Vector3(1119.123f, 1147.512f, 227.91f))))
+      ZipLinePaths(new ZipLinePath(168, true, List(Vector3(1205.446f, 1458.927f, 220.37f), Vector3(1206.823f, 1455.583f, 253.35f))))
+      ZipLinePaths(new ZipLinePath(169, false, List(Vector3(1212.761f, 1666.804f, 265.077f), Vector3(1238.062f, 1703.093f, 240.457f), Vector3(1263.363f, 1739.382f, 215.085f), Vector3(1279.238f, 1762.152f, 197.042f))))
+      ZipLinePaths(new ZipLinePath(170, false, List(Vector3(1212.954f, 780.028f, 193.91f), Vector3(1255.618f, 752.1f, 195.372f), Vector3(1298.282f, 724.172f, 196.091f), Vector3(1340.946f, 696.244f, 196.811f), Vector3(1341.783f, 695.697f, 195.51f))))
+      ZipLinePaths(new ZipLinePath(171, false, List(Vector3(1215.651f, 1358.743f, 251.671f), Vector3(1254.53f, 1391.415f, 254.465f), Vector3(1271.301f, 1405.509f, 255.04f))))
+      ZipLinePaths(new ZipLinePath(172, false, List(Vector3(1215.938f, 1852.856f, 226.888f), Vector3(1206.275f, 1860.843f, 227.299f), Vector3(1195.412f, 1868.23f, 243.848f), Vector3(1185.887f, 1883.405f, 244.091f))))
+      ZipLinePaths(new ZipLinePath(173, true, List(Vector3(1216.935f, 1846.375f, 193.717f), Vector3(1217.026f, 1845.678f, 226.35f))))
+      ZipLinePaths(new ZipLinePath(174, false, List(Vector3(1217.901f, 1306.547f, 252.003f), Vector3(1178.924f, 1329.026f, 230.922f), Vector3(1169.569f, 1334.421f, 221.2f))))
+      ZipLinePaths(new ZipLinePath(175, false, List(Vector3(1222.97f, 892.562f, 296f), Vector3(1273.851f, 894.346f, 299.697f), Vector3(1292.807f, 895.01f, 299.837f), Vector3(1314.263f, 895.475f, 300.301f))))
+      ZipLinePaths(new ZipLinePath(176, true, List(Vector3(1226.215f, 1306.36f, 220.591f), Vector3(1225.078f, 1307.135f, 251.49f))))
+      ZipLinePaths(new ZipLinePath(177, false, List(Vector3(1229.979f, 897.9f, 222.686f), Vector3(1248.429f, 856.834f, 250.003f), Vector3(1265.379f, 819.569f, 273.788f), Vector3(1267.59f, 810.425f, 274.254f))))
+      ZipLinePaths(new ZipLinePath(178, true, List(Vector3(1234.241f, 1678.155f, 195.187f), Vector3(1235.695f, 1678.25f, 226.352f))))
+      ZipLinePaths(new ZipLinePath(179, false, List(Vector3(1243.039f, 1672.894f, 226.877f), Vector3(1257.864f, 1653.72f, 226.354f), Vector3(1272.69f, 1634.546f, 215.348f), Vector3(1302.341f, 1596.197f, 203.081f), Vector3(1318.352f, 1575.489f, 195.226f))))
+      ZipLinePaths(new ZipLinePath(180, false, List(Vector3(1249.659f, 799.131f, 274.221f), Vector3(1230.152f, 794.469f, 271.908f), Vector3(1210.046f, 789.308f, 258.099f), Vector3(1171.632f, 780.485f, 217.049f), Vector3(1146.663f, 774.518f, 193.216f))))
+      ZipLinePaths(new ZipLinePath(181, false, List(Vector3(1250.666f, 1023.941f, 308.491f), Vector3(1273.371f, 979.444f, 307.138f), Vector3(1296.076f, 934.946f, 305.027f), Vector3(1313.786f, 900.238f, 300.301f))))
+      ZipLinePaths(new ZipLinePath(182, false, List(Vector3(1258.081f, 1239.629f, 233.701f), Vector3(1260.773f, 1194.323f, 257.733f), Vector3(1263.464f, 1149.017f, 282.723f), Vector3(1266.156f, 1103.71f, 306.713f), Vector3(1267.717f, 1077.432f, 308.82f))))
+      ZipLinePaths(new ZipLinePath(183, true, List(Vector3(1260.415f, 982.55f, 212.75f), Vector3(1257.704f, 982.99f, 246.35f))))
+      ZipLinePaths(new ZipLinePath(184, true, List(Vector3(1261.826f, 1507.387f, 221.5f), Vector3(1263.065f, 1509.887f, 253.35f))))
+      ZipLinePaths(new ZipLinePath(185, false, List(Vector3(1262.6f, 1515.681f, 253.853f), Vector3(1237.576f, 1558.503f, 260.945f), Vector3(1212.551f, 1601.325f, 267.281f), Vector3(1196.536f, 1628.731f, 267.893f))))
+      ZipLinePaths(new ZipLinePath(186, false, List(Vector3(1263.972f, 1211.529f, 304.001f), Vector3(1230.292f, 1174.694f, 307.831f), Vector3(1196.613f, 1137.86f, 310.924f), Vector3(1162.934f, 1101.025f, 314.017f), Vector3(1140.706f, 1076.714f, 314.501f))))
+      ZipLinePaths(new ZipLinePath(187, false, List(Vector3(1264.862f, 981.913f, 246.854f), Vector3(1281.838f, 982.081f, 242.85f), Vector3(1298.815f, 982.25f, 222.859f))))
+      ZipLinePaths(new ZipLinePath(188, false, List(Vector3(1265.582f, 1404.584f, 253.22f), Vector3(1276.61f, 1372.427f, 251.88f))))
+      ZipLinePaths(new ZipLinePath(189, false, List(Vector3(1271.695f, 1083.292f, 247.734f), Vector3(1269.115f, 1109.294f, 246.993f), Vector3(1266.536f, 1135.296f, 241.156f), Vector3(1259.177f, 1185.399f, 235.122f), Vector3(1251.819f, 1235.503f, 234.087f), Vector3(1244.16f, 1267.106f, 232.753f), Vector3(1243.017f, 1295.431f, 221.094f))))
+      ZipLinePaths(new ZipLinePath(190, false, List(Vector3(1280.299f, 1356.039f, 251.882f), Vector3(1313.643f, 1317.727f, 257.273f), Vector3(1346.987f, 1279.415f, 261.877f), Vector3(1380.332f, 1241.102f, 266.481f), Vector3(1413.676f, 1202.79f, 271.085f), Vector3(1428.714f, 1185.512f, 272.052f))))
+      ZipLinePaths(new ZipLinePath(191, false, List(Vector3(1283.458f, 890.038f, 212.15f), Vector3(1284.727f, 924.985f, 213.25f))))
+      ZipLinePaths(new ZipLinePath(192, true, List(Vector3(1284.624f, 801.067f, 273.7f), Vector3(1281.635f, 798.615f, 279.206f))))
+      ZipLinePaths(new ZipLinePath(193, false, List(Vector3(1292.551f, 1066.859f, 308.492f), Vector3(1313.109f, 1065.355f, 304.285f), Vector3(1331.767f, 1064.051f, 274.575f), Vector3(1369.083f, 1061.442f, 239.914f), Vector3(1393.96f, 1059.703f, 213.35f))))
+      ZipLinePaths(new ZipLinePath(194, true, List(Vector3(1305.056f, 1321.493f, 210.55f), Vector3(1291.481f, 1301.007f, 232.65f))))
+      ZipLinePaths(new ZipLinePath(195, false, List(Vector3(1304.347f, 1371.371f, 253.835f), Vector3(1280.917f, 1375.189f, 258.523f), Vector3(1256.888f, 1380.207f, 243.099f), Vector3(1208.829f, 1386.642f, 237.107f), Vector3(1196.148f, 1392.034f, 228.88f), Vector3(1176.148f, 1391.834f, 221.195f))))
+      ZipLinePaths(new ZipLinePath(196, true, List(Vector3(1306.335f, 1369.803f, 220.18f), Vector3(1307.635f, 1371.319f, 253.251f))))
+      ZipLinePaths(new ZipLinePath(197, false, List(Vector3(1310.992f, 913.011f, 300.297f), Vector3(1290.856f, 918.141f, 295.917f), Vector3(1270.721f, 923.271f, 273.234f), Vector3(1230.45f, 933.531f, 245.426f), Vector3(1197.428f, 941.944f, 219.125f))))
+      ZipLinePaths(new ZipLinePath(198, false, List(Vector3(1312.511f, 1753.802f, 198.17f), Vector3(1321.508f, 1704.613f, 199f), Vector3(1330.504f, 1655.425f, 199.087f), Vector3(1333.743f, 1637.717f, 197.87f))))
+      ZipLinePaths(new ZipLinePath(199, true, List(Vector3(1312.814f, 1008.901f, 234.266f), Vector3(1296.46f, 998.06f, 247.893f))))
+      ZipLinePaths(new ZipLinePath(200, true, List(Vector3(1315.533f, 658.726f, 185.933f), Vector3(1315.364f, 658.643f, 219.55f))))
+      ZipLinePaths(new ZipLinePath(201, true, List(Vector3(1313.047f, 747.979f, 185.79f), Vector3(1333.818f, 745.34f, 213.76f))))
+      ZipLinePaths(new ZipLinePath(202, false, List(Vector3(1326.858f, 659.881f, 220.097f), Vector3(1343.771f, 687.963f, 227.17f), Vector3(1325.685f, 716.046f, 245.475f), Vector3(1333.212f, 763.211f, 263.353f), Vector3(1336.975f, 786.793f, 272.292f), Vector3(1340.738f, 810.376f, 281.231f), Vector3(1348.265f, 857.541f, 299.109f), Vector3(1350.11f, 869.101f, 306.402f), Vector3(1351.955f, 880.661f, 307.438f))))
+      ZipLinePaths(new ZipLinePath(203, false, List(Vector3(1322.759f, 1421.014f, 244.694f), Vector3(1361.905f, 1388.616f, 241.124f), Vector3(1399.517f, 1357.489f, 232.954f))))
+      ZipLinePaths(new ZipLinePath(204, true, List(Vector3(1323.032f, 1295.479f, 204.5f), Vector3(1344.755f, 1292.424f, 211.2f))))
+      ZipLinePaths(new ZipLinePath(205, false, List(Vector3(1326.35f, 956.514f, 222.853f), Vector3(1335.824f, 945.854f, 223.593f), Vector3(1349.999f, 943.194f, 225.853f))))
+      ZipLinePaths(new ZipLinePath(206, false, List(Vector3(1327.717f, 750.522f, 214.26f), Vector3(1290.93f, 785.843f, 214.797f), Vector3(1275.783f, 800.387f, 211.95f))))
+      ZipLinePaths(new ZipLinePath(207, true, List(Vector3(1328.937f, 1374.829f, 210.55f), Vector3(1315.126f, 1364.014f, 220.18f))))
+      ZipLinePaths(new ZipLinePath(208, false, List(Vector3(1333.52f, 1052.305f, 224.259f), Vector3(1336.439f, 1097.932f, 247.538f), Vector3(1339.359f, 1143.56f, 270.128f), Vector3(1342.279f, 1189.187f, 292.717f), Vector3(1348.909f, 1201.159f, 303.208f), Vector3(1343.939f, 1215.132f, 304.058f))))
+      ZipLinePaths(new ZipLinePath(209, false, List(Vector3(1334.659f, 1326.499f, 307.604f), Vector3(1285.117f, 1324.503f, 301.896f), Vector3(1235.575f, 1322.508f, 295.435f), Vector3(1221.775f, 1320.568f, 292.845f))))
+      ZipLinePaths(new ZipLinePath(210, false, List(Vector3(1338.097f, 1355.399f, 211.077f), Vector3(1314.922f, 1314.426f, 228.464f), Vector3(1310.055f, 1305.822f, 232.957f), Vector3(1305.188f, 1297.218f, 233.177f))))
+      ZipLinePaths(new ZipLinePath(211, true, List(Vector3(1341.036f, 1075.189f, 246.36f), Vector3(1324.315f, 1068.659f, 242.637f))))
+      ZipLinePaths(new ZipLinePath(212, false, List(Vector3(1342.657f, 1226.81f, 304.003f), Vector3(1356.708f, 1244.273f, 303.168f), Vector3(1370.759f, 1261.736f, 288.939f), Vector3(1398.861f, 1296.661f, 250.126f), Vector3(1420.902f, 1324.054f, 232.964f))))
+      ZipLinePaths(new ZipLinePath(213, true, List(Vector3(1347.83f, 1082.554f, 212.85f), Vector3(1347.547f, 1079.261f, 246.351f))))
+      ZipLinePaths(new ZipLinePath(214, true, List(Vector3(1348.324f, 957.395f, 226.25f), Vector3(1352.107f, 965.408f, 237.533f))))
+      ZipLinePaths(new ZipLinePath(215, false, List(Vector3(1350.175f, 923.469f, 305.829f), Vector3(1372.266f, 933.302f, 302.84f), Vector3(1394.358f, 943.136f, 290.38f), Vector3(1438.541f, 962.803f, 274.208f), Vector3(1451.536f, 968.587f, 266.392f))))
+      ZipLinePaths(new ZipLinePath(216, false, List(Vector3(1352.617f, 954.329f, 235.372f), Vector3(1352.705f, 935.466f, 234.815f), Vector3(1326.093f, 908.504f, 218.798f), Vector3(1324.059f, 902.349f, 214.434f), Vector3(1321.125f, 911.095f, 212.614f))))
+      ZipLinePaths(new ZipLinePath(217, false, List(Vector3(1359.87f, 1680.928f, 195.69f), Vector3(1357.305f, 1731.828f, 198.145f), Vector3(1355.846f, 1760.771f, 197.43f))))
+      ZipLinePaths(new ZipLinePath(218, false, List(Vector3(1360.625f, 990.729f, 235.33f), Vector3(1331.172f, 1032.362f, 236.479f), Vector3(1317.311f, 1051.953f, 234.77f))))
+      ZipLinePaths(new ZipLinePath(219, true, List(Vector3(1370.028f, 1325.967f, 294.809f), Vector3(1380.014f, 1337.961f, 302.3f))))
+      ZipLinePaths(new ZipLinePath(220, false, List(Vector3(1386.011f, 1481.11f, 259.778f), Vector3(1371.875f, 1500.316f, 256.032f), Vector3(1357.74f, 1519.522f, 242.425f), Vector3(1329.47f, 1557.934f, 224.371f), Vector3(1301.2f, 1596.346f, 206.317f), Vector3(1292.331f, 1608.397f, 196.629f))))
+      ZipLinePaths(new ZipLinePath(221, true, List(Vector3(1386.248f, 1033.103f, 216.339f), Vector3(1378.175f, 1038.077f, 221.843f))))
+      ZipLinePaths(new ZipLinePath(222, false, List(Vector3(1396.703f, 1336.476f, 232.95f), Vector3(1352.996f, 1312.22f, 235.003f), Vector3(1309.289f, 1287.965f, 236.307f), Vector3(1308.415f, 1287.48f, 233.15f))))
+      ZipLinePaths(new ZipLinePath(223, false, List(Vector3(1402.832f, 1790.362f, 238.275f), Vector3(1357.135f, 1784.082f, 219.665f), Vector3(1311.438f, 1777.801f, 200.357f), Vector3(1306.868f, 1777.173f, 196.593f))))
+      ZipLinePaths(new ZipLinePath(224, false, List(Vector3(1403.596f, 1321.775f, 307.617f), Vector3(1418.538f, 1275.358f, 297.279f), Vector3(1433.479f, 1228.941f, 286.22f), Vector3(1446.628f, 1188.094f, 272.067f))))
+      ZipLinePaths(new ZipLinePath(225, false, List(Vector3(1407.208f, 968.784f, 225.906f), Vector3(1452.954f, 962.509f, 204.954f), Vector3(1487.039f, 957.833f, 185.799f))))
+      ZipLinePaths(new ZipLinePath(226, false, List(Vector3(1410.886f, 1015.38f, 224.85f), Vector3(1402.812f, 977.244f, 225.85f))))
+      ZipLinePaths(new ZipLinePath(227, false, List(Vector3(1418.968f, 1157.21f, 272.079f), Vector3(1395.204f, 1155.15f, 268.977f), Vector3(1371.44f, 1153.09f, 261.808f), Vector3(1323.912f, 1148.971f, 243.929f), Vector3(1299.898f, 1147.293f, 230.218f), Vector3(1291.285f, 1147.316f, 227.081f))))
+      ZipLinePaths(new ZipLinePath(228, false, List(Vector3(1425.18f, 1789.32f, 206.882f), Vector3(1375.333f, 1789.595f, 203.687f), Vector3(1325.486f, 1789.87f, 199.742f), Vector3(1296.574f, 1790.029f, 196.532f))))
+      ZipLinePaths(new ZipLinePath(229, false, List(Vector3(1445.087f, 1032.407f, 213.083f), Vector3(1464.295f, 1018.75f, 210.633f), Vector3(1483.503f, 1005.094f, 197.115f), Vector3(1505.784f, 989.253f, 185.682f))))
+      ZipLinePaths(new ZipLinePath(230, false, List(Vector3(1447.744f, 1139.43f, 272.051f), Vector3(1459.359f, 1090.834f, 270.834f), Vector3(1470.974f, 1042.238f, 268.876f), Vector3(1472.136f, 1037.378f, 266.361f))))
+      ZipLinePaths(new ZipLinePath(231, false, List(Vector3(1447.873f, 1015.423f, 261.7f), Vector3(1399.228f, 1023.656f, 254.346f), Vector3(1350.583f, 1031.89f, 246.214f), Vector3(1317.738f, 1038.824f, 238.282f), Vector3(1310.909f, 1040.47f, 234.779f))))
+      ZipLinePaths(new ZipLinePath(232, false, List(Vector3(1454.058f, 1332.984f, 232.951f), Vector3(1499.766f, 1355.128f, 238.278f), Vector3(1513.21f, 1361.641f, 238.042f))))
+      ZipLinePaths(new ZipLinePath(233, false, List(Vector3(1454.086f, 1316.012f, 195.46f), Vector3(1492.612f, 1341.129f, 195.64f))))
+      ZipLinePaths(new ZipLinePath(234, true, List(Vector3(1484.619f, 975.574f, 196.717f), Vector3(1486.5f, 1019.848f, 265.86f))))
+      ZipLinePaths(new ZipLinePath(235, false, List(Vector3(1495.506f, 1365.02f, 198.175f), Vector3(1460.612f, 1394.349f, 221.756f), Vector3(1425.718f, 1423.677f, 244.627f), Vector3(1410.323f, 1436.616f, 262.064f), Vector3(1394.928f, 1449.556f, 265.053f))))
+      ZipLinePaths(new ZipLinePath(236, false, List(Vector3(1508.012f, 1037.494f, 262.404f), Vector3(1484.492f, 1081.185f, 251.434f), Vector3(1460.972f, 1124.876f, 239.663f), Vector3(1437.452f, 1168.567f, 227.892f), Vector3(1413.931f, 1212.258f, 216.121f), Vector3(1410.703f, 1218.255f, 212.973f))))
+      ZipLinePaths(new ZipLinePath(237, false, List(Vector3(1511.057f, 1376.957f, 238.038f), Vector3(1487.839f, 1382.544f, 233.932f), Vector3(1464.621f, 1388.132f, 225.158f), Vector3(1418.186f, 1399.308f, 209.16f), Vector3(1387.537f, 1408.048f, 194.108f))))
+      ZipLinePaths(new ZipLinePath(238, false, List(Vector3(1533.004f, 1221.827f, 201.162f), Vector3(1487.001f, 1202.784f, 206.58f), Vector3(1440.999f, 1183.741f, 211.247f), Vector3(1415.238f, 1173.077f, 212.962f))))
+      ZipLinePaths(new ZipLinePath(239, true, List(Vector3(1541.029f, 1002.385f, 185.132f), Vector3(1539.744f, 1007.686f, 217.352f))))
+      ZipLinePaths(new ZipLinePath(240, false, List(Vector3(1544.376f, 1012.95f, 217.861f), Vector3(1544.619f, 1063.813f, 214.894f), Vector3(1544.862f, 1114.676f, 211.185f), Vector3(1545.105f, 1165.539f, 207.476f), Vector3(1545.319f, 1210.418f, 202.922f))))
+      ZipLinePaths(new ZipLinePath(241, false, List(Vector3(1576.949f, 990.322f, 223.031f), Vector3(1530.215f, 972.799f, 220.748f), Vector3(1483.48f, 955.276f, 217.726f), Vector3(1436.745f, 937.753f, 214.704f), Vector3(1434.876f, 937.052f, 212.651f))))
+      ZipLinePaths(new ZipLinePath(242, true, List(Vector3(1289.844f, 1078.568f, 216.85f), Vector3(1289.422f, 1086.704f, 234.276f))))
+      ZipLinePaths(new ZipLinePath(243, true, List(Vector3(1295.275f, 1006.474f, 234.276f), Vector3(1295.289f, 1014.841f, 216.85f))))
+      ZipLinePaths(new ZipLinePath(244, true, List(Vector3(889.903f, 1392.847f, 216.85f), Vector3(891.002f, 1383.453f, 234.276f))))
+      ZipLinePaths(new ZipLinePath(245, true, List(Vector3(899.389f, 1462.873f, 234.276f), Vector3(899.115f, 1455.859f, 216.85f))))
+      ZipLinePaths(new ZipLinePath(246, true, List(Vector3(1206.547f, 1338.16f, 292.333f), Vector3(1207.199f, 1337.626f, 297.84f))))
+      ZipLinePaths(new ZipLinePath(247, false, List(Vector3(1320.229f, 668.971f, 220.041f), Vector3(1297.599f, 714.589f, 218.575f), Vector3(1274.969f, 760.207f, 215.169f), Vector3(1255.445f, 799.563f, 211.951f))))
+      ZipLinePaths(new ZipLinePath(248, false, List(Vector3(1356.604f, 911.362f, 300.275f), Vector3(1379.938f, 917.926f, 296.868f), Vector3(1403.271f, 924.489f, 285.181f), Vector3(1449.938f, 937.616f, 269.351f), Vector3(1496.605f, 950.742f, 253.521f), Vector3(1543.272f, 963.869f, 237.692f), Vector3(1582.619f, 974.937f, 223.027f))))
+      ZipLinePaths(new ZipLinePath(249, true, List(Vector3(1082.643f, 1290.453f, 214.55f), Vector3(1077.063f, 1283.506f, 219.55f))))
+      ZipLinePaths(new ZipLinePath(250, false, List(Vector3(871.498f, 436.029f, 198.902f), Vector3(873.737f, 485.704f, 210.959f), Vector3(877.66f, 524.343f, 218.903f))))
+      ZipLinePaths(new ZipLinePath(251, true, List(Vector3(1212.524f, 1596.389f, 194.899f), Vector3(1216.017f, 1580.147f, 212.18f))))
+      ZipLinePaths(new ZipLinePath(252, false, List(Vector3(764.967f, 771.161f, 249.219f), Vector3(766.426f, 773.295f, 249.101f), Vector3(807.076f, 832.744f, 194.612f))))
+      ZipLinePaths(new ZipLinePath(253, false, List(Vector3(676.271f, 684.934f, 196.79f), Vector3(682.995f, 735.485f, 197.148f), Vector3(689.719f, 786.037f, 196.758f), Vector3(696.442f, 836.589f, 196.367f), Vector3(698.024f, 848.484f, 195.52f))))
+      ZipLinePaths(new ZipLinePath(254, true, List(Vector3(817.187f, 767.054f, 185.791f), Vector3(816.774f, 767.452f, 217.351f))))
+      ZipLinePaths(new ZipLinePath(255, false, List(Vector3(806.255f, 770.376f, 217.869f), Vector3(783.751f, 777.979f, 213.672f), Vector3(761.247f, 785.583f, 203.003f), Vector3(745.045f, 791.057f, 196.219f))))
+      ZipLinePaths(new ZipLinePath(256, false, List(Vector3(815.529f, 778.081f, 217.866f), Vector3(828.261f, 826.796f, 210.506f), Vector3(840.992f, 875.511f, 202.4f), Vector3(846.983f, 898.436f, 197.557f))))
+      ZipLinePaths(new ZipLinePath(257, false, List(Vector3(819.788f, 763.677f, 217.895f), Vector3(850.532f, 726.309f, 240.426f), Vector3(855.093f, 723.569f, 241.036f))))
+      ZipLinePaths(new ZipLinePath(258, false, List(Vector3(905.596f, 706.507f, 241.162f), Vector3(956.466f, 704.68f, 238.794f), Vector3(1007.335f, 702.852f, 233.081f))))
+      ZipLinePaths(new ZipLinePath(259, false, List(Vector3(704.784f, 875.597f, 201.11f), Vector3(717.929f, 896.92f, 201.064f), Vector3(731.574f, 918.444f, 200.122f), Vector3(758.864f, 961.49f, 198.395f), Vector3(761.539f, 965.711f, 197.45f))))
+      ZipLinePaths(new ZipLinePath(260, false, List(Vector3(893.999f, 456.076f, 196.941f), Vector3(904.293f, 505.965f, 196.623f), Vector3(914.587f, 555.853f, 195.773f), Vector3(918.724f, 575.907f, 192.721f), Vector3(922.862f, 595.96f, 189.971f))))
+      ZipLinePaths(new ZipLinePath(261, true, List(Vector3(795.919f, 940.689f, 196.595f), Vector3(830.961f, 955.602f, 210.15f))))
+      ZipLinePaths(new ZipLinePath(262, false, List(Vector3(647.03f, 933.05f, 195.93f), Vector3(661.956f, 981.799f, 197.893f), Vector3(665.175f, 992.314f, 197.45f))))
+      ZipLinePaths(new ZipLinePath(263, true, List(Vector3(690.613f, 1259.99f, 196.173f), Vector3(706.118f, 1244.747f, 211.35f))))
+      ZipLinePaths(new ZipLinePath(264, true, List(Vector3(637.748f, 1318.521f, 196.587f), Vector3(659.951f, 1326.051f, 211.992f))))
+      ZipLinePaths(new ZipLinePath(265, false, List(Vector3(706.085f, 1366.379f, 212.49f), Vector3(715.565f, 1385.971f, 213.872f), Vector3(725.045f, 1405.564f, 213.05f))))
+      ZipLinePaths(new ZipLinePath(266, true, List(Vector3(1293.009f, 1407.06f, 229.539f), Vector3(1290.49f, 1414.493f, 259.321f))))
+      ZipLinePaths(new ZipLinePath(267, true, List(Vector3(1260.779f, 1465.584f, 227.039f), Vector3(1273.877f, 1457.67f, 254.54f))))
+      ZipLinePaths(new ZipLinePath(268, true, List(Vector3(900.574f, 1093.87f, 213.939f), Vector3(888.281f, 1107.401f, 233.19f))))
+      ZipLinePaths(new ZipLinePath(269, true, List(Vector3(933.058f, 1035.019f, 216.439f), Vector3(929.539f, 1041.274f, 246.221f))))
+      ZipLinePaths(new ZipLinePath(270, true, List(Vector3(816.289f, 2213.624f, 242.635f), Vector3(821.393f, 2071.116f, 202.635f))))
+      ZipLinePaths(new ZipLinePath(271, true, List(Vector3(844.297f, 2026.099f, 202.635f), Vector3(973.751f, 2000.333f, 201.989f))))
+      ZipLinePaths(new ZipLinePath(272, false, List(Vector3(905.182f, 628.614f, 185.95f), Vector3(885.241f, 675.551f, 187.87f), Vector3(866.865f, 718.808f, 186.29f))))
+      ZipLinePaths(new ZipLinePath(273, false, List(Vector3(809.87f, 889.825f, 186f), Vector3(769.309f, 860.583f, 187.897f), Vector3(736.049f, 836.604f, 186.28f))))
+      ZipLinePaths(new ZipLinePath(274, false, List(Vector3(848.913f, 608.999f, 218.84f), Vector3(861.032f, 560.488f, 219.485f), Vector3(863.613f, 549.756f, 218.417f))))
+      ZipLinePaths(new ZipLinePath(275, false, List(Vector3(854.5f, 709.362f, 241.026f), Vector3(814.796f, 688.125f, 219.964f), Vector3(775.887f, 667.312f, 197.944f))))
+      ZipLinePaths(new ZipLinePath(276, false, List(Vector3(827.296f, 970.647f, 219.293f), Vector3(813.585f, 932.726f, 254.124f), Vector3(811.665f, 927.417f, 253.938f))))
+      ZipLinePaths(new ZipLinePath(277, false, List(Vector3(690.329f, 984.723f, 231.851f), Vector3(704.931f, 936.036f, 236.752f), Vector3(719.533f, 887.349f, 240.911f), Vector3(734.135f, 838.662f, 245.069f), Vector3(748.737f, 789.974f, 249.228f), Vector3(754.177f, 771.836f, 249.222f))))
+      ZipLinePaths(new ZipLinePath(278, false, List(Vector3(875.762f, 1394.878f, 234.786f), Vector3(867.423f, 1372.115f, 232.776f), Vector3(859.084f, 1349.352f, 223.285f), Vector3(845.409f, 1312.021f, 212.116f))))
+      ZipLinePaths(new ZipLinePath(279, false, List(Vector3(961.517f, 1415.007f, 247.343f), Vector3(979.775f, 1398.183f, 248.537f), Vector3(998.034f, 1381.359f, 242.23f), Vector3(1034.551f, 1347.71f, 236.358f), Vector3(1071.069f, 1314.061f, 230.485f), Vector3(1085.445f, 1301.175f, 227.303f))))
+      ZipLinePaths(new ZipLinePath(280, false, List(Vector3(1228.337f, 1309.135f, 251.995f), Vector3(1265.385f, 1276.134f, 246.542f), Vector3(1283.909f, 1259.633f, 242.624f))))
+      ZipLinePaths(new ZipLinePath(281, true, List(Vector3(860.587f, 1479.59f, 214.706f), Vector3(868.409f, 1478.511f, 224.479f))))
+      ZipLinePaths(new ZipLinePath(282, true, List(Vector3(1274.085f, 1129.327f, 216.506f), Vector3(1301.615f, 1140.312f, 226.271f))))
+      ZipLinePaths(new ZipLinePath(283, false, List(Vector3(1016.344f, 669.706f, 227.588f), Vector3(1016.653f, 621.568f, 212.295f), Vector3(1016.85f, 590.759f, 207.982f), Vector3(1017.164f, 541.658f, 193.497f), Vector3(1017.349f, 512.775f, 183.271f))))
+      ZipLinePaths(new ZipLinePath(284, false, List(Vector3(1095.865f, 472.467f, 168.211f), Vector3(1096.286f, 460.001f, 170.523f), Vector3(1096.707f, 447.535f, 172.931f), Vector3(1097.314f, 429.584f, 168.664f), Vector3(1097.92f, 411.632f, 163.901f))))
+      ZipLinePaths(new ZipLinePath(285, false, List(Vector3(951.858f, 387.939f, 188.212f), Vector3(951.96f, 381.835f, 187.721f), Vector3(952.062f, 375.731f, 186.032f), Vector3(952.266f, 363.522f, 181.666f), Vector3(952.469f, 351.314f, 178.5f), Vector3(952.673f, 339.105f, 174.333f), Vector3(952.877f, 326.897f, 170.356f), Vector3(953.08f, 314.688f, 166.58f), Vector3(953.284f, 302.48f, 164.053f), Vector3(953.488f, 290.271f, 163.926f), Vector3(953.732f, 275.621f, 163.452f))))
+      ZipLinePaths(new ZipLinePath(286, false, List(Vector3(837.714f, 264.55f, 163.487f), Vector3(838.193f, 255.85f, 163.337f), Vector3(838.3f, 253.916f, 162.774f), Vector3(839.045f, 240.382f, 158.337f), Vector3(839.79f, 226.849f, 153.417f))))
+      ZipLinePaths(new ZipLinePath(287, false, List(Vector3(884.876f, 213.314f, 143.23f), Vector3(887.973f, 162.408f, 143.946f), Vector3(888.216f, 158.416f, 143.28f))))
+      ZipLinePaths(new ZipLinePath(288, false, List(Vector3(776.348f, 254.115f, 153.197f), Vector3(776.224f, 266.482f, 153.979f), Vector3(776.1f, 278.848f, 155.562f), Vector3(775.977f, 291.214f, 159.152f), Vector3(775.853f, 303.581f, 164.142f), Vector3(775.61f, 327.828f, 170.323f), Vector3(775.489f, 339.952f, 174.214f), Vector3(775.428f, 346.014f, 176.759f), Vector3(775.368f, 352.076f, 178.215f))))
+      ZipLinePaths(new ZipLinePath(289, false, List(Vector3(760.354f, 385.699f, 183.342f), Vector3(759.79f, 410.144f, 191.685f), Vector3(759.509f, 422.366f, 195.616f), Vector3(759.227f, 434.588f, 198.548f), Vector3(758.962f, 446.092f, 202.623f), Vector3(758.829f, 451.843f, 203.263f))))
+      ZipLinePaths(new ZipLinePath(290, false, List(Vector3(711.762f, 461.764f, 213.168f), Vector3(713.259f, 480.738f, 218.568f), Vector3(712.907f, 490.925f, 221.321f), Vector3(711.931f, 495.469f, 223.197f), Vector3(712.755f, 499.612f, 223.874f), Vector3(717.35f, 503.016f, 223.69f), Vector3(755.945f, 503.42f, 223.257f))))
+      ZipLinePaths(new ZipLinePath(291, false, List(Vector3(1281.979f, 376.763f, 183.18f), Vector3(1316.967f, 413.866f, 183.982f), Vector3(1323.827f, 421.141f, 183.24f))))
+      ZipLinePaths(new ZipLinePath(292, false, List(Vector3(1493.118f, 393.605f, 163.24f), Vector3(1494.583f, 403.371f, 162.907f), Vector3(1496.048f, 413.138f, 159.87f), Vector3(1495.979f, 425.872f, 155.056f), Vector3(1495.84f, 451.339f, 154.929f), Vector3(1495.457f, 470.964f, 156.642f), Vector3(1495.465f, 480.976f, 158.248f), Vector3(1494.373f, 490.588f, 154.855f), Vector3(1495.206f, 529.838f, 143.18f), Vector3(1495.623f, 549.462f, 142.818f), Vector3(1496.039f, 569.087f, 148.156f), Vector3(1496.456f, 588.711f, 146.344f), Vector3(1496.872f, 608.336f, 143.831f), Vector3(1485.404f, 616.733f, 143.934f), Vector3(1479.343f, 630.506f, 146.634f), Vector3(1477.886f, 647.664f, 153.035f), Vector3(1479.029f, 659.223f, 157.535f), Vector3(1479.715f, 685.339f, 163.136f), Vector3(1481.462f, 690.033f, 163.2f))))
+      ZipLinePaths(new ZipLinePath(293, false, List(Vector3(1488.859f, 696.058f, 163.275f), Vector3(1518.973f, 696.266f, 172.9f), Vector3(1534.516f, 696.374f, 177.82f), Vector3(1551.031f, 696.488f, 182.996f), Vector3(1569.488f, 696.616f, 183.205f))))
+      ZipLinePaths(new ZipLinePath(294, false, List(Vector3(1598.739f, 695.95f, 183.191f), Vector3(1647.716f, 694.45f, 198.065f), Vector3(1649.637f, 694.391f, 198.21f))))
+      ZipLinePaths(new ZipLinePath(295, false, List(Vector3(1686.968f, 669.616f, 208.213f), Vector3(1686.975f, 675.962f, 207.406f), Vector3(1686.982f, 682.309f, 203.803f), Vector3(1686.989f, 688.656f, 203.35f), Vector3(1686.996f, 695.002f, 200.298f), Vector3(1687.01f, 707.695f, 198.993f), Vector3(1687.024f, 720.389f, 199.488f), Vector3(1687.033f, 728.602f, 199.286f), Vector3(1687.042f, 736.815f, 199.685f), Vector3(1687.06f, 753.242f, 202.782f), Vector3(1687.074f, 766.184f, 198.814f), Vector3(1687.089f, 779.126f, 195.346f), Vector3(1687.103f, 792.068f, 190.679f), Vector3(1687.117f, 805.01f, 187.411f), Vector3(1687.131f, 817.703f, 186.067f), Vector3(1687.145f, 830.396f, 188.723f), Vector3(1687.159f, 843.089f, 192.829f), Vector3(1687.173f, 855.783f, 192.635f), Vector3(1687.201f, 880.671f, 188.202f))))
+      ZipLinePaths(new ZipLinePath(296, false, List(Vector3(1688.037f, 913.673f, 188.342f), Vector3(1688.198f, 936.255f, 196.256f), Vector3(1688.358f, 958.837f, 203.292f), Vector3(1688.392f, 963.641f, 203.132f))))
+      ZipLinePaths(new ZipLinePath(297, false, List(Vector3(1719.051f, 955.831f, 203.191f), Vector3(1719.054f, 966.319f, 206.35f), Vector3(1719.055f, 971.562f, 206.579f), Vector3(1719.057f, 976.806f, 208.009f), Vector3(1719.058f, 983.299f, 206.171f), Vector3(1719.06f, 989.791f, 203.433f), Vector3(1719.063f, 1002.776f, 200.158f), Vector3(1719.066f, 1015.761f, 195.282f), Vector3(1719.069f, 1028.746f, 191.407f), Vector3(1719.072f, 1041.48f, 188.344f), Vector3(1719.075f, 1054.215f, 183.98f), Vector3(1719.078f, 1066.949f, 179.367f), Vector3(1719.082f, 1079.684f, 179.353f), Vector3(1719.088f, 1105.152f, 178.427f), Vector3(1719.094f, 1130.621f, 186.5f), Vector3(1719.097f, 1142.107f, 192.315f), Vector3(1719.1f, 1153.593f, 193.43f))))
+      ZipLinePaths(new ZipLinePath(298, false, List(Vector3(1656.032f, 1221.278f, 193.691f), Vector3(1655.949f, 1231.25f, 198.116f), Vector3(1655.816f, 1247.205f, 203.113f), Vector3(1655.675f, 1264.157f, 199.603f), Vector3(1655.534f, 1281.109f, 198.191f))))
+      ZipLinePaths(new ZipLinePath(299, false, List(Vector3(1656.205f, 1310.291f, 198.211f), Vector3(1655.728f, 1334.811f, 204.791f), Vector3(1655.252f, 1359.33f, 212.888f), Vector3(1655.215f, 1361.253f, 213.212f))))
+      ZipLinePaths(new ZipLinePath(300, false, List(Vector3(1633.716f, 1367.62f, 213.197f), Vector3(1617.236f, 1367.789f, 218.096f), Vector3(1608.997f, 1367.873f, 220.706f), Vector3(1600.757f, 1367.957f, 222.815f), Vector3(1576.039f, 1368.209f, 227.236f), Vector3(1563.679f, 1368.335f, 230.446f), Vector3(1551.32f, 1368.461f, 234.257f), Vector3(1535.81f, 1368.619f, 238.516f))))
+      ZipLinePaths(new ZipLinePath(301, false, List(Vector3(1672.725f, 1446.715f, 198.892f), Vector3(1672.61f, 1454.546f, 202.811f), Vector3(1672.489f, 1462.867f, 205.662f), Vector3(1672.368f, 1471.187f, 207.912f), Vector3(1671.996f, 1496.638f, 209.314f), Vector3(1671.811f, 1509.364f, 211.814f), Vector3(1671.625f, 1522.089f, 214.915f), Vector3(1671.511f, 1529.92f, 215.701f), Vector3(1671.454f, 1533.836f, 217.794f), Vector3(1671.396f, 1537.751f, 218.201f))))
+      ZipLinePaths(new ZipLinePath(302, false, List(Vector3(1640.047f, 1548.61f, 223.215f), Vector3(1640.505f, 1568.514f, 228.292f), Vector3(1640.734f, 1578.467f, 231.29f), Vector3(1640.849f, 1583.443f, 232.789f), Vector3(1640.963f, 1588.419f, 233.205f))))
+      ZipLinePaths(new ZipLinePath(303, false, List(Vector3(1655.87f, 1606.72f, 233.9f), Vector3(1655.775f, 1612.969f, 237.636f), Vector3(1655.68f, 1619.217f, 238.471f), Vector3(1655.586f, 1625.466f, 241.005f), Vector3(1655.538f, 1628.59f, 242.473f), Vector3(1655.491f, 1631.714f, 242.94f), Vector3(1654.961f, 1666.706f, 233.2f))))
+      ZipLinePaths(new ZipLinePath(304, false, List(Vector3(1719.529f, 1570.549f, 223.18f), Vector3(1719.582f, 1564.423f, 222.69f), Vector3(1719.635f, 1558.297f, 220.107f), Vector3(1719.742f, 1546.046f, 216.741f), Vector3(1719.796f, 1539.92f, 215.008f), Vector3(1719.849f, 1533.795f, 213.375f), Vector3(1719.902f, 1527.669f, 210.492f), Vector3(1719.956f, 1521.543f, 209.509f), Vector3(1720.067f, 1508.802f, 209.088f), Vector3(1720.178f, 1496.061f, 208.668f), Vector3(1720.289f, 1483.319f, 208.948f), Vector3(1720.345f, 1476.949f, 212.087f), Vector3(1720.4f, 1470.578f, 213.127f), Vector3(1720.618f, 1445.585f, 204.617f), Vector3(1720.727f, 1433.089f, 201.362f), Vector3(1720.836f, 1420.593f, 197.307f), Vector3(1721.037f, 1397.56f, 189.401f), Vector3(1720.537f, 1386.044f, 186.448f), Vector3(1721.238f, 1374.528f, 183.2f))))
+      ZipLinePaths(new ZipLinePath(305, false, List(Vector3(1730.236f, 1367.877f, 183.382f), Vector3(1738.146f, 1367.813f, 186.517f), Vector3(1746.057f, 1367.749f, 188.776f), Vector3(1753.968f, 1367.684f, 191.935f), Vector3(1757.923f, 1367.652f, 192.915f), Vector3(1761.878f, 1367.62f, 193.213f))))
+      ZipLinePaths(new ZipLinePath(306, false, List(Vector3(1016.652f, 498.995f, 183.171f), Vector3(1016.125f, 474.041f, 183.533f), Vector3(1015.597f, 449.088f, 184.801f), Vector3(1015.412f, 440.354f, 185.924f), Vector3(1015.319f, 435.987f, 186.986f), Vector3(1015.227f, 431.62f, 188.148f), Vector3(1015.042f, 422.887f, 188.222f), Vector3(1014.857f, 414.153f, 188.201f))))
+      ZipLinePaths(new ZipLinePath(307, false, List(Vector3(1008.883f, 408.224f, 188.2f), Vector3(1000.386f, 407.959f, 190.022f), Vector3(996.138f, 407.826f, 192.386f), Vector3(991.89f, 407.693f, 192.949f), Vector3(983.394f, 407.428f, 189.721f), Vector3(974.897f, 407.163f, 188.19f))))
+      ZipLinePaths(new ZipLinePath(308, false, List(Vector3(820.337f, 246.805f, 153.19f), Vector3(778.421f, 249.491f, 153.23f))))
+      ZipLinePaths(new ZipLinePath(309, false, List(Vector3(602.831f, 599.918f, 183.211f), Vector3(583.872f, 600.199f, 183.368f), Vector3(564.912f, 600.48f, 183.224f), Vector3(548.947f, 600.716f, 183.228f), Vector3(543.957f, 600.79f, 183.153f), Vector3(534.977f, 600.923f, 179.827f), Vector3(525.996f, 601.056f, 178.201f))))
+      ZipLinePaths(new ZipLinePath(310, false, List(Vector3(519.788f, 612.558f, 178.21f), Vector3(519.461f, 663.555f, 178.948f), Vector3(519.192f, 705.553f, 178.19f))))
+      ZipLinePaths(new ZipLinePath(311, false, List(Vector3(472.031f, 737.508f, 183.333f), Vector3(471.882f, 749.709f, 187.618f), Vector3(471.732f, 761.909f, 191.228f), Vector3(471.583f, 774.11f, 194.637f), Vector3(471.508f, 780.21f, 197.142f), Vector3(471.433f, 786.31f, 199.247f), Vector3(471.337f, 794.205f, 201.757f), Vector3(471.24f, 802.099f, 203.866f), Vector3(471.143f, 809.994f, 206.576f), Vector3(471.095f, 813.941f, 207.731f), Vector3(471.047f, 817.888f, 208.213f))))
+      ZipLinePaths(new ZipLinePath(312, false, List(Vector3(425.006f, 836.2f, 203.19f), Vector3(423.432f, 799.231f, 203.17f))))
+      ZipLinePaths(new ZipLinePath(313, false, List(Vector3(403.332f, 807.446f, 203.211f), Vector3(391.598f, 808.338f, 205.995f), Vector3(385.732f, 808.784f, 207.642f), Vector3(379.865f, 809.23f, 208.2f))))
+      ZipLinePaths(new ZipLinePath(314, false, List(Vector3(375.366f, 818.172f, 208.35f), Vector3(375.41f, 825.167f, 210.7f), Vector3(375.432f, 828.665f, 212.023f), Vector3(375.453f, 832.163f, 212.946f), Vector3(375.534f, 845.155f, 209.365f), Vector3(375.575f, 851.651f, 207.075f), Vector3(375.595f, 854.899f, 205.429f), Vector3(375.615f, 858.147f, 204.184f), Vector3(375.696f, 871.139f, 201.003f), Vector3(375.737f, 877.635f, 198.812f), Vector3(375.777f, 884.131f, 196.821f), Vector3(375.857f, 896.874f, 193.848f), Vector3(375.896f, 903.245f, 194.162f), Vector3(375.936f, 909.616f, 197.576f), Vector3(376.015f, 922.358f, 200.253f), Vector3(376.055f, 928.729f, 203.591f), Vector3(376.095f, 935.1f, 200.33f), Vector3(376.174f, 947.842f, 199.057f), Vector3(376.253f, 960.585f, 203.184f), Vector3(376.293f, 966.956f, 200.597f), Vector3(376.333f, 973.327f, 198.811f), Vector3(376.372f, 979.698f, 196.824f), Vector3(376.412f, 986.069f, 194.438f), Vector3(376.571f, 1011.554f, 188.192f), Vector3(376.65f, 1024.296f, 183.869f), Vector3(376.69f, 1030.667f, 184.707f), Vector3(376.73f, 1037.038f, 187.346f), Vector3(376.809f, 1049.78f, 190.673f), Vector3(376.849f, 1056.151f, 192.937f), Vector3(376.888f, 1062.522f, 191f), Vector3(376.968f, 1075.265f, 188.627f), Vector3(377.007f, 1081.636f, 188.441f), Vector3(377.047f, 1088.007f, 189.654f), Vector3(377.102f, 1096.751f, 189.666f), Vector3(377.156f, 1105.496f, 193.877f), Vector3(377.211f, 1114.241f, 196.188f), Vector3(377.238f, 1118.613f, 197.944f), Vector3(377.265f, 1122.985f, 198.2f))))
+      ZipLinePaths(new ZipLinePath(315, false, List(Vector3(455.425f, 1085.946f, 183.201f), Vector3(455.374f, 1103.412f, 183.805f), Vector3(455.348f, 1112.145f, 184.956f), Vector3(455.335f, 1116.511f, 187.332f), Vector3(455.322f, 1120.878f, 187.907f), Vector3(455.303f, 1127.365f, 185.035f), Vector3(455.283f, 1133.852f, 183.163f), Vector3(455.264f, 1140.339f, 181.641f), Vector3(455.245f, 1146.827f, 179.519f), Vector3(455.206f, 1159.801f, 175.424f), Vector3(455.187f, 1166.289f, 173.577f), Vector3(455.178f, 1169.532f, 172.454f), Vector3(455.168f, 1172.776f, 170.93f), Vector3(455.13f, 1185.501f, 169.651f), Vector3(455.092f, 1198.226f, 172.572f), Vector3(455.055f, 1210.951f, 175.993f), Vector3(455.036f, 1217.314f, 178.504f), Vector3(455.017f, 1223.676f, 175.614f), Vector3(454.981f, 1235.653f, 173.357f), Vector3(454.946f, 1247.63f, 173.201f))))
+      ZipLinePaths(new ZipLinePath(316, false, List(Vector3(455.962f, 1404.88f, 173.49f), Vector3(456.291f, 1455.873f, 174.03f), Vector3(456.406f, 1473.871f, 173.19f))))
+      ZipLinePaths(new ZipLinePath(317, false, List(Vector3(464.578f, 1481.471f, 173.26f), Vector3(476.106f, 1480.883f, 176.977f), Vector3(487.635f, 1480.296f, 179.811f), Vector3(499.164f, 1479.708f, 184.144f), Vector3(504.928f, 1479.415f, 185.911f), Vector3(510.692f, 1479.121f, 187.478f), Vector3(515.496f, 1478.876f, 188.22f))))
+      ZipLinePaths(new ZipLinePath(318, false, List(Vector3(535.622f, 1469.87f, 188.21f), Vector3(536.963f, 1506.843f, 188.2f))))
+      ZipLinePaths(new ZipLinePath(319, false, List(Vector3(552.012f, 1520.061f, 188.233f), Vector3(551.63f, 1532.271f, 191.871f), Vector3(551.247f, 1544.48f, 195.432f), Vector3(550.864f, 1556.69f, 199.294f), Vector3(550.481f, 1568.9f, 203.555f), Vector3(549.955f, 1585.659f, 208.167f), Vector3(549.693f, 1594.038f, 210.873f), Vector3(549.561f, 1598.228f, 212.426f), Vector3(549.43f, 1602.418f, 213.302f))))
+      ZipLinePaths(new ZipLinePath(320, false, List(Vector3(526.961f, 1655.74f, 218.191f), Vector3(535.944f, 1655.735f, 220.4f), Vector3(540.436f, 1655.733f, 222.153f), Vector3(544.928f, 1655.731f, 222.706f), Vector3(557.904f, 1655.724f, 218.829f), Vector3(564.392f, 1655.721f, 216.49f), Vector3(570.88f, 1655.718f, 213.951f), Vector3(577.368f, 1655.715f, 212.562f), Vector3(583.856f, 1655.712f, 209.773f), Vector3(590.344f, 1655.708f, 208.685f), Vector3(596.833f, 1655.705f, 206.196f), Vector3(609.559f, 1655.699f, 203.883f), Vector3(622.286f, 1655.693f, 207.571f), Vector3(635.013f, 1655.687f, 210.658f), Vector3(641.376f, 1655.683f, 213.602f), Vector3(647.739f, 1655.68f, 210.145f), Vector3(660.466f, 1655.674f, 209.683f), Vector3(673.193f, 1655.668f, 213.02f), Vector3(685.919f, 1655.662f, 208.857f), Vector3(692.282f, 1655.659f, 206.376f), Vector3(698.646f, 1655.656f, 204.295f), Vector3(724.099f, 1655.643f, 197.37f), Vector3(736.826f, 1655.637f, 192.907f), Vector3(743.189f, 1655.634f, 194.476f), Vector3(746.371f, 1655.632f, 195.46f), Vector3(749.552f, 1655.631f, 197.444f), Vector3(760.033f, 1655.625f, 201.298f), Vector3(765.274f, 1655.623f, 202.825f), Vector3(770.514f, 1655.62f, 203.251f))))
+      ZipLinePaths(new ZipLinePath(321, false, List(Vector3(775.514f, 1789.676f, 203.21f), Vector3(773.658f, 1826.626f, 203.28f))))
+      ZipLinePaths(new ZipLinePath(322, false, List(Vector3(762.949f, 1831.455f, 203.699f), Vector3(756.071f, 1831.531f, 207.345f), Vector3(749.193f, 1831.606f, 208.523f), Vector3(742.315f, 1831.681f, 211.4f), Vector3(735.437f, 1831.756f, 213.21f))))
+      ZipLinePaths(new ZipLinePath(323, false, List(Vector3(728.262f, 1843.892f, 213.507f), Vector3(728.366f, 1851.282f, 216.603f), Vector3(728.47f, 1858.671f, 219.027f), Vector3(728.574f, 1866.061f, 221.652f), Vector3(728.626f, 1869.755f, 222.564f), Vector3(728.678f, 1873.45f, 223.206f))))
+      ZipLinePaths(new ZipLinePath(324, false, List(Vector3(744.063f, 1895.348f, 224.013f), Vector3(744.108f, 1899.326f, 226.214f), Vector3(744.152f, 1903.304f, 228.118f), Vector3(744.332f, 1919.216f, 232.914f), Vector3(744.416f, 1926.674f, 230.973f), Vector3(744.501f, 1934.133f, 228.333f))))
+      ZipLinePaths(new ZipLinePath(325, false, List(Vector3(759.746f, 1953.04f, 228.29f), Vector3(759.606f, 1959.903f, 230.621f), Vector3(759.466f, 1966.767f, 233.066f), Vector3(759.145f, 1982.454f, 237.818f), Vector3(758.765f, 2001.083f, 238.211f))))
+      ZipLinePaths(new ZipLinePath(326, false, List(Vector3(752.948f, 2008.381f, 238.187f), Vector3(748.352f, 2008.585f, 237.325f), Vector3(743.756f, 2008.789f, 235.782f), Vector3(734.565f, 2009.198f, 232.696f), Vector3(716.182f, 2010.014f, 228.238f))))
+      ZipLinePaths(new ZipLinePath(327, false, List(Vector3(712.171f, 2021.266f, 228.702f), Vector3(712.396f, 2027.728f, 231.262f), Vector3(712.622f, 2034.19f, 233.942f), Vector3(713.072f, 2047.113f, 237.902f), Vector3(713.606f, 2062.429f, 242.555f), Vector3(713.807f, 2068.173f, 243.244f))))
+      ZipLinePaths(new ZipLinePath(328, false, List(Vector3(728.179f, 2083.034f, 243.41f), Vector3(728.087f, 2090.282f, 246.073f), Vector3(727.996f, 2097.53f, 248.433f), Vector3(727.904f, 2104.778f, 251.193f), Vector3(727.813f, 2112.027f, 252.954f), Vector3(727.629f, 2126.523f, 248.528f), Vector3(727.446f, 2141.02f, 243.4f))))
+      ZipLinePaths(new ZipLinePath(329, false, List(Vector3(779.821f, 1928.877f, 228.19f), Vector3(797.77f, 1928.144f, 232.516f), Vector3(806.745f, 1927.778f, 234.128f), Vector3(815.719f, 1927.411f, 237.94f), Vector3(830.718f, 1927.263f, 233.5f), Vector3(845.717f, 1927.115f, 228.36f))))
+      ZipLinePaths(new ZipLinePath(330, false, List(Vector3(862.363f, 1910.578f, 228.233f), Vector3(868.217f, 1910.713f, 227.056f), Vector3(874.07f, 1910.849f, 224.805f), Vector3(885.776f, 1911.119f, 221.102f), Vector3(897.483f, 1911.39f, 217.6f), Vector3(909.189f, 1911.661f, 213.425f))))
+      ZipLinePaths(new ZipLinePath(331, false, List(Vector3(919.883f, 1905.153f, 213.195f), Vector3(920.13f, 1897.232f, 215.577f), Vector3(920.376f, 1889.31f, 217.866f), Vector3(920.962f, 1870.495f, 218.194f))))
+      ZipLinePaths(new ZipLinePath(332, false, List(Vector3(945.907f, 1864.106f, 223.179f), Vector3(970.945f, 1864.053f, 226.924f), Vector3(983.464f, 1864.026f, 229.45f), Vector3(989.723f, 1864.013f, 232.112f), Vector3(995.983f, 1864f, 233.575f), Vector3(1006.783f, 1863.977f, 237.691f), Vector3(1022.493f, 1863.944f, 238.2f))))
+      ZipLinePaths(new ZipLinePath(333, false, List(Vector3(1101.254f, 2039.38f, 243.191f), Vector3(1088.795f, 2039.644f, 243.592f), Vector3(1076.336f, 2039.908f, 244.899f), Vector3(1051.419f, 2040.436f, 243.312f), Vector3(1043.445f, 2040.605f, 246.791f))))
+      ZipLinePaths(new ZipLinePath(334, false, List(Vector3(1032.137f, 2050.7f, 248.19f), Vector3(1031.324f, 2093.69f, 248.19f))))
+      ZipLinePaths(new ZipLinePath(335, false, List(Vector3(1024.946f, 2103.952f, 248.184f), Vector3(1021.128f, 2104.082f, 247.235f), Vector3(1017.31f, 2104.212f, 245.011f), Vector3(1009.674f, 2104.472f, 243.564f), Vector3(1002.038f, 2104.732f, 240.916f), Vector3(994.403f, 2104.991f, 238.396f))))
+      ZipLinePaths(new ZipLinePath(336, false, List(Vector3(984.665f, 2115.902f, 238.498f), Vector3(984.551f, 2126.835f, 242.852f), Vector3(984.437f, 2137.768f, 245.33f), Vector3(984.322f, 2148.701f, 249.808f), Vector3(984.208f, 2159.634f, 253.219f))))
+      ZipLinePaths(new ZipLinePath(337, false, List(Vector3(1000.114f, 2181.035f, 253.65f), Vector3(999.982f, 2187.783f, 256.05f), Vector3(999.916f, 2191.157f, 257.701f), Vector3(999.85f, 2194.532f, 258.351f), Vector3(999.717f, 2201.28f, 260.952f), Vector3(999.585f, 2208.029f, 262.753f), Vector3(999.252f, 2225.024f, 257.521f), Vector3(998.919f, 2242.02f, 253.19f))))
+      ZipLinePaths(new ZipLinePath(338, false, List(Vector3(975.39f, 2247.937f, 253.194f), Vector3(927.624f, 2248.853f, 239.174f), Vector3(912.339f, 2249.146f, 233.254f))))
+      ZipLinePaths(new ZipLinePath(339, false, List(Vector3(984.178f, 2266.025f, 248.795f), Vector3(984.368f, 2284.326f, 246.192f), Vector3(984.558f, 2302.628f, 243.196f))))
+      ZipLinePaths(new ZipLinePath(340, false, List(Vector3(1022.727f, 2168.098f, 248.291f), Vector3(1029.089f, 2168.073f, 246.96f), Vector3(1035.452f, 2168.049f, 244.927f), Vector3(1041.814f, 2168.024f, 242.894f), Vector3(1044.996f, 2168.011f, 241.278f), Vector3(1048.177f, 2167.999f, 240.262f), Vector3(1060.902f, 2167.949f, 238.496f), Vector3(1073.627f, 2167.899f, 238.731f), Vector3(1089.097f, 2167.839f, 238.904f), Vector3(1096.832f, 2167.808f, 239.591f), Vector3(1100.699f, 2167.793f, 242.334f), Vector3(1104.567f, 2167.778f, 243.181f))))
+      ZipLinePaths(new ZipLinePath(341, false, List(Vector3(1111.952f, 2156.833f, 243.2f), Vector3(1112.678f, 2115.833f, 243.24f))))
+      ZipLinePaths(new ZipLinePath(342, false, List(Vector3(1120.083f, 2103.886f, 243.225f), Vector3(1131.271f, 2103.613f, 239.605f), Vector3(1142.459f, 2103.341f, 235.91f), Vector3(1153.647f, 2103.068f, 232.514f), Vector3(1164.834f, 2102.796f, 228.445f))))
+      ZipLinePaths(new ZipLinePath(343, false, List(Vector3(1182.14f, 2087.616f, 228.225f), Vector3(1187.861f, 2087.641f, 227.269f), Vector3(1193.582f, 2087.666f, 224.633f), Vector3(1205.024f, 2087.716f, 221.561f), Vector3(1216.466f, 2087.766f, 217.889f), Vector3(1227.908f, 2087.816f, 213.546f))))
+      ZipLinePaths(new ZipLinePath(344, false, List(Vector3(1246.648f, 2072.441f, 213.193f), Vector3(1252.75f, 2072.281f, 212.004f), Vector3(1258.853f, 2072.121f, 208.938f), Vector3(1271.058f, 2071.8f, 206.006f), Vector3(1295.469f, 2071.159f, 198.263f))))
+      ZipLinePaths(new ZipLinePath(345, false, List(Vector3(1308.848f, 2041.255f, 198.2f), Vector3(1321.595f, 2041.049f, 197.872f), Vector3(1327.969f, 2040.946f, 197.56f), Vector3(1334.342f, 2040.844f, 196.647f), Vector3(1347.089f, 2040.638f, 191.921f), Vector3(1353.462f, 2040.535f, 189.358f), Vector3(1356.649f, 2040.484f, 188.676f), Vector3(1359.836f, 2040.433f, 187.995f), Vector3(1377.332f, 2040.151f, 193.147f), Vector3(1386.079f, 2040.01f, 195.923f), Vector3(1390.453f, 2039.939f, 197.511f), Vector3(1394.827f, 2039.869f, 198.4f))))
+      ZipLinePaths(new ZipLinePath(346, false, List(Vector3(1416.676f, 1890.96f, 218.215f), Vector3(1416.322f, 1856.951f, 227.305f), Vector3(1415.825f, 1809.339f, 238.135f))))
+      ZipLinePaths(new ZipLinePath(347, false, List(Vector3(1447.552f, 1891.489f, 218.239f), Vector3(1447.824f, 1882.556f, 219.813f), Vector3(1448.097f, 1873.623f, 222.71f), Vector3(1448.369f, 1864.691f, 224.806f), Vector3(1448.505f, 1860.224f, 226.654f), Vector3(1448.641f, 1855.758f, 228.22f))))
+      ZipLinePaths(new ZipLinePath(348, false, List(Vector3(1603.929f, 1672.213f, 223.508f), Vector3(1609.247f, 1672.265f, 225.317f), Vector3(1614.566f, 1672.316f, 227.644f), Vector3(1622.784f, 1672.396f, 229.569f), Vector3(1631.003f, 1672.476f, 232.694f), Vector3(1639.705f, 1672.561f, 233.209f))))
+      ZipLinePaths(new ZipLinePath(349, false, List(Vector3(1071.874f, 217.362f, 143.135f), Vector3(1075.187f, 246.758f, 149.615f), Vector3(1075.001f, 273.955f, 160.196f), Vector3(1074.433f, 288.103f, 163.436f), Vector3(1080.365f, 302.251f, 163.976f), Vector3(1087.747f, 316.399f, 164.267f), Vector3(1095.129f, 330.547f, 163.857f), Vector3(1108.319f, 358.364f, 163.255f))))
+      ZipLinePaths(new ZipLinePath(350, false, List(Vector3(1126.922f, 406.781f, 163.147f), Vector3(1139.227f, 412.457f, 164.141f), Vector3(1151.532f, 418.033f, 166.046f), Vector3(1176.141f, 428.985f, 165.457f), Vector3(1200.551f, 434.386f, 171.439f), Vector3(1225.361f, 436.388f, 178.422f), Vector3(1237.425f, 437.112f, 181.369f), Vector3(1243.456f, 435.273f, 182.842f), Vector3(1249.488f, 433.435f, 183.226f))))
+      ZipLinePaths(new ZipLinePath(351, false, List(Vector3(976.744f, 153.992f, 143.01f), Vector3(977.459f, 161.322f, 145.813f), Vector3(978.274f, 170.653f, 149.022f), Vector3(979.304f, 188.314f, 155.14f), Vector3(979.884f, 204.475f, 160.058f), Vector3(978.564f, 220.836f, 163.776f), Vector3(968.873f, 240.673f, 164.006f), Vector3(962.182f, 252.51f, 163.15f))))
+      ZipLinePaths(new ZipLinePath(352, false, List(Vector3(915.3f, 242.709f, 163.14f), Vector3(892.78f, 254.164f, 163.864f), Vector3(873.959f, 264.419f, 164.493f), Vector3(865.454f, 268.224f, 164.699f), Vector3(857.047f, 272.332f, 163.967f), Vector3(847.54f, 273.24f, 163.14f))))
+      ZipLinePaths(new ZipLinePath(353, false, List(Vector3(850.016f, 313.937f, 163.154f), Vector3(851.875f, 330.642f, 168.036f), Vector3(852.733f, 347.447f, 173.436f), Vector3(853.391f, 364.052f, 178.236f), Vector3(851.92f, 372.405f, 181.236f), Vector3(850.449f, 380.757f, 184.236f), Vector3(849.903f, 383.662f, 184.826f), Vector3(857.763f, 404.967f, 185.414f))))
+      ZipLinePaths(new ZipLinePath(354, false, List(Vector3(999.272f, 110.243f, 143.14f), Vector3(975.32f, 109.409f, 144.463f), Vector3(951.369f, 108.976f, 146.491f), Vector3(903.465f, 109.909f, 148.29f), Vector3(865.142f, 109.176f, 147.437f), Vector3(840.712f, 115.986f, 146.736f), Vector3(816.281f, 153.796f, 145.236f), Vector3(813.449f, 162.943f, 143.14f))))
+      ZipLinePaths(new ZipLinePath(355, false, List(Vector3(793.348f, 215.24f, 143.142f), Vector3(777.178f, 222.349f, 144.83f), Vector3(761.408f, 229.859f, 146.825f), Vector3(724.868f, 249.478f, 148.414f), Vector3(719.867f, 278.066f, 153.799f), Vector3(720.665f, 306.654f, 161.784f), Vector3(713.164f, 336.042f, 165.268f), Vector3(702.462f, 363.83f, 166.353f), Vector3(686.882f, 389.303f, 163.142f))))
+      ZipLinePaths(new ZipLinePath(356, false, List(Vector3(633.169f, 397.14f, 163.143f), Vector3(605.993f, 410.372f, 164.411f), Vector3(596.218f, 423.604f, 166.187f), Vector3(589.968f, 447.667f, 168.938f), Vector3(587.268f, 478.38f, 175.401f), Vector3(588.968f, 509.092f, 184.464f), Vector3(610.595f, 560.61f, 185.838f), Vector3(618.614f, 568.535f, 183.144f))))
+      ZipLinePaths(new ZipLinePath(357, false, List(Vector3(313.406f, 1229.852f, 173.13f), Vector3(338.439f, 1227.908f, 176.796f), Vector3(363.471f, 1226.764f, 177.758f), Vector3(388.503f, 1228.12f, 176.69f), Vector3(413.535f, 1242.276f, 174.422f), Vector3(421.225f, 1250.419f, 172.87f))))
+      ZipLinePaths(new ZipLinePath(358, false, List(Vector3(400.806f, 1286.539f, 173.14f), Vector3(413.261f, 1315.389f, 174.687f), Vector3(421.717f, 1331.039f, 175.139f), Vector3(436.173f, 1358.29f, 175.966f), Vector3(445.129f, 1375.54f, 174.192f), Vector3(455.025f, 1383.393f, 173.25f))))
+      ZipLinePaths(new ZipLinePath(359, false, List(Vector3(473.924f, 1357.231f, 173.255f), Vector3(489.493f, 1355.978f, 176.417f), Vector3(532.11f, 1359.281f, 191.664f), Vector3(542.667f, 1357.76f, 193.221f), Vector3(553.225f, 1354.44f, 192.978f), Vector3(574.341f, 1331.2f, 190.491f), Vector3(583.726f, 1319.583f, 188.213f))))
+      ZipLinePaths(new ZipLinePath(360, false, List(Vector3(871.063f, 2357.891f, 243.25f), Vector3(853.39f, 2351.203f, 243.371f), Vector3(835.717f, 2344.015f, 244.193f), Vector3(818.045f, 2334.977f, 244.692f), Vector3(800.372f, 2322.739f, 244.992f), Vector3(762.899f, 2305.651f, 245.891f), Vector3(750.563f, 2278.707f, 247.14f), Vector3(738.626f, 2252.763f, 246.19f), Vector3(729.181f, 2236.187f, 245.188f), Vector3(716.957f, 2203.652f, 243.25f))))
+      ZipLinePaths(new ZipLinePath(361, false, List(Vector3(701.114f, 2159.581f, 243.13f), Vector3(676.278f, 2156.712f, 244.456f), Vector3(651.441f, 2155.243f, 245.482f), Vector3(640.513f, 2155.181f, 246.605f), Vector3(636.319f, 2153.866f, 245.631f), Vector3(631.572f, 2151.549f, 243.14f))))
+      ZipLinePaths(new ZipLinePath(362, false, List(Vector3(584.654f, 2136.17f, 243.142f), Vector3(559.91f, 2085.271f, 246.047f), Vector3(556.012f, 2018.31f, 227.197f), Vector3(568.313f, 1984.829f, 224.771f), Vector3(591.013f, 1968.089f, 223.959f), Vector3(614.664f, 1963.118f, 224.002f), Vector3(621.714f, 1951.348f, 224.446f), Vector3(630.106f, 1927.935f, 225.697f), Vector3(641.698f, 1904.522f, 226.547f), Vector3(649.245f, 1892.815f, 226.173f), Vector3(652.218f, 1886.962f, 226.285f), Vector3(651.491f, 1881.109f, 223.798f), Vector3(651.087f, 1869.402f, 219.423f), Vector3(650.683f, 1857.696f, 214.849f), Vector3(652.529f, 1819.989f, 205.924f), Vector3(675.576f, 1782.283f, 205.199f), Vector3(688.468f, 1776.87f, 204.45f), Vector3(702.021f, 1773.798f, 203.849f), Vector3(712.174f, 1769.926f, 203.252f))))
+      ZipLinePaths(new ZipLinePath(363, false, List(Vector3(759.295f, 1749.047f, 203.14f), Vector3(776.975f, 1744.772f, 203.259f), Vector3(785.816f, 1743.035f, 203.971f), Vector3(794.656f, 1739.297f, 204.483f), Vector3(805.403f, 1727.828f, 204.759f), Vector3(810.777f, 1721.494f, 204.497f), Vector3(813.463f, 1716.927f, 204.166f), Vector3(817.55f, 1700.759f, 203.14f))))
+      ZipLinePaths(new ZipLinePath(364, false, List(Vector3(1058.578f, 2320.326f, 243.13f), Vector3(1109.572f, 2319.579f, 243.885f), Vector3(1124.57f, 2319.359f, 243.14f))))
+      ZipLinePaths(new ZipLinePath(365, false, List(Vector3(1126.83f, 2280.158f, 243.14f), Vector3(1142.435f, 2272.359f, 243.249f), Vector3(1177.84f, 2255.76f, 244.063f), Vector3(1230.451f, 2249.961f, 244.046f), Vector3(1248.101f, 2256.233f, 243.07f))))
+      ZipLinePaths(new ZipLinePath(366, false, List(Vector3(1255.276f, 2294.393f, 243.146f), Vector3(1284.893f, 2309.059f, 243.882f), Vector3(1314.511f, 2323.526f, 244.528f), Vector3(1339.759f, 2322.607f, 237.148f), Vector3(1365.007f, 2322.287f, 226.969f), Vector3(1384.228f, 2320.903f, 223.146f))))
+      ZipLinePaths(new ZipLinePath(367, false, List(Vector3(1386.825f, 2264.216f, 223.08f), Vector3(1364.395f, 2219.526f, 223.891f), Vector3(1361.703f, 2214.163f, 223.14f))))
+      ZipLinePaths(new ZipLinePath(368, false, List(Vector3(1422.85f, 2276.601f, 223.14f), Vector3(1446.379f, 2234.273f, 223.892f), Vector3(1456.732f, 2213.056f, 223.14f))))
+      ZipLinePaths(new ZipLinePath(369, false, List(Vector3(1482.817f, 2150.7f, 223.14f), Vector3(1506.01f, 2103.6f, 224.078f), Vector3(1517.143f, 2085.137f, 223.14f))))
+      ZipLinePaths(new ZipLinePath(370, false, List(Vector3(1552.37f, 2085.239f, 223.14f), Vector3(1552.544f, 2060.239f, 222.477f), Vector3(1552.718f, 2035.239f, 215.118f), Vector3(1553.066f, 1985.239f, 211.542f), Vector3(1553.414f, 1935.239f, 215.167f), Vector3(1553.762f, 1885.239f, 223.991f), Vector3(1553.776f, 1883.239f, 223.25f))))
+      ZipLinePaths(new ZipLinePath(371, false, List(Vector3(1579.071f, 1833.389f, 223.14f), Vector3(1580.239f, 1824.555f, 225.36f), Vector3(1580.081f, 1813.472f, 226.39f), Vector3(1579.087f, 1755.799f, 227.67f), Vector3(1551.894f, 1698.526f, 228.35f), Vector3(1553.643f, 1647.741f, 225.947f), Vector3(1552.481f, 1638.816f, 223.14f))))
+      ZipLinePaths(new ZipLinePath(372, false, List(Vector3(1584.84f, 1635.059f, 223.149f), Vector3(1585.738f, 1620.366f, 222.776f), Vector3(1586.635f, 1605.673f, 221.317f), Vector3(1588.031f, 1586.286f, 213.2f), Vector3(1587.426f, 1561.899f, 209.055f), Vector3(1582.821f, 1537.513f, 204.31f), Vector3(1576.281f, 1510.2f, 198.51f))))
+      ZipLinePaths(new ZipLinePath(373, false, List(Vector3(1394.807f, 2214.354f, 223.156f), Vector3(1395.435f, 2200.517f, 223.103f), Vector3(1396.064f, 2191.081f, 221.372f), Vector3(1396.734f, 2141.625f, 206.591f), Vector3(1399.101f, 2134.836f, 203.154f))))
+      ZipLinePaths(new ZipLinePath(374, false, List(Vector3(1420.624f, 2088.402f, 203.14f), Vector3(1421.17f, 2063.451f, 204.095f), Vector3(1420.516f, 2038.501f, 207.355f), Vector3(1420.06f, 2016.546f, 205.797f), Vector3(1415.199f, 2006.567f, 203.25f))))
+      ZipLinePaths(new ZipLinePath(375, false, List(Vector3(1498.604f, 1508.597f, 196.804f), Vector3(1460.323f, 1489.823f, 223.692f), Vector3(1422.042f, 1471.048f, 249.813f), Vector3(1409.026f, 1463.665f, 260.349f), Vector3(1395.211f, 1458.682f, 265.003f))))
+      ZipLinePaths(new ZipLinePath(376, false, List(Vector3(1864.299f, 1327.779f, 193.14f), Vector3(1814.317f, 1329.165f, 193.957f), Vector3(1787.327f, 1329.913f, 193.25f))))
+      ZipLinePaths(new ZipLinePath(377, false, List(Vector3(1782.437f, 1289.688f, 193.25f), Vector3(1775.027f, 1268.099f, 194.165f), Vector3(1757.218f, 1234.911f, 194.182f), Vector3(1744.608f, 1210.523f, 194.478f), Vector3(1735.598f, 1183.335f, 194.174f), Vector3(1714.544f, 1169.712f, 193.25f))))
+      ZipLinePaths(new ZipLinePath(378, false, List(Vector3(1685.673f, 1202.774f, 193.14f), Vector3(1635.673f, 1202.42f, 194.176f), Vector3(1623.673f, 1202.335f, 193.43f))))
+      ZipLinePaths(new ZipLinePath(379, false, List(Vector3(589.162f, 1287.888f, 187.36f), Vector3(606.508f, 1241.031f, 190.011f), Vector3(623.855f, 1194.175f, 191.917f), Vector3(641.201f, 1147.318f, 193.824f), Vector3(652.649f, 1116.393f, 194.39f))))
+      ZipLinePaths(new ZipLinePath(380, false, List(Vector3(654.164f, 891.092f, 187.24f), Vector3(646.279f, 841.718f, 192.507f), Vector3(638.393f, 792.343f, 194.029f), Vector3(630.507f, 742.969f, 193.551f), Vector3(622.621f, 693.595f, 191.074f), Vector3(618.205f, 665.945f, 185.14f))))
+      ZipLinePaths(new ZipLinePath(381, false, List(Vector3(761.584f, 541.531f, 187.14f), Vector3(779.403f, 494.815f, 194.028f), Vector3(797.222f, 448.099f, 193.57f), Vector3(810.765f, 412.594f, 186.55f))))
+      ZipLinePaths(new ZipLinePath(382, false, List(Vector3(1222.018f, 631.67f, 196.892f), Vector3(1232.851f, 583.016f, 193.697f), Vector3(1243.685f, 534.361f, 189.756f), Vector3(1254.519f, 485.708f, 185.815f), Vector3(1260.369f, 459.436f, 182.691f))))
+      ZipLinePaths(new ZipLinePath(383, false, List(Vector3(1271.689f, 782.181f, 274.208f), Vector3(1277.334f, 762.195f, 272.418f), Vector3(1282.98f, 742.209f, 247.122f), Vector3(1294.272f, 702.237f, 219.284f), Vector3(1301.047f, 678.254f, 201.102f))))
+      ZipLinePaths(new ZipLinePath(384, false, List(Vector3(1368.124f, 1341.561f, 296.172f), Vector3(1364.566f, 1365.321f, 292.123f), Vector3(1361.008f, 1389.081f, 279.805f), Vector3(1353.892f, 1436.601f, 262.712f), Vector3(1353.334f, 1440.328f, 259.543f))))
+      ZipLinePaths(new ZipLinePath(385, false, List(Vector3(1348.286f, 1441.756f, 259.543f), Vector3(1314.196f, 1425.256f, 255.043f))))
+      ZipLinePaths(new ZipLinePath(386, false, List(Vector3(1060.551f, 1605.738f, 278.033f), Vector3(1107.398f, 1625.112f, 273.261f), Vector3(1154.246f, 1644.486f, 267.73f), Vector3(1157.001f, 1645.625f, 265.434f))))
+      ZipLinePaths(new ZipLinePath(387, false, List(Vector3(954.548f, 1391.85f, 224.246f), Vector3(946.487f, 1390.942f, 233.408f), Vector3(938.426f, 1390.034f, 234.764f))))
+      ZipLinePaths(new ZipLinePath(388, false, List(Vector3(916.348f, 1384.567f, 234.767f), Vector3(930.496f, 1358.334f, 275.657f), Vector3(937.57f, 1345.218f, 311.353f), Vector3(944.644f, 1332.101f, 315.548f))))
+      ZipLinePaths(new ZipLinePath(389, false, List(Vector3(1366.672f, 1311.332f, 296.193f), Vector3(1355.793f, 1291.42f, 291.968f), Vector3(1344.913f, 1271.507f, 275.896f), Vector3(1323.154f, 1231.682f, 254.893f), Vector3(1301.395f, 1191.856f, 233.891f), Vector3(1294.367f, 1178.408f, 225.36f))))
+      ZipLinePaths(new ZipLinePath(390, false, List(Vector3(783.039f, 1209.045f, 217.8f), Vector3(757.026f, 1252.86f, 216.442f), Vector3(731.012f, 1296.676f, 214.34f), Vector3(718.26f, 1318.154f, 212.49f))))
+      ZipLinePaths(new ZipLinePath(391, true, List(Vector3(1374.548f, 1288.463f, 211.2f), Vector3(1373.826f, 1281.376f, 224.2f))))
+      ZipLinePaths(new ZipLinePath(392, false, List(Vector3(1026.257f, 843.695f, 185.942f), Vector3(1028.149f, 852.608f, 195.5f), Vector3(1028.419f, 856.395f, 196.141f))))
+      ZipLinePaths(new ZipLinePath(393, false, List(Vector3(1166.499f, 889.383f, 196.147f), Vector3(1172.461f, 895.042f, 211.579f), Vector3(1176.159f, 898.61f, 211.891f))))
+      ZipLinePaths(new ZipLinePath(394, false, List(Vector3(1118.547f, 990.403f, 204.698f), Vector3(1121.775f, 995.338f, 211.55f), Vector3(1124.542f, 999.568f, 212.35f))))
+      ZipLinePaths(new ZipLinePath(395, false, List(Vector3(1205.96f, 995.02f, 212.6f), Vector3(1238.316f, 1003.723f, 250.267f), Vector3(1243.219f, 1000.629f, 251.421f))))
+      ZipLinePaths(new ZipLinePath(396, false, List(Vector3(1238.847f, 1034.95f, 254.212f), Vector3(1226.866f, 990.364f, 274.176f), Vector3(1214.885f, 945.778f, 294.579f), Vector3(1212.968f, 938.644f, 296.041f))))
+      ZipLinePaths(new ZipLinePath(397, false, List(Vector3(1218.983f, 891.836f, 296.012f), Vector3(1238.388f, 846.056f, 285.407f), Vector3(1255.51f, 805.662f, 274.234f))))
+      ZipLinePaths(new ZipLinePath(398, false, List(Vector3(1291.711f, 807.736f, 274.383f), Vector3(1321.944f, 844.617f, 254.485f), Vector3(1351.777f, 880.498f, 233.914f), Vector3(1377.191f, 907.137f, 212.703f))))
+      ZipLinePaths(new ZipLinePath(399, false, List(Vector3(1406.765f, 919.786f, 212.679f), Vector3(1407.449f, 916.317f, 212.18f), Vector3(1411.14f, 901.425f, 185.702f))))
+      ZipLinePaths(new ZipLinePath(400, false, List(Vector3(1331.335f, 910.391f, 212.572f), Vector3(1331.967f, 904.956f, 212.32f), Vector3(1337.491f, 876.897f, 193.028f))))
+      ZipLinePaths(new ZipLinePath(401, false, List(Vector3(1257.393f, 959.594f, 213.244f), Vector3(1257.67f, 955.326f, 212.8f), Vector3(1258.499f, 948.124f, 195.843f))))
+      ZipLinePaths(new ZipLinePath(402, false, List(Vector3(1241.54f, 848.057f, 211.951f), Vector3(1238.514f, 847.292f, 211.5f), Vector3(1224.848f, 843.823f, 185.972f))))
+      ZipLinePaths(new ZipLinePath(403, false, List(Vector3(996.539f, 837.803f, 195.145f), Vector3(996.865f, 833.708f, 194.678f), Vector3(997.015f, 825.448f, 185.844f))))
+      ZipLinePaths(new ZipLinePath(404, false, List(Vector3(872.179f, 908.625f, 208.904f), Vector3(873.49f, 904.836f, 208.601f), Vector3(887.154f, 880.725f, 197.6f), Vector3(893.144f, 869.566f, 187.283f))))
+      ZipLinePaths(new ZipLinePath(405, false, List(Vector3(747.407f, 1402.556f, 204.704f), Vector3(755.396f, 1401.347f, 213.3f), Vector3(758.872f, 1401.143f, 213.347f))))
+      ZipLinePaths(new ZipLinePath(406, false, List(Vector3(750.093f, 1561.501f, 212.656f), Vector3(753.513f, 1564.077f, 212.532f), Vector3(758.477f, 1569.104f, 200.151f))))
+      ZipLinePaths(new ZipLinePath(407, false, List(Vector3(946.019f, 1502.417f, 212.646f), Vector3(945.91f, 1506.223f, 212.4f), Vector3(945.729f, 1510.968f, 197.607f))))
+      ZipLinePaths(new ZipLinePath(408, false, List(Vector3(973.283f, 1524.192f, 226.152f), Vector3(971.004f, 1527.568f, 225.9f), Vector3(966.521f, 1539.625f, 197.502f))))
+      ZipLinePaths(new ZipLinePath(409, false, List(Vector3(1016.489f, 1476.031f, 201.447f), Vector3(1012.699f, 1481.305f, 225.545f), Vector3(1010.752f, 1483.124f, 226.146f))))
+      ZipLinePaths(new ZipLinePath(410, false, List(Vector3(1075.853f, 1401.411f, 225.686f), Vector3(1072.731f, 1402.664f, 225.274f), Vector3(1056.124f, 1409.047f, 204.842f))))
+      ZipLinePaths(new ZipLinePath(411, false, List(Vector3(1148.506f, 1446.867f, 220.562f), Vector3(1143.938f, 1454.651f, 219.37f), Vector3(1139.37f, 1462.434f, 214.04f))))
+      ZipLinePaths(new ZipLinePath(412, false, List(Vector3(1278.732f, 1509.007f, 222.004f), Vector3(1291.364f, 1524.6f, 220.425f), Vector3(1304.195f, 1540.394f, 213.35f), Vector3(1307.016f, 1543.923f, 209.65f), Vector3(1310.036f, 1547.652f, 193.654f))))
+      ZipLinePaths(new ZipLinePath(413, false, List(Vector3(1347.651f, 1449.073f, 220.296f), Vector3(1347.577f, 1452.166f, 220.04f), Vector3(1347.094f, 1466.267f, 194.846f))))
+      ZipLinePaths(new ZipLinePath(414, false, List(Vector3(1377.227f, 1428.314f, 220.289f), Vector3(1380.011f, 1429.335f, 220.008f), Vector3(1390.577f, 1434.033f, 194.848f))))
+      ZipLinePaths(new ZipLinePath(415, false, List(Vector3(1348.868f, 1387.999f, 220.307f), Vector3(1351.913f, 1371.802f, 218.025f), Vector3(1354.957f, 1355.606f, 211.576f))))
+      ZipLinePaths(new ZipLinePath(416, false, List(Vector3(1398.041f, 1347.441f, 232.949f), Vector3(1394.732f, 1347.912f, 232.435f), Vector3(1385.039f, 1349.7f, 211.562f))))
+      ZipLinePaths(new ZipLinePath(417, false, List(Vector3(1453.473f, 1359.667f, 232.956f), Vector3(1457.288f, 1359.47f, 232.693f), Vector3(1468.838f, 1358.513f, 187.157f))))
+      ZipLinePaths(new ZipLinePath(418, false, List(Vector3(1430.748f, 1320.637f, 232.954f), Vector3(1431.562f, 1316.973f, 232.584f), Vector3(1436.177f, 1305.54f, 194.848f))))
+      ZipLinePaths(new ZipLinePath(419, false, List(Vector3(1421.757f, 1366.067f, 232.988f), Vector3(1405.097f, 1410.405f, 252.602f), Vector3(1392.284f, 1443.842f, 266.389f))))
+      ZipLinePaths(new ZipLinePath(420, true, List(Vector3(973.389f, 913.595f, 196.95f), Vector3(971.862f, 927.004f, 204.35f))))
+    }
+
+    ZipLines()
+
+  }
+}

--- a/pslogin/src/main/scala/zonemaps/Ugd03.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd03.scala
@@ -1,0 +1,954 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd03 { // Adlivun
+  val ZoneMap = new ZoneMap("ugd03") {
+    Scale = MapScale.Dim2048
+    Checksum = 0L
+
+    Building10020()
+
+    def Building10020(): Unit = { // Name: ceiling_bldg_a_10020 Type: ceiling_bldg_a GUID: 1, MapID: 10020
+      LocalBuilding("ceiling_bldg_a_10020", 1, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(845.85f, 782.72f, 106.07f), ceiling_bldg_a)))
+      LocalObject(808, Door.Constructor(Vector3(844.4113f, 798.6173f, 107.849f)), owning_building_guid = 1)
+      LocalObject(809, Door.Constructor(Vector3(845.2345f, 763.904f, 113.355f)), owning_building_guid = 1)
+      LocalObject(810, Door.Constructor(Vector3(858.5089f, 771.0483f, 107.849f)), owning_building_guid = 1)
+      LocalObject(811, Door.Constructor(Vector3(865.1314f, 777.3246f, 113.355f)), owning_building_guid = 1)
+    }
+
+    Building10028()
+
+    def Building10028(): Unit = { // Name: ceiling_bldg_a_10028 Type: ceiling_bldg_a GUID: 2, MapID: 10028
+      LocalBuilding("ceiling_bldg_a_10028", 2, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1089.56f, 1080.75f, 112.69f), ceiling_bldg_a)))
+      LocalObject(846, Door.Constructor(Vector3(1081.78f, 1094.688f, 114.469f)), owning_building_guid = 2)
+      LocalObject(847, Door.Constructor(Vector3(1096.651f, 1063.31f, 119.975f)), owning_building_guid = 2)
+      LocalObject(848, Door.Constructor(Vector3(1105.872f, 1075.236f, 114.469f)), owning_building_guid = 2)
+      LocalObject(849, Door.Constructor(Vector3(1109.369f, 1083.664f, 119.975f)), owning_building_guid = 2)
+    }
+
+    Building10019()
+
+    def Building10019(): Unit = { // Name: ceiling_bldg_b_10019 Type: ceiling_bldg_b GUID: 3, MapID: 10019
+      LocalBuilding("ceiling_bldg_b_10019", 3, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(677.51f, 874.3f, 101.68f), ceiling_bldg_b)))
+      LocalObject(770, Door.Constructor(Vector3(675.7744f, 868.4519f, 103.459f)), owning_building_guid = 3)
+      LocalObject(771, Door.Constructor(Vector3(693.6315f, 870.2904f, 103.459f)), owning_building_guid = 3)
+    }
+
+    Building10029()
+
+    def Building10029(): Unit = { // Name: ceiling_bldg_b_10029 Type: ceiling_bldg_b GUID: 4, MapID: 10029
+      LocalBuilding("ceiling_bldg_b_10029", 4, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.55f, 1224.66f, 101.59f), ceiling_bldg_b)))
+      LocalObject(828, Door.Constructor(Vector3(1003.656f, 1241.019f, 103.369f)), owning_building_guid = 4)
+      LocalObject(830, Door.Constructor(Vector3(1012.598f, 1225.453f, 103.369f)), owning_building_guid = 4)
+    }
+
+    Building10011()
+
+    def Building10011(): Unit = { // Name: ceiling_bldg_b_10011 Type: ceiling_bldg_b GUID: 5, MapID: 10011
+      LocalBuilding("ceiling_bldg_b_10011", 5, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1328.95f, 1247.9f, 111.73f), ceiling_bldg_b)))
+      LocalObject(891, Door.Constructor(Vector3(1330.965f, 1264.39f, 113.509f)), owning_building_guid = 5)
+      LocalObject(893, Door.Constructor(Vector3(1334.966f, 1246.89f, 113.509f)), owning_building_guid = 5)
+    }
+
+    Building10301()
+
+    def Building10301(): Unit = { // Name: ceiling_bldg_c_10301 Type: ceiling_bldg_c GUID: 6, MapID: 10301
+      LocalBuilding("ceiling_bldg_c_10301", 6, 10301, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.93f, 652.46f, 123.63f), ceiling_bldg_c)))
+      LocalObject(793, Door.Constructor(Vector3(760.2493f, 654.6059f, 125.409f)), owning_building_guid = 6)
+      LocalObject(800, Door.Constructor(Vector3(787.3882f, 696.5608f, 125.409f)), owning_building_guid = 6)
+      LocalObject(802, Door.Constructor(Vector3(806.8972f, 672.4693f, 125.409f)), owning_building_guid = 6)
+    }
+
+    Building10085()
+
+    def Building10085(): Unit = { // Name: ceiling_bldg_d_10085 Type: ceiling_bldg_d GUID: 7, MapID: 10085
+      LocalBuilding("ceiling_bldg_d_10085", 7, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.2f, 1198.95f, 111.11f), ceiling_bldg_d)))
+      LocalObject(853, Door.Constructor(Vector3(1168.71f, 1198.966f, 112.845f)), owning_building_guid = 7)
+      LocalObject(854, Door.Constructor(Vector3(1186.216f, 1181.44f, 112.845f)), owning_building_guid = 7)
+      LocalObject(855, Door.Constructor(Vector3(1186.216f, 1216.44f, 112.845f)), owning_building_guid = 7)
+      LocalObject(856, Door.Constructor(Vector3(1203.71f, 1198.966f, 112.845f)), owning_building_guid = 7)
+      LocalObject(971, Painbox.Constructor(Vector3(1186.107f, 1198.747f, 119.418f), painbox_continuous), owning_building_guid = 7)
+    }
+
+    Building10024()
+
+    def Building10024(): Unit = { // Name: ceiling_bldg_g_10024 Type: ceiling_bldg_g GUID: 8, MapID: 10024
+      LocalBuilding("ceiling_bldg_g_10024", 8, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(705.96f, 1266.02f, 88.19f), ceiling_bldg_g)))
+      LocalObject(776, Door.Constructor(Vector3(701.7747f, 1283.875f, 89.969f)), owning_building_guid = 8)
+      LocalObject(781, Door.Constructor(Vector3(716.9544f, 1252.418f, 89.969f)), owning_building_guid = 8)
+    }
+
+    Building10026()
+
+    def Building10026(): Unit = { // Name: ceiling_bldg_g_10026 Type: ceiling_bldg_g GUID: 9, MapID: 10026
+      LocalBuilding("ceiling_bldg_g_10026", 9, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(780.44f, 1084.53f, 99.81f), ceiling_bldg_g)))
+      LocalObject(796, Door.Constructor(Vector3(772.456f, 1068.02f, 101.589f)), owning_building_guid = 9)
+      LocalObject(799, Door.Constructor(Vector3(780.456f, 1102.02f, 101.589f)), owning_building_guid = 9)
+    }
+
+    Building10016()
+
+    def Building10016(): Unit = { // Name: ceiling_bldg_g_10016 Type: ceiling_bldg_g GUID: 10, MapID: 10016
+      LocalBuilding("ceiling_bldg_g_10016", 10, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1249.74f, 1307.4f, 94.99f), ceiling_bldg_g)))
+      LocalObject(863, Door.Constructor(Vector3(1232.641f, 1300.771f, 96.769f)), owning_building_guid = 10)
+      LocalObject(871, Door.Constructor(Vector3(1261.68f, 1320.181f, 96.769f)), owning_building_guid = 10)
+    }
+
+    Building10021()
+
+    def Building10021(): Unit = { // Name: ceiling_bldg_g_10021 Type: ceiling_bldg_g GUID: 11, MapID: 10021
+      LocalBuilding("ceiling_bldg_g_10021", 11, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.23f, 652.87f, 88.19f), ceiling_bldg_g)))
+      LocalObject(896, Door.Constructor(Vector3(1341.246f, 636.36f, 89.969f)), owning_building_guid = 11)
+      LocalObject(898, Door.Constructor(Vector3(1349.246f, 670.36f, 89.969f)), owning_building_guid = 11)
+    }
+
+    Building10023()
+
+    def Building10023(): Unit = { // Name: ceiling_bldg_h_10023 Type: ceiling_bldg_h GUID: 12, MapID: 10023
+      LocalBuilding("ceiling_bldg_h_10023", 12, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.77f, 1249.92f, 103.44f), ceiling_bldg_h)))
+      LocalObject(813, Door.Constructor(Vector3(887.8799f, 1262.048f, 105.219f)), owning_building_guid = 12)
+      LocalObject(815, Door.Constructor(Vector3(894.4103f, 1233.825f, 105.219f)), owning_building_guid = 12)
+      LocalObject(818, Door.Constructor(Vector3(915.1321f, 1253.392f, 107.719f)), owning_building_guid = 12)
+    }
+
+    Building10030()
+
+    def Building10030(): Unit = { // Name: ceiling_bldg_h_10030 Type: ceiling_bldg_h GUID: 13, MapID: 10030
+      LocalBuilding("ceiling_bldg_h_10030", 13, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1133.55f, 738.99f, 104.66f), ceiling_bldg_h)))
+      LocalObject(850, Door.Constructor(Vector3(1117.06f, 735.006f, 106.439f)), owning_building_guid = 13)
+      LocalObject(851, Door.Constructor(Vector3(1137.534f, 755.5f, 106.439f)), owning_building_guid = 13)
+      LocalObject(852, Door.Constructor(Vector3(1144.635f, 727.802f, 108.939f)), owning_building_guid = 13)
+    }
+
+    Building10017()
+
+    def Building10017(): Unit = { // Name: ceiling_bldg_h_10017 Type: ceiling_bldg_h GUID: 14, MapID: 10017
+      LocalBuilding("ceiling_bldg_h_10017", 14, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1246.32f, 775.32f, 92.82f), ceiling_bldg_h)))
+      LocalObject(862, Door.Constructor(Vector3(1232.196f, 782.2896f, 97.099f)), owning_building_guid = 14)
+      LocalObject(866, Door.Constructor(Vector3(1247.928f, 758.4124f, 94.599f)), owning_building_guid = 14)
+      LocalObject(870, Door.Constructor(Vector3(1260.615f, 784.4556f, 94.599f)), owning_building_guid = 14)
+    }
+
+    Building10015()
+
+    def Building10015(): Unit = { // Name: ceiling_bldg_h_10015 Type: ceiling_bldg_h GUID: 15, MapID: 10015
+      LocalBuilding("ceiling_bldg_h_10015", 15, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1385.18f, 1124.38f, 120.28f), ceiling_bldg_h)))
+      LocalObject(902, Door.Constructor(Vector3(1368.69f, 1120.396f, 122.059f)), owning_building_guid = 15)
+      LocalObject(905, Door.Constructor(Vector3(1389.164f, 1140.89f, 122.059f)), owning_building_guid = 15)
+      LocalObject(909, Door.Constructor(Vector3(1396.265f, 1113.192f, 124.559f)), owning_building_guid = 15)
+    }
+
+    Building10025()
+
+    def Building10025(): Unit = { // Name: ceiling_bldg_j_10025 Type: ceiling_bldg_j GUID: 16, MapID: 10025
+      LocalBuilding("ceiling_bldg_j_10025", 16, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(744.75f, 1147.08f, 98.87f), ceiling_bldg_j)))
+      LocalObject(788, Door.Constructor(Vector3(736.8647f, 1156.792f, 100.649f)), owning_building_guid = 16)
+      LocalObject(791, Door.Constructor(Vector3(752.5978f, 1137.363f, 100.649f)), owning_building_guid = 16)
+    }
+
+    Building10014()
+
+    def Building10014(): Unit = { // Name: ceiling_bldg_j_10014 Type: ceiling_bldg_j GUID: 17, MapID: 10014
+      LocalBuilding("ceiling_bldg_j_10014", 17, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1255.3f, 1091.51f, 109.62f), ceiling_bldg_j)))
+      LocalObject(868, Door.Constructor(Vector3(1255.316f, 1079f, 111.399f)), owning_building_guid = 17)
+      LocalObject(869, Door.Constructor(Vector3(1255.316f, 1104f, 111.399f)), owning_building_guid = 17)
+    }
+
+    Building10238()
+
+    def Building10238(): Unit = { // Name: ceiling_bldg_j_10238 Type: ceiling_bldg_j GUID: 18, MapID: 10238
+      LocalBuilding("ceiling_bldg_j_10238", 18, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1393.65f, 837.81f, 98.87f), ceiling_bldg_j)))
+      LocalObject(907, Door.Constructor(Vector3(1393.666f, 825.3f, 100.649f)), owning_building_guid = 18)
+      LocalObject(908, Door.Constructor(Vector3(1393.666f, 850.3f, 100.649f)), owning_building_guid = 18)
+    }
+
+    Building10027()
+
+    def Building10027(): Unit = { // Name: ceiling_bldg_z_10027 Type: ceiling_bldg_z GUID: 19, MapID: 10027
+      LocalBuilding("ceiling_bldg_z_10027", 19, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(916.61f, 913.02f, 110.84f), ceiling_bldg_z)))
+      LocalObject(814, Door.Constructor(Vector3(892.12f, 917.036f, 112.619f)), owning_building_guid = 19)
+      LocalObject(823, Door.Constructor(Vector3(949.12f, 917.036f, 112.619f)), owning_building_guid = 19)
+    }
+
+    Building10013()
+
+    def Building10013(): Unit = { // Name: ground_bldg_a_10013 Type: ground_bldg_a GUID: 85, MapID: 10013
+      LocalBuilding("ground_bldg_a_10013", 85, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(933.13f, 698.34f, 81.85f), ground_bldg_a)))
+      LocalObject(820, Door.Constructor(Vector3(929.3392f, 714.15f, 83.629f)), owning_building_guid = 85)
+      LocalObject(822, Door.Constructor(Vector3(947.2369f, 689.1008f, 83.629f)), owning_building_guid = 85)
+    }
+
+    Building10003()
+
+    def Building10003(): Unit = { // Name: ground_bldg_c_10003 Type: ground_bldg_c GUID: 86, MapID: 10003
+      LocalBuilding("ground_bldg_c_10003", 86, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(750.69f, 808.58f, 91.29f), ground_bldg_c)))
+      LocalObject(774, Door.Constructor(Vector3(700.9291f, 812.9419f, 93.069f)), owning_building_guid = 86)
+      LocalObject(780, Door.Constructor(Vector3(715.4828f, 840.3133f, 93.069f)), owning_building_guid = 86)
+      LocalObject(790, Door.Constructor(Vector3(750.1529f, 804.3535f, 93.069f)), owning_building_guid = 86)
+    }
+
+    Building10295()
+
+    def Building10295(): Unit = { // Name: ground_bldg_c_10295 Type: ground_bldg_c GUID: 87, MapID: 10295
+      LocalBuilding("ground_bldg_c_10295", 87, 10295, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(942.14f, 752.71f, 85.39f), ground_bldg_c)))
+      LocalObject(821, Door.Constructor(Vector3(940.63f, 756.694f, 87.169f)), owning_building_guid = 87)
+      LocalObject(825, Door.Constructor(Vector3(988.124f, 741.22f, 87.169f)), owning_building_guid = 87)
+      LocalObject(826, Door.Constructor(Vector3(988.124f, 772.22f, 87.169f)), owning_building_guid = 87)
+    }
+
+    Building10170()
+
+    def Building10170(): Unit = { // Name: ground_bldg_c_10170 Type: ground_bldg_c GUID: 88, MapID: 10170
+      LocalBuilding("ground_bldg_c_10170", 88, 10170, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1209.14f, 1162.92f, 80.39f), ground_bldg_c)))
+      LocalObject(858, Door.Constructor(Vector3(1211.09f, 1166.708f, 82.169f)), owning_building_guid = 88)
+      LocalObject(861, Door.Constructor(Vector3(1231.371f, 1121.059f, 82.169f)), owning_building_guid = 88)
+      LocalObject(867, Door.Constructor(Vector3(1254.408f, 1141.802f, 82.169f)), owning_building_guid = 88)
+    }
+
+    Building10302()
+
+    def Building10302(): Unit = { // Name: ground_bldg_c_10302 Type: ground_bldg_c GUID: 89, MapID: 10302
+      LocalBuilding("ground_bldg_c_10302", 89, 10302, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1236.42f, 689.57f, 84.46f), ground_bldg_c)))
+      LocalObject(864, Door.Constructor(Vector3(1234.91f, 693.554f, 86.239f)), owning_building_guid = 89)
+      LocalObject(872, Door.Constructor(Vector3(1282.404f, 678.08f, 86.239f)), owning_building_guid = 89)
+      LocalObject(873, Door.Constructor(Vector3(1282.404f, 709.08f, 86.239f)), owning_building_guid = 89)
+    }
+
+    Building10237()
+
+    def Building10237(): Unit = { // Name: ground_bldg_d_10237 Type: ground_bldg_d GUID: 90, MapID: 10237
+      LocalBuilding("ground_bldg_d_10237", 90, 10237, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(713.63f, 978.09f, 54.81f), ground_bldg_d)))
+      LocalObject(772, Door.Constructor(Vector3(698.0391f, 970.164f, 56.545f)), owning_building_guid = 90)
+      LocalObject(777, Door.Constructor(Vector3(705.704f, 993.681f, 56.545f)), owning_building_guid = 90)
+      LocalObject(783, Door.Constructor(Vector3(721.5936f, 962.4958f, 56.545f)), owning_building_guid = 90)
+      LocalObject(785, Door.Constructor(Vector3(729.2242f, 986.0536f, 56.545f)), owning_building_guid = 90)
+    }
+
+    Building10234()
+
+    def Building10234(): Unit = { // Name: ground_bldg_d_10234 Type: ground_bldg_d GUID: 91, MapID: 10234
+      LocalBuilding("ground_bldg_d_10234", 91, 10234, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.49f, 732.12f, 94.62f), ground_bldg_d)))
+      LocalObject(789, Door.Constructor(Vector3(747.0414f, 726.1162f, 96.355f)), owning_building_guid = 91)
+      LocalObject(792, Door.Constructor(Vector3(757.4862f, 748.5685f, 96.355f)), owning_building_guid = 91)
+      LocalObject(795, Door.Constructor(Vector3(769.4569f, 715.6793f, 96.355f)), owning_building_guid = 91)
+      LocalObject(798, Door.Constructor(Vector3(779.9307f, 738.0869f, 96.355f)), owning_building_guid = 91)
+    }
+
+    Building10357()
+
+    def Building10357(): Unit = { // Name: ground_bldg_d_10357 Type: ground_bldg_d GUID: 92, MapID: 10357
+      LocalBuilding("ground_bldg_d_10357", 92, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(902.88f, 1372.77f, 43.35f), ground_bldg_d)))
+      LocalObject(812, Door.Constructor(Vector3(885.39f, 1372.786f, 45.085f)), owning_building_guid = 92)
+      LocalObject(816, Door.Constructor(Vector3(902.896f, 1355.26f, 45.085f)), owning_building_guid = 92)
+      LocalObject(817, Door.Constructor(Vector3(902.896f, 1390.26f, 45.085f)), owning_building_guid = 92)
+      LocalObject(819, Door.Constructor(Vector3(920.39f, 1372.786f, 45.085f)), owning_building_guid = 92)
+    }
+
+    Building10074()
+
+    def Building10074(): Unit = { // Name: ground_bldg_d_10074 Type: ground_bldg_d GUID: 93, MapID: 10074
+      LocalBuilding("ground_bldg_d_10074", 93, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1054.39f, 1246.85f, 72.94f), ground_bldg_d)))
+      LocalObject(836, Door.Constructor(Vector3(1036.9f, 1246.866f, 74.675f)), owning_building_guid = 93)
+      LocalObject(839, Door.Constructor(Vector3(1054.406f, 1229.34f, 74.675f)), owning_building_guid = 93)
+      LocalObject(840, Door.Constructor(Vector3(1054.406f, 1264.34f, 74.675f)), owning_building_guid = 93)
+      LocalObject(845, Door.Constructor(Vector3(1071.9f, 1246.866f, 74.675f)), owning_building_guid = 93)
+    }
+
+    Building10291()
+
+    def Building10291(): Unit = { // Name: ground_bldg_d_10291 Type: ground_bldg_d GUID: 94, MapID: 10291
+      LocalBuilding("ground_bldg_d_10291", 94, 10291, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1226.43f, 1243.3f, 94.69f), ground_bldg_d)))
+      LocalObject(857, Door.Constructor(Vector3(1208.94f, 1243.316f, 96.425f)), owning_building_guid = 94)
+      LocalObject(859, Door.Constructor(Vector3(1226.446f, 1225.79f, 96.425f)), owning_building_guid = 94)
+      LocalObject(860, Door.Constructor(Vector3(1226.446f, 1260.79f, 96.425f)), owning_building_guid = 94)
+      LocalObject(865, Door.Constructor(Vector3(1243.94f, 1243.316f, 96.425f)), owning_building_guid = 94)
+    }
+
+    Building10135()
+
+    def Building10135(): Unit = { // Name: ground_bldg_e_10135 Type: ground_bldg_e GUID: 95, MapID: 10135
+      LocalBuilding("ground_bldg_e_10135", 95, 10135, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1056.2f, 739.36f, 68.24f), ground_bldg_e)))
+      LocalObject(835, Door.Constructor(Vector3(1033.179f, 726.7191f, 75.519f)), owning_building_guid = 95)
+      LocalObject(837, Door.Constructor(Vector3(1042.885f, 708.2314f, 70.019f)), owning_building_guid = 95)
+      LocalObject(842, Door.Constructor(Vector3(1058.492f, 706.6871f, 75.519f)), owning_building_guid = 95)
+      LocalObject(844, Door.Constructor(Vector3(1067.806f, 742.6246f, 70.019f)), owning_building_guid = 95)
+    }
+
+    Building10002()
+
+    def Building10002(): Unit = { // Name: ground_bldg_f_10002 Type: ground_bldg_f GUID: 96, MapID: 10002
+      LocalBuilding("ground_bldg_f_10002", 96, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(689.69f, 665.37f, 76.67f), ground_bldg_f)))
+      LocalObject(760, Door.Constructor(Vector3(662.3607f, 656.8664f, 78.449f)), owning_building_guid = 96)
+      LocalObject(779, Door.Constructor(Vector3(713.3111f, 685.332f, 78.449f)), owning_building_guid = 96)
+    }
+
+    Building10061()
+
+    def Building10061(): Unit = { // Name: ground_bldg_f_10061 Type: ground_bldg_f GUID: 97, MapID: 10061
+      LocalBuilding("ground_bldg_f_10061", 97, 10061, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(991.58f, 1312.88f, 67.64f), ground_bldg_f)))
+      LocalObject(824, Door.Constructor(Vector3(987.9187f, 1282.171f, 69.419f)), owning_building_guid = 97)
+      LocalObject(829, Door.Constructor(Vector3(1005.768f, 1337.738f, 69.419f)), owning_building_guid = 97)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: ground_bldg_f_10001 Type: ground_bldg_f GUID: 98, MapID: 10001
+      LocalBuilding("ground_bldg_f_10001", 98, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1315.3f, 1276.75f, 76.67f), ground_bldg_f)))
+      LocalObject(876, Door.Constructor(Vector3(1286.276f, 1266.071f, 78.449f)), owning_building_guid = 98)
+      LocalObject(897, Door.Constructor(Vector3(1343.89f, 1275.394f, 78.449f)), owning_building_guid = 98)
+    }
+
+    Building10147()
+
+    def Building10147(): Unit = { // Name: ground_bldg_g_10147 Type: ground_bldg_g GUID: 99, MapID: 10147
+      LocalBuilding("ground_bldg_g_10147", 99, 10147, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(624.24f, 967.02f, 72.09f), ground_bldg_g)))
+      LocalObject(752, Door.Constructor(Vector3(616.256f, 950.51f, 73.869f)), owning_building_guid = 99)
+      LocalObject(754, Door.Constructor(Vector3(624.256f, 984.51f, 73.869f)), owning_building_guid = 99)
+    }
+
+    Building10154()
+
+    def Building10154(): Unit = { // Name: ground_bldg_h_10154 Type: ground_bldg_h GUID: 100, MapID: 10154
+      LocalBuilding("ground_bldg_h_10154", 100, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(654.94f, 1129.19f, 68.99f), ground_bldg_h)))
+      LocalObject(755, Door.Constructor(Vector3(638.45f, 1125.206f, 70.769f)), owning_building_guid = 100)
+      LocalObject(759, Door.Constructor(Vector3(658.924f, 1145.7f, 70.769f)), owning_building_guid = 100)
+      LocalObject(764, Door.Constructor(Vector3(666.025f, 1118.002f, 73.269f)), owning_building_guid = 100)
+    }
+
+    Building10004()
+
+    def Building10004(): Unit = { // Name: ground_bldg_i_10004 Type: ground_bldg_i GUID: 101, MapID: 10004
+      LocalBuilding("ground_bldg_i_10004", 101, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(641.6f, 811.71f, 80.39f), ground_bldg_i)))
+      LocalObject(753, Door.Constructor(Vector3(617.2995f, 807.0613f, 82.169f)), owning_building_guid = 101)
+      LocalObject(763, Door.Constructor(Vector3(664.5754f, 823.3397f, 82.169f)), owning_building_guid = 101)
+    }
+
+    Building10306()
+
+    def Building10306(): Unit = { // Name: ground_bldg_i_10306 Type: ground_bldg_i GUID: 102, MapID: 10306
+      LocalBuilding("ground_bldg_i_10306", 102, 10306, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1310.62f, 1122.78f, 80.99f), ground_bldg_i)))
+      LocalObject(875, Door.Constructor(Vector3(1285.052f, 1119.71f, 82.769f)), owning_building_guid = 102)
+      LocalObject(894, Door.Constructor(Vector3(1335.045f, 1118.837f, 82.769f)), owning_building_guid = 102)
+    }
+
+    Building10075()
+
+    def Building10075(): Unit = { // Name: ground_bldg_j_10075 Type: ground_bldg_j GUID: 103, MapID: 10075
+      LocalBuilding("ground_bldg_j_10075", 103, 10075, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1060.18f, 1311.97f, 73.4f), ground_bldg_j)))
+      LocalObject(841, Door.Constructor(Vector3(1056.538f, 1300.002f, 75.179f)), owning_building_guid = 103)
+      LocalObject(843, Door.Constructor(Vector3(1063.847f, 1323.91f, 75.179f)), owning_building_guid = 103)
+    }
+
+    Building10322()
+
+    def Building10322(): Unit = { // Name: NW_Redoubt Type: redoubt GUID: 104, MapID: 10322
+      LocalBuilding("NW_Redoubt", 104, 10322, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(718.55f, 1209.17f, 43.36f), redoubt)))
+      LocalObject(1023, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 104)
+      LocalObject(775, Door.Constructor(Vector3(701.5834f, 1213.417f, 45.095f)), owning_building_guid = 104)
+      LocalObject(778, Door.Constructor(Vector3(709.5589f, 1223.861f, 55.139f)), owning_building_guid = 104)
+      LocalObject(782, Door.Constructor(Vector3(717.5706f, 1221.859f, 55.119f)), owning_building_guid = 104)
+      LocalObject(784, Door.Constructor(Vector3(725.3601f, 1219.95f, 55.119f)), owning_building_guid = 104)
+      LocalObject(786, Door.Constructor(Vector3(733.3605f, 1217.96f, 55.139f)), owning_building_guid = 104)
+      LocalObject(787, Door.Constructor(Vector3(735.5438f, 1204.949f, 45.095f)), owning_building_guid = 104)
+      LocalObject(1045, Terminal.Constructor(Vector3(713.951f, 1191.242f, 43.3158f), vanu_equipment_term), owning_building_guid = 104)
+      LocalObject(1047, Terminal.Constructor(Vector3(723.0927f, 1227.324f, 43.3135f), vanu_equipment_term), owning_building_guid = 104)
+      LocalObject(982, SpawnTube.Constructor(Vector3(718.55f, 1209.17f, 43.36f), Vector3(0, 0, 194)), owning_building_guid = 104)
+      LocalObject(970, Painbox.Constructor(Vector3(718.6603f, 1209.442f, 51.149f), painbox_continuous), owning_building_guid = 104)
+    }
+
+    Building10359()
+
+    def Building10359(): Unit = { // Name: SE_Redoubt Type: redoubt GUID: 105, MapID: 10359
+      LocalBuilding("SE_Redoubt", 105, 10359, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1397.63f, 773.07f, 43.36f), redoubt)))
+      LocalObject(1027, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 105)
+      LocalObject(903, Door.Constructor(Vector3(1380.14f, 773.086f, 45.095f)), owning_building_guid = 105)
+      LocalObject(904, Door.Constructor(Vector3(1385.352f, 785.149f, 55.139f)), owning_building_guid = 105)
+      LocalObject(906, Door.Constructor(Vector3(1393.61f, 785.145f, 55.119f)), owning_building_guid = 105)
+      LocalObject(910, Door.Constructor(Vector3(1401.63f, 785.177f, 55.119f)), owning_building_guid = 105)
+      LocalObject(911, Door.Constructor(Vector3(1409.874f, 785.182f, 55.139f)), owning_building_guid = 105)
+      LocalObject(912, Door.Constructor(Vector3(1415.14f, 773.086f, 45.095f)), owning_building_guid = 105)
+      LocalObject(1082, Terminal.Constructor(Vector3(1397.505f, 754.5616f, 43.3158f), vanu_equipment_term), owning_building_guid = 105)
+      LocalObject(1083, Terminal.Constructor(Vector3(1397.646f, 791.784f, 43.3135f), vanu_equipment_term), owning_building_guid = 105)
+      LocalObject(983, SpawnTube.Constructor(Vector3(1397.63f, 773.07f, 43.36f), Vector3(0, 0, 180)), owning_building_guid = 105)
+      LocalObject(973, Painbox.Constructor(Vector3(1397.671f, 773.3606f, 51.149f), painbox_continuous), owning_building_guid = 105)
+    }
+
+    Building10005()
+
+    def Building10005(): Unit = { // Name: SW_Stasis Type: vanu_control_point GUID: 211, MapID: 10005
+      LocalBuilding("SW_Stasis", 211, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(662.53f, 731.92f, 71.25f), vanu_control_point)))
+      LocalObject(1022, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 211)
+      LocalObject(751, Door.Constructor(Vector3(610.1769f, 740.5507f, 73.029f)), owning_building_guid = 211)
+      LocalObject(756, Door.Constructor(Vector3(642.492f, 688.1669f, 73.029f)), owning_building_guid = 211)
+      LocalObject(757, Door.Constructor(Vector3(648.6942f, 729.0295f, 77.97f)), owning_building_guid = 211)
+      LocalObject(758, Door.Constructor(Vector3(655.8808f, 744.3877f, 77.97f)), owning_building_guid = 211)
+      LocalObject(761, Door.Constructor(Vector3(663.4542f, 747.4326f, 103.029f)), owning_building_guid = 211)
+      LocalObject(762, Door.Constructor(Vector3(664.0893f, 721.8351f, 77.97f)), owning_building_guid = 211)
+      LocalObject(765, Door.Constructor(Vector3(666.1021f, 739.6136f, 103.009f)), owning_building_guid = 211)
+      LocalObject(766, Door.Constructor(Vector3(668.8757f, 732.0895f, 103.009f)), owning_building_guid = 211)
+      LocalObject(767, Door.Constructor(Vector3(671.239f, 737.2011f, 77.97f)), owning_building_guid = 211)
+      LocalObject(768, Door.Constructor(Vector3(671.8712f, 724.4004f, 103.029f)), owning_building_guid = 211)
+      LocalObject(769, Door.Constructor(Vector3(673.0169f, 767.94f, 73.029f)), owning_building_guid = 211)
+      LocalObject(773, Door.Constructor(Vector3(699.4913f, 730.4573f, 73.029f)), owning_building_guid = 211)
+      LocalObject(1032, Terminal.Constructor(Vector3(649.8383f, 735.5905f, 76.263f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1033, Terminal.Constructor(Vector3(651.4671f, 739.1439f, 76.267f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1034, Terminal.Constructor(Vector3(653.808f, 724.6984f, 76.267f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1035, Terminal.Constructor(Vector3(657.4075f, 723.016f, 76.263f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1036, Terminal.Constructor(Vector3(662.4866f, 743.2345f, 76.263f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1037, Terminal.Constructor(Vector3(666.0861f, 741.5521f, 76.267f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1038, Terminal.Constructor(Vector3(668.4279f, 727.1069f, 76.267f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1039, Terminal.Constructor(Vector3(670.1102f, 730.7064f, 76.263f), vanu_equipment_term), owning_building_guid = 211)
+      LocalObject(1097, SpawnTube.Constructor(Vector3(659.9666f, 733.1154f, 76.389f), Vector3(0, 0, 340)), owning_building_guid = 211)
+      LocalObject(969, Painbox.Constructor(Vector3(660.1337f, 733.4966f, 85.5918f), painbox_continuous), owning_building_guid = 211)
+      LocalObject(974, Painbox.Constructor(Vector3(646.2076f, 727.696f, 80.14f), painbox_door_radius_continuous), owning_building_guid = 211)
+      LocalObject(975, Painbox.Constructor(Vector3(655.5827f, 746.0699f, 80.14f), painbox_door_radius_continuous), owning_building_guid = 211)
+      LocalObject(976, Painbox.Constructor(Vector3(664.7043f, 719.9772f, 80.14f), painbox_door_radius_continuous), owning_building_guid = 211)
+      LocalObject(977, Painbox.Constructor(Vector3(673.4529f, 737.9102f, 79.54f), painbox_door_radius_continuous), owning_building_guid = 211)
+    }
+
+    Building10173()
+
+    def Building10173(): Unit = { // Name: NE_Stasis Type: vanu_control_point GUID: 212, MapID: 10173
+      LocalBuilding("NE_Stasis", 212, 10173, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1318.15f, 1204.93f, 71.05f), vanu_control_point)))
+      LocalObject(1026, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 212)
+      LocalObject(874, Door.Constructor(Vector3(1283.918f, 1218.946f, 72.829f)), owning_building_guid = 212)
+      LocalObject(877, Door.Constructor(Vector3(1295.976f, 1174.669f, 72.829f)), owning_building_guid = 212)
+      LocalObject(880, Door.Constructor(Vector3(1308.16f, 1202.946f, 77.77f)), owning_building_guid = 212)
+      LocalObject(883, Door.Constructor(Vector3(1311.976f, 1190.669f, 102.829f)), owning_building_guid = 212)
+      LocalObject(884, Door.Constructor(Vector3(1311.944f, 1215.191f, 102.829f)), owning_building_guid = 212)
+      LocalObject(885, Door.Constructor(Vector3(1312.162f, 1198.922f, 102.809f)), owning_building_guid = 212)
+      LocalObject(886, Door.Constructor(Vector3(1312.129f, 1206.941f, 102.809f)), owning_building_guid = 212)
+      LocalObject(889, Door.Constructor(Vector3(1320.134f, 1190.94f, 77.77f)), owning_building_guid = 212)
+      LocalObject(890, Door.Constructor(Vector3(1320.134f, 1214.94f, 77.77f)), owning_building_guid = 212)
+      LocalObject(892, Door.Constructor(Vector3(1332.14f, 1202.914f, 77.77f)), owning_building_guid = 212)
+      LocalObject(899, Door.Constructor(Vector3(1351.944f, 1239.191f, 72.829f)), owning_building_guid = 212)
+      LocalObject(901, Door.Constructor(Vector3(1364.394f, 1178.914f, 72.829f)), owning_building_guid = 212)
+      LocalObject(1068, Terminal.Constructor(Vector3(1311.442f, 1208.663f, 76.063f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1069, Terminal.Constructor(Vector3(1311.514f, 1197.095f, 76.067f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1071, Terminal.Constructor(Vector3(1314.254f, 1211.47f, 76.067f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1072, Terminal.Constructor(Vector3(1314.321f, 1194.283f, 76.063f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1074, Terminal.Constructor(Vector3(1326.075f, 1194.358f, 76.067f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1075, Terminal.Constructor(Vector3(1326.009f, 1211.545f, 76.063f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1076, Terminal.Constructor(Vector3(1328.821f, 1197.14f, 76.063f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1077, Terminal.Constructor(Vector3(1328.816f, 1208.733f, 76.067f), vanu_equipment_term), owning_building_guid = 212)
+      LocalObject(1098, SpawnTube.Constructor(Vector3(1320.15f, 1202.93f, 76.189f), Vector3(0, 0, 180)), owning_building_guid = 212)
+      LocalObject(972, Painbox.Constructor(Vector3(1319.863f, 1202.629f, 85.3918f), painbox_continuous), owning_building_guid = 212)
+      LocalObject(978, Painbox.Constructor(Vector3(1305.837f, 1203.037f, 79.34f), painbox_door_radius_continuous), owning_building_guid = 212)
+      LocalObject(979, Painbox.Constructor(Vector3(1319.839f, 1189.257f, 79.94f), painbox_door_radius_continuous), owning_building_guid = 212)
+      LocalObject(980, Painbox.Constructor(Vector3(1320.192f, 1216.896f, 79.94f), painbox_door_radius_continuous), owning_building_guid = 212)
+      LocalObject(981, Painbox.Constructor(Vector3(1334.933f, 1203.317f, 79.94f), painbox_door_radius_continuous), owning_building_guid = 212)
+    }
+
+    Building10012()
+
+    def Building10012(): Unit = { // Name: Core Type: vanu_core GUID: 213, MapID: 10012
+      LocalBuilding("Core", 213, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1026.95f, 1013.73f, 97.73f), vanu_core)))
+      LocalObject(827, Door.Constructor(Vector3(994.457f, 1001.752f, 104.518f)), owning_building_guid = 213)
+      LocalObject(831, Door.Constructor(Vector3(1022.928f, 973.237f, 104.518f)), owning_building_guid = 213)
+      LocalObject(832, Door.Constructor(Vector3(1022.928f, 973.237f, 109.518f)), owning_building_guid = 213)
+      LocalObject(833, Door.Constructor(Vector3(1022.972f, 1030.223f, 109.518f)), owning_building_guid = 213)
+      LocalObject(834, Door.Constructor(Vector3(1022.972f, 1030.223f, 114.518f)), owning_building_guid = 213)
+      LocalObject(838, Door.Constructor(Vector3(1051.443f, 1001.708f, 114.518f)), owning_building_guid = 213)
+    }
+
+    Building10156()
+
+    def Building10156(): Unit = { // Name: NW_ATPlant Type: vanu_vehicle_station GUID: 256, MapID: 10156
+      LocalBuilding("NW_ATPlant", 256, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(772.18f, 1217.7f, 43.18f), vanu_vehicle_station)))
+      LocalObject(1024, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 256)
+      LocalObject(794, Door.Constructor(Vector3(761.205f, 1206.612f, 44.959f)), owning_building_guid = 256)
+      LocalObject(797, Door.Constructor(Vector3(779.6216f, 1189.222f, 64.871f)), owning_building_guid = 256)
+      LocalObject(801, Door.Constructor(Vector3(801.209f, 1182.579f, 74.959f)), owning_building_guid = 256)
+      LocalObject(803, Door.Constructor(Vector3(808.4747f, 1186.411f, 74.939f)), owning_building_guid = 256)
+      LocalObject(804, Door.Constructor(Vector3(811.1083f, 1233.146f, 64.883f)), owning_building_guid = 256)
+      LocalObject(805, Door.Constructor(Vector3(815.5405f, 1190.205f, 74.939f)), owning_building_guid = 256)
+      LocalObject(806, Door.Constructor(Vector3(818.1613f, 1236.896f, 44.959f)), owning_building_guid = 256)
+      LocalObject(807, Door.Constructor(Vector3(822.8236f, 1194.072f, 74.959f)), owning_building_guid = 256)
+      LocalObject(913, Door.Constructor(Vector3(817.9047f, 1168.759f, 49.813f)), owning_building_guid = 256)
+      LocalObject(1017, Terminal.Constructor(Vector3(780.8441f, 1200.851f, 63.097f), vanu_air_vehicle_term), owning_building_guid = 256)
+      LocalObject(1099, VehicleSpawnPad.Constructor(Vector3(785.5449f, 1208.388f, 63.096f), vanu_vehicle_creation_pad, Vector3(0, 0, -28)), owning_building_guid = 256, terminal_guid = 1017)
+      LocalObject(1018, Terminal.Constructor(Vector3(812.0989f, 1217.48f, 63.097f), vanu_air_vehicle_term), owning_building_guid = 256)
+      LocalObject(1100, VehicleSpawnPad.Constructor(Vector3(803.218f, 1217.785f, 63.096f), vanu_vehicle_creation_pad, Vector3(0, 0, -28)), owning_building_guid = 256, terminal_guid = 1018)
+      LocalObject(1052, Terminal.Constructor(Vector3(789.0759f, 1197.368f, 45.68f), vanu_equipment_term), owning_building_guid = 256)
+      LocalObject(1053, Terminal.Constructor(Vector3(810.2666f, 1208.635f, 45.68f), vanu_equipment_term), owning_building_guid = 256)
+      LocalObject(1105, Terminal.Constructor(Vector3(802.3574f, 1198.242f, 48.18f), vanu_vehicle_term), owning_building_guid = 256)
+      LocalObject(1101, VehicleSpawnPad.Constructor(Vector3(809.3684f, 1184.826f, 45.585f), vanu_vehicle_creation_pad, Vector3(0, 0, 152)), owning_building_guid = 256, terminal_guid = 1105)
+    }
+
+    Building10007()
+
+    def Building10007(): Unit = { // Name: SE_ATPlant Type: vanu_vehicle_station GUID: 257, MapID: 10007
+      LocalBuilding("SE_ATPlant", 257, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1352.53f, 780.12f, 43.78f), vanu_vehicle_station)))
+      LocalObject(1025, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 257)
+      LocalObject(878, Door.Constructor(Vector3(1298.814f, 795.5347f, 75.559f)), owning_building_guid = 257)
+      LocalObject(879, Door.Constructor(Vector3(1305.402f, 800.4932f, 75.539f)), owning_building_guid = 257)
+      LocalObject(881, Door.Constructor(Vector3(1310.118f, 753.9674f, 45.559f)), owning_building_guid = 257)
+      LocalObject(882, Door.Constructor(Vector3(1311.787f, 805.3461f, 75.539f)), owning_building_guid = 257)
+      LocalObject(887, Door.Constructor(Vector3(1316.497f, 758.7747f, 65.483f)), owning_building_guid = 257)
+      LocalObject(888, Door.Constructor(Vector3(1318.364f, 810.2671f, 75.559f)), owning_building_guid = 257)
+      LocalObject(895, Door.Constructor(Vector3(1340.725f, 807.0831f, 65.471f)), owning_building_guid = 257)
+      LocalObject(900, Door.Constructor(Vector3(1361.635f, 792.7887f, 45.559f)), owning_building_guid = 257)
+      LocalObject(914, Door.Constructor(Vector3(1299.712f, 821.3058f, 50.413f)), owning_building_guid = 257)
+      LocalObject(1019, Terminal.Constructor(Vector3(1313.068f, 774.0926f, 63.697f), vanu_air_vehicle_term), owning_building_guid = 257)
+      LocalObject(1103, VehicleSpawnPad.Constructor(Vector3(1321.888f, 775.1802f, 63.696f), vanu_vehicle_creation_pad, Vector3(0, 0, 143)), owning_building_guid = 257, terminal_guid = 1019)
+      LocalObject(1020, Terminal.Constructor(Vector3(1341.337f, 795.4058f, 63.697f), vanu_air_vehicle_term), owning_building_guid = 257)
+      LocalObject(1104, VehicleSpawnPad.Constructor(Vector3(1337.873f, 787.2261f, 63.696f), vanu_vehicle_creation_pad, Vector3(0, 0, 143)), owning_building_guid = 257, terminal_guid = 1020)
+      LocalObject(1070, Terminal.Constructor(Vector3(1313.494f, 783.1147f, 46.28f), vanu_equipment_term), owning_building_guid = 257)
+      LocalObject(1078, Terminal.Constructor(Vector3(1332.662f, 797.5583f, 46.28f), vanu_equipment_term), owning_building_guid = 257)
+      LocalObject(1106, Terminal.Constructor(Vector3(1319.68f, 794.6179f, 48.78f), vanu_vehicle_term), owning_building_guid = 257)
+      LocalObject(1102, VehicleSpawnPad.Constructor(Vector3(1310.657f, 806.7718f, 46.185f), vanu_vehicle_creation_pad, Vector3(0, 0, -37)), owning_building_guid = 257, terminal_guid = 1106)
+    }
+
+    Building10212()
+
+    def Building10212(): Unit = { // Name: GW_Cavern3_W Type: warpgate_cavern GUID: 258, MapID: 10212
+      LocalBuilding("GW_Cavern3_W", 258, 10212, FoundationBuilder(WarpGate.Structure(Vector3(154.12f, 833.73f, 32.98f))))
+    }
+
+    Building10405()
+
+    def Building10405(): Unit = { // Name: GW_Cavern3_S Type: warpgate_cavern GUID: 259, MapID: 10405
+      LocalBuilding("GW_Cavern3_S", 259, 10405, FoundationBuilder(WarpGate.Structure(Vector3(949.84f, 285.73f, 29.82f))))
+    }
+
+    Building10214()
+
+    def Building10214(): Unit = { // Name: GW_Cavern3_N Type: warpgate_cavern GUID: 260, MapID: 10214
+      LocalBuilding("GW_Cavern3_N", 260, 10214, FoundationBuilder(WarpGate.Structure(Vector3(1128.81f, 1755.28f, 14.5f))))
+    }
+
+    Building10215()
+
+    def Building10215(): Unit = { // Name: GW_Cavern3_E Type: warpgate_cavern GUID: 261, MapID: 10215
+      LocalBuilding("GW_Cavern3_E", 261, 10215, FoundationBuilder(WarpGate.Structure(Vector3(1889.78f, 1018.32f, 33.14f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(1028, Terminal.Constructor(Vector3(624.28f, 958.12f, 74.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1029, Terminal.Constructor(Vector3(624.38f, 975.77f, 74.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1030, Terminal.Constructor(Vector3(634.07f, 835.13f, 80.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1031, Terminal.Constructor(Vector3(647.92f, 794.89f, 80.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1040, Terminal.Constructor(Vector3(684.98f, 878.61f, 107.18f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1041, Terminal.Constructor(Vector3(689.91f, 646.49f, 76.69f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1042, Terminal.Constructor(Vector3(704.82f, 1254.2f, 88.18f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1043, Terminal.Constructor(Vector3(710.23f, 1277.36f, 88.11f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1044, Terminal.Constructor(Vector3(711.35f, 1221.54f, 43.33f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1046, Terminal.Constructor(Vector3(719.63f, 809.77f, 91.26f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1048, Terminal.Constructor(Vector3(725.86f, 1196.85f, 43.3f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1049, Terminal.Constructor(Vector3(769.95f, 1078.39f, 99.83f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1050, Terminal.Constructor(Vector3(780.02f, 670.64f, 112.67f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1051, Terminal.Constructor(Vector3(788.59f, 1093.02f, 99.81f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1054, Terminal.Constructor(Vector3(844.02f, 778.6f, 106.01f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1055, Terminal.Constructor(Vector3(846.68f, 782.07f, 111.52f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1056, Terminal.Constructor(Vector3(892.74f, 1362.69f, 43.29f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1057, Terminal.Constructor(Vector3(901.96f, 911.49f, 110.81f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1058, Terminal.Constructor(Vector3(913.09f, 1382.92f, 43.27f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1059, Terminal.Constructor(Vector3(931.79f, 694.1f, 81.75f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1060, Terminal.Constructor(Vector3(939.31f, 922.44f, 110.81f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1061, Terminal.Constructor(Vector3(965.76f, 756.59f, 85.54f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1062, Terminal.Constructor(Vector3(970.27f, 1330.25f, 72.43f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1063, Terminal.Constructor(Vector3(1044.21f, 1256.84f, 72.9f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1064, Terminal.Constructor(Vector3(1064.8f, 1236.89f, 72.91f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1065, Terminal.Constructor(Vector3(1134.99f, 739.94f, 107.09f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1066, Terminal.Constructor(Vector3(1226.99f, 1239f, 96.63f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1067, Terminal.Constructor(Vector3(1239.95f, 1091.6f, 109.43f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1073, Terminal.Constructor(Vector3(1318.38f, 909.65f, 59.3f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1079, Terminal.Constructor(Vector3(1362.64f, 657.92f, 88.17f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1080, Terminal.Constructor(Vector3(1387.46f, 783.22f, 43.32f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1081, Terminal.Constructor(Vector3(1388.46f, 1124.9f, 122.73f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(1084, Terminal.Constructor(Vector3(1407.92f, 763.14f, 43.3f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(43, ProximityTerminal.Constructor(Vector3(671.13f, 701.13f, 69.9f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(44, ProximityTerminal.Constructor(Vector3(737.38f, 1261.19f, 51.62f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(45, ProximityTerminal.Constructor(Vector3(1020.78f, 1217.26f, 64.92f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(46, ProximityTerminal.Constructor(Vector3(1340.04f, 1166.81f, 69.59f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(47, ProximityTerminal.Constructor(Vector3(579.33f, 1056.62f, 41.42f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(48, ProximityTerminal.Constructor(Vector3(636.55f, 1292.57f, 41.36f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(49, ProximityTerminal.Constructor(Vector3(687.24f, 830.88f, 70.1f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(50, ProximityTerminal.Constructor(Vector3(743.37f, 1368.45f, 59.02f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(51, ProximityTerminal.Constructor(Vector3(756.64f, 1114.73f, 59f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(52, ProximityTerminal.Constructor(Vector3(913.82f, 1019.54f, 61.84f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(53, ProximityTerminal.Constructor(Vector3(928.1f, 1348.9f, 41.36f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(54, ProximityTerminal.Constructor(Vector3(1108.67f, 1281.84f, 41.36f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(55, ProximityTerminal.Constructor(Vector3(1184.81f, 1112.77f, 41.36f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(56, ProximityTerminal.Constructor(Vector3(1286.46f, 1233.98f, 69.59f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(57, ProximityTerminal.Constructor(Vector3(1342.38f, 1104.26f, 67.85f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(58, ProximityTerminal.Constructor(Vector3(1436.35f, 841.23f, 68.56f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(942, ProximityTerminal.Constructor(Vector3(930.26f, 904.42f, 105.99f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(943, ProximityTerminal.Constructor(Vector3(930.97f, 903.87f, 106.04f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(944, ProximityTerminal.Constructor(Vector3(946.33f, 474.23f, 47.38f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(945, ProximityTerminal.Constructor(Vector3(991.84f, 757.6f, 85.29f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(946, ProximityTerminal.Constructor(Vector3(992.69f, 757.95f, 85.39f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(947, ProximityTerminal.Constructor(Vector3(993.29f, 755.79f, 85.34f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(948, ProximityTerminal.Constructor(Vector3(998.74f, 1229.32f, 107.18f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(949, ProximityTerminal.Constructor(Vector3(1144.18f, 1543.48f, 47.43f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(950, ProximityTerminal.Constructor(Vector3(1287.42f, 693.51f, 84.73f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(951, ProximityTerminal.Constructor(Vector3(1402.34f, 845.88f, 98.92f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(952, ProximityTerminal.Constructor(Vector3(709.62f, 964.7f, 54.77f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(953, ProximityTerminal.Constructor(Vector3(727.34f, 816.47f, 91.39f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(954, ProximityTerminal.Constructor(Vector3(992.66f, 756.8f, 85.39f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(955, ProximityTerminal.Constructor(Vector3(1074.65f, 1304.35f, 73.4f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(956, ProximityTerminal.Constructor(Vector3(1076.72f, 1310.3f, 73.4f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(957, ProximityTerminal.Constructor(Vector3(1238.29f, 1314.99f, 97.59f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(958, ProximityTerminal.Constructor(Vector3(1246.89f, 776.94f, 95.32f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("NW_Redoubt", "NW_ATPlant")
+      LatticeLink("GW_Cavern3_W", "NW_ATPlant")
+      LatticeLink("NE_Stasis", "Core")
+      LatticeLink("SW_Stasis", "Core")
+      LatticeLink("SE_Redoubt", "SE_ATPlant")
+      LatticeLink("NW_Redoubt", "NE_Stasis")
+      LatticeLink("SE_Redoubt", "SW_Stasis")
+      LatticeLink("SW_Stasis", "NW_ATPlant")
+      LatticeLink("NE_Stasis", "SE_ATPlant")
+      LatticeLink("GW_Cavern3_N", "NW_Redoubt")
+      LatticeLink("GW_Cavern3_S", "SE_Redoubt")
+      LatticeLink("GW_Cavern3_E", "SE_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, true, List(Vector3(595.769f, 971.013f, 68.367f), Vector3(617.24f, 982.719f, 85.965f))))
+      ZipLinePaths(new ZipLinePath(2, false, List(Vector3(597.42f, 911.907f, 87.951f), Vector3(611.503f, 936.96f, 72.997f))))
+      ZipLinePaths(new ZipLinePath(3, true, List(Vector3(622.076f, 1023.44f, 63.331f), Vector3(622.719f, 1018.502f, 93.332f))))
+      ZipLinePaths(new ZipLinePath(4, false, List(Vector3(628.066f, 653.647f, 80.947f), Vector3(652.793f, 654.85f, 98.078f), Vector3(677.121f, 654.452f, 121.481f), Vector3(710.524f, 646.688f, 122.73f), Vector3(744.227f, 642.925f, 123.98f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(631.571f, 1017.425f, 93.82f), Vector3(653.945f, 1018.949f, 91.508f), Vector3(676.32f, 1020.473f, 70.296f), Vector3(688.877f, 1021.349f, 58.994f), Vector3(701.634f, 1022.026f, 51.414f))))
+      ZipLinePaths(new ZipLinePath(6, false, List(Vector3(639.683f, 966.037f, 84.225f), Vector3(689.438f, 956.275f, 90.453f), Vector3(739.193f, 946.514f, 95.94f), Vector3(788.948f, 936.752f, 101.427f), Vector3(838.703f, 926.99f, 106.914f), Vector3(883.58f, 918.186f, 111.693f))))
+      ZipLinePaths(new ZipLinePath(7, false, List(Vector3(641.629f, 1156.085f, 64.865f), Vector3(665.451f, 1200.132f, 77.38f), Vector3(688.672f, 1243.979f, 89.156f), Vector3(690.138f, 1247.258f, 89.3f))))
+      ZipLinePaths(new ZipLinePath(8, true, List(Vector3(647.373f, 1216.143f, 59.351f), Vector3(649.375f, 1217.21f, 92.651f))))
+      ZipLinePaths(new ZipLinePath(9, false, List(Vector3(656.468f, 1211.522f, 93.177f), Vector3(681.191f, 1213.828f, 92.881f), Vector3(705.915f, 1216.135f, 82.302f), Vector3(730.384f, 1218.306f, 73.437f), Vector3(754.853f, 1220.477f, 67.488f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(664.549f, 761.402f, 102.108f), Vector3(675.283f, 781.529f, 101.954f), Vector3(696.017f, 800.657f, 94.508f), Vector3(698.568f, 805.866f, 92.115f))))
+      ZipLinePaths(new ZipLinePath(11, false, List(Vector3(667.071f, 1071.46f, 59.851f), Vector3(640.825f, 1029.389f, 67.036f), Vector3(639.251f, 1026.864f, 63.832f))))
+      ZipLinePaths(new ZipLinePath(12, true, List(Vector3(681.428f, 851.663f, 102.023f), Vector3(682.274f, 857.674f, 107.525f))))
+      ZipLinePaths(new ZipLinePath(13, false, List(Vector3(688.419f, 814.561f, 92.096f), Vector3(651.401f, 848.164f, 92.076f), Vector3(614.383f, 881.766f, 91.308f), Vector3(600.317f, 894.536f, 87.967f))))
+      ZipLinePaths(new ZipLinePath(14, false, List(Vector3(690.738f, 1071.926f, 59.857f), Vector3(718.545f, 1031.94f, 51.832f))))
+      ZipLinePaths(new ZipLinePath(15, false, List(Vector3(704.126f, 1290.795f, 89.088f), Vector3(725.776f, 1332.843f, 70.701f), Vector3(733.841f, 1348.508f, 59.9f))))
+      ZipLinePaths(new ZipLinePath(16, false, List(Vector3(709.91f, 748.459f, 89.816f), Vector3(718.399f, 769.508f, 85.932f), Vector3(726.888f, 790.558f, 75.963f))))
+      ZipLinePaths(new ZipLinePath(17, false, List(Vector3(716.417f, 703.283f, 88.381f), Vector3(693.333f, 697.461f, 86.535f), Vector3(670.25f, 691.64f, 73.819f), Vector3(667.48f, 690.942f, 70.78f))))
+      ZipLinePaths(new ZipLinePath(18, false, List(Vector3(716.858f, 1244.631f, 89.045f), Vector3(728.226f, 1196.511f, 97.219f), Vector3(734.592f, 1169.563f, 99.721f))))
+      ZipLinePaths(new ZipLinePath(19, false, List(Vector3(717.701f, 634.43f, 104.6f), Vector3(687.153f, 675.26f, 104.696f), Vector3(662.594f, 708.085f, 102.1f))))
+      ZipLinePaths(new ZipLinePath(20, true, List(Vector3(718.911f, 629.346f, 70.251f), Vector3(717.944f, 629.452f, 104.1f))))
+      ZipLinePaths(new ZipLinePath(21, true, List(Vector3(727.332f, 763.987f, 84.168f), Vector3(744.248f, 750.002f, 87.851f))))
+      ZipLinePaths(new ZipLinePath(22, false, List(Vector3(732.261f, 1124.261f, 99.745f), Vector3(727.12f, 1101.174f, 100.445f), Vector3(721.979f, 1078.088f, 84.275f), Vector3(711.698f, 1031.915f, 68.074f), Vector3(702.623f, 1001.287f, 55.689f))))
+      ZipLinePaths(new ZipLinePath(23, false, List(Vector3(732.939f, 1112.987f, 59.85f), Vector3(694.976f, 1114.277f, 59.85f))))
+      ZipLinePaths(new ZipLinePath(24, false, List(Vector3(733.315f, 1043.086f, 44.023f), Vector3(783.468f, 1035.628f, 50.227f), Vector3(833.622f, 1028.17f, 55.683f), Vector3(883.775f, 1020.711f, 61.138f), Vector3(905.443f, 1018.487f, 62.496f))))
+      ZipLinePaths(new ZipLinePath(25, false, List(Vector3(734.343f, 605.285f, 69.928f), Vector3(750.482f, 605.113f, 67.796f), Vector3(766.621f, 604.942f, 53.571f))))
+      ZipLinePaths(new ZipLinePath(26, false, List(Vector3(737.579f, 931.404f, 51.22f), Vector3(716.598f, 908.304f, 73.219f), Vector3(709.877f, 905.151f, 70.799f))))
+      ZipLinePaths(new ZipLinePath(27, false, List(Vector3(746.348f, 668.394f, 122.776f), Vector3(740.464f, 689.729f, 113.792f), Vector3(735.78f, 711.064f, 93.308f), Vector3(735.132f, 714.654f, 88.352f))))
+      ZipLinePaths(new ZipLinePath(28, true, List(Vector3(756.1f, 1155.746f, 99.22f), Vector3(760.176f, 1186.748f, 76.063f))))
+      ZipLinePaths(new ZipLinePath(29, true, List(Vector3(758.959f, 1194.575f, 63.456f), Vector3(764.26f, 1195.303f, 46.03f))))
+      ZipLinePaths(new ZipLinePath(30, false, List(Vector3(759.687f, 1211.316f, 63.947f), Vector3(710.624f, 1201.801f, 63.107f), Vector3(692.961f, 1198.375f, 59.852f))))
+      ZipLinePaths(new ZipLinePath(31, false, List(Vector3(764.413f, 1133.386f, 99.716f), Vector3(783.198f, 1108.766f, 100.661f))))
+      ZipLinePaths(new ZipLinePath(32, false, List(Vector3(765.981f, 1159.159f, 99.716f), Vector3(810.625f, 1183.744f, 102.261f), Vector3(855.268f, 1211.829f, 104.064f), Vector3(870.587f, 1219.715f, 104.201f), Vector3(885.906f, 1225.201f, 104.337f))))
+      ZipLinePaths(new ZipLinePath(33, false, List(Vector3(771.91f, 1172.993f, 63.947f), Vector3(723.732f, 1159.705f, 63.095f), Vector3(690.971f, 1150.67f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(34, true, List(Vector3(776.173f, 1384.778f, 59.389f), Vector3(775.563f, 1385.205f, 93.17f))))
+      ZipLinePaths(new ZipLinePath(35, true, List(Vector3(776.538f, 590.261f, 41.751f), Vector3(770.792f, 585.914f, 54.699f))))
+      ZipLinePaths(new ZipLinePath(36, false, List(Vector3(778.127f, 1380.551f, 93.692f), Vector3(780.733f, 1332.62f, 80.418f), Vector3(783.339f, 1284.689f, 66.407f), Vector3(784.33f, 1266.475f, 59.124f))))
+      ZipLinePaths(new ZipLinePath(37, false, List(Vector3(779.095f, 1230.403f, 63.946f), Vector3(739.117f, 1262.004f, 62.663f), Vector3(706.979f, 1287.409f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(38, false, List(Vector3(790.673f, 706.23f, 124.487f), Vector3(826.321f, 741.589f, 115.105f), Vector3(834.85f, 750.027f, 114.023f))))
+      ZipLinePaths(new ZipLinePath(39, false, List(Vector3(792.934f, 1321.527f, 59.855f), Vector3(842.515f, 1314.349f, 70.136f), Vector3(845.431f, 1313.927f, 67.129f))))
+      ZipLinePaths(new ZipLinePath(40, true, List(Vector3(804.465f, 725.206f, 70.251f), Vector3(796.278f, 734.802f, 87.85f))))
+      ZipLinePaths(new ZipLinePath(41, false, List(Vector3(826.335f, 762.948f, 110.827f), Vector3(781.175f, 783.752f, 106.282f), Vector3(751.369f, 797.483f, 101.617f))))
+      ZipLinePaths(new ZipLinePath(42, true, List(Vector3(826.402f, 1227.598f, 46.03f), Vector3(831.918f, 1228.608f, 63.456f))))
+      ZipLinePaths(new ZipLinePath(43, false, List(Vector3(840.839f, 1179.419f, 74.023f), Vector3(884.232f, 1154.925f, 70.614f), Vector3(892.042f, 1150.516f, 69.24f))))
+      ZipLinePaths(new ZipLinePath(44, false, List(Vector3(856.866f, 760.258f, 106.973f), Vector3(863.339f, 738.383f, 103.32f), Vector3(869.812f, 716.508f, 92.22f), Vector3(882.757f, 672.758f, 66.763f), Vector3(883.534f, 670.133f, 62.646f))))
+      ZipLinePaths(new ZipLinePath(45, false, List(Vector3(863.236f, 1245.084f, 105.631f), Vector3(846.791f, 1264.905f, 103.229f), Vector3(832.947f, 1284.727f, 93.958f), Vector3(811.857f, 1324.369f, 73.568f), Vector3(794.902f, 1350.533f, 61.081f))))
+      ZipLinePaths(new ZipLinePath(46, true, List(Vector3(864.625f, 1267.214f, 66.624f), Vector3(863.782f, 1265.734f, 97.64f))))
+      ZipLinePaths(new ZipLinePath(47, false, List(Vector3(866.119f, 1262.615f, 98.148f), Vector3(839.194f, 1221.252f, 90.849f), Vector3(818.73f, 1189.815f, 82.843f))))
+      ZipLinePaths(new ZipLinePath(48, false, List(Vector3(867.992f, 776.508f, 112.423f), Vector3(897.561f, 733.592f, 107.972f), Vector3(921.895f, 700.86f, 101.848f))))
+      ZipLinePaths(new ZipLinePath(49, false, List(Vector3(874.239f, 963.551f, 62.593f), Vector3(846.249f, 1006.177f, 62.656f), Vector3(818.258f, 1048.804f, 61.98f), Vector3(790.268f, 1091.43f, 61.303f), Vector3(786.426f, 1097.281f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(50, true, List(Vector3(878.08f, 1211.27f, 68.74f), Vector3(879.584f, 1210.817f, 101.5f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(883.719f, 1201.219f, 102.011f), Vector3(915.265f, 1162.523f, 105.556f), Vector3(946.811f, 1123.826f, 108.357f), Vector3(978.357f, 1085.13f, 111.159f), Vector3(1009.903f, 1046.434f, 113.96f), Vector3(1016.843f, 1037.921f, 113.549f))))
+      ZipLinePaths(new ZipLinePath(52, false, List(Vector3(894.869f, 621.373f, 98.009f), Vector3(854.043f, 649.44f, 105.507f), Vector3(835.995f, 610.128f, 120.408f), Vector3(808.048f, 664.316f, 124.498f))))
+      ZipLinePaths(new ZipLinePath(53, false, List(Vector3(895.912f, 1177.993f, 80.149f), Vector3(911.404f, 1158.136f, 80.364f), Vector3(926.896f, 1138.28f, 72.893f), Vector3(957.881f, 1098.567f, 62.501f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(899.473f, 935f, 62.594f), Vector3(876.765f, 890.548f, 66.273f), Vector3(854.057f, 846.096f, 69.21f), Vector3(831.349f, 801.645f, 72.147f), Vector3(819.086f, 777.641f, 70.751f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(908.183f, 913.064f, 100.237f), Vector3(867.304f, 885.33f, 93.219f), Vector3(826.426f, 857.596f, 85.468f), Vector3(785.548f, 829.861f, 77.717f), Vector3(764.291f, 815.439f, 70.758f))))
+      ZipLinePaths(new ZipLinePath(56, false, List(Vector3(911.107f, 1174.015f, 69.257f), Vector3(961.534f, 1174.277f, 62.381f), Vector3(1011.962f, 1174.538f, 53.076f))))
+      ZipLinePaths(new ZipLinePath(57, false, List(Vector3(917.5f, 902.31f, 100.231f), Vector3(877.638f, 869.806f, 98.397f), Vector3(838.975f, 838.202f, 95.82f), Vector3(800.312f, 806.598f, 93.243f), Vector3(761.649f, 774.994f, 90.667f), Vector3(757.956f, 768.465f, 88.352f))))
+      ZipLinePaths(new ZipLinePath(58, false, List(Vector3(919.336f, 713.814f, 82.701f), Vector3(871.433f, 727.84f, 86.378f), Vector3(823.53f, 741.866f, 89.315f), Vector3(809.159f, 746.074f, 88.351f))))
+      ZipLinePaths(new ZipLinePath(59, true, List(Vector3(920.936f, 918.429f, 98.892f), Vector3(930.88f, 917.027f, 106.39f))))
+      ZipLinePaths(new ZipLinePath(60, true, List(Vector3(931.553f, 1025.102f, 68.29f), Vector3(986.02f, 1001.745f, 103.056f))))
+      ZipLinePaths(new ZipLinePath(61, true, List(Vector3(942.175f, 878.239f, 62.093f), Vector3(943.987f, 879.733f, 96.131f))))
+      ZipLinePaths(new ZipLinePath(62, false, List(Vector3(947.606f, 886.439f, 96.628f), Vector3(939.941f, 912.104f, 98.851f), Vector3(932.276f, 910.769f, 100.281f))))
+      ZipLinePaths(new ZipLinePath(63, true, List(Vector3(948.062f, 1085.025f, 61.993f), Vector3(949.074f, 1086.391f, 96.35f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(948.659f, 1092.809f, 96.85f), Vector3(970.915f, 1138.642f, 99.74f), Vector3(993.172f, 1184.475f, 101.885f), Vector3(1010.628f, 1220.422f, 102.44f))))
+      ZipLinePaths(new ZipLinePath(65, false, List(Vector3(948.992f, 1063.97f, 71.392f), Vector3(937.88f, 1016.375f, 82.682f), Vector3(926.769f, 968.78f, 93.233f), Vector3(918.324f, 932.607f, 100.241f))))
+      ZipLinePaths(new ZipLinePath(66, false, List(Vector3(953.017f, 912.695f, 111.692f), Vector3(966.054f, 864.624f, 108.046f), Vector3(979.091f, 816.552f, 103.66f), Vector3(991.085f, 772.327f, 97.368f))))
+      ZipLinePaths(new ZipLinePath(67, false, List(Vector3(953.159f, 878.01f, 96.653f), Vector3(1001.65f, 866.321f, 86.763f), Vector3(1050.141f, 854.633f, 76.144f), Vector3(1098.632f, 842.944f, 65.526f), Vector3(1136.513f, 834.006f, 55.215f))))
+      ZipLinePaths(new ZipLinePath(68, false, List(Vector3(954.303f, 919.458f, 111.69f), Vector3(995.314f, 949.714f, 110.578f), Vector3(1013.81f, 963.359f, 108.58f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(976.326f, 1280.215f, 80.595f), Vector3(991.029f, 1263.616f, 100.993f), Vector3(1006.532f, 1246.817f, 102.503f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(976.772f, 907.016f, 70.833f), Vector3(1027.604f, 902.932f, 71.139f), Vector3(1078.436f, 898.848f, 70.695f), Vector3(1129.268f, 894.764f, 70.252f), Vector3(1134.251f, 894.363f, 70.097f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(980.673f, 1225.401f, 53.07f), Vector3(986.931f, 1201.197f, 53.07f))))
+      ZipLinePaths(new ZipLinePath(72, false, List(Vector3(985.328f, 1009.551f, 103.617f), Vector3(962.989f, 1018.146f, 99.408f), Vector3(940.651f, 1026.742f, 86.734f), Vector3(895.973f, 1043.931f, 69.146f), Vector3(885.46f, 1047.976f, 62.529f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(987.286f, 993.985f, 103.561f), Vector3(951.211f, 959.387f, 102.946f), Vector3(922.351f, 931.709f, 100.23f))))
+      ZipLinePaths(new ZipLinePath(74, false, List(Vector3(991.669f, 1240.497f, 102.448f), Vector3(942.154f, 1246.661f, 106.414f), Vector3(922.348f, 1249.127f, 106.791f))))
+      ZipLinePaths(new ZipLinePath(75, true, List(Vector3(997.886f, 1001.888f, 98.08f), Vector3(998.308f, 1001.92f, 108.08f))))
+      ZipLinePaths(new ZipLinePath(76, false, List(Vector3(999.78f, 736.423f, 86.154f), Vector3(1033.248f, 727.68f, 80.234f))))
+      ZipLinePaths(new ZipLinePath(77, true, List(Vector3(1000.418f, 720.566f, 63.331f), Vector3(1002.71f, 707.743f, 77.048f))))
+      ZipLinePaths(new ZipLinePath(78, true, List(Vector3(1008.413f, 723.293f, 63.331f), Vector3(1017.74f, 732.348f, 63.331f))))
+      ZipLinePaths(new ZipLinePath(79, true, List(Vector3(1010.377f, 989.51f, 103.08f), Vector3(1007.82f, 1015.348f, 113.08f))))
+      ZipLinePaths(new ZipLinePath(80, false, List(Vector3(1015.78f, 1119.224f, 62.694f), Vector3(1017.258f, 1170.106f, 66.551f), Vector3(1017.635f, 1183.076f, 65.768f))))
+      ZipLinePaths(new ZipLinePath(81, false, List(Vector3(1015.913f, 856.541f, 62.705f), Vector3(1015.379f, 807.652f, 73.915f), Vector3(1015.251f, 795.919f, 76.088f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(1020.05f, 964.844f, 103.522f), Vector3(1014.081f, 915.391f, 99.916f), Vector3(1008.112f, 865.937f, 95.573f), Vector3(1002.142f, 816.483f, 91.229f), Vector3(998.583f, 781.355f, 86.198f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(1021.393f, 1038.505f, 113.581f), Vector3(1023.559f, 1062.368f, 112.81f), Vector3(1026.326f, 1087.631f, 101.555f), Vector3(1031.256f, 1136.757f, 88.792f), Vector3(1036.187f, 1185.883f, 76.03f), Vector3(1037.157f, 1195.252f, 72.654f))))
+      ZipLinePaths(new ZipLinePath(84, false, List(Vector3(1022.311f, 963.688f, 108.626f), Vector3(1021.282f, 941.241f, 104.749f), Vector3(1020.254f, 918.794f, 88.819f), Vector3(1018.856f, 888.266f, 69.743f))))
+      ZipLinePaths(new ZipLinePath(85, true, List(Vector3(1024.216f, 1237.287f, 101.928f), Vector3(1022.885f, 1236.282f, 107.438f))))
+      ZipLinePaths(new ZipLinePath(86, false, List(Vector3(1025.717f, 1248.9f, 102.662f), Vector3(1019.157f, 1290.883f, 77.791f))))
+      ZipLinePaths(new ZipLinePath(87, false, List(Vector3(1030.526f, 1043.28f, 108.581f), Vector3(1060.287f, 1082.425f, 114.331f), Vector3(1068.936f, 1079.388f, 113.542f))))
+      ZipLinePaths(new ZipLinePath(88, true, List(Vector3(1031.956f, 1098.93f, 71.733f), Vector3(1017.253f, 1035.007f, 108.08f))))
+      ZipLinePaths(new ZipLinePath(89, true, List(Vector3(1032.161f, 1288.907f, 63.331f), Vector3(1013.199f, 1290.127f, 63.331f))))
+      ZipLinePaths(new ZipLinePath(90, false, List(Vector3(1033.844f, 1237.622f, 102.493f), Vector3(1069.373f, 1274.123f, 100.766f), Vector3(1104.903f, 1310.623f, 98.295f), Vector3(1140.432f, 1347.124f, 95.825f), Vector3(1164.118f, 1371.458f, 93.15f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(1034.374f, 1170.445f, 53.073f), Vector3(1071.018f, 1135.457f, 59.658f), Vector3(1099.04f, 1108.701f, 62.896f))))
+      ZipLinePaths(new ZipLinePath(92, true, List(Vector3(1037.704f, 986.625f, 103.08f), Vector3(1008.671f, 1016.569f, 103.08f))))
+      ZipLinePaths(new ZipLinePath(93, false, List(Vector3(1038.931f, 1285.894f, 76.25f), Vector3(1047.65f, 1294.159f, 83.937f), Vector3(1056.369f, 1302.425f, 83.265f))))
+      ZipLinePaths(new ZipLinePath(94, false, List(Vector3(1042.946f, 1314.831f, 83.284f), Vector3(1029.474f, 1325.092f, 81.244f), Vector3(1016.003f, 1335.353f, 69.474f))))
+      ZipLinePaths(new ZipLinePath(95, true, List(Vector3(1048.868f, 1001.705f, 98.08f), Vector3(1048.716f, 1001.779f, 113.08f))))
+      ZipLinePaths(new ZipLinePath(96, true, List(Vector3(1050.738f, 892.293f, 70.931f), Vector3(1030.048f, 969.873f, 108.08f))))
+      ZipLinePaths(new ZipLinePath(97, false, List(Vector3(1059.265f, 1222.82f, 73.793f), Vector3(1055.342f, 1172.574f, 70.201f), Vector3(1058.848f, 1129.879f, 62.697f))))
+      ZipLinePaths(new ZipLinePath(98, false, List(Vector3(1061.142f, 1002.705f, 113.644f), Vector3(1084.951f, 1003.95f, 111.69f), Vector3(1108.761f, 1005.195f, 96.273f), Vector3(1156.381f, 1007.685f, 78.199f), Vector3(1204f, 1010.176f, 60.126f), Vector3(1206.801f, 1010.322f, 55.667f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(1068.7f, 1088.587f, 72.146f), Vector3(1030.278f, 1056.665f, 70.605f), Vector3(991.859f, 1024.744f, 72.816f), Vector3(953.44f, 992.822f, 77.127f), Vector3(940.041f, 974.242f, 78.338f), Vector3(926.642f, 955.662f, 72.35f))))
+      ZipLinePaths(new ZipLinePath(100, true, List(Vector3(1070.703f, 1182.499f, 65.267f), Vector3(1071.896f, 1181.097f, 99.132f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(1072.49f, 703.019f, 74.582f), Vector3(1122.923f, 696.068f, 72.359f), Vector3(1173.357f, 689.117f, 69.381f), Vector3(1185.223f, 687.481f, 67.424f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(1075.826f, 1172.464f, 99.643f), Vector3(1059.78f, 1125.381f, 105.503f), Vector3(1043.734f, 1078.299f, 110.607f), Vector3(1031.539f, 1042.516f, 113.589f))))
+      ZipLinePaths(new ZipLinePath(103, true, List(Vector3(1086.981f, 909.865f, 75.232f), Vector3(1058.547f, 991.146f, 112.996f))))
+      ZipLinePaths(new ZipLinePath(104, true, List(Vector3(1087.994f, 1101.369f, 72.933f), Vector3(1091.579f, 1063.563f, 113.04f))))
+      ZipLinePaths(new ZipLinePath(105, false, List(Vector3(1093.367f, 814.482f, 62.395f), Vector3(1097.482f, 865.146f, 67.271f), Vector3(1099.257f, 887.001f, 67.998f))))
+      ZipLinePaths(new ZipLinePath(106, false, List(Vector3(1108.968f, 1065.041f, 113.578f), Vector3(1115.996f, 1042.885f, 110.55f), Vector3(1123.024f, 1020.73f, 95.861f), Vector3(1137.081f, 976.421f, 77.441f), Vector3(1141.86f, 961.357f, 70.272f))))
+      ZipLinePaths(new ZipLinePath(107, false, List(Vector3(1109.326f, 719.601f, 105.195f), Vector3(1064.788f, 696.899f, 104.857f), Vector3(1020.251f, 674.197f, 103.774f), Vector3(975.714f, 651.495f, 102.692f), Vector3(931.176f, 628.793f, 101.61f), Vector3(916.306f, 624.537f, 98.183f))))
+      ZipLinePaths(new ZipLinePath(108, false, List(Vector3(1112.701f, 1072.817f, 113.492f), Vector3(1126.783f, 1092.701f, 112.58f), Vector3(1140.865f, 1112.586f, 99.194f), Vector3(1169.03f, 1152.355f, 84.168f), Vector3(1188.911f, 1180.428f, 70.467f))))
+      ZipLinePaths(new ZipLinePath(109, false, List(Vector3(1116.494f, 1011.005f, 75.45f), Vector3(1160.328f, 988.101f, 63.755f), Vector3(1187.832f, 973.73f, 53.559f))))
+      ZipLinePaths(new ZipLinePath(110, false, List(Vector3(1117.678f, 834.135f, 51.078f), Vector3(1068.972f, 844.563f, 55.228f))))
+      ZipLinePaths(new ZipLinePath(111, true, List(Vector3(1118.78f, 977.911f, 62.593f), Vector3(1118.424f, 973.771f, 92.59f))))
+      ZipLinePaths(new ZipLinePath(112, false, List(Vector3(1119.944f, 971.229f, 93.091f), Vector3(1125.29f, 921.608f, 96.903f), Vector3(1130.637f, 871.986f, 99.956f), Vector3(1135.984f, 822.365f, 103.009f), Vector3(1141.33f, 772.743f, 106.063f), Vector3(1142.4f, 762.819f, 105.298f))))
+      ZipLinePaths(new ZipLinePath(113, false, List(Vector3(1126.862f, 957.212f, 75.033f), Vector3(1164.602f, 991.481f, 74.353f), Vector3(1202.341f, 1025.749f, 72.915f), Vector3(1235.641f, 1055.984f, 70.441f))))
+      ZipLinePaths(new ZipLinePath(114, false, List(Vector3(1138.22f, 776.829f, 60.837f), Vector3(1185.416f, 778.843f, 80.756f), Vector3(1224.284f, 780.501f, 96.211f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(1145.49f, 1219.031f, 70.445f), Vector3(1110.657f, 1221.727f, 65.772f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(1145.658f, 1046.987f, 62.895f), Vector3(1173.99f, 1089.16f, 68.031f), Vector3(1202.012f, 1130.178f, 70.442f))))
+      ZipLinePaths(new ZipLinePath(117, true, List(Vector3(1145.854f, 848.204f, 41.711f), Vector3(1136.769f, 851.408f, 53.017f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(1150.993f, 1202.394f, 111.938f), Vector3(1102.384f, 1213.637f, 108.625f), Vector3(1053.776f, 1224.88f, 105.269f), Vector3(1032.86f, 1233.202f, 102.45f))))
+      ZipLinePaths(new ZipLinePath(119, false, List(Vector3(1157.936f, 755.227f, 105.205f), Vector3(1194.167f, 722.066f, 96.587f), Vector3(1230.397f, 688.906f, 85.32f))))
+      ZipLinePaths(new ZipLinePath(120, false, List(Vector3(1182.377f, 1225.952f, 111.96f), Vector3(1211.207f, 1266.997f, 103.516f), Vector3(1230.428f, 1294.36f, 95.849f))))
+      ZipLinePaths(new ZipLinePath(121, false, List(Vector3(1183.368f, 1372.605f, 93.007f), Vector3(1227.066f, 1346.365f, 95.448f), Vector3(1257.054f, 1328.356f, 95.84f))))
+      ZipLinePaths(new ZipLinePath(122, false, List(Vector3(1196.442f, 691.273f, 100.784f), Vector3(1157.75f, 723.895f, 107.82f), Vector3(1153.198f, 727.733f, 108.014f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(1197.646f, 931.98f, 56.108f), Vector3(1208.098f, 981.536f, 62.846f), Vector3(1218.551f, 1031.092f, 68.83f), Vector3(1223.675f, 1055.384f, 70.444f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(1198.424f, 1256.573f, 86.345f), Vector3(1182.542f, 1269.419f, 86.762f), Vector3(1166.661f, 1282.265f, 83.094f), Vector3(1127.897f, 1310.958f, 69.897f), Vector3(1114.717f, 1320.713f, 64.233f))))
+      ZipLinePaths(new ZipLinePath(125, true, List(Vector3(1198.609f, 684.319f, 66.924f), Vector3(1199.063f, 682.308f, 100.28f))))
+      ZipLinePaths(new ZipLinePath(126, false, List(Vector3(1199.772f, 1022.014f, 55.634f), Vector3(1150.254f, 1024.653f, 62.833f), Vector3(1148.274f, 1024.758f, 62.898f))))
+      ZipLinePaths(new ZipLinePath(127, true, List(Vector3(1203.743f, 1205.042f, 69.941f), Vector3(1200.635f, 1212.965f, 85.83f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(1203.809f, 691.086f, 100.782f), Vector3(1212.171f, 700.648f, 104.414f), Vector3(1220.534f, 710.211f, 105.048f), Vector3(1237.259f, 729.336f, 97.217f), Vector3(1254.312f, 748.836f, 93.592f))))
+      ZipLinePaths(new ZipLinePath(129, false, List(Vector3(1218.115f, 1081.456f, 77.607f), Vector3(1168.182f, 1082.952f, 76.137f), Vector3(1118.249f, 1084.447f, 73.92f), Vector3(1088.289f, 1085.344f, 71.988f))))
+      ZipLinePaths(new ZipLinePath(130, false, List(Vector3(1222.88f, 1118.832f, 81.22f), Vector3(1175.596f, 1104.086f, 75.102f), Vector3(1128.312f, 1089.34f, 68.25f), Vector3(1107.507f, 1082.852f, 62.899f))))
+      ZipLinePaths(new ZipLinePath(131, false, List(Vector3(1226.808f, 732.805f, 67.43f), Vector3(1191.254f, 768.664f, 61.05f), Vector3(1163.368f, 796.789f, 53.076f))))
+      ZipLinePaths(new ZipLinePath(132, false, List(Vector3(1233.261f, 747.07f, 93.355f), Vector3(1223.936f, 727.816f, 90.392f), Vector3(1214.611f, 708.563f, 67.471f))))
+      ZipLinePaths(new ZipLinePath(133, false, List(Vector3(1236.826f, 1287.784f, 95.841f), Vector3(1252.226f, 1264.968f, 94.594f), Vector3(1259.126f, 1242.353f, 94.248f), Vector3(1263.97f, 1229.77f, 92.27f), Vector3(1268.914f, 1214.787f, 89.594f))))
+      ZipLinePaths(new ZipLinePath(134, false, List(Vector3(1238.011f, 1087.458f, 79.528f), Vector3(1256.071f, 1040.094f, 74.678f), Vector3(1274.132f, 992.73f, 69.08f), Vector3(1292.192f, 945.365f, 63.481f), Vector3(1292.546f, 944.437f, 60.154f))))
+      ZipLinePaths(new ZipLinePath(135, true, List(Vector3(1239.379f, 1157.428f, 91.67f), Vector3(1229.535f, 1148.836f, 80.74f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(1243.286f, 1071.458f, 110.467f), Vector3(1195.837f, 1055.729f, 112.502f), Vector3(1148.388f, 1040f, 113.797f), Vector3(1100.939f, 1024.271f, 115.092f), Vector3(1060.08f, 1011.891f, 113.685f))))
+      ZipLinePaths(new ZipLinePath(137, false, List(Vector3(1246.826f, 1113.238f, 110.476f), Vector3(1227.56f, 1124.142f, 107.77f), Vector3(1208.294f, 1135.046f, 87.974f), Vector3(1185.175f, 1148.131f, 70.65f))))
+      ZipLinePaths(new ZipLinePath(138, true, List(Vector3(1257.492f, 1082.723f, 77.837f), Vector3(1269.3f, 1091.048f, 109.97f))))
+      ZipLinePaths(new ZipLinePath(139, true, List(Vector3(1261.129f, 646.49f, 41.671f), Vector3(1256.709f, 663.872f, 67.12f))))
+      ZipLinePaths(new ZipLinePath(140, false, List(Vector3(1261.935f, 800.968f, 93.356f), Vector3(1310.395f, 816.495f, 97.405f), Vector3(1358.855f, 832.022f, 100.714f), Vector3(1370.406f, 836.262f, 99.718f))))
+      ZipLinePaths(new ZipLinePath(141, false, List(Vector3(1264.266f, 1055.81f, 71.423f), Vector3(1280.247f, 1103.405f, 81.102f), Vector3(1282.754f, 1110.87f, 81.848f))))
+      ZipLinePaths(new ZipLinePath(142, false, List(Vector3(1269.421f, 1295.131f, 96.089f), Vector3(1265.331f, 1245.509f, 92.181f), Vector3(1261.242f, 1195.888f, 87.536f), Vector3(1257.643f, 1152.221f, 81.199f))))
+      ZipLinePaths(new ZipLinePath(143, false, List(Vector3(1269.62f, 1116.62f, 81.595f), Vector3(1248.045f, 1106.837f, 81.616f), Vector3(1237.257f, 1110.195f, 81.152f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(1270.147f, 1315.938f, 95.853f), Vector3(1307.494f, 1284.474f, 107.335f), Vector3(1325.421f, 1269.371f, 112.6f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(1272.251f, 1072.732f, 110.472f), Vector3(1294.76f, 1061.355f, 111.827f), Vector3(1317.269f, 1049.978f, 103.687f), Vector3(1362.286f, 1027.223f, 96.165f), Vector3(1401.124f, 1007.594f, 87.966f))))
+      ZipLinePaths(new ZipLinePath(146, false, List(Vector3(1285.557f, 1176.984f, 101.904f), Vector3(1268.858f, 1130.389f, 109.765f), Vector3(1263.18f, 1114.547f, 110.471f))))
+      ZipLinePaths(new ZipLinePath(147, false, List(Vector3(1286.559f, 1195.88f, 101.906f), Vector3(1237.591f, 1202.38f, 110.405f), Vector3(1219.962f, 1204.72f, 111.984f))))
+      ZipLinePaths(new ZipLinePath(148, false, List(Vector3(1288.633f, 1214.884f, 101.906f), Vector3(1247.251f, 1187.369f, 97.108f), Vector3(1226.56f, 1173.612f, 90.72f))))
+      ZipLinePaths(new ZipLinePath(149, false, List(Vector3(1290.826f, 718.326f, 85.269f), Vector3(1321.687f, 758.543f, 91.79f), Vector3(1352.547f, 798.76f, 97.355f), Vector3(1375.13f, 828.049f, 99.719f))))
+      ZipLinePaths(new ZipLinePath(150, false, List(Vector3(1294.656f, 744.295f, 78.185f), Vector3(1325.753f, 706.069f, 70.457f), Vector3(1347.522f, 679.31f, 59.862f))))
+      ZipLinePaths(new ZipLinePath(151, true, List(Vector3(1299.9f, 760.768f, 46.63f), Vector3(1296.678f, 760.338f, 64.056f))))
+      ZipLinePaths(new ZipLinePath(152, false, List(Vector3(1335.766f, 635.184f, 89.041f), Vector3(1293.37f, 663.502f, 88.496f), Vector3(1283.394f, 670.164f, 85.259f))))
+      ZipLinePaths(new ZipLinePath(153, false, List(Vector3(1339.691f, 1169.995f, 91.574f), Vector3(1331.518f, 1128.805f, 91.322f))))
+      ZipLinePaths(new ZipLinePath(154, false, List(Vector3(1340.717f, 673.945f, 89.042f), Vector3(1293.814f, 673.438f, 85.22f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(1346.98f, 1243.609f, 112.552f), Vector3(1365.815f, 1197.503f, 117.758f), Vector3(1383.897f, 1153.241f, 121.128f))))
+      ZipLinePaths(new ZipLinePath(156, true, List(Vector3(1351.016f, 1254.782f, 112.074f), Vector3(1348.091f, 1254.931f, 117.579f))))
+      ZipLinePaths(new ZipLinePath(157, false, List(Vector3(1355.713f, 1145.351f, 122.442f), Vector3(1308.557f, 1161.641f, 119.865f), Vector3(1261.402f, 1177.931f, 116.539f), Vector3(1218.961f, 1192.593f, 111.982f))))
+      ZipLinePaths(new ZipLinePath(158, false, List(Vector3(1356.956f, 1121.272f, 121.169f), Vector3(1344.419f, 1103.447f, 123.439f), Vector3(1331.882f, 1085.622f, 97.41f), Vector3(1320.599f, 1069.579f, 74.574f), Vector3(1309.316f, 1053.536f, 67.839f))))
+      ZipLinePaths(new ZipLinePath(159, true, List(Vector3(1357.74f, 895.959f, 59.35f), Vector3(1360.201f, 894.144f, 93.751f))))
+      ZipLinePaths(new ZipLinePath(160, true, List(Vector3(1361.935f, 804.341f, 64.056f), Vector3(1357.002f, 801.86f, 46.63f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(1362.178f, 886.635f, 94.264f), Vector3(1335.084f, 844.963f, 89.573f), Vector3(1315.035f, 814.126f, 83.439f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(1364.3f, 1153.417f, 122.494f), Vector3(1356.834f, 1163.739f, 122.87f), Vector3(1334.369f, 1184.662f, 101.953f))))
+      ZipLinePaths(new ZipLinePath(163, false, List(Vector3(1365.132f, 689.391f, 92.669f), Vector3(1349.931f, 707.329f, 91.865f), Vector3(1334.731f, 725.267f, 76.399f), Vector3(1320.754f, 742.953f, 64.585f))))
+      ZipLinePaths(new ZipLinePath(164, true, List(Vector3(1367.319f, 685.024f, 59.35f), Vector3(1369.049f, 684.262f, 92.131f))))
+      ZipLinePaths(new ZipLinePath(165, true, List(Vector3(1367.378f, 1307.869f, 69.287f), Vector3(1366.65f, 1309.663f, 99.29f))))
+      ZipLinePaths(new ZipLinePath(166, false, List(Vector3(1368.273f, 1305.847f, 99.844f), Vector3(1368.455f, 1295.812f, 98.705f), Vector3(1368.338f, 1284.377f, 95.52f), Vector3(1368.104f, 1261.507f, 80.35f), Vector3(1367.916f, 1243.211f, 69.842f))))
+      ZipLinePaths(new ZipLinePath(167, true, List(Vector3(1368.901f, 675.463f, 92.14f), Vector3(1354.678f, 673.232f, 88.541f))))
+      ZipLinePaths(new ZipLinePath(168, false, List(Vector3(1370.444f, 896.269f, 94.24f), Vector3(1410.474f, 915.351f, 69.813f), Vector3(1423.818f, 921.711f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(169, false, List(Vector3(1374.328f, 851.615f, 99.725f), Vector3(1339.342f, 901.528f, 91.012f), Vector3(1313.456f, 944.441f, 81.564f), Vector3(1287.57f, 987.354f, 72.116f), Vector3(1263.714f, 1026.901f, 61.023f))))
+      ZipLinePaths(new ZipLinePath(170, false, List(Vector3(1379.289f, 821.763f, 99.73f), Vector3(1346.288f, 784.372f, 90.076f), Vector3(1319.407f, 753.3f, 78.291f))))
+      ZipLinePaths(new ZipLinePath(171, false, List(Vector3(1391.245f, 823.148f, 99.721f), Vector3(1377.189f, 775.284f, 97.042f), Vector3(1363.132f, 727.421f, 93.615f), Vector3(1349.076f, 679.557f, 90.188f), Vector3(1348.233f, 676.685f, 89.041f))))
+      ZipLinePaths(new ZipLinePath(172, false, List(Vector3(1401.064f, 994.658f, 87.999f), Vector3(1359.762f, 968.901f, 77.283f), Vector3(1318.459f, 943.144f, 65.823f), Vector3(1309.373f, 937.477f, 60.167f))))
+      ZipLinePaths(new ZipLinePath(173, false, List(Vector3(1403.96f, 1159.131f, 102.791f), Vector3(1364.256f, 1189.526f, 103.601f), Vector3(1324.053f, 1219.322f, 103.67f), Vector3(1319.789f, 1223.569f, 101.9f))))
+      ZipLinePaths(new ZipLinePath(174, false, List(Vector3(1404.913f, 726.942f, 54.268f), Vector3(1415.572f, 723.945f, 61.051f), Vector3(1426.231f, 720.948f, 59.866f))))
+      ZipLinePaths(new ZipLinePath(175, true, List(Vector3(1407.877f, 1157.284f, 68.2f), Vector3(1410.102f, 1155.769f, 102.29f))))
+      ZipLinePaths(new ZipLinePath(176, false, List(Vector3(1441.888f, 920.159f, 59.857f), Vector3(1448.313f, 870.457f, 70.052f), Vector3(1449.069f, 864.609f, 69.246f))))
+      ZipLinePaths(new ZipLinePath(177, true, List(Vector3(921.825f, 917.111f, 62.093f), Vector3(910.937f, 927.938f, 106.39f))))
+      ZipLinePaths(new ZipLinePath(178, false, List(Vector3(936.213f, 867.162f, 62.594f), Vector3(946.107f, 818.178f, 66.55f), Vector3(950.856f, 794.666f, 64.818f))))
+      ZipLinePaths(new ZipLinePath(179, false, List(Vector3(619.323f, 951.023f, 83.943f), Vector3(616.715f, 926.938f, 81.874f), Vector3(614.108f, 902.854f, 72.325f), Vector3(613.065f, 893.22f, 67.528f))))
+      ZipLinePaths(new ZipLinePath(180, false, List(Vector3(245.714f, 848.102f, 43.132f), Vector3(296.709f, 848.756f, 43.882f), Vector3(323.707f, 849.102f, 43.135f))))
+      ZipLinePaths(new ZipLinePath(181, false, List(Vector3(380.613f, 839.591f, 43.291f), Vector3(399.483f, 840.484f, 51.34f), Vector3(418.353f, 841.378f, 53.222f))))
+      ZipLinePaths(new ZipLinePath(182, false, List(Vector3(423.423f, 847.719f, 53.214f), Vector3(424.065f, 872.128f, 60.785f), Vector3(424.386f, 884.333f, 66.332f), Vector3(424.707f, 896.537f, 68.202f))))
+      ZipLinePaths(new ZipLinePath(183, false, List(Vector3(462.449f, 888.611f, 73.2f), Vector3(511.515f, 888.994f, 87.828f), Vector3(514.401f, 889.017f, 88.205f))))
+      ZipLinePaths(new ZipLinePath(184, false, List(Vector3(529.355f, 904.244f, 88.305f), Vector3(543.173f, 903.908f, 93.112f), Vector3(557.977f, 903.548f, 93.203f))))
+      ZipLinePaths(new ZipLinePath(185, false, List(Vector3(369.424f, 856.903f, 43.137f), Vector3(370.753f, 870.317f, 43.183f), Vector3(372.082f, 883.73f, 42.93f), Vector3(372.593f, 929.659f, 26.657f), Vector3(392.704f, 974.788f, 25.183f), Vector3(440.126f, 1067.446f, 23.137f))))
+      ZipLinePaths(new ZipLinePath(186, false, List(Vector3(461.151f, 1105.585f, 25.899f), Vector3(509.539f, 1102.527f, 43.908f), Vector3(525.022f, 1101.548f, 42.586f))))
+      ZipLinePaths(new ZipLinePath(187, false, List(Vector3(546.503f, 1044.498f, 41.76f), Vector3(549.481f, 1035.018f, 62.544f), Vector3(550.578f, 1029.883f, 62.594f))))
+      ZipLinePaths(new ZipLinePath(188, false, List(Vector3(588.661f, 1034.477f, 62.594f), Vector3(618.061f, 1076.138f, 62.575f), Vector3(626.132f, 1087.575f, 59.872f))))
+      ZipLinePaths(new ZipLinePath(189, false, List(Vector3(567.287f, 1091.792f, 59.85f), Vector3(566.47f, 1087.667f, 59.901f), Vector3(564.019f, 1075.292f, 41.828f))))
+      ZipLinePaths(new ZipLinePath(190, false, List(Vector3(674.348f, 1054.132f, 42.211f), Vector3(676.883f, 1066.163f, 59.553f), Vector3(677.417f, 1068.695f, 59.85f))))
+      ZipLinePaths(new ZipLinePath(191, true, List(Vector3(715.551f, 1254.657f, 41.711f), Vector3(719.445f, 1248.623f, 52.27f))))
+      ZipLinePaths(new ZipLinePath(192, false, List(Vector3(730.179f, 1259.137f, 51.721f), Vector3(725.114f, 1277.521f, 56.281f), Vector3(720.048f, 1295.905f, 59.862f))))
+      ZipLinePaths(new ZipLinePath(193, false, List(Vector3(739.333f, 1249.902f, 51.803f), Vector3(747.707f, 1237.638f, 61.155f), Vector3(756.08f, 1225.373f, 67.572f))))
+      ZipLinePaths(new ZipLinePath(194, false, List(Vector3(784.345f, 1158.64f, 63.956f), Vector3(786.322f, 1148.447f, 62.598f), Vector3(788.299f, 1138.255f, 59.86f))))
+      ZipLinePaths(new ZipLinePath(195, false, List(Vector3(802.066f, 1126.481f, 59.856f), Vector3(845.835f, 1151.296f, 68.917f), Vector3(855.276f, 1156.648f, 69.245f))))
+      ZipLinePaths(new ZipLinePath(196, false, List(Vector3(809.589f, 1096.782f, 59.851f), Vector3(859.53f, 1086.64f, 62.576f), Vector3(909.472f, 1076.499f, 64.558f), Vector3(917.306f, 1074.908f, 62.493f))))
+      ZipLinePaths(new ZipLinePath(197, false, List(Vector3(739.925f, 1121.005f, 59.851f), Vector3(724.109f, 1169.36f, 58.494f), Vector3(717.596f, 1189.27f, 57.265f), Vector3(716.976f, 1191.166f, 56.882f), Vector3(715.115f, 1196.855f, 54.211f))))
+      ZipLinePaths(new ZipLinePath(198, false, List(Vector3(708.861f, 1189.259f, 56.684f), Vector3(723.914f, 1163.117f, 99.532f), Vector3(726.509f, 1159.805f, 99.717f))))
+      ZipLinePaths(new ZipLinePath(199, false, List(Vector3(766.786f, 1064.421f, 100.684f), Vector3(744.404f, 1056.068f, 97.217f), Vector3(722.023f, 1047.715f, 86.674f), Vector3(677.259f, 1031.01f, 71.931f), Vector3(656.668f, 1023.326f, 63.855f))))
+      ZipLinePaths(new ZipLinePath(200, false, List(Vector3(783.594f, 1061.932f, 100.672f), Vector3(804.372f, 1049.105f, 98.415f), Vector3(825.15f, 1036.279f, 90.67f), Vector3(866.706f, 1010.626f, 79.938f), Vector3(908.262f, 984.973f, 69.207f), Vector3(929.871f, 971.633f, 62.605f))))
+      ZipLinePaths(new ZipLinePath(201, false, List(Vector3(936.867f, 757.882f, 86.26f), Vector3(888.988f, 761.779f, 100.866f), Vector3(864.09f, 763.805f, 106.935f))))
+      ZipLinePaths(new ZipLinePath(202, false, List(Vector3(937.908f, 750.375f, 86.289f), Vector3(918.478f, 737.428f, 82.43f), Vector3(899.047f, 724.481f, 69.121f), Vector3(894.384f, 721.374f, 62.642f))))
+      ZipLinePaths(new ZipLinePath(203, false, List(Vector3(868.071f, 721.611f, 62.603f), Vector3(847.144f, 722.775f, 69.972f), Vector3(826.218f, 723.939f, 70.76f))))
+      ZipLinePaths(new ZipLinePath(204, false, List(Vector3(805.619f, 664.018f, 42.212f), Vector3(791.589f, 676f, 70.301f), Vector3(789.047f, 678.172f, 70.751f))))
+      ZipLinePaths(new ZipLinePath(205, false, List(Vector3(947.93f, 423.772f, 43.135f), Vector3(903.179f, 446.076f, 45.082f), Vector3(858.428f, 468.38f, 45.882f), Vector3(813.677f, 490.683f, 45.081f), Vector3(790.406f, 502.281f, 43.135f))))
+      ZipLinePaths(new ZipLinePath(206, false, List(Vector3(919.391f, 482.058f, 53.372f), Vector3(919.499f, 493.516f, 57.359f), Vector3(919.608f, 504.973f, 61.073f), Vector3(919.716f, 516.431f, 64.786f), Vector3(919.825f, 527.888f, 68.225f))))
+      ZipLinePaths(new ZipLinePath(207, false, List(Vector3(903.584f, 556.412f, 83.215f), Vector3(903.852f, 566.832f, 85.348f), Vector3(904.12f, 577.252f, 88.597f), Vector3(904.387f, 587.672f, 92.146f), Vector3(904.655f, 598.092f, 93.811f))))
+      ZipLinePaths(new ZipLinePath(208, false, List(Vector3(793.715f, 540.457f, 42.854f), Vector3(827.38f, 578.564f, 47.499f), Vector3(861.045f, 616.671f, 51.401f), Vector3(865.666f, 621.901f, 51.304f))))
+      ZipLinePaths(new ZipLinePath(209, false, List(Vector3(889.504f, 637.051f, 42.212f), Vector3(892.089f, 649.448f, 62.344f), Vector3(892.966f, 651.613f, 62.594f))))
+      ZipLinePaths(new ZipLinePath(210, false, List(Vector3(951.854f, 636.424f, 40.682f), Vector3(948.828f, 647.958f, 62.17f), Vector3(947.164f, 656.161f, 62.594f))))
+      ZipLinePaths(new ZipLinePath(211, false, List(Vector3(1071.14f, 654.136f, 40.718f), Vector3(1064.402f, 662.815f, 63.377f), Vector3(1063.335f, 664.8f, 63.831f))))
+      ZipLinePaths(new ZipLinePath(212, false, List(Vector3(1082.249f, 692.541f, 63.831f), Vector3(1089.854f, 706.044f, 63.412f), Vector3(1097.458f, 719.547f, 62.394f))))
+      ZipLinePaths(new ZipLinePath(213, false, List(Vector3(1129.616f, 797.599f, 62.785f), Vector3(1175.716f, 818.7f, 69.054f), Vector3(1193.795f, 826.976f, 69.241f))))
+      ZipLinePaths(new ZipLinePath(214, false, List(Vector3(1260.129f, 863.553f, 69.249f), Vector3(1278.477f, 876.77f, 67.795f), Vector3(1296.825f, 889.987f, 60.16f))))
+      ZipLinePaths(new ZipLinePath(215, false, List(Vector3(1273.776f, 820.533f, 69.268f), Vector3(1276.763f, 813.405f, 75.03f), Vector3(1280.549f, 806.276f, 74.649f))))
+      ZipLinePaths(new ZipLinePath(216, false, List(Vector3(1344.93f, 825.989f, 64.548f), Vector3(1346.993f, 873.881f, 59.876f))))
+      ZipLinePaths(new ZipLinePath(217, true, List(Vector3(1339.858f, 929.759f, 41.711f), Vector3(1318.114f, 908.199f, 68.808f))))
+      ZipLinePaths(new ZipLinePath(218, false, List(Vector3(1030.151f, 1713.887f, 23.14f), Vector3(1006.194f, 1699.563f, 26.603f), Vector3(982.238f, 1687.64f, 29.17f), Vector3(934.325f, 1678.794f, 37.248f), Vector3(898.87f, 1678.435f, 45.05f), Vector3(888.329f, 1676.453f, 43.14f))))
+      ZipLinePaths(new ZipLinePath(219, false, List(Vector3(848.815f, 1671.583f, 43.141f), Vector3(845.118f, 1664.51f, 44.601f), Vector3(836.221f, 1647.438f, 46.061f), Vector3(823.827f, 1623.292f, 48.887f), Vector3(812.239f, 1574.001f, 57.282f), Vector3(810.939f, 1556.451f, 61.617f), Vector3(811.09f, 1547.475f, 63.184f), Vector3(819.04f, 1538.3f, 63.456f))))
+      ZipLinePaths(new ZipLinePath(220, false, List(Vector3(868.882f, 1435.428f, 42.945f), Vector3(905.951f, 1403.482f, 53.947f), Vector3(943.021f, 1371.536f, 64.215f), Vector3(960.642f, 1362.453f, 62.601f))))
+      ZipLinePaths(new ZipLinePath(221, false, List(Vector3(937.234f, 1295.401f, 62.596f), Vector3(915.49f, 1285.599f, 65.559f), Vector3(893.746f, 1275.796f, 67.126f))))
+      ZipLinePaths(new ZipLinePath(222, false, List(Vector3(840.873f, 1401.981f, 54.899f), Vector3(854.118f, 1354.514f, 64.089f), Vector3(860.475f, 1331.73f, 67.131f))))
+      ZipLinePaths(new ZipLinePath(223, false, List(Vector3(776.421f, 1253.584f, 53.384f), Vector3(735.488f, 1253.999f, 82.838f), Vector3(730.985f, 1254.045f, 87.489f), Vector3(726.483f, 1254.09f, 89.041f))))
+      ZipLinePaths(new ZipLinePath(224, false, List(Vector3(687.379f, 1281.924f, 89.056f), Vector3(646.928f, 1254.989f, 78.015f), Vector3(606.477f, 1228.054f, 66.247f), Vector3(593.533f, 1219.435f, 59.867f))))
+      ZipLinePaths(new ZipLinePath(225, false, List(Vector3(704.658f, 1288.16f, 89.048f), Vector3(755.051f, 1287.183f, 82.015f), Vector3(805.444f, 1286.205f, 74.249f), Vector3(824.218f, 1285.841f, 67.133f))))
+      ZipLinePaths(new ZipLinePath(226, true, List(Vector3(844.815f, 1286.36f, 66.624f), Vector3(847.467f, 1287.213f, 96.622f))))
+      ZipLinePaths(new ZipLinePath(227, false, List(Vector3(839.532f, 1286.398f, 97.146f), Vector3(819.924f, 1273.129f, 91.276f), Vector3(800.317f, 1259.86f, 81.805f), Vector3(761.102f, 1233.322f, 65.734f), Vector3(734.741f, 1208.16f, 54.236f))))
+      ZipLinePaths(new ZipLinePath(228, false, List(Vector3(832.911f, 1249.75f, 42.211f), Vector3(843.646f, 1254.481f, 66.64f), Vector3(845.363f, 1255.237f, 67.125f))))
+      ZipLinePaths(new ZipLinePath(229, false, List(Vector3(863.404f, 1270.313f, 98.145f), Vector3(863.198f, 1285.183f, 97.207f), Vector3(862.992f, 1300.053f, 94.075f))))
+      ZipLinePaths(new ZipLinePath(230, false, List(Vector3(865.722f, 1311.216f, 94.071f), Vector3(868.416f, 1330.263f, 85.658f), Vector3(871.11f, 1349.31f, 61.342f), Vector3(873.962f, 1369.478f, 42.045f))))
+      ZipLinePaths(new ZipLinePath(231, true, List(Vector3(851.285f, 1311.441f, 66.624f), Vector3(863.553f, 1307.425f, 93.57f))))
+      ZipLinePaths(new ZipLinePath(232, false, List(Vector3(914.737f, 1389.299f, 44.225f), Vector3(949.158f, 1356.677f, 63.697f), Vector3(955.907f, 1350.281f, 62.619f))))
+      ZipLinePaths(new ZipLinePath(233, false, List(Vector3(924.083f, 1365.718f, 44.222f), Vector3(896.58f, 1326.667f, 59.757f), Vector3(888.604f, 1315.343f, 64.395f), Vector3(880.629f, 1304.018f, 67.156f))))
+      ZipLinePaths(new ZipLinePath(234, false, List(Vector3(911.533f, 1328.871f, 52.857f), Vector3(914.633f, 1279.494f, 60.854f), Vector3(917.734f, 1230.116f, 68.106f), Vector3(919.036f, 1209.378f, 69.244f))))
+      ZipLinePaths(new ZipLinePath(235, false, List(Vector3(924.721f, 1198.763f, 69.239f), Vector3(972.718f, 1215.952f, 68.696f), Vector3(999.068f, 1225.389f, 65.768f))))
+      ZipLinePaths(new ZipLinePath(236, false, List(Vector3(1030.019f, 1253.007f, 73.812f), Vector3(982.302f, 1255.186f, 89.326f), Vector3(934.584f, 1257.365f, 104.505f), Vector3(920.423f, 1258.175f, 106.812f))))
+      ZipLinePaths(new ZipLinePath(237, false, List(Vector3(863.545f, 1238.247f, 105.601f), Vector3(849.048f, 1235.318f, 101.887f), Vector3(834.551f, 1232.388f, 77.573f))))
+      ZipLinePaths(new ZipLinePath(238, false, List(Vector3(896.085f, 1222.855f, 42.212f), Vector3(893.519f, 1214.151f, 68.902f), Vector3(893.252f, 1213.244f, 69.121f), Vector3(892.984f, 1212.338f, 69.24f))))
+      ZipLinePaths(new ZipLinePath(239, false, List(Vector3(890.882f, 1211.784f, 102.01f), Vector3(913.426f, 1221.384f, 96.86f), Vector3(935.971f, 1230.983f, 88.63f), Vector3(981.059f, 1250.183f, 74.518f), Vector3(1004.93f, 1260.348f, 65.788f))))
+      ZipLinePaths(new ZipLinePath(240, false, List(Vector3(731.968f, 946.628f, 42.211f), Vector3(730.363f, 950.87f, 51.2f), Vector3(729.36f, 955.145f, 55.24f), Vector3(728.156f, 959.076f, 55.66f))))
+      ZipLinePaths(new ZipLinePath(241, false, List(Vector3(690.086f, 971.539f, 55.689f), Vector3(679.401f, 966.341f, 62.045f), Vector3(668.716f, 961.144f, 63.86f))))
+      ZipLinePaths(new ZipLinePath(242, false, List(Vector3(622.095f, 943.343f, 72.955f), Vector3(654.892f, 905.636f, 72.118f), Vector3(666.699f, 892.061f, 70.751f))))
+      ZipLinePaths(new ZipLinePath(243, false, List(Vector3(645.091f, 888.102f, 42.212f), Vector3(653.24f, 872.267f, 70.744f), Vector3(655.488f, 867.899f, 70.751f))))
+      ZipLinePaths(new ZipLinePath(244, false, List(Vector3(620.426f, 919.306f, 42.211f), Vector3(629.595f, 924.542f, 63.781f), Vector3(632.347f, 926.451f, 63.831f))))
+      ZipLinePaths(new ZipLinePath(245, false, List(Vector3(649.583f, 1071.378f, 42.211f), Vector3(659.85f, 1083.011f, 59.781f), Vector3(661.806f, 1085.227f, 59.85f))))
+      ZipLinePaths(new ZipLinePath(246, false, List(Vector3(734.689f, 1077.906f, 42.211f), Vector3(741.524f, 1083.509f, 59.801f), Vector3(743.532f, 1085.732f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(247, false, List(Vector3(709.956f, 1074.547f, 42.212f), Vector3(699.011f, 1081.242f, 59.754f), Vector3(696.383f, 1083.257f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(248, false, List(Vector3(820.188f, 1246.386f, 63.948f), Vector3(831.947f, 1257.798f, 66.436f), Vector3(843.707f, 1269.21f, 67.129f))))
+      ZipLinePaths(new ZipLinePath(249, false, List(Vector3(877.568f, 1254.981f, 67.125f), Vector3(872.845f, 1220.395f, 69.241f))))
+      ZipLinePaths(new ZipLinePath(250, true, List(Vector3(845.981f, 1185.464f, 41.711f), Vector3(859.485f, 1177.367f, 68.74f))))
+      ZipLinePaths(new ZipLinePath(251, false, List(Vector3(1144.739f, 1649.306f, 23.148f), Vector3(1194.351f, 1645.963f, 35.819f), Vector3(1212.834f, 1644.717f, 42.718f), Vector3(1222.075f, 1644.094f, 43.276f), Vector3(1231.317f, 1643.472f, 43.148f))))
+      ZipLinePaths(new ZipLinePath(252, false, List(Vector3(1227.85f, 1610.461f, 43.135f), Vector3(1229.804f, 1586.178f, 44.07f), Vector3(1228.358f, 1561.896f, 44.905f), Vector3(1240.066f, 1513.33f, 45.129f), Vector3(1251.701f, 1489.533f, 44.117f), Vector3(1266.336f, 1465.736f, 43.21f))))
+      ZipLinePaths(new ZipLinePath(253, false, List(Vector3(1134.072f, 1592.592f, 23.217f), Vector3(1151.421f, 1592.184f, 30.682f), Vector3(1167.171f, 1591.775f, 33.188f))))
+      ZipLinePaths(new ZipLinePath(254, false, List(Vector3(1175.593f, 1584.054f, 33.224f), Vector3(1174.719f, 1566.227f, 38.716f), Vector3(1174.282f, 1557.313f, 41.722f), Vector3(1174.063f, 1552.857f, 42.824f), Vector3(1173.845f, 1548.4f, 43.246f))))
+      ZipLinePaths(new ZipLinePath(255, false, List(Vector3(1158.087f, 1525.105f, 48.26f), Vector3(1159.791f, 1505.263f, 53.135f), Vector3(1160.643f, 1495.342f, 55.83f), Vector3(1161.069f, 1490.382f, 57.377f), Vector3(1161.495f, 1485.421f, 58.24f))))
+      ZipLinePaths(new ZipLinePath(256, false, List(Vector3(1168.947f, 1481.166f, 58.294f), Vector3(1184.724f, 1480.379f, 63.525f), Vector3(1192.613f, 1479.985f, 66.403f), Vector3(1200.501f, 1479.591f, 68.205f))))
+      ZipLinePaths(new ZipLinePath(257, false, List(Vector3(1208.601f, 1472.023f, 68.227f), Vector3(1208.31f, 1455.703f, 73.09f), Vector3(1208.165f, 1447.544f, 75.782f), Vector3(1208.092f, 1443.464f, 77.129f), Vector3(1208.02f, 1439.384f, 78.198f))))
+      ZipLinePaths(new ZipLinePath(258, false, List(Vector3(1169.756f, 1292.65f, 42.212f), Vector3(1179.642f, 1286.138f, 70.391f), Vector3(1183.899f, 1283.421f, 70.441f))))
+      ZipLinePaths(new ZipLinePath(259, false, List(Vector3(1102.447f, 1188.444f, 42.212f), Vector3(1095.153f, 1188.352f, 65.517f), Vector3(1090.986f, 1188.609f, 65.768f))))
+      ZipLinePaths(new ZipLinePath(260, true, List(Vector3(694.51f, 741.781f, 76.599f), Vector3(688.903f, 728.66f, 101.6f))))
+      ZipLinePaths(new ZipLinePath(261, true, List(Vector3(629.166f, 733.948f, 74.099f), Vector3(643.196f, 744.321f, 101.6f))))
+      ZipLinePaths(new ZipLinePath(262, false, List(Vector3(1353.63f, 747.113f, 53.986f), Vector3(1391.4f, 713.131f, 59.157f), Vector3(1402.509f, 703.136f, 59.852f))))
+      ZipLinePaths(new ZipLinePath(263, false, List(Vector3(1346.229f, 658.639f, 59.857f), Vector3(1330.56f, 672.779f, 65.587f), Vector3(1314.892f, 686.919f, 67.132f))))
+      ZipLinePaths(new ZipLinePath(264, true, List(Vector3(1331.453f, 668.413f, 41.711f), Vector3(1350.394f, 668.947f, 59.35f))))
+      ZipLinePaths(new ZipLinePath(265, false, List(Vector3(1344.101f, 609.861f, 42.211f), Vector3(1361.166f, 616.692f, 59.11f), Vector3(1363.021f, 617.434f, 59.327f), Vector3(1364.875f, 618.177f, 59.545f), Vector3(1368.585f, 619.662f, 59.881f))))
+      ZipLinePaths(new ZipLinePath(266, false, List(Vector3(1439.681f, 676.189f, 59.852f), Vector3(1443.939f, 678.26f, 59.801f), Vector3(1458.843f, 685.511f, 42.212f))))
+      ZipLinePaths(new ZipLinePath(267, false, List(Vector3(1390.255f, 604.317f, 59.851f), Vector3(1354.764f, 627.739f, 88.29f), Vector3(1352.605f, 629.307f, 89.415f), Vector3(1350.845f, 630.474f, 89.04f))))
+      ZipLinePaths(new ZipLinePath(268, false, List(Vector3(1746.911f, 999.303f, 43.135f), Vector3(1724.334f, 954.686f, 45.081f), Vector3(1714.4f, 935.055f, 43.135f))))
+      ZipLinePaths(new ZipLinePath(269, false, List(Vector3(1688.086f, 871.654f, 43.135f), Vector3(1679.453f, 862.013f, 43.74f), Vector3(1676.219f, 844.372f, 44.644f), Vector3(1651.953f, 817.89f, 44.453f), Vector3(1633.164f, 814.917f, 43.103f))))
+      ZipLinePaths(new ZipLinePath(270, false, List(Vector3(1620.102f, 856.378f, 43.135f), Vector3(1574.771f, 877.48f, 44.604f), Vector3(1529.44f, 898.583f, 44.513f), Vector3(1485.923f, 918.842f, 42.847f))))
+      ZipLinePaths(new ZipLinePath(271, false, List(Vector3(1461.886f, 923.554f, 42.515f), Vector3(1449.823f, 925.983f, 59.4f), Vector3(1446.194f, 926.978f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(272, false, List(Vector3(1398.87f, 921.689f, 59.85f), Vector3(1380.721f, 916.061f, 61.55f), Vector3(1362.572f, 910.433f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(273, false, List(Vector3(1359.474f, 897.941f, 94.479f), Vector3(1361.148f, 948.464f, 101.977f), Vector3(1362.823f, 998.988f, 108.705f), Vector3(1364.498f, 1049.51f, 115.434f), Vector3(1366.172f, 1100.031f, 122.163f), Vector3(1366.271f, 1103.003f, 120.819f))))
+      ZipLinePaths(new ZipLinePath(274, false, List(Vector3(1354.682f, 897.716f, 94.275f), Vector3(1343.985f, 903.132f, 94.229f), Vector3(1333.289f, 908.548f, 88.707f), Vector3(1311.896f, 919.381f, 80.864f), Vector3(1269.11f, 941.045f, 66.717f), Vector3(1226.325f, 962.709f, 52.57f), Vector3(1209.21f, 971.375f, 42.236f))))
+      ZipLinePaths(new ZipLinePath(275, false, List(Vector3(1274.319f, 944.513f, 60.151f), Vector3(1267.87f, 995.053f, 58.667f), Vector3(1265.467f, 1013.881f, 55.631f))))
+      ZipLinePaths(new ZipLinePath(276, false, List(Vector3(1222.162f, 1005.468f, 55.63f), Vector3(1207.972f, 984.884f, 56.288f), Vector3(1193.781f, 964.3f, 56.846f), Vector3(1181.293f, 946.186f, 55.226f))))
+      ZipLinePaths(new ZipLinePath(277, true, List(Vector3(1194.95f, 1107.768f, 41.711f), Vector3(1218.82f, 1105.194f, 69.941f))))
+      ZipLinePaths(new ZipLinePath(278, true, List(Vector3(1123.832f, 1080.507f, 41.711f), Vector3(1116.495f, 1068.461f, 62.393f))))
+      ZipLinePaths(new ZipLinePath(279, true, List(Vector3(1034.543f, 1133.645f, 41.711f), Vector3(1037.79f, 1115.293f, 62.193f))))
+      ZipLinePaths(new ZipLinePath(280, true, List(Vector3(906.983f, 1073.184f, 41.711f), Vector3(914.912f, 1061.557f, 61.993f))))
+      ZipLinePaths(new ZipLinePath(281, true, List(Vector3(975.064f, 873.634f, 41.711f), Vector3(977.547f, 890.666f, 62.093f))))
+      ZipLinePaths(new ZipLinePath(282, false, List(Vector3(1147.666f, 899.276f, 62.797f), Vector3(1177.835f, 858.782f, 70.663f), Vector3(1180.201f, 855.606f, 69.242f))))
+      ZipLinePaths(new ZipLinePath(283, true, List(Vector3(1194.793f, 868.656f, 41.711f), Vector3(1197.048f, 853.824f, 68.739f))))
+      ZipLinePaths(new ZipLinePath(284, true, List(Vector3(1238.114f, 831.003f, 68.741f), Vector3(1247.279f, 835.486f, 98.74f))))
+      ZipLinePaths(new ZipLinePath(285, false, List(Vector3(1248.833f, 828.196f, 99.256f), Vector3(1251.872f, 816.912f, 97.397f), Vector3(1254.912f, 805.628f, 93.371f))))
+      ZipLinePaths(new ZipLinePath(286, false, List(Vector3(1248.384f, 837.722f, 99.256f), Vector3(1248.72f, 862.495f, 95.127f), Vector3(1249.057f, 887.268f, 87.915f), Vector3(1249.729f, 936.814f, 75.849f), Vector3(1250.401f, 986.361f, 63.783f), Vector3(1250.731f, 1010.648f, 55.645f))))
+      ZipLinePaths(new ZipLinePath(287, false, List(Vector3(1230.23f, 791.562f, 96.216f), Vector3(1218.028f, 808.975f, 92.428f), Vector3(1205.827f, 827.087f, 77.33f))))
+      ZipLinePaths(new ZipLinePath(288, false, List(Vector3(1245.69f, 872.174f, 69.241f), Vector3(1234.739f, 921.78f, 65.479f), Vector3(1223.788f, 971.385f, 60.979f), Vector3(1216.273f, 1005.428f, 55.632f))))
+      ZipLinePaths(new ZipLinePath(289, true, List(Vector3(1257.469f, 740.652f, 41.711f), Vector3(1262.312f, 727.352f, 66.624f))))
+      ZipLinePaths(new ZipLinePath(290, false, List(Vector3(1310.319f, 709.589f, 67.145f), Vector3(1325.971f, 725.913f, 63.854f), Vector3(1341.622f, 742.237f, 54.005f))))
+      ZipLinePaths(new ZipLinePath(291, false, List(Vector3(1066.185f, 345.278f, 43.135f), Vector3(1090.987f, 394.68f, 45.06f), Vector3(1123.79f, 403.783f, 45.673f), Vector3(1156.593f, 422.686f, 46.286f), Vector3(1179.195f, 433.738f, 47.086f), Vector3(1201.797f, 438.591f, 45.486f), Vector3(1237.251f, 434.604f, 43.135f))))
+      ZipLinePaths(new ZipLinePath(292, false, List(Vector3(1272.832f, 405.679f, 43.135f), Vector3(1294.179f, 431.04f, 46.641f), Vector3(1302.453f, 466.721f, 48.643f), Vector3(1302.127f, 502.402f, 48.746f), Vector3(1293.351f, 530.733f, 46.31f), Vector3(1282.175f, 551.063f, 45.675f), Vector3(1262.223f, 581.125f, 44.003f), Vector3(1253.687f, 594.169f, 42.981f))))
+      ZipLinePaths(new ZipLinePath(293, false, List(Vector3(1200.595f, 640.757f, 52.22f), Vector3(1168.131f, 678.489f, 57.706f), Vector3(1135.666f, 716.221f, 62.455f), Vector3(1131.771f, 720.748f, 62.396f))))
+      ZipLinePaths(new ZipLinePath(294, false, List(Vector3(1219.446f, 577.213f, 42.939f), Vector3(1175.25f, 600.595f, 44.341f), Vector3(1153.152f, 612.286f, 44.469f), Vector3(1131.055f, 623.978f, 43.198f), Vector3(1128.403f, 625.381f, 42.211f))))
+      ZipLinePaths(new ZipLinePath(295, false, List(Vector3(1113.809f, 605.958f, 42.211f), Vector3(1072.225f, 578.187f, 43.962f), Vector3(1040.622f, 557.081f, 42.211f))))
+      ZipLinePaths(new ZipLinePath(296, false, List(Vector3(1012.342f, 557.626f, 50.268f), Vector3(989.945f, 568.578f, 49.742f), Vector3(967.548f, 579.531f, 47.916f), Vector3(922.755f, 601.437f, 43.816f), Vector3(918.275f, 603.627f, 42.373f))))
+      ZipLinePaths(new ZipLinePath(297, false, List(Vector3(1033.85f, 552.731f, 51.556f), Vector3(1018.965f, 601.166f, 58.072f), Vector3(1004.079f, 649.601f, 63.85f), Vector3(1002.62f, 654.35f, 63.834f))))
+      ZipLinePaths(new ZipLinePath(298, false, List(Vector3(1308.288f, 670.018f, 42.254f), Vector3(1305.111f, 674.774f, 66.289f), Vector3(1301.934f, 679.531f, 67.124f))))
+      ZipLinePaths(new ZipLinePath(299, false, List(Vector3(1407.327f, 760.918f, 53.937f), Vector3(1419.914f, 741.887f, 56.392f), Vector3(1426.207f, 732.371f, 59.071f), Vector3(1432.5f, 722.855f, 59.855f))))
+      ZipLinePaths(new ZipLinePath(300, false, List(Vector3(1414.956f, 810.604f, 42.452f), Vector3(1425.75f, 818.247f, 68.99f), Vector3(1428.91f, 820.812f, 69.24f))))
+      ZipLinePaths(new ZipLinePath(301, false, List(Vector3(1425.967f, 865.543f, 69.246f), Vector3(1402.712f, 873.841f, 67.036f), Vector3(1379.458f, 882.138f, 62.133f), Vector3(1372.016f, 884.794f, 59.857f))))
+      ZipLinePaths(new ZipLinePath(302, false, List(Vector3(1268.025f, 904.827f, 60.151f), Vector3(1263.757f, 902.727f, 60.1f), Vector3(1254.573f, 899.329f, 42.212f))))
+      ZipLinePaths(new ZipLinePath(303, true, List(Vector3(1428.244f, 1018.152f, 43.262f), Vector3(1408.2f, 1003.259f, 87.531f))))
+      ZipLinePaths(new ZipLinePath(304, false, List(Vector3(1379.635f, 1065.961f, 42.212f), Vector3(1371.185f, 1066.559f, 67.74f), Vector3(1365.717f, 1066.945f, 67.839f))))
+      ZipLinePaths(new ZipLinePath(305, false, List(Vector3(1326.501f, 1050.083f, 67.866f), Vector3(1328.553f, 1045.581f, 67.818f), Vector3(1334.452f, 1032.638f, 42.212f))))
+      ZipLinePaths(new ZipLinePath(306, false, List(Vector3(1292.772f, 1057.474f, 67.839f), Vector3(1288.802f, 1055.895f, 67.589f), Vector3(1280.42f, 1052.562f, 42.211f))))
+      ZipLinePaths(new ZipLinePath(307, true, List(Vector3(1284.273f, 1206.771f, 76.399f), Vector3(1295.186f, 1221.284f, 101.4f))))
+      ZipLinePaths(new ZipLinePath(308, true, List(Vector3(1348.044f, 1190.75f, 73.899f), Vector3(1330.058f, 1181.224f, 101.4f))))
+      ZipLinePaths(new ZipLinePath(309, false, List(Vector3(1329.397f, 1225.476f, 101.9f), Vector3(1329.965f, 1233.585f, 111.129f), Vector3(1330.533f, 1241.695f, 112.558f))))
+      ZipLinePaths(new ZipLinePath(310, false, List(Vector3(1345.622f, 1270.449f, 112.588f), Vector3(1348.906f, 1276.707f, 111.787f), Vector3(1353.99f, 1284.564f, 90.887f), Vector3(1358.757f, 1295.48f, 69.788f))))
+      ZipLinePaths(new ZipLinePath(311, false, List(Vector3(1339.331f, 1270.575f, 112.644f), Vector3(1335.904f, 1293.307f, 111.479f), Vector3(1332.477f, 1316.04f, 91.271f), Vector3(1326.294f, 1357.048f, 69.844f))))
+      ZipLinePaths(new ZipLinePath(312, false, List(Vector3(1293.195f, 1460.466f, 43.003f), Vector3(1304.584f, 1411.778f, 43.654f), Vector3(1307.09f, 1401.067f, 42.884f))))
+      ZipLinePaths(new ZipLinePath(313, true, List(Vector3(1289.895f, 1360.424f, 55.23f), Vector3(1300.183f, 1350.843f, 69.287f))))
+      ZipLinePaths(new ZipLinePath(314, false, List(Vector3(1259.444f, 1278.484f, 70.442f), Vector3(1253.348f, 1271.49f, 86.369f), Vector3(1250.736f, 1268.492f, 86.33f))))
+      ZipLinePaths(new ZipLinePath(315, false, List(Vector3(1274.596f, 1241.349f, 70.441f), Vector3(1263.641f, 1240.252f, 86.68f), Vector3(1255.817f, 1239.468f, 86.331f))))
+      ZipLinePaths(new ZipLinePath(316, false, List(Vector3(1214.538f, 1287.232f, 86.33f), Vector3(1193.34f, 1333.233f, 93.024f), Vector3(1177.13f, 1368.41f, 92.951f))))
+      ZipLinePaths(new ZipLinePath(317, false, List(Vector3(1113.475f, 1299.019f, 63.833f), Vector3(1150.486f, 1264.243f, 69.233f), Vector3(1165f, 1250.605f, 70.443f))))
+      ZipLinePaths(new ZipLinePath(318, false, List(Vector3(747.8f, 1289.149f, 42.211f), Vector3(753.436f, 1302.617f, 59.563f), Vector3(755.512f, 1307.579f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(319, true, List(Vector3(804.848f, 1407.705f, 41.797f), Vector3(784.69f, 1401.489f, 59.372f))))
+      ZipLinePaths(new ZipLinePath(320, false, List(Vector3(759.088f, 857.776f, 42.212f), Vector3(742.757f, 847.212f, 71.134f), Vector3(740.65f, 845.849f, 70.751f))))
+      ZipLinePaths(new ZipLinePath(321, true, List(Vector3(828.794f, 769.675f, 70.251f), Vector3(840.305f, 765.899f, 106.42f))))
+      ZipLinePaths(new ZipLinePath(322, false, List(Vector3(913.898f, 667.581f, 100.812f), Vector3(910.081f, 645.955f, 99.928f), Vector3(906.265f, 624.328f, 98.046f))))
+      ZipLinePaths(new ZipLinePath(323, false, List(Vector3(1383.419f, 938.651f, 41.978f), Vector3(1391.808f, 942.877f, 59.369f), Vector3(1393.629f, 942.458f, 59.851f))))
+      ZipLinePaths(new ZipLinePath(324, false, List(Vector3(1280.215f, 1185.361f, 101.932f), Vector3(1263.28f, 1198.155f, 99.615f), Vector3(1246.344f, 1210.948f, 86.363f))))
+    }
+
+    ZipLines()
+
+  }
+}

--- a/pslogin/src/main/scala/zonemaps/Ugd03.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd03.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd03 { // Adlivun
   val ZoneMap = new ZoneMap("ugd03") {
     Scale = MapScale.Dim2048
-    Checksum = 0L
+    Checksum = 1673539651L
 
     Building10020()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd04.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd04.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd04 { // Byblos
   val ZoneMap = new ZoneMap("ugd04") {
     Scale = MapScale.Dim2048
-    Checksum = 0L
+    Checksum = 3797992164L
 
     Building10076()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd04.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd04.scala
@@ -1,0 +1,739 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd04 { // Byblos
+  val ZoneMap = new ZoneMap("ugd04") {
+    Scale = MapScale.Dim2048
+    Checksum = 0L
+
+    Building10076()
+
+    def Building10076(): Unit = { // Name: ceiling_bldg_a_10076 Type: ceiling_bldg_a GUID: 1, MapID: 10076
+      LocalBuilding("ceiling_bldg_a_10076", 1, 10076, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1039.99f, 1095.48f, 207.81f), ceiling_bldg_a)))
+      LocalObject(667, Door.Constructor(Vector3(1029.274f, 1107.31f, 209.589f)), owning_building_guid = 1)
+      LocalObject(672, Door.Constructor(Vector3(1050.822f, 1080.083f, 215.095f)), owning_building_guid = 1)
+      LocalObject(673, Door.Constructor(Vector3(1057.124f, 1093.777f, 209.589f)), owning_building_guid = 1)
+      LocalObject(674, Door.Constructor(Vector3(1058.636f, 1102.775f, 215.095f)), owning_building_guid = 1)
+    }
+
+    Building10031()
+
+    def Building10031(): Unit = { // Name: ceiling_bldg_b_10031 Type: ceiling_bldg_b GUID: 2, MapID: 10031
+      LocalBuilding("ceiling_bldg_b_10031", 2, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(870.26f, 1148.19f, 178.45f), ceiling_bldg_b)))
+      LocalObject(648, Door.Constructor(Vector3(872.7868f, 1142.638f, 180.229f)), owning_building_guid = 2)
+      LocalObject(652, Door.Constructor(Vector3(885.0576f, 1155.74f, 180.229f)), owning_building_guid = 2)
+    }
+
+    Building10290()
+
+    def Building10290(): Unit = { // Name: ceiling_bldg_c_10290 Type: ceiling_bldg_c GUID: 3, MapID: 10290
+      LocalBuilding("ceiling_bldg_c_10290", 3, 10290, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.74f, 1334.76f, 162.68f), ceiling_bldg_c)))
+      LocalObject(630, Door.Constructor(Vector3(786.8789f, 1312.529f, 164.459f)), owning_building_guid = 3)
+      LocalObject(636, Door.Constructor(Vector3(807.6219f, 1289.492f, 164.459f)), owning_building_guid = 3)
+      LocalObject(641, Door.Constructor(Vector3(832.528f, 1332.81f, 164.459f)), owning_building_guid = 3)
+    }
+
+    Building10057()
+
+    def Building10057(): Unit = { // Name: ceiling_bldg_d_10057 Type: ceiling_bldg_d GUID: 4, MapID: 10057
+      LocalBuilding("ceiling_bldg_d_10057", 4, 10057, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(709.3f, 999.79f, 174.85f), ceiling_bldg_d)))
+      LocalObject(621, Door.Constructor(Vector3(693.3103f, 992.6534f, 176.585f)), owning_building_guid = 4)
+      LocalObject(623, Door.Constructor(Vector3(702.1634f, 1015.78f, 176.585f)), owning_building_guid = 4)
+      LocalObject(625, Door.Constructor(Vector3(716.3992f, 983.8055f, 176.585f)), owning_building_guid = 4)
+      LocalObject(626, Door.Constructor(Vector3(725.2844f, 1006.889f, 176.585f)), owning_building_guid = 4)
+      LocalObject(762, Painbox.Constructor(Vector3(709.302f, 1000.013f, 183.158f), painbox_continuous), owning_building_guid = 4)
+    }
+
+    Building10279()
+
+    def Building10279(): Unit = { // Name: ceiling_bldg_d_10279 Type: ceiling_bldg_d GUID: 5, MapID: 10279
+      LocalBuilding("ceiling_bldg_d_10279", 5, 10279, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.27f, 1060.78f, 198.86f), ceiling_bldg_d)))
+      LocalObject(688, Door.Constructor(Vector3(1142.284f, 1056.528f, 200.595f)), owning_building_guid = 5)
+      LocalObject(691, Door.Constructor(Vector3(1155.054f, 1077.754f, 200.595f)), owning_building_guid = 5)
+      LocalObject(692, Door.Constructor(Vector3(1163.522f, 1043.794f, 200.595f)), owning_building_guid = 5)
+      LocalObject(694, Door.Constructor(Vector3(1176.244f, 1064.996f, 200.595f)), owning_building_guid = 5)
+      LocalObject(765, Painbox.Constructor(Vector3(1159.05f, 1060.821f, 207.168f), painbox_continuous), owning_building_guid = 5)
+    }
+
+    Building10056()
+
+    def Building10056(): Unit = { // Name: ceiling_bldg_e_10056 Type: ceiling_bldg_e GUID: 6, MapID: 10056
+      LocalBuilding("ceiling_bldg_e_10056", 6, 10056, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837.17f, 1077.23f, 193.72f), ceiling_bldg_e)))
+      LocalObject(640, Door.Constructor(Vector3(825.7902f, 1081.213f, 195.499f)), owning_building_guid = 6)
+      LocalObject(644, Door.Constructor(Vector3(854.0325f, 1105.309f, 200.999f)), owning_building_guid = 6)
+      LocalObject(646, Door.Constructor(Vector3(863.2781f, 1074.38f, 200.999f)), owning_building_guid = 6)
+      LocalObject(647, Door.Constructor(Vector3(865.9316f, 1095.092f, 195.499f)), owning_building_guid = 6)
+    }
+
+    Building10058()
+
+    def Building10058(): Unit = { // Name: ceiling_bldg_f_10058 Type: ceiling_bldg_f GUID: 7, MapID: 10058
+      LocalBuilding("ceiling_bldg_f_10058", 7, 10058, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(699.42f, 1116.72f, 164.46f), ceiling_bldg_f)))
+      LocalObject(622, Door.Constructor(Vector3(695.7913f, 1145.111f, 166.239f)), owning_building_guid = 7)
+      LocalObject(624, Door.Constructor(Vector3(714.9769f, 1089.991f, 166.239f)), owning_building_guid = 7)
+    }
+
+    Building10077()
+
+    def Building10077(): Unit = { // Name: ceiling_bldg_g_10077 Type: ceiling_bldg_g GUID: 8, MapID: 10077
+      LocalBuilding("ceiling_bldg_g_10077", 8, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1136.66f, 968.13f, 183.11f), ceiling_bldg_g)))
+      LocalObject(685, Door.Constructor(Vector3(1119.488f, 964.8085f, 184.889f)), owning_building_guid = 8)
+      LocalObject(690, Door.Constructor(Vector3(1154.39f, 963.4429f, 184.889f)), owning_building_guid = 8)
+    }
+
+    Building10030()
+
+    def Building10030(): Unit = { // Name: ceiling_bldg_h_10030 Type: ceiling_bldg_h GUID: 9, MapID: 10030
+      LocalBuilding("ceiling_bldg_h_10030", 9, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(894.28f, 1280.67f, 179.98f), ceiling_bldg_h)))
+      LocalObject(650, Door.Constructor(Vector3(879.0871f, 1288.218f, 181.759f)), owning_building_guid = 9)
+      LocalObject(654, Door.Constructor(Vector3(895.5801f, 1264.974f, 184.259f)), owning_building_guid = 9)
+      LocalObject(656, Door.Constructor(Vector3(907.9444f, 1290.757f, 181.759f)), owning_building_guid = 9)
+    }
+
+    Building10283()
+
+    def Building10283(): Unit = { // Name: ground_bldg_a_10283 Type: ground_bldg_a GUID: 83, MapID: 10283
+      LocalBuilding("ground_bldg_a_10283", 83, 10283, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(872.31f, 871.53f, 124f), ground_bldg_a)))
+      LocalObject(645, Door.Constructor(Vector3(858.162f, 879.54f, 125.779f)), owning_building_guid = 83)
+      LocalObject(653, Door.Constructor(Vector3(888.688f, 875.546f, 125.779f)), owning_building_guid = 83)
+    }
+
+    Building10022()
+
+    def Building10022(): Unit = { // Name: ground_bldg_a_10022 Type: ground_bldg_a GUID: 84, MapID: 10022
+      LocalBuilding("ground_bldg_a_10022", 84, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.4f, 1234.86f, 124f), ground_bldg_a)))
+      LocalObject(671, Door.Constructor(Vector3(1049.252f, 1242.87f, 125.779f)), owning_building_guid = 84)
+      LocalObject(679, Door.Constructor(Vector3(1079.778f, 1238.876f, 125.779f)), owning_building_guid = 84)
+    }
+
+    Building10288()
+
+    def Building10288(): Unit = { // Name: ground_bldg_b_10288 Type: ground_bldg_b GUID: 85, MapID: 10288
+      LocalBuilding("ground_bldg_b_10288", 85, 10288, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.58f, 779.96f, 113f), ground_bldg_b)))
+      LocalObject(649, Door.Constructor(Vector3(877.595f, 796.45f, 114.779f)), owning_building_guid = 85)
+      LocalObject(651, Door.Constructor(Vector3(881.596f, 778.95f, 114.779f)), owning_building_guid = 85)
+      LocalObject(655, Door.Constructor(Vector3(900.102f, 785.976f, 120.279f)), owning_building_guid = 85)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: ground_bldg_c_10001 Type: ground_bldg_c GUID: 86, MapID: 10001
+      LocalBuilding("ground_bldg_c_10001", 86, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(789.88f, 853.2f, 131f), ground_bldg_c)))
+      LocalObject(628, Door.Constructor(Vector3(778.39f, 807.216f, 132.779f)), owning_building_guid = 86)
+      LocalObject(633, Door.Constructor(Vector3(793.864f, 854.71f, 132.779f)), owning_building_guid = 86)
+      LocalObject(637, Door.Constructor(Vector3(809.39f, 807.216f, 132.779f)), owning_building_guid = 86)
+    }
+
+    Building10222()
+
+    def Building10222(): Unit = { // Name: ground_bldg_c_10222 Type: ground_bldg_c GUID: 87, MapID: 10222
+      LocalBuilding("ground_bldg_c_10222", 87, 10222, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1395.18f, 1160.54f, 130.8f), ground_bldg_c)))
+      LocalObject(722, Door.Constructor(Vector3(1391.295f, 1162.289f, 132.579f)), owning_building_guid = 87)
+      LocalObject(723, Door.Constructor(Vector3(1413.9f, 1206.851f, 132.579f)), owning_building_guid = 87)
+      LocalObject(724, Door.Constructor(Vector3(1435.82f, 1184.931f, 132.579f)), owning_building_guid = 87)
+    }
+
+    Building10154()
+
+    def Building10154(): Unit = { // Name: ground_bldg_d_10154 Type: ground_bldg_d GUID: 88, MapID: 10154
+      LocalBuilding("ground_bldg_d_10154", 88, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(831.35f, 734.45f, 111f), ground_bldg_d)))
+      LocalObject(638, Door.Constructor(Vector3(815.7736f, 742.4045f, 112.735f)), owning_building_guid = 88)
+      LocalObject(639, Door.Constructor(Vector3(823.3954f, 718.8736f, 112.735f)), owning_building_guid = 88)
+      LocalObject(642, Door.Constructor(Vector3(839.2851f, 750.0588f, 112.735f)), owning_building_guid = 88)
+      LocalObject(643, Door.Constructor(Vector3(846.9587f, 726.5149f, 112.735f)), owning_building_guid = 88)
+    }
+
+    Building10155()
+
+    def Building10155(): Unit = { // Name: ground_bldg_d_10155 Type: ground_bldg_d GUID: 89, MapID: 10155
+      LocalBuilding("ground_bldg_d_10155", 89, 10155, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1132.27f, 1293.23f, 118.79f), ground_bldg_d)))
+      LocalObject(684, Door.Constructor(Vector3(1117.745f, 1303.008f, 120.525f)), owning_building_guid = 89)
+      LocalObject(686, Door.Constructor(Vector3(1122.492f, 1278.705f, 120.525f)), owning_building_guid = 89)
+      LocalObject(687, Door.Constructor(Vector3(1142.064f, 1307.721f, 120.525f)), owning_building_guid = 89)
+      LocalObject(689, Door.Constructor(Vector3(1146.761f, 1283.436f, 120.525f)), owning_building_guid = 89)
+    }
+
+    Building10023()
+
+    def Building10023(): Unit = { // Name: ground_bldg_e_10023 Type: ground_bldg_e GUID: 90, MapID: 10023
+      LocalBuilding("ground_bldg_e_10023", 90, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1044.11f, 1336.51f, 116.41f), ground_bldg_e)))
+      LocalObject(669, Door.Constructor(Vector3(1034.913f, 1344.307f, 118.189f)), owning_building_guid = 90)
+      LocalObject(675, Door.Constructor(Vector3(1067.463f, 1324.493f, 123.689f)), owning_building_guid = 90)
+      LocalObject(676, Door.Constructor(Vector3(1069.915f, 1356.681f, 123.689f)), owning_building_guid = 90)
+      LocalObject(678, Door.Constructor(Vector3(1077.362f, 1342.878f, 118.189f)), owning_building_guid = 90)
+    }
+
+    Building10156()
+
+    def Building10156(): Unit = { // Name: ground_bldg_e_10156 Type: ground_bldg_e GUID: 91, MapID: 10156
+      LocalBuilding("ground_bldg_e_10156", 91, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1083.61f, 698.32f, 116.81f), ground_bldg_e)))
+      LocalObject(677, Door.Constructor(Vector3(1074.413f, 706.1166f, 118.589f)), owning_building_guid = 91)
+      LocalObject(680, Door.Constructor(Vector3(1106.963f, 686.3034f, 124.089f)), owning_building_guid = 91)
+      LocalObject(681, Door.Constructor(Vector3(1109.415f, 718.4909f, 124.089f)), owning_building_guid = 91)
+      LocalObject(683, Door.Constructor(Vector3(1116.862f, 704.6882f, 118.589f)), owning_building_guid = 91)
+    }
+
+    Building10008()
+
+    def Building10008(): Unit = { // Name: ground_bldg_f_10008 Type: ground_bldg_f GUID: 92, MapID: 10008
+      LocalBuilding("ground_bldg_f_10008", 92, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1138.19f, 625.25f, 113.54f), ground_bldg_f)))
+      LocalObject(682, Door.Constructor(Vector3(1110.067f, 630.5721f, 115.319f)), owning_building_guid = 92)
+      LocalObject(693, Door.Constructor(Vector3(1168.418f, 631.7859f, 115.319f)), owning_building_guid = 92)
+    }
+
+    Building10009()
+
+    def Building10009(): Unit = { // Name: ground_bldg_g_10009 Type: ground_bldg_g GUID: 93, MapID: 10009
+      LocalBuilding("ground_bldg_g_10009", 93, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1368.37f, 871.02f, 119f), ground_bldg_g)))
+      LocalObject(720, Door.Constructor(Vector3(1360.855f, 887.7485f, 120.779f)), owning_building_guid = 93)
+      LocalObject(721, Door.Constructor(Vector3(1381.758f, 859.7654f, 120.779f)), owning_building_guid = 93)
+    }
+
+    Building10010()
+
+    def Building10010(): Unit = { // Name: ground_bldg_h_10010 Type: ground_bldg_h GUID: 94, MapID: 10010
+      LocalBuilding("ground_bldg_h_10010", 94, 10010, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1312.56f, 941.38f, 118.56f), ground_bldg_h)))
+      LocalObject(714, Door.Constructor(Vector3(1303.717f, 926.9027f, 120.339f)), owning_building_guid = 94)
+      LocalObject(715, Door.Constructor(Vector3(1303.703f, 955.8715f, 120.339f)), owning_building_guid = 94)
+      LocalObject(718, Door.Constructor(Vector3(1328.309f, 941.3072f, 122.839f)), owning_building_guid = 94)
+    }
+
+    Building10298()
+
+    def Building10298(): Unit = { // Name: ground_bldg_i_10298 Type: ground_bldg_i GUID: 95, MapID: 10298
+      LocalBuilding("ground_bldg_i_10298", 95, 10298, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1290.66f, 1171.46f, 134.92f), ground_bldg_i)))
+      LocalObject(704, Door.Constructor(Vector3(1273.733f, 1153.416f, 136.699f)), owning_building_guid = 95)
+      LocalObject(712, Door.Constructor(Vector3(1302.412f, 1194.373f, 136.699f)), owning_building_guid = 95)
+    }
+
+    Building10350()
+
+    def Building10350(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 96, MapID: 10350
+      LocalBuilding("N_Redoubt", 96, 10350, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(781.91f, 1176.43f, 109.13f), redoubt)))
+      LocalObject(816, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 96)
+      LocalObject(627, Door.Constructor(Vector3(773.4349f, 1161.108f, 110.865f)), owning_building_guid = 96)
+      LocalObject(629, Door.Constructor(Vector3(786.5674f, 1159.849f, 120.909f)), owning_building_guid = 96)
+      LocalObject(631, Door.Constructor(Vector3(790.4033f, 1191.719f, 110.865f)), owning_building_guid = 96)
+      LocalObject(632, Door.Constructor(Vector3(790.5598f, 1167.062f, 120.889f)), owning_building_guid = 96)
+      LocalObject(634, Door.Constructor(Vector3(794.4199f, 1174.092f, 120.889f)), owning_building_guid = 96)
+      LocalObject(635, Door.Constructor(Vector3(798.427f, 1181.313f, 120.909f)), owning_building_guid = 96)
+      LocalObject(830, Terminal.Constructor(Vector3(765.7828f, 1185.513f, 109.0858f), vanu_equipment_term), owning_building_guid = 96)
+      LocalObject(836, Terminal.Constructor(Vector3(798.2699f, 1167.343f, 109.0835f), vanu_equipment_term), owning_building_guid = 96)
+      LocalObject(775, SpawnTube.Constructor(Vector3(781.91f, 1176.43f, 109.13f), Vector3(0, 0, 299)), owning_building_guid = 96)
+      LocalObject(763, Painbox.Constructor(Vector3(782.1441f, 1176.253f, 116.919f), painbox_continuous), owning_building_guid = 96)
+    }
+
+    Building10354()
+
+    def Building10354(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 97, MapID: 10354
+      LocalBuilding("S_Redoubt", 97, 10354, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1026.2f, 729.8f, 124.4f), redoubt)))
+      LocalObject(817, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 97)
+      LocalObject(660, Door.Constructor(Vector3(1009.968f, 735.5583f, 136.179f)), owning_building_guid = 97)
+      LocalObject(661, Door.Constructor(Vector3(1010.342f, 722.4229f, 126.135f)), owning_building_guid = 97)
+      LocalObject(665, Door.Constructor(Vector3(1017.453f, 739.0447f, 136.159f)), owning_building_guid = 97)
+      LocalObject(666, Door.Constructor(Vector3(1024.708f, 742.4631f, 136.159f)), owning_building_guid = 97)
+      LocalObject(668, Door.Constructor(Vector3(1032.178f, 745.9517f, 136.179f)), owning_building_guid = 97)
+      LocalObject(670, Door.Constructor(Vector3(1042.063f, 737.2145f, 126.135f)), owning_building_guid = 97)
+      LocalObject(843, Terminal.Constructor(Vector3(1018.305f, 746.7673f, 124.3535f), vanu_equipment_term), owning_building_guid = 97)
+      LocalObject(846, Terminal.Constructor(Vector3(1033.909f, 712.9728f, 124.3558f), vanu_equipment_term), owning_building_guid = 97)
+      LocalObject(776, SpawnTube.Constructor(Vector3(1026.2f, 729.8f, 124.4f), Vector3(0, 0, 155)), owning_building_guid = 97)
+      LocalObject(764, Painbox.Constructor(Vector3(1026.115f, 730.0808f, 132.189f), painbox_continuous), owning_building_guid = 97)
+    }
+
+    Building10285()
+
+    def Building10285(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 154, MapID: 10285
+      LocalBuilding("S_Stasis", 154, 10285, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(647.64f, 755.35f, 139.61f), vanu_control_point)))
+      LocalObject(814, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 154)
+      LocalObject(601, Door.Constructor(Vector3(611.1205f, 763.9373f, 141.389f)), owning_building_guid = 154)
+      LocalObject(604, Door.Constructor(Vector3(632.1003f, 755.4609f, 171.389f)), owning_building_guid = 154)
+      LocalObject(605, Door.Constructor(Vector3(635.5374f, 748.0574f, 146.33f)), owning_building_guid = 154)
+      LocalObject(606, Door.Constructor(Vector3(639.7699f, 758.5145f, 171.369f)), owning_building_guid = 154)
+      LocalObject(607, Door.Constructor(Vector3(641.7611f, 702.6169f, 141.389f)), owning_building_guid = 154)
+      LocalObject(608, Door.Constructor(Vector3(641.9103f, 763.7706f, 146.33f)), owning_building_guid = 154)
+      LocalObject(609, Door.Constructor(Vector3(647.1385f, 761.6781f, 171.369f)), owning_building_guid = 154)
+      LocalObject(610, Door.Constructor(Vector3(647.1663f, 792.3372f, 141.389f)), owning_building_guid = 154)
+      LocalObject(611, Door.Constructor(Vector3(651.2506f, 741.6844f, 146.33f)), owning_building_guid = 154)
+      LocalObject(612, Door.Constructor(Vector3(654.6605f, 765.0719f, 171.389f)), owning_building_guid = 154)
+      LocalObject(613, Door.Constructor(Vector3(657.6295f, 757.4349f, 146.33f)), owning_building_guid = 154)
+      LocalObject(620, Door.Constructor(Vector3(692.3818f, 737.6293f, 141.389f)), owning_building_guid = 154)
+      LocalObject(820, Terminal.Constructor(Vector3(636.3433f, 754.7145f, 144.623f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(821, Terminal.Constructor(Vector3(637.835f, 758.3971f, 144.627f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(822, Terminal.Constructor(Vector3(641.005f, 743.9242f, 144.627f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(823, Terminal.Constructor(Vector3(644.6388f, 742.4835f, 144.623f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(824, Terminal.Constructor(Vector3(648.4553f, 762.9833f, 144.623f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(826, Terminal.Constructor(Vector3(652.1378f, 761.4916f, 144.627f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(827, Terminal.Constructor(Vector3(655.3082f, 747.0178f, 144.627f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(828, Terminal.Constructor(Vector3(656.7999f, 750.7004f, 144.623f), vanu_equipment_term), owning_building_guid = 154)
+      LocalObject(880, SpawnTube.Constructor(Vector3(646.5804f, 752.7275f, 144.749f), Vector3(0, 0, 247)), owning_building_guid = 154)
+      LocalObject(761, Painbox.Constructor(Vector3(646.191f, 752.8744f, 153.9518f), painbox_continuous), owning_building_guid = 154)
+      LocalObject(767, Painbox.Constructor(Vector3(633.8731f, 747.6716f, 148.5f), painbox_door_radius_continuous), owning_building_guid = 154)
+      LocalObject(768, Painbox.Constructor(Vector3(641.0864f, 765.9443f, 147.9f), painbox_door_radius_continuous), owning_building_guid = 154)
+      LocalObject(769, Painbox.Constructor(Vector3(652.7124f, 739.271f, 148.5f), painbox_door_radius_continuous), owning_building_guid = 154)
+      LocalObject(770, Painbox.Constructor(Vector3(659.4526f, 758.1463f, 148.5f), painbox_door_radius_continuous), owning_building_guid = 154)
+    }
+
+    Building10215()
+
+    def Building10215(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 155, MapID: 10215
+      LocalBuilding("N_Stasis", 155, 10215, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1294.35f, 1355.27f, 144.89f), vanu_control_point)))
+      LocalObject(819, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 155)
+      LocalObject(703, Door.Constructor(Vector3(1247.211f, 1364.952f, 146.669f)), owning_building_guid = 155)
+      LocalObject(705, Door.Constructor(Vector3(1284.874f, 1351.482f, 151.61f)), owning_building_guid = 155)
+      LocalObject(706, Door.Constructor(Vector3(1288.421f, 1368.101f, 151.61f)), owning_building_guid = 155)
+      LocalObject(707, Door.Constructor(Vector3(1289.124f, 1344.477f, 176.669f)), owning_building_guid = 155)
+      LocalObject(708, Door.Constructor(Vector3(1290.983f, 1408.223f, 146.669f)), owning_building_guid = 155)
+      LocalObject(709, Door.Constructor(Vector3(1295.943f, 1349.125f, 176.649f)), owning_building_guid = 155)
+      LocalObject(710, Door.Constructor(Vector3(1301.239f, 1318.927f, 146.669f)), owning_building_guid = 155)
+      LocalObject(711, Door.Constructor(Vector3(1301.455f, 1347.972f, 151.61f)), owning_building_guid = 155)
+      LocalObject(713, Door.Constructor(Vector3(1302.65f, 1353.52f, 176.649f)), owning_building_guid = 155)
+      LocalObject(716, Door.Constructor(Vector3(1305.002f, 1364.553f, 151.61f)), owning_building_guid = 155)
+      LocalObject(717, Door.Constructor(Vector3(1309.673f, 1357.859f, 176.669f)), owning_building_guid = 155)
+      LocalObject(719, Door.Constructor(Vector3(1331.806f, 1353.155f, 146.669f)), owning_building_guid = 155)
+      LocalObject(856, Terminal.Constructor(Vector3(1284.522f, 1358.258f, 149.903f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(857, Terminal.Constructor(Vector3(1285.351f, 1362.144f, 149.907f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(858, Terminal.Constructor(Vector3(1290.987f, 1348.441f, 149.907f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(859, Terminal.Constructor(Vector3(1294.873f, 1347.611f, 149.903f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(860, Terminal.Constructor(Vector3(1295.071f, 1368.462f, 149.903f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(861, Terminal.Constructor(Vector3(1298.9f, 1367.674f, 149.907f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(862, Terminal.Constructor(Vector3(1304.535f, 1353.972f, 149.907f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(863, Terminal.Constructor(Vector3(1305.365f, 1357.858f, 149.903f), vanu_equipment_term), owning_building_guid = 155)
+      LocalObject(881, SpawnTube.Constructor(Vector3(1294.938f, 1358.037f, 150.029f), Vector3(0, 0, 57)), owning_building_guid = 155)
+      LocalObject(766, Painbox.Constructor(Vector3(1295.347f, 1357.96f, 159.2318f), painbox_continuous), owning_building_guid = 155)
+      LocalObject(771, Painbox.Constructor(Vector3(1283.202f, 1350.465f, 153.78f), painbox_door_radius_continuous), owning_building_guid = 155)
+      LocalObject(772, Painbox.Constructor(Vector3(1286.563f, 1370.224f, 153.78f), painbox_door_radius_continuous), owning_building_guid = 155)
+      LocalObject(773, Painbox.Constructor(Vector3(1302.644f, 1345.975f, 153.18f), painbox_door_radius_continuous), owning_building_guid = 155)
+      LocalObject(774, Painbox.Constructor(Vector3(1306.574f, 1365.222f, 153.78f), painbox_door_radius_continuous), owning_building_guid = 155)
+    }
+
+    Building10000()
+
+    def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 156, MapID: 10000
+      LocalBuilding("Core", 156, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.99f, 1015.28f, 166.4f), vanu_core)))
+      LocalObject(657, Door.Constructor(Vector3(972.7982f, 985.2183f, 173.188f)), owning_building_guid = 156)
+      LocalObject(658, Door.Constructor(Vector3(976.3412f, 1025.357f, 178.188f)), owning_building_guid = 156)
+      LocalObject(659, Door.Constructor(Vector3(976.3412f, 1025.357f, 183.188f)), owning_building_guid = 156)
+      LocalObject(662, Door.Constructor(Vector3(1012.937f, 981.6753f, 173.188f)), owning_building_guid = 156)
+      LocalObject(663, Door.Constructor(Vector3(1012.937f, 981.6753f, 178.188f)), owning_building_guid = 156)
+      LocalObject(664, Door.Constructor(Vector3(1016.48f, 1021.814f, 183.188f)), owning_building_guid = 156)
+    }
+
+    Building10011()
+
+    def Building10011(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 183, MapID: 10011
+      LocalBuilding("N_ATPlant", 183, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(656.27f, 1262.7f, 108.8f), vanu_vehicle_station)))
+      LocalObject(815, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 183)
+      LocalObject(602, Door.Constructor(Vector3(621.247f, 1298.142f, 110.579f)), owning_building_guid = 183)
+      LocalObject(603, Door.Constructor(Vector3(627.3662f, 1293.008f, 130.503f)), owning_building_guid = 183)
+      LocalObject(614, Door.Constructor(Vector3(659.2061f, 1318.507f, 140.579f)), owning_building_guid = 183)
+      LocalObject(615, Door.Constructor(Vector3(665.5197f, 1313.203f, 140.559f)), owning_building_guid = 183)
+      LocalObject(616, Door.Constructor(Vector3(670.6623f, 1256.678f, 110.579f)), owning_building_guid = 183)
+      LocalObject(617, Door.Constructor(Vector3(671.6845f, 1308.073f, 140.559f)), owning_building_guid = 183)
+      LocalObject(618, Door.Constructor(Vector3(677.9588f, 1302.772f, 140.579f)), owning_building_guid = 183)
+      LocalObject(619, Door.Constructor(Vector3(679.8865f, 1280.268f, 130.491f)), owning_building_guid = 183)
+      LocalObject(725, Door.Constructor(Vector3(684.5188f, 1323.429f, 115.433f)), owning_building_guid = 183)
+      LocalObject(809, Terminal.Constructor(Vector3(641.5201f, 1299.794f, 128.717f), vanu_air_vehicle_term), owning_building_guid = 183)
+      LocalObject(882, VehicleSpawnPad.Constructor(Vector3(644.5638f, 1291.446f, 128.716f), vanu_vehicle_creation_pad, Vector3(0, 0, 220)), owning_building_guid = 183, terminal_guid = 809)
+      LocalObject(810, Terminal.Constructor(Vector3(668.6462f, 1277.045f, 128.717f), vanu_air_vehicle_term), owning_building_guid = 183)
+      LocalObject(883, VehicleSpawnPad.Constructor(Vector3(659.8969f, 1278.58f, 128.716f), vanu_vehicle_creation_pad, Vector3(0, 0, 220)), owning_building_guid = 183, terminal_guid = 810)
+      LocalObject(825, Terminal.Constructor(Vector3(650.4069f, 1301.409f, 111.3f), vanu_equipment_term), owning_building_guid = 183)
+      LocalObject(829, Terminal.Constructor(Vector3(668.792f, 1285.982f, 111.3f), vanu_equipment_term), owning_building_guid = 183)
+      LocalObject(888, Terminal.Constructor(Vector3(663.0067f, 1297.969f, 113.8f), vanu_vehicle_term), owning_building_guid = 183)
+      LocalObject(884, VehicleSpawnPad.Constructor(Vector3(672.8193f, 1309.495f, 111.205f), vanu_vehicle_creation_pad, Vector3(0, 0, 40)), owning_building_guid = 183, terminal_guid = 888)
+    }
+
+    Building10002()
+
+    def Building10002(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 184, MapID: 10002
+      LocalBuilding("S_ATPlant", 184, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1188.77f, 698.47f, 110f), vanu_vehicle_station)))
+      LocalObject(818, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 184)
+      LocalObject(695, Door.Constructor(Vector3(1192.092f, 683.2264f, 111.779f)), owning_building_guid = 184)
+      LocalObject(696, Door.Constructor(Vector3(1197.018f, 739.5303f, 131.703f)), owning_building_guid = 184)
+      LocalObject(697, Door.Constructor(Vector3(1197.714f, 747.488f, 111.779f)), owning_building_guid = 184)
+      LocalObject(698, Door.Constructor(Vector3(1216.706f, 689.2009f, 131.691f)), owning_building_guid = 184)
+      LocalObject(699, Door.Constructor(Vector3(1234.035f, 703.6877f, 141.779f)), owning_building_guid = 184)
+      LocalObject(700, Door.Constructor(Vector3(1234.779f, 711.868f, 141.759f)), owning_building_guid = 184)
+      LocalObject(701, Door.Constructor(Vector3(1235.445f, 719.8604f, 141.759f)), owning_building_guid = 184)
+      LocalObject(702, Door.Constructor(Vector3(1236.169f, 728.0746f, 141.779f)), owning_building_guid = 184)
+      LocalObject(726, Door.Constructor(Vector3(1254.719f, 710.1626f, 116.633f)), owning_building_guid = 184)
+      LocalObject(811, Terminal.Constructor(Vector3(1207.619f, 696.5599f, 129.917f), vanu_air_vehicle_term), owning_building_guid = 184)
+      LocalObject(885, VehicleSpawnPad.Constructor(Vector3(1203.858f, 704.6073f, 129.916f), vanu_vehicle_creation_pad, Vector3(0, 0, -85)), owning_building_guid = 184, terminal_guid = 811)
+      LocalObject(812, Terminal.Constructor(Vector3(1210.696f, 731.829f, 129.917f), vanu_air_vehicle_term), owning_building_guid = 184)
+      LocalObject(886, VehicleSpawnPad.Constructor(Vector3(1205.603f, 724.5471f, 129.916f), vanu_vehicle_creation_pad, Vector3(0, 0, -85)), owning_building_guid = 184, terminal_guid = 812)
+      LocalObject(854, Terminal.Constructor(Vector3(1215.024f, 701.5666f, 112.5f), vanu_equipment_term), owning_building_guid = 184)
+      LocalObject(855, Terminal.Constructor(Vector3(1217.116f, 725.4753f, 112.5f), vanu_equipment_term), owning_building_guid = 184)
+      LocalObject(889, Terminal.Constructor(Vector3(1221.525f, 713.1812f, 115f), vanu_vehicle_term), owning_building_guid = 184)
+      LocalObject(887, VehicleSpawnPad.Constructor(Vector3(1236.595f, 711.7543f, 112.405f), vanu_vehicle_creation_pad, Vector3(0, 0, 95)), owning_building_guid = 184, terminal_guid = 889)
+    }
+
+    Building10273()
+
+    def Building10273(): Unit = { // Name: GW_Cavern4_W Type: warpgate_cavern GUID: 185, MapID: 10273
+      LocalBuilding("GW_Cavern4_W", 185, 10273, FoundationBuilder(WarpGate.Structure(Vector3(125.73f, 933.91f, 100.82f))))
+    }
+
+    Building10180()
+
+    def Building10180(): Unit = { // Name: GW_Cavern4_S Type: warpgate_cavern GUID: 186, MapID: 10180
+      LocalBuilding("GW_Cavern4_S", 186, 10180, FoundationBuilder(WarpGate.Structure(Vector3(856.92f, 191.61f, 101.24f))))
+    }
+
+    Building10178()
+
+    def Building10178(): Unit = { // Name: GW_Cavern4_N Type: warpgate_cavern GUID: 187, MapID: 10178
+      LocalBuilding("GW_Cavern4_N", 187, 10178, FoundationBuilder(WarpGate.Structure(Vector3(934.2f, 1858.96f, 81.44f))))
+    }
+
+    Building10179()
+
+    def Building10179(): Unit = { // Name: GW_Cavern4_E Type: warpgate_cavern GUID: 188, MapID: 10179
+      LocalBuilding("GW_Cavern4_E", 188, 10179, FoundationBuilder(WarpGate.Structure(Vector3(1701.9f, 1247.33f, 81.06f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(831, Terminal.Constructor(Vector3(768.65f, 1172.64f, 109.09f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(832, Terminal.Constructor(Vector3(778.06f, 1189.82f, 109.09f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(833, Terminal.Constructor(Vector3(785.86f, 1163.1f, 109.09f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(834, Terminal.Constructor(Vector3(791.15f, 1304.88f, 162.68f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(835, Terminal.Constructor(Vector3(795.55f, 1180.29f, 109.09f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(837, Terminal.Constructor(Vector3(799.83f, 1295.35f, 162.68f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(838, Terminal.Constructor(Vector3(835.57f, 1094.07f, 193.71f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(839, Terminal.Constructor(Vector3(845.78f, 1062f, 193.71f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(840, Terminal.Constructor(Vector3(891.69f, 781.33f, 118.5f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(841, Terminal.Constructor(Vector3(892.08f, 790.5f, 118.5f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(842, Terminal.Constructor(Vector3(1013.04f, 734.64f, 124.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(844, Terminal.Constructor(Vector3(1021.43f, 716.77f, 124.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(845, Terminal.Constructor(Vector3(1030.94f, 742.92f, 124.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(847, Terminal.Constructor(Vector3(1039.09f, 725.04f, 124.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(848, Terminal.Constructor(Vector3(1046.56f, 1319.12f, 116.4f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(849, Terminal.Constructor(Vector3(1048.6f, 1352.78f, 116.4f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(850, Terminal.Constructor(Vector3(1085.88f, 680.98f, 116.8f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(851, Terminal.Constructor(Vector3(1088.05f, 714.6f, 116.8f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(852, Terminal.Constructor(Vector3(1147.46f, 1067.68f, 198.82f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(853, Terminal.Constructor(Vector3(1171.04f, 1053.54f, 198.82f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(864, Terminal.Constructor(Vector3(1361.59f, 876.44f, 121.5f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(865, Terminal.Constructor(Vector3(1374.98f, 865.79f, 121.5f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(866, Terminal.Constructor(Vector3(1421.6f, 1202.05f, 130.8f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(867, Terminal.Constructor(Vector3(1430.67f, 1192.45f, 130.8f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(20, ProximityTerminal.Constructor(Vector3(767.07f, 1043.25f, 107.89f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(21, ProximityTerminal.Constructor(Vector3(847f, 673.56f, 120f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(22, ProximityTerminal.Constructor(Vector3(881.98f, 1036.96f, 108.75f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(23, ProximityTerminal.Constructor(Vector3(899.09f, 1236.49f, 108.2f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(24, ProximityTerminal.Constructor(Vector3(1110.72f, 824.41f, 121.1f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(25, ProximityTerminal.Constructor(Vector3(1134.79f, 901.31f, 121.2f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(26, ProximityTerminal.Constructor(Vector3(1253.3f, 841.23f, 131.86f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(27, ProximityTerminal.Constructor(Vector3(1360.82f, 675.16f, 127.1f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(28, ProximityTerminal.Constructor(Vector3(603.17f, 847.99f, 135.54f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(29, ProximityTerminal.Constructor(Vector3(606.13f, 977.59f, 112.1f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(30, ProximityTerminal.Constructor(Vector3(619.93f, 1098.07f, 108.2f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(31, ProximityTerminal.Constructor(Vector3(732.74f, 1226.37f, 160.93f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(32, ProximityTerminal.Constructor(Vector3(798.31f, 1142.05f, 108.2f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(33, ProximityTerminal.Constructor(Vector3(844.64f, 1384.9f, 108.2f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(34, ProximityTerminal.Constructor(Vector3(984.09f, 1019.83f, 101.27f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(35, ProximityTerminal.Constructor(Vector3(1064.74f, 889.79f, 124.1f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(36, ProximityTerminal.Constructor(Vector3(1144.21f, 1082.92f, 125.8f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(37, ProximityTerminal.Constructor(Vector3(1180.8f, 1176.04f, 162.7f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(38, ProximityTerminal.Constructor(Vector3(1370.85f, 1290.92f, 135.45f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(743, ProximityTerminal.Constructor(Vector3(1042.73f, 1094.72f, 213.31f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(744, ProximityTerminal.Constructor(Vector3(1308.76f, 941.45f, 121.06f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(745, ProximityTerminal.Constructor(Vector3(675.37f, 1119.01f, 169.46f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(746, ProximityTerminal.Constructor(Vector3(874.59f, 868.25f, 124f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(747, ProximityTerminal.Constructor(Vector3(883.88f, 1139.21f, 183.94f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(748, ProximityTerminal.Constructor(Vector3(1065.61f, 1231.69f, 124f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(749, ProximityTerminal.Constructor(Vector3(1128.28f, 600.54f, 118.54f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(750, ProximityTerminal.Constructor(Vector3(1281.84f, 1173.09f, 134.92f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("N_Redoubt", "N_ATPlant")
+      LatticeLink("GW_Cavern4_W", "N_ATPlant")
+      LatticeLink("N_Stasis", "Core")
+      LatticeLink("S_Stasis", "Core")
+      LatticeLink("S_Redoubt", "S_ATPlant")
+      LatticeLink("N_Redoubt", "N_Stasis")
+      LatticeLink("S_Redoubt", "S_Stasis")
+      LatticeLink("S_Stasis", "N_ATPlant")
+      LatticeLink("N_Stasis", "S_ATPlant")
+      LatticeLink("GW_Cavern4_N", "N_Redoubt")
+      LatticeLink("GW_Cavern4_S", "S_Redoubt")
+      LatticeLink("GW_Cavern4_E", "S_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, false, List(Vector3(581.513f, 991.906f, 137.91f), Vector3(647.981f, 1071.977f, 136.15f))))
+      ZipLinePaths(new ZipLinePath(2, true, List(Vector3(626.942f, 1309.392f, 111.65f), Vector3(624.976f, 1314.648f, 129.076f))))
+      ZipLinePaths(new ZipLinePath(3, true, List(Vector3(664.909f, 1132.887f, 135.55f), Vector3(739.272f, 1093.882f, 108.549f))))
+      ZipLinePaths(new ZipLinePath(4, true, List(Vector3(682.606f, 1258.328f, 129.075f), Vector3(681.167f, 1263.188f, 111.65f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(691.973f, 1020.927f, 175.717f), Vector3(693.182f, 1024.821f, 175.258f), Vector3(711.325f, 1083.23f, 165.286f))))
+      ZipLinePaths(new ZipLinePath(6, true, List(Vector3(725.251f, 1223.128f, 139.881f), Vector3(728.817f, 1227.398f, 161.281f))))
+      ZipLinePaths(new ZipLinePath(7, true, List(Vector3(737.366f, 827.503f, 151.8f), Vector3(726.502f, 823.006f, 118.25f))))
+      ZipLinePaths(new ZipLinePath(8, true, List(Vector3(735.172f, 1225.683f, 108.549f), Vector3(688.37f, 1136.702f, 135.65f))))
+      ZipLinePaths(new ZipLinePath(9, true, List(Vector3(736.016f, 1225.55f, 161.283f), Vector3(739.078f, 1230.956f, 139.881f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(739.34f, 1233.309f, 161.821f), Vector3(707.454f, 1294.883f, 129.621f))))
+      ZipLinePaths(new ZipLinePath(11, true, List(Vector3(744.27f, 823.732f, 118.25f), Vector3(733.396f, 821.193f, 151.8f))))
+      ZipLinePaths(new ZipLinePath(12, true, List(Vector3(791.397f, 1293.352f, 135.65f), Vector3(758.017f, 1258.464f, 122.944f), Vector3(732.648f, 1231.949f, 116.434f), Vector3(727.975f, 1227.065f, 117.548f), Vector3(723.969f, 1222.879f, 117.311f), Vector3(723.302f, 1222.181f, 108.549f))))
+      ZipLinePaths(new ZipLinePath(13, true, List(Vector3(798.178f, 1075.67f, 108.549f), Vector3(661.15f, 1118.363f, 135.65f))))
+      ZipLinePaths(new ZipLinePath(14, true, List(Vector3(806.089f, 1287.723f, 135.65f), Vector3(831.731f, 1254.03f, 124.546f), Vector3(838.141f, 1245.607f, 124.791f), Vector3(839.889f, 1243.31f, 126.432f), Vector3(852.71f, 1226.464f, 123.637f), Vector3(863.783f, 1211.914f, 108.549f))))
+      ZipLinePaths(new ZipLinePath(15, true, List(Vector3(833.04f, 1260.868f, 108.549f), Vector3(819.031f, 1323.108f, 130.591f))))
+      ZipLinePaths(new ZipLinePath(16, false, List(Vector3(851.698f, 1111.512f, 200.062f), Vector3(852.693f, 1113.453f, 199.565f), Vector3(867.626f, 1142.578f, 179.294f))))
+      ZipLinePaths(new ZipLinePath(17, true, List(Vector3(867.508f, 786.909f, 109.085f), Vector3(866.403f, 786.948f, 109.085f))))
+      ZipLinePaths(new ZipLinePath(18, false, List(Vector3(869.055f, 1094.282f, 194.562f), Vector3(975.227f, 1037.114f, 182.263f))))
+      ZipLinePaths(new ZipLinePath(19, true, List(Vector3(872.768f, 1156.774f, 178.792f), Vector3(872.526f, 1156.915f, 184.299f))))
+      ZipLinePaths(new ZipLinePath(20, false, List(Vector3(877.117f, 1420.782f, 133.161f), Vector3(857.119f, 1366.35f, 136.091f))))
+      ZipLinePaths(new ZipLinePath(21, false, List(Vector3(879.233f, 1301.494f, 180.934f), Vector3(878.289f, 1302.333f, 180.345f), Vector3(849.027f, 1328.33f, 163.573f))))
+      ZipLinePaths(new ZipLinePath(22, false, List(Vector3(897.112f, 1147.069f, 179.322f), Vector3(1020.979f, 1092.058f, 208.671f))))
+      ZipLinePaths(new ZipLinePath(23, false, List(Vector3(916.429f, 1293.681f, 180.655f), Vector3(918.128f, 1294.889f, 180.196f), Vector3(1025.18f, 1371.005f, 116.593f))))
+      ZipLinePaths(new ZipLinePath(24, false, List(Vector3(944.17f, 535.579f, 137.951f), Vector3(921.003f, 693.13f, 130.68f))))
+      ZipLinePaths(new ZipLinePath(25, false, List(Vector3(952.003f, 869.708f, 169.18f), Vector3(952.645f, 872.988f, 169.476f), Vector3(972.562f, 974.671f, 172.23f))))
+      ZipLinePaths(new ZipLinePath(26, true, List(Vector3(959.837f, 871.038f, 137.15f), Vector3(949.586f, 868.014f, 168.681f))))
+      ZipLinePaths(new ZipLinePath(27, false, List(Vector3(961.064f, 985.742f, 172.285f), Vector3(958.734f, 983.378f, 171.793f), Vector3(886.507f, 910.111f, 115.886f))))
+      ZipLinePaths(new ZipLinePath(28, true, List(Vector3(961.268f, 870.931f, 168.673f), Vector3(951.672f, 867.573f, 137.15f))))
+      ZipLinePaths(new ZipLinePath(29, false, List(Vector3(965.127f, 1028.015f, 177.262f), Vector3(865.98f, 1067.626f, 200.071f))))
+      ZipLinePaths(new ZipLinePath(30, true, List(Vector3(972.362f, 1005.172f, 176.75f), Vector3(972.277f, 1005.349f, 181.75f))))
+      ZipLinePaths(new ZipLinePath(31, true, List(Vector3(973.345f, 1005.29f, 166.75f), Vector3(973.617f, 1005.373f, 171.75f))))
+      ZipLinePaths(new ZipLinePath(32, true, List(Vector3(993.984f, 986.374f, 171.75f), Vector3(992.517f, 978.742f, 176.75f))))
+      ZipLinePaths(new ZipLinePath(33, true, List(Vector3(997.002f, 1028.654f, 176.75f), Vector3(998.338f, 1029.743f, 166.75f))))
+      ZipLinePaths(new ZipLinePath(34, true, List(Vector3(1015.197f, 1001.46f, 181.75f), Vector3(1015.881f, 1001.237f, 176.75f))))
+      ZipLinePaths(new ZipLinePath(35, true, List(Vector3(1015.632f, 1001.636f, 171.75f), Vector3(1015.663f, 1002.099f, 166.75f))))
+      ZipLinePaths(new ZipLinePath(36, false, List(Vector3(1055.766f, 1084.677f, 214.167f), Vector3(1146.026f, 1093.29f, 199.697f))))
+      ZipLinePaths(new ZipLinePath(37, false, List(Vector3(1081.513f, 906.371f, 141.875f), Vector3(1023.761f, 976.866f, 171.749f), Vector3(1021.898f, 979.14f, 172.226f))))
+      ZipLinePaths(new ZipLinePath(38, false, List(Vector3(1114.566f, 973.674f, 183.961f), Vector3(1024.122f, 981.71f, 177.251f))))
+      ZipLinePaths(new ZipLinePath(39, false, List(Vector3(1115.268f, 685.916f, 123.153f), Vector3(1181.004f, 708.419f, 130.773f))))
+      ZipLinePaths(new ZipLinePath(40, false, List(Vector3(1123.754f, 557.336f, 129.97f), Vector3(1158.099f, 615.656f, 128.58f))))
+      ZipLinePaths(new ZipLinePath(41, false, List(Vector3(1124.52f, 1165.66f, 148.45f), Vector3(1148.819f, 1098.341f, 199.221f), Vector3(1150.439f, 1093.853f, 199.695f))))
+      ZipLinePaths(new ZipLinePath(42, false, List(Vector3(1134.069f, 1054.513f, 199.724f), Vector3(1065.117f, 1089.592f, 208.634f))))
+      ZipLinePaths(new ZipLinePath(43, false, List(Vector3(1164.887f, 1028.954f, 199.752f), Vector3(1164.038f, 1022.243f, 199.227f), Vector3(1158.098f, 975.268f, 183.98f))))
+      ZipLinePaths(new ZipLinePath(44, false, List(Vector3(1169.577f, 1152.768f, 195.641f), Vector3(1028.773f, 1021.258f, 182.191f))))
+      ZipLinePaths(new ZipLinePath(45, false, List(Vector3(1170.844f, 624.946f, 127.89f), Vector3(1225.847f, 674.335f, 130.77f))))
+      ZipLinePaths(new ZipLinePath(46, true, List(Vector3(1171.626f, 1156.954f, 163.054f), Vector3(1173.541f, 1158.297f, 195.14f))))
+      ZipLinePaths(new ZipLinePath(47, true, List(Vector3(1173.21f, 1162.139f, 195.14f), Vector3(1167.157f, 1165.41f, 163.054f))))
+      ZipLinePaths(new ZipLinePath(48, false, List(Vector3(1189.596f, 755.543f, 130.771f), Vector3(1205.016f, 803.983f, 126.811f))))
+      ZipLinePaths(new ZipLinePath(49, true, List(Vector3(1203.213f, 674.437f, 130.276f), Vector3(1203.45f, 682.914f, 112.85f))))
+      ZipLinePaths(new ZipLinePath(50, true, List(Vector3(1209.026f, 745.489f, 112.85f), Vector3(1209.818f, 754.294f, 130.276f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(1263.84f, 868.575f, 164.611f), Vector3(1093.376f, 876.512f, 155.131f))))
+      ZipLinePaths(new ZipLinePath(52, false, List(Vector3(1318.75f, 680.79f, 127.95f), Vector3(1250.792f, 681.997f, 130.77f))))
+      ZipLinePaths(new ZipLinePath(53, false, List(Vector3(1324.778f, 1160.543f, 121.851f), Vector3(1374.004f, 1173.648f, 125.151f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(1326.534f, 812.464f, 127.903f), Vector3(1272.628f, 860.86f, 164.679f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(1395.087f, 937.296f, 108.756f), Vector3(1392.3f, 970.925f, 138.355f), Vector3(1391.902f, 975.729f, 138.032f))))
+      ZipLinePaths(new ZipLinePath(56, true, List(Vector3(986.787f, 1005.346f, 110.778f), Vector3(978.945f, 1022.841f, 166.75f))))
+      ZipLinePaths(new ZipLinePath(57, true, List(Vector3(1011.11f, 984.732f, 166.75f), Vector3(987.858f, 1005.35f, 101.621f))))
+      ZipLinePaths(new ZipLinePath(58, false, List(Vector3(960.539f, 879.005f, 137.679f), Vector3(961.773f, 885.076f, 137.23f), Vector3(980.297f, 976.141f, 102.151f))))
+      ZipLinePaths(new ZipLinePath(59, false, List(Vector3(1183.993f, 1068.618f, 199.718f), Vector3(1190.361f, 1066.146f, 199.274f), Vector3(1387.772f, 989.533f, 138.009f))))
+      ZipLinePaths(new ZipLinePath(60, false, List(Vector3(1084.42f, 1046.639f, 114.856f), Vector3(1075.727f, 1042.173f, 114.359f), Vector3(1014.875f, 1010.907f, 102.126f))))
+      ZipLinePaths(new ZipLinePath(61, false, List(Vector3(1010.405f, 982.383f, 102.144f), Vector3(1050.911f, 927.105f, 124.33f), Vector3(1053.612f, 923.42f, 124.874f))))
+      ZipLinePaths(new ZipLinePath(62, false, List(Vector3(677.233f, 983.867f, 175.757f), Vector3(671.145f, 983.323f, 175.268f), Vector3(579.83f, 975.152f, 138.106f))))
+      ZipLinePaths(new ZipLinePath(63, false, List(Vector3(847.264f, 1345.05f, 163.558f), Vector3(848.71f, 1347.394f, 163.079f), Vector3(893.565f, 1420.056f, 133.129f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(1122.172f, 840.008f, 162.85f), Vector3(960.065f, 860.059f, 169.19f))))
+      ZipLinePaths(new ZipLinePath(65, false, List(Vector3(1126.119f, 849.46f, 162.859f), Vector3(1159.44f, 957.63f, 183.969f))))
+      ZipLinePaths(new ZipLinePath(66, true, List(Vector3(1130.343f, 837.741f, 132.35f), Vector3(1122.353f, 845.266f, 162.35f))))
+      ZipLinePaths(new ZipLinePath(67, true, List(Vector3(1128.075f, 844.958f, 162.35f), Vector3(1122.301f, 843.642f, 132.35f))))
+      ZipLinePaths(new ZipLinePath(68, false, List(Vector3(1280.401f, 949.391f, 114.45f), Vector3(1180.426f, 1027.86f, 199.264f), Vector3(1175.094f, 1032.045f, 199.72f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(1070.591f, 880.007f, 141.902f), Vector3(1094.877f, 919.673f, 164.819f), Vector3(1117.258f, 956.228f, 184.011f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(1037.273f, 821.082f, 124.85f), Vector3(991.292f, 822.466f, 124.95f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(738.475f, 885.729f, 133.976f), Vector3(732.984f, 829.777f, 152.327f))))
+      ZipLinePaths(new ZipLinePath(72, false, List(Vector3(738.037f, 819.262f, 152.3f), Vector3(688.763f, 746.446f, 155.98f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(1201.659f, 845.23f, 109.05f), Vector3(1202.098f, 839.399f, 126.767f), Vector3(1202.245f, 837.456f, 126.802f))))
+      ZipLinePaths(new ZipLinePath(74, false, List(Vector3(1223.133f, 796.668f, 109.055f), Vector3(1221.229f, 800.077f, 126.927f), Vector3(1219.326f, 803.487f, 126.811f))))
+      ZipLinePaths(new ZipLinePath(75, false, List(Vector3(1165.269f, 852.174f, 109.043f), Vector3(1164.509f, 857.593f, 122.345f), Vector3(1164.256f, 859.399f, 122.05f))))
+      ZipLinePaths(new ZipLinePath(76, true, List(Vector3(766.451f, 1184.81f, 109.436f), Vector3(782.652f, 1188.998f, 119.48f))))
+      ZipLinePaths(new ZipLinePath(77, true, List(Vector3(773.648f, 1170.141f, 119.48f), Vector3(797.279f, 1167.873f, 109.436f))))
+      ZipLinePaths(new ZipLinePath(78, false, List(Vector3(919.547f, 1267.287f, 118.234f), Vector3(884.979f, 1164.413f, 179.325f))))
+      ZipLinePaths(new ZipLinePath(79, false, List(Vector3(1016.912f, 1194.737f, 122.496f), Vector3(899.344f, 1154.515f, 179.438f), Vector3(895.552f, 1153.218f, 179.356f))))
+      ZipLinePaths(new ZipLinePath(80, true, List(Vector3(1033.725f, 713.661f, 124.706f), Vector3(1018.227f, 720.002f, 134.75f))))
+      ZipLinePaths(new ZipLinePath(81, true, List(Vector3(1036.573f, 730.427f, 134.75f), Vector3(1018.869f, 745.466f, 124.706f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(1123.651f, 972.872f, 125.04f), Vector3(1139.528f, 1077.659f, 126.65f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(1349.973f, 835.703f, 127.85f), Vector3(1298.615f, 864.67f, 126.95f))))
+      ZipLinePaths(new ZipLinePath(84, false, List(Vector3(614.049f, 988.948f, 120.578f), Vector3(588.185f, 985.552f, 137.464f), Vector3(584.619f, 985.067f, 137.927f))))
+      ZipLinePaths(new ZipLinePath(85, false, List(Vector3(753.458f, 1014.26f, 116.412f), Vector3(825.993f, 1066.964f, 194.024f), Vector3(828.333f, 1068.664f, 194.561f))))
+      ZipLinePaths(new ZipLinePath(86, false, List(Vector3(850.041f, 1042.272f, 140.472f), Vector3(743.271f, 1019.952f, 175.179f), Vector3(736.153f, 1018.464f, 175.701f))))
+      ZipLinePaths(new ZipLinePath(87, false, List(Vector3(928.243f, 1122.438f, 136.017f), Vector3(899.093f, 1259.06f, 183.358f))))
+      ZipLinePaths(new ZipLinePath(88, false, List(Vector3(952.197f, 1363.522f, 117.919f), Vector3(898.492f, 1426.42f, 132.868f))))
+      ZipLinePaths(new ZipLinePath(89, false, List(Vector3(926.366f, 1092.493f, 136.033f), Vector3(929.541f, 1088.451f, 135.574f), Vector3(977.178f, 1027.828f, 102.161f))))
+      ZipLinePaths(new ZipLinePath(90, false, List(Vector3(960.002f, 1008.314f, 102.157f), Vector3(891.126f, 1051.974f, 135.668f), Vector3(886.534f, 1054.885f, 136.126f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(207.89f, 910.311f, 113.14f), Vector3(293.154f, 909.306f, 116.84f), Vector3(321.318f, 889.302f, 118.053f), Vector3(353.3f, 877.25f, 115.91f), Vector3(378.041f, 884.824f, 115.139f), Vector3(413.882f, 910.698f, 115.967f), Vector3(436.729f, 918.823f, 113.12f))))
+      ZipLinePaths(new ZipLinePath(92, false, List(Vector3(427.575f, 953.375f, 113.14f), Vector3(460.915f, 1023.964f, 116.107f), Vector3(474.954f, 1054.653f, 116.138f), Vector3(515.093f, 1076.339f, 115.67f), Vector3(536.745f, 1079.732f, 111.65f))))
+      ZipLinePaths(new ZipLinePath(93, false, List(Vector3(479.791f, 936.61f, 113.388f), Vector3(495.652f, 937.365f, 119.11f), Vector3(502.613f, 938.121f, 118.339f), Vector3(503.635f, 963.631f, 123.797f), Vector3(503.538f, 978.868f, 123.3f), Vector3(513.642f, 982.705f, 123.308f))))
+      ZipLinePaths(new ZipLinePath(94, false, List(Vector3(1679.359f, 1156.319f, 93.135f), Vector3(1679.016f, 1150.787f, 96.119f), Vector3(1646.872f, 1086.92f, 97.109f), Vector3(1633.827f, 1073.554f, 96.398f), Vector3(1586.838f, 1075.32f, 112.677f), Vector3(1568.938f, 1072.514f, 113.155f))))
+      ZipLinePaths(new ZipLinePath(95, false, List(Vector3(1557.496f, 1031.021f, 113.14f), Vector3(1522.762f, 960.766f, 115.661f), Vector3(1506.029f, 928.012f, 115.536f), Vector3(1470.937f, 908.527f, 116.235f), Vector3(1444.142f, 919.885f, 113.738f), Vector3(1432.746f, 921.543f, 109.47f))))
+      ZipLinePaths(new ZipLinePath(96, false, List(Vector3(842.904f, 332.934f, 113.14f), Vector3(828.167f, 338.012f, 114.07f), Vector3(816.33f, 353.302f, 115.603f), Vector3(754.962f, 479.348f, 116.62f), Vector3(781.494f, 530.593f, 110.14f))))
+      ZipLinePaths(new ZipLinePath(97, true, List(Vector3(788.315f, 539.096f, 109.284f), Vector3(805.739f, 539.416f, 116.084f), Vector3(810.607f, 538.671f, 125.568f), Vector3(835.92f, 534.799f, 143.575f), Vector3(884.599f, 527.353f, 152.231f), Vector3(888.493f, 526.757f, 174.148f), Vector3(938.471f, 520.011f, 137.591f))))
+      ZipLinePaths(new ZipLinePath(98, false, List(Vector3(731.311f, 591.258f, 109.766f), Vector3(731.638f, 608.153f, 124.1f), Vector3(736.713f, 637.551f, 137.163f), Vector3(738.405f, 647.35f, 137.407f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(858.162f, 343.607f, 113.461f), Vector3(858.386f, 357.982f, 113.64f), Vector3(871.709f, 363.657f, 113.074f), Vector3(871.476f, 375.138f, 116.324f), Vector3(871.544f, 386.62f, 118.074f), Vector3(873.379f, 405.483f, 118.475f), Vector3(882.869f, 406.77f, 118.381f))))
+      ZipLinePaths(new ZipLinePath(100, false, List(Vector3(920.189f, 433.581f, 128.311f), Vector3(919.775f, 444.103f, 132.255f), Vector3(923.762f, 454.626f, 133.096f), Vector3(934.043f, 460.273f, 133.773f), Vector3(933.925f, 469.42f, 133.551f), Vector3(921.08f, 474.627f, 133.209f), Vector3(922.658f, 483.881f, 133.137f), Vector3(935.235f, 493.135f, 133.566f), Vector3(936.146f, 498.55f, 133.381f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(1422.417f, 983.83f, 133.314f), Vector3(1428.703f, 983.946f, 132.72f), Vector3(1434.989f, 984.061f, 130.225f), Vector3(1448.161f, 989.292f, 128.737f), Vector3(1448.105f, 1017.954f, 128.183f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(1494.966f, 1049.656f, 123.828f), Vector3(1498.045f, 1062.638f, 122.913f), Vector3(1511.389f, 1066.815f, 122.819f), Vector3(1511.932f, 1073.712f, 122.582f), Vector3(1512.476f, 1080.609f, 120.845f), Vector3(1513.562f, 1094.403f, 118.271f), Vector3(1526.748f, 1094.198f, 116.998f), Vector3(1539.934f, 1093.992f, 113.226f))))
+      ZipLinePaths(new ZipLinePath(103, false, List(Vector3(939.789f, 207.271f, 113.209f), Vector3(958.515f, 207.177f, 115.548f), Vector3(977.242f, 207.084f, 110.91f), Vector3(1027.178f, 206.836f, 95.72f), Vector3(1076.155f, 206.592f, 80.509f), Vector3(1078.076f, 206.583f, 75.2f))))
+      ZipLinePaths(new ZipLinePath(104, false, List(Vector3(1083.268f, 239.176f, 74.184f), Vector3(1146.821f, 272.079f, 79.019f), Vector3(1181.375f, 271.281f, 88.881f), Vector3(1201.423f, 272.171f, 95.01f), Vector3(1221.471f, 273.061f, 93.145f))))
+      ZipLinePaths(new ZipLinePath(105, false, List(Vector3(1254.623f, 265.032f, 93.14f), Vector3(1277.415f, 310.652f, 95.518f), Vector3(1300.207f, 356.271f, 95.29f), Vector3(1322.999f, 401.891f, 95.062f), Vector3(1324.786f, 405.469f, 93.14f))))
+      ZipLinePaths(new ZipLinePath(106, false, List(Vector3(1287.494f, 431.131f, 93.143f), Vector3(1216.539f, 429.215f, 116.06f), Vector3(1183.181f, 442.797f, 115.261f), Vector3(1168.423f, 474.38f, 115.962f), Vector3(1167.006f, 513.135f, 110.994f))))
+      ZipLinePaths(new ZipLinePath(107, false, List(Vector3(947.304f, 1751.256f, 93.143f), Vector3(1022.07f, 1715.558f, 97.088f), Vector3(1088.146f, 1715.014f, 116.168f), Vector3(1121.539f, 1698.073f, 114.974f), Vector3(1135.688f, 1672.479f, 113.142f))))
+      ZipLinePaths(new ZipLinePath(108, false, List(Vector3(1156.156f, 1614.299f, 113.14f), Vector3(1165.89f, 1600.735f, 115.415f), Vector3(1166.124f, 1536.271f, 116.594f), Vector3(1170.068f, 1480.177f, 113.813f), Vector3(1163.413f, 1447.482f, 109.93f))))
+      ZipLinePaths(new ZipLinePath(109, false, List(Vector3(866.689f, 1803.032f, 91.411f), Vector3(823.044f, 1805.965f, 100.645f), Vector3(773.898f, 1805.898f, 113.754f), Vector3(762.335f, 1805.887f, 113.15f))))
+      ZipLinePaths(new ZipLinePath(110, false, List(Vector3(719.69f, 1792.509f, 113.143f), Vector3(719.386f, 1776.864f, 111.112f), Vector3(718.475f, 1729.929f, 95.817f), Vector3(687.661f, 1660.449f, 96.011f), Vector3(702.261f, 1629.14f, 93.723f), Vector3(746.162f, 1610.03f, 93.143f))))
+      ZipLinePaths(new ZipLinePath(111, false, List(Vector3(785.498f, 1606.097f, 93.146f), Vector3(785.599f, 1535.452f, 116.464f), Vector3(804.299f, 1500.206f, 115.294f), Vector3(814.583f, 1481.916f, 113.147f))))
+      ZipLinePaths(new ZipLinePath(112, false, List(Vector3(739.761f, 1220.297f, 161.795f), Vector3(741.855f, 1217.845f, 161.278f), Vector3(773.272f, 1181.066f, 119.988f))))
+      ZipLinePaths(new ZipLinePath(113, false, List(Vector3(788.874f, 1190.56f, 120.035f), Vector3(806.9f, 1273.41f, 163.308f), Vector3(808.102f, 1278.933f, 163.587f))))
+      ZipLinePaths(new ZipLinePath(114, false, List(Vector3(773.704f, 1162.971f, 120.002f), Vector3(728.518f, 1101.093f, 164.841f), Vector3(725.506f, 1096.968f, 165.278f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(781.928f, 1311.432f, 163.576f), Vector3(770.548f, 1309.973f, 163.027f), Vector3(705.455f, 1301.629f, 129.618f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(671.03f, 1148.894f, 164.705f), Vector3(669.801f, 1152.329f, 164.248f), Vector3(631.716f, 1258.818f, 119.037f))))
+      ZipLinePaths(new ZipLinePath(117, false, List(Vector3(888.237f, 1456.234f, 128.212f), Vector3(889.896f, 1478.612f, 123.1f), Vector3(900.126f, 1480.202f, 122.403f), Vector3(924.891f, 1479.896f, 114.905f), Vector3(932.607f, 1481.17f, 113.155f), Vector3(936.023f, 1490.444f, 112.406f), Vector3(935.556f, 1500.991f, 108.433f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(903.953f, 1539.55f, 98.452f), Vector3(904.279f, 1550.875f, 103.037f), Vector3(905.605f, 1575.099f, 97.631f), Vector3(921.619f, 1576.126f, 102.303f), Vector3(934.133f, 1576.452f, 103.576f), Vector3(935.661f, 1588.105f, 103.522f))))
+      ZipLinePaths(new ZipLinePath(119, false, List(Vector3(952.101f, 1628.841f, 103.426f), Vector3(951.056f, 1655.014f, 103.109f), Vector3(941.355f, 1655.54f, 103.145f), Vector3(908.955f, 1656.066f, 98.182f), Vector3(903.854f, 1665.792f, 98.018f), Vector3(907.154f, 1687.154f, 92.936f), Vector3(923.854f, 1686.517f, 93.257f))))
+      ZipLinePaths(new ZipLinePath(120, false, List(Vector3(855.153f, 612.968f, 148.912f), Vector3(926.126f, 528.2f, 137.883f))))
+      ZipLinePaths(new ZipLinePath(121, true, List(Vector3(1289.034f, 1388.523f, 147.739f), Vector3(1293.101f, 1393.799f, 163.074f), Vector3(1294.686f, 1400.643f, 161.175f))))
+      ZipLinePaths(new ZipLinePath(122, true, List(Vector3(1311.001f, 1390.936f, 164.914f), Vector3(1311.03f, 1383.145f, 166.497f), Vector3(1311.074f, 1371.459f, 174.89f), Vector3(1311.096f, 1365.615f, 174.89f), Vector3(1311.133f, 1355.877f, 187.506f), Vector3(1311.169f, 1346.138f, 191.6f), Vector3(1311.177f, 1344.19f, 191.6f), Vector3(1310.743f, 1326.36f, 150.239f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(1206.788f, 1314.093f, 136.06f), Vector3(1239.102f, 1336.775f, 144.7f), Vector3(1243.718f, 1340.015f, 145.26f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(1305.939f, 1292.807f, 145.176f), Vector3(1307.056f, 1286.93f, 144.781f), Vector3(1314.874f, 1245.797f, 131.299f), Vector3(1316.483f, 1237.336f, 126.475f))))
+      ZipLinePaths(new ZipLinePath(125, true, List(Vector3(635.732f, 787.036f, 144.959f), Vector3(641.69f, 782.608f, 169.61f), Vector3(677.814f, 746.027f, 177.406f), Vector3(686.856f, 736.488f, 155.479f))))
+      ZipLinePaths(new ZipLinePath(126, true, List(Vector3(638.583f, 708.756f, 155.915f), Vector3(642.303f, 716.658f, 157.733f), Vector3(646.974f, 721.968f, 142.459f))))
+      ZipLinePaths(new ZipLinePath(127, false, List(Vector3(700.844f, 755.122f, 137.391f), Vector3(724.482f, 799.439f, 148.167f), Vector3(734.679f, 818.556f, 152.31f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(651.24f, 839.686f, 137.367f), Vector3(680.057f, 970.631f, 175.22f), Vector3(681.978f, 979.361f, 175.738f))))
+      ZipLinePaths(new ZipLinePath(129, false, List(Vector3(832.657f, 618.498f, 150.19f), Vector3(790.345f, 645.137f, 151.52f), Vector3(748.032f, 671.776f, 151.043f), Vector3(705.72f, 698.415f, 150.567f), Vector3(703.181f, 700.013f, 148.89f))))
+      ZipLinePaths(new ZipLinePath(130, false, List(Vector3(792.263f, 556.276f, 109.54f), Vector3(806.498f, 568.729f, 132.501f), Vector3(812.997f, 574.414f, 138.376f), Vector3(819.495f, 580.1f, 137.243f))))
+      ZipLinePaths(new ZipLinePath(131, false, List(Vector3(905.264f, 797.915f, 121.166f), Vector3(949.727f, 838.795f, 137.088f), Vector3(956.079f, 844.635f, 137.665f))))
+      ZipLinePaths(new ZipLinePath(132, false, List(Vector3(866.636f, 793.426f, 134.32f), Vector3(817.722f, 805.405f, 131.811f))))
+      ZipLinePaths(new ZipLinePath(133, false, List(Vector3(817.815f, 812.227f, 131.813f), Vector3(851.308f, 872.076f, 124.853f))))
+      ZipLinePaths(new ZipLinePath(134, false, List(Vector3(739.172f, 733.542f, 137.481f), Vector3(762.696f, 737.81f, 132.936f), Vector3(786.221f, 742.078f, 122.69f), Vector3(808.362f, 746.094f, 111.881f))))
+      ZipLinePaths(new ZipLinePath(135, false, List(Vector3(749.635f, 682.739f, 137.377f), Vector3(771.007f, 693.48f, 136.152f), Vector3(792.38f, 704.22f, 125.454f), Vector3(815.847f, 716.014f, 111.879f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(770.807f, 810.481f, 131.821f), Vector3(721.399f, 803.395f, 135.775f), Vector3(679.896f, 797.442f, 137.451f))))
+      ZipLinePaths(new ZipLinePath(137, false, List(Vector3(668.436f, 839.169f, 126.948f), Vector3(668.162f, 835.637f, 137.7f), Vector3(668.04f, 830.457f, 137.345f))))
+      ZipLinePaths(new ZipLinePath(138, false, List(Vector3(696.207f, 769.157f, 126.745f), Vector3(691.358f, 769.345f, 137.5f), Vector3(687.522f, 769.379f, 137.353f))))
+      ZipLinePaths(new ZipLinePath(139, false, List(Vector3(777.383f, 693.723f, 109.054f), Vector3(768.922f, 695.463f, 127.2f), Vector3(764.501f, 695.909f, 126.752f))))
+      ZipLinePaths(new ZipLinePath(140, false, List(Vector3(714.7f, 806.943f, 118.655f), Vector3(716.023f, 798.557f, 127.8f), Vector3(716.384f, 794.616f, 126.942f))))
+      ZipLinePaths(new ZipLinePath(141, false, List(Vector3(837.198f, 679.723f, 109.056f), Vector3(841.194f, 674.804f, 121.161f), Vector3(842.792f, 671.297f, 120.844f))))
+      ZipLinePaths(new ZipLinePath(142, false, List(Vector3(980.767f, 823.824f, 124.941f), Vector3(974.252f, 832.646f, 138.475f), Vector3(972.08f, 835.587f, 137.654f))))
+      ZipLinePaths(new ZipLinePath(143, false, List(Vector3(854.641f, 623.48f, 147.703f), Vector3(873.038f, 670.732f, 143.255f), Vector3(890.352f, 715.204f, 137.432f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(897.213f, 726.019f, 137.43f), Vector3(923f, 770.018f, 138.179f), Vector3(948.786f, 814.017f, 138.324f), Vector3(963.955f, 839.899f, 137.65f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(870.548f, 724.109f, 120.954f), Vector3(877.373f, 728.026f, 137.485f), Vector3(881.138f, 728.81f, 137.433f))))
+      ZipLinePaths(new ZipLinePath(146, false, List(Vector3(909.652f, 723.91f, 121.052f), Vector3(906.728f, 720.913f, 137.485f), Vector3(903.654f, 717.805f, 137.441f))))
+      ZipLinePaths(new ZipLinePath(147, false, List(Vector3(944.951f, 580.171f, 113.352f), Vector3(939.778f, 573.055f, 127.401f), Vector3(937.12f, 569.75f, 126.95f))))
+      ZipLinePaths(new ZipLinePath(148, false, List(Vector3(931.01f, 546.086f, 126.943f), Vector3(933.092f, 538.266f, 137.799f), Vector3(933.786f, 535.659f, 137.95f))))
+      ZipLinePaths(new ZipLinePath(149, false, List(Vector3(1009.159f, 752.719f, 124.85f), Vector3(991.619f, 799.006f, 125.778f), Vector3(985.772f, 814.968f, 124.95f))))
+      ZipLinePaths(new ZipLinePath(150, false, List(Vector3(628.63f, 911.352f, 126.753f), Vector3(622.808f, 922.572f, 129.078f), Vector3(605.34f, 956.232f, 125.252f), Vector3(591.184f, 983.513f, 118.093f))))
+      ZipLinePaths(new ZipLinePath(151, false, List(Vector3(916.791f, 916.103f, 110.541f), Vector3(927.088f, 910.021f, 125.3f), Vector3(931.332f, 907.814f, 124.85f))))
+      ZipLinePaths(new ZipLinePath(152, false, List(Vector3(985.233f, 890.658f, 114.677f), Vector3(983.342f, 879.305f, 125.383f), Vector3(982.712f, 875.521f, 124.952f))))
+      ZipLinePaths(new ZipLinePath(153, false, List(Vector3(788.586f, 904.202f, 133.771f), Vector3(800.969f, 904.082f, 135.354f), Vector3(838.117f, 903.72f, 125.166f), Vector3(850.742f, 903.597f, 115.87f))))
+      ZipLinePaths(new ZipLinePath(154, false, List(Vector3(723.819f, 909.915f, 133.841f), Vector3(716.155f, 968.988f, 175.181f), Vector3(715.644f, 972.926f, 175.708f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(757.2f, 918.818f, 133.758f), Vector3(752.902f, 967.566f, 125.833f), Vector3(751.772f, 994.343f, 120.207f))))
+      ZipLinePaths(new ZipLinePath(156, false, List(Vector3(736.038f, 1019.345f, 113.91f), Vector3(724.248f, 1060.438f, 140.6f), Vector3(723.526f, 1062.954f, 140.141f))))
+      ZipLinePaths(new ZipLinePath(157, false, List(Vector3(753.396f, 1079.35f, 140.243f), Vector3(728.852f, 1090.832f, 164.844f), Vector3(725.346f, 1092.473f, 165.261f))))
+      ZipLinePaths(new ZipLinePath(158, false, List(Vector3(881.321f, 940.867f, 115.863f), Vector3(870.806f, 989.707f, 129.7f), Vector3(860.291f, 1038.547f, 140.352f), Vector3(859.054f, 1044.292f, 140.464f))))
+      ZipLinePaths(new ZipLinePath(159, false, List(Vector3(880.79f, 1033.59f, 109.7f), Vector3(881.104f, 1056.676f, 136.541f), Vector3(881.144f, 1059.561f, 136.088f))))
+      ZipLinePaths(new ZipLinePath(160, false, List(Vector3(923.653f, 1069.12f, 109.871f), Vector3(920.338f, 1084.106f, 136.341f), Vector3(919.41f, 1090.862f, 135.986f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(976.603f, 1041.599f, 177.302f), Vector3(973.324f, 1045.539f, 176.772f), Vector3(924.127f, 1104.639f, 136.049f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(989.279f, 722.262f, 124.851f), Vector3(942.352f, 727.252f, 122.74f), Vector3(924.486f, 729.048f, 120.951f))))
+      ZipLinePaths(new ZipLinePath(163, false, List(Vector3(870.525f, 934.977f, 115.886f), Vector3(748.961f, 1004.118f, 176.348f), Vector3(740.046f, 1009.188f, 175.719f))))
+      ZipLinePaths(new ZipLinePath(164, false, List(Vector3(947.755f, 531.199f, 138.181f), Vector3(964.835f, 579.115f, 135.685f), Vector3(981.915f, 627.03f, 132.071f), Vector3(998.995f, 674.945f, 128.457f), Vector3(1009.377f, 704.07f, 124.851f))))
+      ZipLinePaths(new ZipLinePath(165, false, List(Vector3(1025.061f, 697.578f, 124.85f), Vector3(1053.263f, 655.104f, 126.921f), Vector3(1081.465f, 612.63f, 128.15f), Vector3(1109.667f, 570.156f, 129.38f), Vector3(1119.068f, 555.998f, 129.97f))))
+      ZipLinePaths(new ZipLinePath(166, false, List(Vector3(895.122f, 840.51f, 119.871f), Vector3(873.021f, 797.24f, 135.021f), Vector3(872.137f, 795.509f, 134.621f))))
+      ZipLinePaths(new ZipLinePath(167, false, List(Vector3(874.806f, 787.157f, 133.531f), Vector3(887.407f, 738.836f, 137.875f), Vector3(888.415f, 734.97f, 137.431f))))
+      ZipLinePaths(new ZipLinePath(168, false, List(Vector3(824.106f, 711.113f, 111.875f), Vector3(849.633f, 715.773f, 120.367f))))
+      ZipLinePaths(new ZipLinePath(169, false, List(Vector3(844.487f, 761.271f, 111.351f), Vector3(853.672f, 773.247f, 130.373f), Vector3(862.857f, 785.223f, 135.795f), Vector3(864.898f, 787.885f, 135.215f))))
+      ZipLinePaths(new ZipLinePath(170, false, List(Vector3(907.484f, 845.903f, 119.871f), Vector3(910.119f, 849.755f, 126.493f), Vector3(912.755f, 853.606f, 124.88f))))
+      ZipLinePaths(new ZipLinePath(171, false, List(Vector3(1112.038f, 682.725f, 123.151f), Vector3(1120.959f, 632.652f, 129.102f), Vector3(1122.358f, 624.798f, 128.352f))))
+      ZipLinePaths(new ZipLinePath(172, false, List(Vector3(1122.941f, 604.904f, 128.95f), Vector3(1120.249f, 561.988f, 129.97f))))
+      ZipLinePaths(new ZipLinePath(173, false, List(Vector3(1171.009f, 531.472f, 109.666f), Vector3(1168.828f, 536.526f, 118.944f), Vector3(1167.582f, 539.414f, 118.285f))))
+      ZipLinePaths(new ZipLinePath(174, false, List(Vector3(1047.224f, 748.42f, 124.85f), Vector3(1043.657f, 799.293f, 125.325f), Vector3(1043.377f, 803.283f, 124.85f))))
+      ZipLinePaths(new ZipLinePath(175, false, List(Vector3(1059.966f, 892.132f, 124.857f), Vector3(1072.008f, 890.537f, 142.8f), Vector3(1075.157f, 890.218f, 141.854f))))
+      ZipLinePaths(new ZipLinePath(176, false, List(Vector3(853.667f, 663.625f, 120.841f), Vector3(852.606f, 651.134f, 137.7f), Vector3(852.418f, 648.93f, 137.35f))))
+      ZipLinePaths(new ZipLinePath(177, false, List(Vector3(1265.763f, 620.851f, 119.889f), Vector3(1247.709f, 666.201f, 129.597f), Vector3(1244.523f, 674.521f, 130.779f))))
+      ZipLinePaths(new ZipLinePath(178, false, List(Vector3(1170.515f, 541.815f, 118.29f), Vector3(1218.82f, 551.299f, 125.086f), Vector3(1267.125f, 560.783f, 119.88f))))
+      ZipLinePaths(new ZipLinePath(179, false, List(Vector3(1251.983f, 620.364f, 109.047f), Vector3(1260.922f, 617.29f, 120.227f), Vector3(1264.173f, 616.172f, 119.876f))))
+      ZipLinePaths(new ZipLinePath(180, false, List(Vector3(1253.004f, 779.277f, 109.057f), Vector3(1250.953f, 784.935f, 123f), Vector3(1249.389f, 788.084f, 122.843f))))
+      ZipLinePaths(new ZipLinePath(181, false, List(Vector3(1184.063f, 747.02f, 130.77f), Vector3(1128.565f, 820.543f, 132.85f))))
+      ZipLinePaths(new ZipLinePath(182, false, List(Vector3(1185.879f, 718.32f, 130.772f), Vector3(1136.233f, 719.36f, 126.816f), Vector3(1121.339f, 719.673f, 124.292f))))
+      ZipLinePaths(new ZipLinePath(183, false, List(Vector3(1140.607f, 823.278f, 121.948f), Vector3(1137.174f, 825.352f, 132.8f), Vector3(1135.352f, 827.061f, 132.852f))))
+      ZipLinePaths(new ZipLinePath(184, false, List(Vector3(1050.043f, 744.286f, 124.851f), Vector3(1075.381f, 788.401f, 135.697f), Vector3(1100.719f, 832.515f, 133.264f), Vector3(1101.713f, 834.245f, 132.862f))))
+      ZipLinePaths(new ZipLinePath(185, false, List(Vector3(1257.734f, 828.176f, 126.819f), Vector3(1255.031f, 833.706f, 133.337f), Vector3(1254.13f, 835.549f, 132.711f))))
+      ZipLinePaths(new ZipLinePath(186, false, List(Vector3(1239.454f, 850.121f, 126.803f), Vector3(1243.189f, 852.848f, 132.837f), Vector3(1244.433f, 853.756f, 132.709f))))
+      ZipLinePaths(new ZipLinePath(187, false, List(Vector3(1196.063f, 823.001f, 126.812f), Vector3(1157.416f, 854.391f, 132.165f), Vector3(1143.503f, 865.692f, 132.852f))))
+      ZipLinePaths(new ZipLinePath(188, false, List(Vector3(1279.621f, 932.893f, 114.524f), Vector3(1279.227f, 909.182f, 132.704f), Vector3(1279.031f, 897.327f, 134.359f), Vector3(1278.834f, 885.471f, 132.745f))))
+      ZipLinePaths(new ZipLinePath(189, false, List(Vector3(1124.713f, 916.18f, 126.843f), Vector3(1115.263f, 905.232f, 142.214f), Vector3(1111.588f, 900.975f, 141.854f))))
+      ZipLinePaths(new ZipLinePath(190, false, List(Vector3(1340.865f, 846.029f, 111.852f), Vector3(1335.426f, 835.885f, 127.9f), Vector3(1334.807f, 834.266f, 127.841f))))
+      ZipLinePaths(new ZipLinePath(191, false, List(Vector3(1326.86f, 785.22f, 127.855f), Vector3(1262.414f, 741.409f, 142.717f), Vector3(1253.207f, 735.15f, 140.846f))))
+      ZipLinePaths(new ZipLinePath(192, false, List(Vector3(1389.355f, 995.955f, 138.183f), Vector3(1362.137f, 1038.774f, 134.124f), Vector3(1334.919f, 1081.594f, 128.97f), Vector3(1310.903f, 1119.376f, 121.854f))))
+      ZipLinePaths(new ZipLinePath(193, false, List(Vector3(1327.53f, 1147.16f, 109.05f), Vector3(1318.545f, 1143.592f, 122f), Vector3(1316.298f, 1142.7f, 121.847f))))
+      ZipLinePaths(new ZipLinePath(194, false, List(Vector3(1396.002f, 1228.28f, 109.05f), Vector3(1395.947f, 1220.255f, 124.75f), Vector3(1396.165f, 1217.902f, 125.303f))))
+      ZipLinePaths(new ZipLinePath(195, false, List(Vector3(1396.44f, 1268.505f, 109.042f), Vector3(1393.148f, 1276.026f, 126.361f), Vector3(1389.556f, 1284.23f, 134.333f), Vector3(1385.964f, 1292.435f, 136.304f))))
+      ZipLinePaths(new ZipLinePath(196, false, List(Vector3(1338.752f, 1192.75f, 109.052f), Vector3(1331.086f, 1199.688f, 126.4f), Vector3(1329.17f, 1201.422f, 126.347f))))
+      ZipLinePaths(new ZipLinePath(197, false, List(Vector3(1405.842f, 1227.371f, 125.3f), Vector3(1356.422f, 1219.821f, 126.45f), Vector3(1329.735f, 1215.744f, 126.45f))))
+      ZipLinePaths(new ZipLinePath(198, false, List(Vector3(1301.27f, 1208.518f, 135.532f), Vector3(1292.542f, 1214.94f, 152.2f), Vector3(1290.359f, 1216.546f, 151.952f))))
+      ZipLinePaths(new ZipLinePath(199, false, List(Vector3(1306.218f, 1234.485f, 134.651f), Vector3(1303.755f, 1236.99f, 141.014f), Vector3(1302.278f, 1238.493f, 140.954f))))
+      ZipLinePaths(new ZipLinePath(200, false, List(Vector3(1283.492f, 1260.547f, 140.965f), Vector3(1277.346f, 1264.371f, 151.8f), Vector3(1274.929f, 1265.421f, 151.848f))))
+      ZipLinePaths(new ZipLinePath(201, false, List(Vector3(1349.313f, 1281.663f, 126.542f), Vector3(1355.484f, 1290.119f, 136.966f), Vector3(1357.541f, 1292.938f, 136.311f))))
+      ZipLinePaths(new ZipLinePath(202, false, List(Vector3(1341.799f, 1295.97f, 145.061f), Vector3(1351.709f, 1288.523f, 145.53f), Vector3(1381.437f, 1266.181f, 137.67f), Vector3(1411.749f, 1243.401f, 126.441f))))
+      ZipLinePaths(new ZipLinePath(203, false, List(Vector3(1375.896f, 1157.863f, 125.181f), Vector3(1188.609f, 1075.48f, 199.971f), Vector3(1182.567f, 1072.822f, 199.731f))))
+      ZipLinePaths(new ZipLinePath(204, false, List(Vector3(1090.567f, 1089.597f, 126.743f), Vector3(1021.866f, 1037.4f, 182.072f), Vector3(1017.744f, 1034.268f, 182.343f))))
+      ZipLinePaths(new ZipLinePath(205, false, List(Vector3(1129.258f, 1111.212f, 126.753f), Vector3(1132.878f, 1111.43f, 136.65f), Vector3(1136.499f, 1111.648f, 135.552f))))
+      ZipLinePaths(new ZipLinePath(206, false, List(Vector3(1149.892f, 1116.521f, 135.546f), Vector3(1156.366f, 1117.722f, 148.401f), Vector3(1159.485f, 1118.147f, 148.442f))))
+      ZipLinePaths(new ZipLinePath(207, false, List(Vector3(1212.807f, 1063.577f, 121.952f), Vector3(1207.698f, 1073.111f, 136.4f), Vector3(1205.341f, 1077.512f, 135.447f))))
+      ZipLinePaths(new ZipLinePath(208, false, List(Vector3(1264.462f, 877.804f, 132.71f), Vector3(1246.819f, 925.65f, 134.208f), Vector3(1229.176f, 973.497f, 134.824f), Vector3(1211.532f, 1021.344f, 135.44f), Vector3(1193.889f, 1069.188f, 136.057f), Vector3(1190.083f, 1079.507f, 135.45f))))
+      ZipLinePaths(new ZipLinePath(209, false, List(Vector3(1217.471f, 1083.948f, 135.453f), Vector3(1210.336f, 1099.103f, 152.484f), Vector3(1209.063f, 1102.378f, 152.225f))))
+      ZipLinePaths(new ZipLinePath(210, false, List(Vector3(1240.544f, 1094.16f, 121.956f), Vector3(1232.679f, 1097.464f, 135.575f), Vector3(1230.057f, 1098.565f, 135.442f))))
+      ZipLinePaths(new ZipLinePath(211, false, List(Vector3(1186.014f, 1121.699f, 152.224f), Vector3(1164.017f, 1098.726f, 199.092f), Vector3(1160.498f, 1095.05f, 199.687f))))
+      ZipLinePaths(new ZipLinePath(212, false, List(Vector3(1204.12f, 1417.056f, 109.12f), Vector3(1213.4f, 1417.169f, 127.718f), Vector3(1216.493f, 1417.207f, 128.044f))))
+      ZipLinePaths(new ZipLinePath(213, false, List(Vector3(1229.154f, 1404.634f, 128.041f), Vector3(1238.575f, 1406.62f, 145.262f), Vector3(1244.193f, 1407.981f, 145.044f))))
+      ZipLinePaths(new ZipLinePath(214, false, List(Vector3(1161.559f, 1423.931f, 109.309f), Vector3(1156.185f, 1421.327f, 124.378f), Vector3(1151.826f, 1419.556f, 124.321f))))
+      ZipLinePaths(new ZipLinePath(215, false, List(Vector3(1098.527f, 1217.84f, 119.349f), Vector3(1096.811f, 1211.274f, 126.3f), Vector3(1096.106f, 1207.218f, 126.545f))))
+      ZipLinePaths(new ZipLinePath(216, false, List(Vector3(1096.231f, 1182.333f, 126.55f), Vector3(1103.04f, 1179.974f, 138.388f), Vector3(1109.849f, 1177.616f, 145.726f), Vector3(1117.458f, 1174.98f, 148.338f), Vector3(1125.068f, 1172.344f, 148.455f))))
+      ZipLinePaths(new ZipLinePath(217, false, List(Vector3(929.798f, 1116.506f, 135.992f), Vector3(1010.892f, 1103.806f, 205.572f), Vector3(1023.303f, 1101.565f, 208.656f))))
+      ZipLinePaths(new ZipLinePath(218, false, List(Vector3(1028.069f, 1258.8f, 107.069f), Vector3(1021.764f, 1250.92f, 122.861f), Vector3(1017.858f, 1243.717f, 122.444f))))
+      ZipLinePaths(new ZipLinePath(219, false, List(Vector3(1104.627f, 1364.967f, 109.072f), Vector3(1094.893f, 1362.829f, 115.616f), Vector3(1085.159f, 1360.69f, 114.962f))))
+      ZipLinePaths(new ZipLinePath(220, false, List(Vector3(1108.235f, 1301.184f, 119.665f), Vector3(931.115f, 1285.88f, 180.638f), Vector3(925.402f, 1285.386f, 180.536f))))
+      ZipLinePaths(new ZipLinePath(221, false, List(Vector3(1110.124f, 1304.157f, 119.641f), Vector3(1070.944f, 1318.948f, 122.751f))))
+      ZipLinePaths(new ZipLinePath(222, false, List(Vector3(1183.721f, 1312.937f, 119.247f), Vector3(1193.741f, 1311.441f, 136.45f), Vector3(1197.081f, 1310.942f, 136.048f))))
+      ZipLinePaths(new ZipLinePath(223, false, List(Vector3(1164.092f, 1318.913f, 109.053f), Vector3(1166.906f, 1313.922f, 119.15f), Vector3(1169.72f, 1308.93f, 119.25f))))
+      ZipLinePaths(new ZipLinePath(224, false, List(Vector3(1146.193f, 1413.844f, 124.331f), Vector3(1146.462f, 1363.929f, 123.112f), Vector3(1146.73f, 1314.015f, 120.12f), Vector3(1146.747f, 1311.02f, 119.64f))))
+      ZipLinePaths(new ZipLinePath(225, false, List(Vector3(1223.321f, 1378.103f, 145.156f), Vector3(1174.206f, 1372.073f, 138.402f), Vector3(1125.091f, 1366.042f, 131.231f), Vector3(1080.888f, 1360.615f, 123.895f))))
+      ZipLinePaths(new ZipLinePath(226, false, List(Vector3(1096.022f, 1374.066f, 124.331f), Vector3(1074.29f, 1362.048f, 122.751f))))
+      ZipLinePaths(new ZipLinePath(227, false, List(Vector3(1149.499f, 1415.419f, 124.331f), Vector3(1197.765f, 1402.559f, 127.332f), Vector3(1217.072f, 1397.415f, 128.051f))))
+      ZipLinePaths(new ZipLinePath(228, false, List(Vector3(814.131f, 1461.802f, 112.384f), Vector3(824.706f, 1416.337f, 138.113f), Vector3(835.28f, 1370.872f, 159.039f), Vector3(842.259f, 1347.165f, 163.573f))))
+      ZipLinePaths(new ZipLinePath(229, false, List(Vector3(876.429f, 1343.77f, 136.094f), Vector3(926.629f, 1348.837f, 131.986f), Vector3(976.829f, 1353.905f, 124.559f), Vector3(1023.092f, 1358.575f, 116.544f))))
+      ZipLinePaths(new ZipLinePath(230, false, List(Vector3(807.727f, 1380.755f, 109.058f), Vector3(806.274f, 1370.518f, 122.642f), Vector3(804.82f, 1358.281f, 130.736f), Vector3(804.404f, 1354.785f, 131.099f))))
+      ZipLinePaths(new ZipLinePath(231, false, List(Vector3(706.406f, 1320.177f, 137.21f), Vector3(738.095f, 1316.223f, 136.05f))))
+      ZipLinePaths(new ZipLinePath(232, false, List(Vector3(722.69f, 1345.392f, 109.052f), Vector3(731.902f, 1339.244f, 130f), Vector3(741.728f, 1332.685f, 137.239f), Vector3(744.799f, 1330.635f, 136.056f))))
+      ZipLinePaths(new ZipLinePath(233, false, List(Vector3(907.818f, 1320.599f, 109.047f), Vector3(895.035f, 1324.75f, 125.795f), Vector3(882.252f, 1328.9f, 136.141f), Vector3(880.06f, 1329.612f, 136.089f))))
+      ZipLinePaths(new ZipLinePath(234, false, List(Vector3(1014.461f, 1221.339f, 122.453f), Vector3(977.636f, 1187.782f, 130.037f), Vector3(940.81f, 1154.225f, 134.301f), Vector3(920.924f, 1136.104f, 135.992f))))
+      ZipLinePaths(new ZipLinePath(235, false, List(Vector3(547.329f, 1083.474f, 110.82f), Vector3(622.869f, 1031.432f, 153.65f), Vector3(668.493f, 997.886f, 175.414f), Vector3(675.972f, 992.387f, 175.762f))))
+      ZipLinePaths(new ZipLinePath(236, false, List(Vector3(615.829f, 1087.478f, 109.051f), Vector3(622.879f, 1087.122f, 123.044f), Vector3(635.568f, 1086.48f, 136.1f), Vector3(640.503f, 1086.231f, 136.144f))))
+      ZipLinePaths(new ZipLinePath(237, false, List(Vector3(620.27f, 1254.43f, 119.008f), Vector3(641.552f, 1210.009f, 128.818f), Vector3(660.281f, 1170.918f, 136.059f))))
+      ZipLinePaths(new ZipLinePath(238, false, List(Vector3(635.795f, 1193.298f, 109.043f), Vector3(639.224f, 1187.391f, 122.944f), Vector3(648.75f, 1170.982f, 136.4f), Vector3(650.274f, 1168.356f, 136.04f))))
+      ZipLinePaths(new ZipLinePath(239, false, List(Vector3(926.527f, 1170.817f, 109.363f), Vector3(923.763f, 1165.504f, 125.927f), Vector3(918.072f, 1154.567f, 138.117f), Vector3(915.145f, 1148.942f, 137.957f))))
+      ZipLinePaths(new ZipLinePath(240, false, List(Vector3(789.839f, 1155.974f, 120.007f), Vector3(794.331f, 1108.861f, 139.687f), Vector3(795.499f, 1096.612f, 140.378f))))
+      ZipLinePaths(new ZipLinePath(241, false, List(Vector3(803.454f, 1182.012f, 119.972f), Vector3(830.713f, 1190.844f, 140.6f), Vector3(833.92f, 1191.883f, 140.248f))))
+      ZipLinePaths(new ZipLinePath(242, false, List(Vector3(828.546f, 1027.546f, 109.549f), Vector3(837.077f, 1041.018f, 140.638f), Vector3(839.779f, 1044.485f, 140.443f))))
+      ZipLinePaths(new ZipLinePath(243, false, List(Vector3(658.973f, 1029.373f, 109.083f), Vector3(664.074f, 1050.972f, 136.7f), Vector3(665.095f, 1055.292f, 136.044f))))
+      ZipLinePaths(new ZipLinePath(244, false, List(Vector3(777.972f, 893.413f, 133.751f), Vector3(787.343f, 858.747f, 131.85f))))
+      ZipLinePaths(new ZipLinePath(245, false, List(Vector3(685.721f, 1051.781f, 140.05f), Vector3(670.758f, 1004.096f, 141.016f), Vector3(655.795f, 956.412f, 139.45f), Vector3(640.832f, 908.728f, 137.884f), Vector3(632.154f, 881.072f, 136.36f))))
+      ZipLinePaths(new ZipLinePath(246, false, List(Vector3(671.383f, 1075.859f, 140.045f), Vector3(701.364f, 1029.762f, 175.213f), Vector3(703.394f, 1026.64f, 175.696f))))
+      ZipLinePaths(new ZipLinePath(247, false, List(Vector3(889.471f, 1158.689f, 179.31f), Vector3(890.333f, 1209.645f, 181.438f), Vector3(891.178f, 1259.603f, 183.33f))))
+      ZipLinePaths(new ZipLinePath(248, false, List(Vector3(740.683f, 1013.973f, 175.689f), Vector3(779.565f, 1045.775f, 185.238f), Vector3(818.447f, 1077.575f, 194.64f), Vector3(819.972f, 1078.822f, 194.579f))))
+      ZipLinePaths(new ZipLinePath(249, false, List(Vector3(833.687f, 1301.586f, 160.773f), Vector3(860.142f, 1284.02f, 180.145f), Vector3(863.922f, 1281.511f, 180.531f))))
+      ZipLinePaths(new ZipLinePath(250, false, List(Vector3(1010.241f, 1240.344f, 122.449f), Vector3(930.779f, 1274.878f, 180.319f), Vector3(922.833f, 1278.331f, 180.514f))))
+      ZipLinePaths(new ZipLinePath(251, false, List(Vector3(1133.814f, 1048.795f, 199.728f), Vector3(1086.372f, 1035.111f, 191.631f), Vector3(1038.929f, 1021.427f, 183.736f), Vector3(1032.287f, 1019.512f, 182.166f))))
+      ZipLinePaths(new ZipLinePath(252, false, List(Vector3(889.938f, 1124.978f, 179.34f), Vector3(966.938f, 1027.831f, 182.22f))))
+      ZipLinePaths(new ZipLinePath(253, true, List(Vector3(933.672f, 524.813f, 137.773f), Vector3(885.162f, 531.286f, 172.306f), Vector3(835.681f, 537.888f, 161.853f), Vector3(797.842f, 542.937f, 108.985f))))
+      ZipLinePaths(new ZipLinePath(254, true, List(Vector3(541.168f, 1083.547f, 110.794f), Vector3(552.16f, 1043.303f, 211.598f), Vector3(568.619f, 981.507f, 137.554f))))
+      ZipLinePaths(new ZipLinePath(255, true, List(Vector3(572.976f, 987.122f, 137.826f), Vector3(560.277f, 1045.507f, 211.626f), Vector3(551.469f, 1085.998f, 109.947f))))
+      ZipLinePaths(new ZipLinePath(256, true, List(Vector3(817.329f, 1476.263f, 112.635f), Vector3(822.261f, 1473.141f, 116.242f), Vector3(823.905f, 1472.1f, 116.783f), Vector3(844.456f, 1459.09f, 211.505f), Vector3(885.935f, 1433.592f, 132.763f))))
+      ZipLinePaths(new ZipLinePath(257, true, List(Vector3(880.19f, 1426.678f, 132.713f), Vector3(822.094f, 1465.025f, 211.507f), Vector3(819.173f, 1467.223f, 112.528f))))
+    }
+
+    ZipLines()
+
+  }
+}

--- a/pslogin/src/main/scala/zonemaps/Ugd05.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd05.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd05 { // Annwn
   val ZoneMap = new ZoneMap("ugd05") {
     Scale = MapScale.Dim2048
-    Checksum = 0L
+    Checksum = 1769572498L
 
     Building10116()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd05.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd05.scala
@@ -1,0 +1,617 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd05 { // Annwn
+  val ZoneMap = new ZoneMap("ugd05") {
+    Scale = MapScale.Dim2048
+    Checksum = 0L
+
+    Building10116()
+
+    def Building10116(): Unit = { // Name: ceiling_bldg_a_10116 Type: ceiling_bldg_a GUID: 1, MapID: 10116
+      LocalBuilding("ceiling_bldg_a_10116", 1, 10116, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.36f, 953.39f, 272.03f), ceiling_bldg_a)))
+      LocalObject(478, Door.Constructor(Vector3(1278.85f, 936.597f, 279.315f)), owning_building_guid = 1)
+      LocalObject(479, Door.Constructor(Vector3(1292.775f, 968.4059f, 273.809f)), owning_building_guid = 1)
+      LocalObject(480, Door.Constructor(Vector3(1293.9f, 937.462f, 273.809f)), owning_building_guid = 1)
+      LocalObject(481, Door.Constructor(Vector3(1302.555f, 940.3514f, 279.315f)), owning_building_guid = 1)
+    }
+
+    Building10014()
+
+    def Building10014(): Unit = { // Name: ceiling_bldg_b_10014 Type: ceiling_bldg_b GUID: 2, MapID: 10014
+      LocalBuilding("ceiling_bldg_b_10014", 2, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.8f, 980.41f, 242.69f), ceiling_bldg_b)))
+      LocalObject(391, Door.Constructor(Vector3(982.511f, 975.5684f, 244.469f)), owning_building_guid = 2)
+      LocalObject(396, Door.Constructor(Vector3(991.5198f, 991.0958f, 244.469f)), owning_building_guid = 2)
+    }
+
+    Building10002()
+
+    def Building10002(): Unit = { // Name: ceiling_bldg_b_10002 Type: ceiling_bldg_b GUID: 3, MapID: 10002
+      LocalBuilding("ceiling_bldg_b_10002", 3, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1192.36f, 1130.14f, 256.99f), ceiling_bldg_b)))
+      LocalObject(445, Door.Constructor(Vector3(1194.375f, 1146.63f, 258.769f)), owning_building_guid = 3)
+      LocalObject(448, Door.Constructor(Vector3(1198.376f, 1129.13f, 258.769f)), owning_building_guid = 3)
+    }
+
+    Building10004()
+
+    def Building10004(): Unit = { // Name: ceiling_bldg_d_10004 Type: ceiling_bldg_d GUID: 4, MapID: 10004
+      LocalBuilding("ceiling_bldg_d_10004", 4, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1208.22f, 913.48f, 275.19f), ceiling_bldg_d)))
+      LocalObject(442, Door.Constructor(Vector3(1190.778f, 911.9379f, 276.925f)), owning_building_guid = 4)
+      LocalObject(450, Door.Constructor(Vector3(1206.678f, 930.9219f, 276.925f)), owning_building_guid = 4)
+      LocalObject(452, Door.Constructor(Vector3(1209.728f, 896.0551f, 276.925f)), owning_building_guid = 4)
+      LocalObject(462, Door.Constructor(Vector3(1225.645f, 914.9884f, 276.925f)), owning_building_guid = 4)
+      LocalObject(506, Painbox.Constructor(Vector3(1208.295f, 913.6905f, 283.498f), painbox_continuous), owning_building_guid = 4)
+    }
+
+    Building10036()
+
+    def Building10036(): Unit = { // Name: ceiling_bldg_g_10036 Type: ceiling_bldg_g GUID: 5, MapID: 10036
+      LocalBuilding("ceiling_bldg_g_10036", 5, 10036, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1142.28f, 928.25f, 402.85f), ceiling_bldg_g)))
+      LocalObject(430, Door.Constructor(Vector3(1134.296f, 911.74f, 404.629f)), owning_building_guid = 5)
+      LocalObject(431, Door.Constructor(Vector3(1142.296f, 945.74f, 404.629f)), owning_building_guid = 5)
+    }
+
+    Building10013()
+
+    def Building10013(): Unit = { // Name: ceiling_bldg_i_10013 Type: ceiling_bldg_i GUID: 6, MapID: 10013
+      LocalBuilding("ceiling_bldg_i_10013", 6, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.84f, 1093.24f, 286.02f), ceiling_bldg_i)))
+      LocalObject(384, Door.Constructor(Vector3(965.35f, 1096.756f, 287.799f)), owning_building_guid = 6)
+      LocalObject(408, Door.Constructor(Vector3(1015.35f, 1096.756f, 287.799f)), owning_building_guid = 6)
+    }
+
+    Building10117()
+
+    def Building10117(): Unit = { // Name: ceiling_bldg_j_10117 Type: ceiling_bldg_j GUID: 7, MapID: 10117
+      LocalBuilding("ceiling_bldg_j_10117", 7, 10117, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1013.22f, 1222.5f, 246.4f), ceiling_bldg_j)))
+      LocalObject(404, Door.Constructor(Vector3(1001.271f, 1218.864f, 248.179f)), owning_building_guid = 7)
+      LocalObject(409, Door.Constructor(Vector3(1025.179f, 1226.173f, 248.179f)), owning_building_guid = 7)
+    }
+
+    Building10114()
+
+    def Building10114(): Unit = { // Name: ceiling_bldg_j_10114 Type: ceiling_bldg_j GUID: 8, MapID: 10114
+      LocalBuilding("ceiling_bldg_j_10114", 8, 10114, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1048.57f, 1135.38f, 275.22f), ceiling_bldg_j)))
+      LocalObject(411, Door.Constructor(Vector3(1038.456f, 1128.052f, 276.999f)), owning_building_guid = 8)
+      LocalObject(414, Door.Constructor(Vector3(1058.681f, 1142.746f, 276.999f)), owning_building_guid = 8)
+    }
+
+    Building10115()
+
+    def Building10115(): Unit = { // Name: ceiling_bldg_j_10115 Type: ceiling_bldg_j GUID: 9, MapID: 10115
+      LocalBuilding("ceiling_bldg_j_10115", 9, 10115, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.81f, 798.93f, 197.93f), ceiling_bldg_j)))
+      LocalObject(428, Door.Constructor(Vector3(1128.826f, 786.42f, 199.709f)), owning_building_guid = 9)
+      LocalObject(429, Door.Constructor(Vector3(1128.826f, 811.42f, 199.709f)), owning_building_guid = 9)
+    }
+
+    Building10037()
+
+    def Building10037(): Unit = { // Name: ceiling_bldg_z_10037 Type: ceiling_bldg_z GUID: 10, MapID: 10037
+      LocalBuilding("ceiling_bldg_z_10037", 10, 10037, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1015.45f, 1060.53f, 401.85f), ceiling_bldg_z)))
+      LocalObject(395, Door.Constructor(Vector3(990.96f, 1064.546f, 403.629f)), owning_building_guid = 10)
+      LocalObject(412, Door.Constructor(Vector3(1047.96f, 1064.546f, 403.629f)), owning_building_guid = 10)
+    }
+
+    Building10009()
+
+    def Building10009(): Unit = { // Name: ceiling_bldg_z_10009 Type: ceiling_bldg_z GUID: 11, MapID: 10009
+      LocalBuilding("ceiling_bldg_z_10009", 11, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1068.84f, 852.69f, 258.04f), ceiling_bldg_z)))
+      LocalObject(413, Door.Constructor(Vector3(1053.668f, 872.3293f, 259.819f)), owning_building_guid = 11)
+      LocalObject(421, Door.Constructor(Vector3(1095.355f, 833.4553f, 259.819f)), owning_building_guid = 11)
+    }
+
+    Building10031()
+
+    def Building10031(): Unit = { // Name: ceiling_bldg_z_10031 Type: ceiling_bldg_z GUID: 12, MapID: 10031
+      LocalBuilding("ceiling_bldg_z_10031", 12, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.06f, 1036.8f, 234.92f), ceiling_bldg_z)))
+      LocalObject(436, Door.Constructor(Vector3(1168.57f, 1040.816f, 236.699f)), owning_building_guid = 12)
+      LocalObject(461, Door.Constructor(Vector3(1225.57f, 1040.816f, 236.699f)), owning_building_guid = 12)
+    }
+
+    Building10038()
+
+    def Building10038(): Unit = { // Name: ground_bldg_a_10038 Type: ground_bldg_a GUID: 23, MapID: 10038
+      LocalBuilding("ground_bldg_a_10038", 23, 10038, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1235.85f, 1129.52f, 189.73f), ground_bldg_a)))
+      LocalObject(457, Door.Constructor(Vector3(1221.054f, 1122.782f, 191.509f)), owning_building_guid = 23)
+      LocalObject(472, Door.Constructor(Vector3(1242.228f, 1145.131f, 191.509f)), owning_building_guid = 23)
+    }
+
+    Building10005()
+
+    def Building10005(): Unit = { // Name: ground_bldg_b_10005 Type: ground_bldg_b GUID: 24, MapID: 10005
+      LocalBuilding("ground_bldg_b_10005", 24, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1113.49f, 784.48f, 241.05f), ground_bldg_b)))
+      LocalObject(423, Door.Constructor(Vector3(1104.678f, 798.5632f, 242.829f)), owning_building_guid = 24)
+      LocalObject(426, Door.Constructor(Vector3(1118.801f, 787.4811f, 242.829f)), owning_building_guid = 24)
+      LocalObject(427, Door.Constructor(Vector3(1128.761f, 804.5875f, 248.329f)), owning_building_guid = 24)
+    }
+
+    Building10213()
+
+    def Building10213(): Unit = { // Name: ground_bldg_c_10213 Type: ground_bldg_c GUID: 25, MapID: 10213
+      LocalBuilding("ground_bldg_c_10213", 25, 10213, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(996.82f, 984.32f, 310.7f), ground_bldg_c)))
+      LocalObject(378, Door.Constructor(Vector3(949.452f, 985.9983f, 312.479f)), owning_building_guid = 25)
+      LocalObject(381, Door.Constructor(Vector3(955.8972f, 955.6757f, 312.479f)), owning_building_guid = 25)
+      LocalObject(401, Door.Constructor(Vector3(999.1253f, 980.737f, 312.479f)), owning_building_guid = 25)
+    }
+
+    Building10006()
+
+    def Building10006(): Unit = { // Name: ground_bldg_c_10006 Type: ground_bldg_c GUID: 26, MapID: 10006
+      LocalBuilding("ground_bldg_c_10006", 26, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.71f, 1059.42f, 379.18f), ground_bldg_c)))
+      LocalObject(454, Door.Constructor(Vector3(1213.342f, 1061.098f, 380.959f)), owning_building_guid = 26)
+      LocalObject(456, Door.Constructor(Vector3(1219.787f, 1030.776f, 380.959f)), owning_building_guid = 26)
+      LocalObject(476, Door.Constructor(Vector3(1263.015f, 1055.837f, 380.959f)), owning_building_guid = 26)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: ground_bldg_d_10001 Type: ground_bldg_d GUID: 27, MapID: 10001
+      LocalBuilding("ground_bldg_d_10001", 27, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.17f, 1133.19f, 320.03f), ground_bldg_d)))
+      LocalObject(440, Door.Constructor(Vector3(1175.68f, 1133.206f, 321.765f)), owning_building_guid = 27)
+      LocalObject(443, Door.Constructor(Vector3(1193.186f, 1115.68f, 321.765f)), owning_building_guid = 27)
+      LocalObject(444, Door.Constructor(Vector3(1193.186f, 1150.68f, 321.765f)), owning_building_guid = 27)
+      LocalObject(453, Door.Constructor(Vector3(1210.68f, 1133.206f, 321.765f)), owning_building_guid = 27)
+    }
+
+    Building10020()
+
+    def Building10020(): Unit = { // Name: ground_bldg_e_10020 Type: ground_bldg_e GUID: 28, MapID: 10020
+      LocalBuilding("ground_bldg_e_10020", 28, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.04f, 851.77f, 235.98f), ground_bldg_e)))
+      LocalObject(385, Door.Constructor(Vector3(966.024f, 850.78f, 237.759f)), owning_building_guid = 28)
+      LocalObject(390, Door.Constructor(Vector3(982.024f, 884.28f, 243.259f)), owning_building_guid = 28)
+      LocalObject(400, Door.Constructor(Vector3(997.05f, 879.786f, 237.759f)), owning_building_guid = 28)
+      LocalObject(406, Door.Constructor(Vector3(1003.05f, 859.786f, 243.259f)), owning_building_guid = 28)
+    }
+
+    Building10007()
+
+    def Building10007(): Unit = { // Name: ground_bldg_f_10007 Type: ground_bldg_f GUID: 29, MapID: 10007
+      LocalBuilding("ground_bldg_f_10007", 29, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1090.77f, 844.07f, 321.32f), ground_bldg_f)))
+      LocalObject(416, Door.Constructor(Vector3(1062.523f, 839.4526f, 323.099f)), owning_building_guid = 29)
+      LocalObject(424, Door.Constructor(Vector3(1116.939f, 860.5503f, 323.099f)), owning_building_guid = 29)
+    }
+
+    Building10022()
+
+    def Building10022(): Unit = { // Name: ground_bldg_f_10022 Type: ground_bldg_f GUID: 30, MapID: 10022
+      LocalBuilding("ground_bldg_f_10022", 30, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1123.7f, 1147.15f, 234.98f), ground_bldg_f)))
+      LocalObject(422, Door.Constructor(Vector3(1098.984f, 1132.717f, 236.759f)), owning_building_guid = 30)
+      LocalObject(432, Door.Constructor(Vector3(1142.225f, 1171.914f, 236.759f)), owning_building_guid = 30)
+    }
+
+    Building10024()
+
+    def Building10024(): Unit = { // Name: ground_bldg_i_10024 Type: ground_bldg_i GUID: 31, MapID: 10024
+      LocalBuilding("ground_bldg_i_10024", 31, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1218.75f, 1051.94f, 287.43f), ground_bldg_i)))
+      LocalObject(446, Door.Constructor(Vector3(1194.947f, 1045.191f, 289.209f)), owning_building_guid = 31)
+      LocalObject(471, Door.Constructor(Vector3(1240.625f, 1065.528f, 289.209f)), owning_building_guid = 31)
+    }
+
+    Building10039()
+
+    def Building10039(): Unit = { // Name: ground_bldg_z_10039 Type: ground_bldg_z GUID: 32, MapID: 10039
+      LocalBuilding("ground_bldg_z_10039", 32, 10039, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(954.47f, 849.74f, 178.4f), ground_bldg_z)))
+      LocalObject(372, Door.Constructor(Vector3(935.0992f, 848.0531f, 191.179f)), owning_building_guid = 32)
+      LocalObject(373, Door.Constructor(Vector3(937.5516f, 869.1636f, 180.179f)), owning_building_guid = 32)
+      LocalObject(376, Door.Constructor(Vector3(944.9157f, 872.2894f, 196.679f)), owning_building_guid = 32)
+      LocalObject(379, Door.Constructor(Vector3(953.1809f, 832.3434f, 185.679f)), owning_building_guid = 32)
+      LocalObject(380, Door.Constructor(Vector3(955.7963f, 867.1307f, 185.679f)), owning_building_guid = 32)
+      LocalObject(383, Door.Constructor(Vector3(964.0615f, 827.1847f, 196.679f)), owning_building_guid = 32)
+      LocalObject(387, Door.Constructor(Vector3(971.4255f, 830.3105f, 180.179f)), owning_building_guid = 32)
+      LocalObject(388, Door.Constructor(Vector3(973.8467f, 851.4641f, 191.179f)), owning_building_guid = 32)
+    }
+
+    Building10209()
+
+    def Building10209(): Unit = { // Name: NW_Redoubt Type: redoubt GUID: 33, MapID: 10209
+      LocalBuilding("NW_Redoubt", 33, 10209, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(887.44f, 1064.63f, 163.23f), redoubt)))
+      LocalObject(552, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 33)
+      LocalObject(363, Door.Constructor(Vector3(869.9915f, 1063.426f, 164.965f)), owning_building_guid = 33)
+      LocalObject(364, Door.Constructor(Vector3(874.3493f, 1075.823f, 175.009f)), owning_building_guid = 33)
+      LocalObject(365, Door.Constructor(Vector3(882.5875f, 1076.395f, 174.989f)), owning_building_guid = 33)
+      LocalObject(366, Door.Constructor(Vector3(890.5857f, 1076.987f, 174.989f)), owning_building_guid = 33)
+      LocalObject(367, Door.Constructor(Vector3(898.8093f, 1077.567f, 175.009f)), owning_building_guid = 33)
+      LocalObject(368, Door.Constructor(Vector3(904.9062f, 1065.867f, 164.965f)), owning_building_guid = 33)
+      LocalObject(559, Terminal.Constructor(Vector3(886.1505f, 1083.3f, 163.1835f), vanu_equipment_term), owning_building_guid = 33)
+      LocalObject(560, Terminal.Constructor(Vector3(888.6063f, 1046.158f, 163.1858f), vanu_equipment_term), owning_building_guid = 33)
+      LocalObject(516, SpawnTube.Constructor(Vector3(887.44f, 1064.63f, 163.23f), Vector3(0, 0, 176)), owning_building_guid = 33)
+      LocalObject(503, Painbox.Constructor(Vector3(887.4609f, 1064.923f, 171.019f), painbox_continuous), owning_building_guid = 33)
+    }
+
+    Building10210()
+
+    def Building10210(): Unit = { // Name: SE_Redoubt Type: redoubt GUID: 34, MapID: 10210
+      LocalBuilding("SE_Redoubt", 34, 10210, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1157.92f, 849.04f, 158.73f), redoubt)))
+      LocalObject(555, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 34)
+      LocalObject(433, Door.Constructor(Vector3(1146.69f, 862.4484f, 160.465f)), owning_building_guid = 34)
+      LocalObject(434, Door.Constructor(Vector3(1159.281f, 866.2097f, 170.509f)), owning_building_guid = 34)
+      LocalObject(435, Door.Constructor(Vector3(1164.586f, 859.8812f, 170.489f)), owning_building_guid = 34)
+      LocalObject(437, Door.Constructor(Vector3(1169.188f, 835.6368f, 160.465f)), owning_building_guid = 34)
+      LocalObject(438, Door.Constructor(Vector3(1169.766f, 853.7581f, 170.489f)), owning_building_guid = 34)
+      LocalObject(439, Door.Constructor(Vector3(1175.069f, 847.446f, 170.509f)), owning_building_guid = 34)
+      LocalObject(586, Terminal.Constructor(Vector3(1143.661f, 837.2388f, 158.6858f), vanu_equipment_term), owning_building_guid = 34)
+      LocalObject(590, Terminal.Constructor(Vector3(1172.266f, 861.0569f, 158.6835f), vanu_equipment_term), owning_building_guid = 34)
+      LocalObject(517, SpawnTube.Constructor(Vector3(1157.92f, 849.04f, 158.73f), Vector3(0, 0, 230)), owning_building_guid = 34)
+      LocalObject(505, Painbox.Constructor(Vector3(1158.169f, 849.1951f, 166.519f), painbox_continuous), owning_building_guid = 34)
+    }
+
+    Building10012()
+
+    def Building10012(): Unit = { // Name: NW_Stasis Type: vanu_control_point GUID: 68, MapID: 10012
+      LocalBuilding("NW_Stasis", 68, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(995.33f, 1106.69f, 329.62f), vanu_control_point)))
+      LocalObject(554, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 68)
+      LocalObject(375, Door.Constructor(Vector3(943.5559f, 1095.08f, 331.399f)), owning_building_guid = 68)
+      LocalObject(392, Door.Constructor(Vector3(983.5845f, 1098.827f, 336.34f)), owning_building_guid = 68)
+      LocalObject(393, Door.Constructor(Vector3(984.4945f, 1115.759f, 336.34f)), owning_building_guid = 68)
+      LocalObject(394, Door.Constructor(Vector3(990.3757f, 1121.419f, 361.399f)), owning_building_guid = 68)
+      LocalObject(397, Door.Constructor(Vector3(991.5599f, 1144.016f, 331.399f)), owning_building_guid = 68)
+      LocalObject(398, Door.Constructor(Vector3(993.1413f, 1058.616f, 331.399f)), owning_building_guid = 68)
+      LocalObject(399, Door.Constructor(Vector3(995.7598f, 1115.161f, 361.379f)), owning_building_guid = 68)
+      LocalObject(402, Door.Constructor(Vector3(1000.554f, 1097.923f, 336.34f)), owning_building_guid = 68)
+      LocalObject(403, Door.Constructor(Vector3(1001.15f, 1109.224f, 361.379f)), owning_building_guid = 68)
+      LocalObject(405, Door.Constructor(Vector3(1001.426f, 1114.849f, 336.34f)), owning_building_guid = 68)
+      LocalObject(407, Door.Constructor(Vector3(1006.808f, 1103.217f, 361.399f)), owning_building_guid = 68)
+      LocalObject(410, Door.Constructor(Vector3(1030.148f, 1119.18f, 331.399f)), owning_building_guid = 68)
+      LocalObject(573, Terminal.Constructor(Vector3(982.1874f, 1105.339f, 334.633f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(574, Terminal.Constructor(Vector3(982.3665f, 1109.244f, 334.637f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(576, Terminal.Constructor(Vector3(989.9484f, 1096.727f, 334.637f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(577, Terminal.Constructor(Vector3(991.0513f, 1117.164f, 334.633f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(578, Terminal.Constructor(Vector3(993.916f, 1096.515f, 334.633f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(579, Terminal.Constructor(Vector3(995.0189f, 1116.953f, 334.637f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(580, Terminal.Constructor(Vector3(1002.601f, 1104.437f, 334.637f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(581, Terminal.Constructor(Vector3(1002.813f, 1108.404f, 334.633f), vanu_equipment_term), owning_building_guid = 68)
+      LocalObject(615, SpawnTube.Constructor(Vector3(992.5055f, 1106.838f, 334.759f), Vector3(0, 0, 318)), owning_building_guid = 68)
+      LocalObject(504, Painbox.Constructor(Vector3(992.5176f, 1107.254f, 343.9618f), painbox_continuous), owning_building_guid = 68)
+      LocalObject(508, Painbox.Constructor(Vector3(981.7784f, 1096.659f, 338.51f), painbox_door_radius_continuous), owning_building_guid = 68)
+      LocalObject(509, Painbox.Constructor(Vector3(983.5879f, 1117.207f, 338.51f), painbox_door_radius_continuous), owning_building_guid = 68)
+      LocalObject(510, Painbox.Constructor(Vector3(1001.82f, 1096.431f, 338.51f), painbox_door_radius_continuous), owning_building_guid = 68)
+      LocalObject(511, Painbox.Constructor(Vector3(1003.214f, 1116.336f, 337.91f), painbox_door_radius_continuous), owning_building_guid = 68)
+    }
+
+    Building10003()
+
+    def Building10003(): Unit = { // Name: SE_Stasis Type: vanu_control_point GUID: 69, MapID: 10003
+      LocalBuilding("SE_Stasis", 69, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1232.73f, 922.42f, 322.62f), vanu_control_point)))
+      LocalObject(557, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 69)
+      LocalObject(441, Door.Constructor(Vector3(1181.393f, 909.0106f, 324.399f)), owning_building_guid = 69)
+      LocalObject(458, Door.Constructor(Vector3(1221.266f, 914.1519f, 329.34f)), owning_building_guid = 69)
+      LocalObject(459, Door.Constructor(Vector3(1221.585f, 931.1053f, 329.34f)), owning_building_guid = 69)
+      LocalObject(463, Door.Constructor(Vector3(1227.265f, 936.9673f, 354.399f)), owning_building_guid = 69)
+      LocalObject(464, Door.Constructor(Vector3(1227.66f, 959.5913f, 324.399f)), owning_building_guid = 69)
+      LocalObject(465, Door.Constructor(Vector3(1232.22f, 874.2994f, 324.399f)), owning_building_guid = 69)
+      LocalObject(467, Door.Constructor(Vector3(1232.864f, 930.9014f, 354.379f)), owning_building_guid = 69)
+      LocalObject(468, Door.Constructor(Vector3(1238.256f, 913.8412f, 329.34f)), owning_building_guid = 69)
+      LocalObject(469, Door.Constructor(Vector3(1238.458f, 925.1559f, 354.379f)), owning_building_guid = 69)
+      LocalObject(470, Door.Constructor(Vector3(1238.538f, 930.7868f, 329.34f)), owning_building_guid = 69)
+      LocalObject(473, Door.Constructor(Vector3(1244.322f, 919.3499f, 354.399f)), owning_building_guid = 69)
+      LocalObject(477, Door.Constructor(Vector3(1267.091f, 936.1172f, 324.399f)), owning_building_guid = 69)
+      LocalObject(594, Terminal.Constructor(Vector3(1219.643f, 920.611f, 327.633f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(595, Terminal.Constructor(Vector3(1219.685f, 924.5197f, 327.637f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(596, Terminal.Constructor(Vector3(1227.699f, 912.2751f, 327.637f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(597, Terminal.Constructor(Vector3(1228.088f, 932.7386f, 327.633f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(598, Terminal.Constructor(Vector3(1231.672f, 912.2022f, 327.633f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(599, Terminal.Constructor(Vector3(1232.061f, 932.6658f, 327.637f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(601, Terminal.Constructor(Vector3(1240.076f, 920.4219f, 327.637f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(602, Terminal.Constructor(Vector3(1240.148f, 924.3945f, 327.633f), vanu_equipment_term), owning_building_guid = 69)
+      LocalObject(616, SpawnTube.Constructor(Vector3(1229.902f, 922.4694f, 327.759f), Vector3(0, 0, 316)), owning_building_guid = 69)
+      LocalObject(507, Painbox.Constructor(Vector3(1229.9f, 922.8856f, 336.9618f), painbox_continuous), owning_building_guid = 69)
+      LocalObject(512, Painbox.Constructor(Vector3(1219.537f, 911.9223f, 331.51f), painbox_door_radius_continuous), owning_building_guid = 69)
+      LocalObject(513, Painbox.Constructor(Vector3(1220.628f, 932.5208f, 331.51f), painbox_door_radius_continuous), owning_building_guid = 69)
+      LocalObject(514, Painbox.Constructor(Vector3(1239.574f, 912.394f, 331.51f), painbox_door_radius_continuous), owning_building_guid = 69)
+      LocalObject(515, Painbox.Constructor(Vector3(1240.272f, 932.335f, 330.91f), painbox_door_radius_continuous), owning_building_guid = 69)
+    }
+
+    Building10000()
+
+    def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 70, MapID: 10000
+      LocalBuilding("Core", 70, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1093.35f, 991.55f, 292.73f), vanu_core)))
+      LocalObject(415, Door.Constructor(Vector3(1060.857f, 979.572f, 299.518f)), owning_building_guid = 70)
+      LocalObject(417, Door.Constructor(Vector3(1089.328f, 951.057f, 299.518f)), owning_building_guid = 70)
+      LocalObject(418, Door.Constructor(Vector3(1089.328f, 951.057f, 304.518f)), owning_building_guid = 70)
+      LocalObject(419, Door.Constructor(Vector3(1089.372f, 1008.043f, 304.518f)), owning_building_guid = 70)
+      LocalObject(420, Door.Constructor(Vector3(1089.372f, 1008.043f, 309.518f)), owning_building_guid = 70)
+      LocalObject(425, Door.Constructor(Vector3(1117.843f, 979.528f, 309.518f)), owning_building_guid = 70)
+    }
+
+    Building10044()
+
+    def Building10044(): Unit = { // Name: NW_ATPlant Type: vanu_vehicle_station GUID: 97, MapID: 10044
+      LocalBuilding("NW_ATPlant", 97, 10044, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(930.3f, 1141.53f, 164.95f), vanu_vehicle_station)))
+      LocalObject(553, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 97)
+      LocalObject(369, Door.Constructor(Vector3(914.9034f, 1139.01f, 166.729f)), owning_building_guid = 97)
+      LocalObject(370, Door.Constructor(Vector3(919.5815f, 1114.117f, 186.641f)), owning_building_guid = 97)
+      LocalObject(371, Door.Constructor(Vector3(933.1416f, 1096.054f, 196.729f)), owning_building_guid = 97)
+      LocalObject(374, Door.Constructor(Vector3(941.2718f, 1094.883f, 196.709f)), owning_building_guid = 97)
+      LocalObject(377, Door.Constructor(Vector3(949.2183f, 1093.8f, 196.709f)), owning_building_guid = 97)
+      LocalObject(382, Door.Constructor(Vector3(957.3834f, 1092.647f, 196.729f)), owning_building_guid = 97)
+      LocalObject(386, Door.Constructor(Vector3(970.8724f, 1131.144f, 186.653f)), owning_building_guid = 97)
+      LocalObject(389, Door.Constructor(Vector3(978.7827f, 1130.033f, 166.729f)), owning_building_guid = 97)
+      LocalObject(482, Door.Constructor(Vector3(938.5251f, 1075.059f, 171.583f)), owning_building_guid = 97)
+      LocalObject(547, Terminal.Constructor(Vector3(927.406f, 1122.807f, 184.867f), vanu_air_vehicle_term), owning_building_guid = 97)
+      LocalObject(617, VehicleSpawnPad.Constructor(Vector3(935.6392f, 1126.141f, 184.866f), vanu_vehicle_creation_pad, Vector3(0, 0, 8)), owning_building_guid = 97, terminal_guid = 547)
+      LocalObject(548, Terminal.Constructor(Vector3(962.4658f, 1117.888f, 184.867f), vanu_air_vehicle_term), owning_building_guid = 97)
+      LocalObject(619, VehicleSpawnPad.Constructor(Vector3(955.4604f, 1123.355f, 184.866f), vanu_vehicle_creation_pad, Vector3(0, 0, 8)), owning_building_guid = 97, terminal_guid = 548)
+      LocalObject(562, Terminal.Constructor(Vector3(932.0184f, 1115.15f, 167.45f), vanu_equipment_term), owning_building_guid = 97)
+      LocalObject(567, Terminal.Constructor(Vector3(955.7848f, 1111.81f, 167.45f), vanu_equipment_term), owning_building_guid = 97)
+      LocalObject(623, Terminal.Constructor(Vector3(943.2768f, 1108.05f, 169.95f), vanu_vehicle_term), owning_building_guid = 97)
+      LocalObject(618, VehicleSpawnPad.Constructor(Vector3(941.0632f, 1093.076f, 167.355f), vanu_vehicle_creation_pad, Vector3(0, 0, 188)), owning_building_guid = 97, terminal_guid = 623)
+    }
+
+    Building10197()
+
+    def Building10197(): Unit = { // Name: SE_ATPlant Type: vanu_vehicle_station GUID: 98, MapID: 10197
+      LocalBuilding("SE_ATPlant", 98, 10197, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1244.82f, 841.97f, 159.95f), vanu_vehicle_station)))
+      LocalObject(556, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 98)
+      LocalObject(447, Door.Constructor(Vector3(1195.006f, 843.136f, 161.729f)), owning_building_guid = 98)
+      LocalObject(449, Door.Constructor(Vector3(1202.975f, 843.6932f, 181.653f)), owning_building_guid = 98)
+      LocalObject(451, Door.Constructor(Vector3(1208.165f, 884.1538f, 191.729f)), owning_building_guid = 98)
+      LocalObject(455, Door.Constructor(Vector3(1216.391f, 884.7241f, 191.709f)), owning_building_guid = 98)
+      LocalObject(460, Door.Constructor(Vector3(1224.39f, 885.3164f, 191.709f)), owning_building_guid = 98)
+      LocalObject(466, Door.Constructor(Vector3(1232.585f, 885.8615f, 191.729f)), owning_building_guid = 98)
+      LocalObject(474, Door.Constructor(Vector3(1249.605f, 871.0125f, 181.641f)), owning_building_guid = 98)
+      LocalObject(475, Door.Constructor(Vector3(1259.356f, 847.6357f, 161.729f)), owning_building_guid = 98)
+      LocalObject(483, Door.Constructor(Vector3(1222.955f, 905.278f, 166.583f)), owning_building_guid = 98)
+      LocalObject(549, Terminal.Constructor(Vector3(1208.442f, 858.4074f, 179.867f), vanu_air_vehicle_term), owning_building_guid = 98)
+      LocalObject(620, VehicleSpawnPad.Constructor(Vector3(1216.431f, 854.5162f, 179.866f), vanu_vehicle_creation_pad, Vector3(0, 0, 176)), owning_building_guid = 98, terminal_guid = 549)
+      LocalObject(550, Terminal.Constructor(Vector3(1243.758f, 860.886f, 179.867f), vanu_air_vehicle_term), owning_building_guid = 98)
+      LocalObject(622, VehicleSpawnPad.Constructor(Vector3(1236.398f, 855.9124f, 179.866f), vanu_vehicle_creation_pad, Vector3(0, 0, 176)), owning_building_guid = 98, terminal_guid = 550)
+      LocalObject(593, Terminal.Constructor(Vector3(1213.713f, 865.7419f, 162.45f), vanu_equipment_term), owning_building_guid = 98)
+      LocalObject(600, Terminal.Constructor(Vector3(1237.654f, 867.4161f, 162.45f), vanu_equipment_term), owning_building_guid = 98)
+      LocalObject(624, Terminal.Constructor(Vector3(1225.166f, 872.0201f, 164.95f), vanu_vehicle_term), owning_building_guid = 98)
+      LocalObject(621, VehicleSpawnPad.Constructor(Vector3(1224.218f, 887.1278f, 162.355f), vanu_vehicle_creation_pad, Vector3(0, 0, -4)), owning_building_guid = 98, terminal_guid = 624)
+    }
+
+    Building10104()
+
+    def Building10104(): Unit = { // Name: GW_Cavern5_W Type: warpgate_cavern GUID: 99, MapID: 10104
+      LocalBuilding("GW_Cavern5_W", 99, 10104, FoundationBuilder(WarpGate.Structure(Vector3(253.29f, 1123.65f, 220.95f))))
+    }
+
+    Building10105()
+
+    def Building10105(): Unit = { // Name: GW_Cavern5_S Type: warpgate_cavern GUID: 100, MapID: 10105
+      LocalBuilding("GW_Cavern5_S", 100, 10105, FoundationBuilder(WarpGate.Structure(Vector3(1018.63f, 190.66f, 230.9f))))
+    }
+
+    Building10107()
+
+    def Building10107(): Unit = { // Name: GW_Cavern5_N Type: warpgate_cavern GUID: 101, MapID: 10107
+      LocalBuilding("GW_Cavern5_N", 101, 10107, FoundationBuilder(WarpGate.Structure(Vector3(1217.45f, 1790.01f, 231.29f))))
+    }
+
+    Building10106()
+
+    def Building10106(): Unit = { // Name: GW_Cavern5_E Type: warpgate_cavern GUID: 102, MapID: 10106
+      LocalBuilding("GW_Cavern5_E", 102, 10106, FoundationBuilder(WarpGate.Structure(Vector3(1860.2f, 893.34f, 231.08f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(558, Terminal.Constructor(Vector3(878.19f, 1054.2f, 163.19f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(561, Terminal.Constructor(Vector3(896.75f, 1075.17f, 163.19f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(563, Terminal.Constructor(Vector3(941.54f, 850.15f, 189.36f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(564, Terminal.Constructor(Vector3(945.16f, 843.7f, 183.9f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(565, Terminal.Constructor(Vector3(950.41f, 852.49f, 178.37f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(566, Terminal.Constructor(Vector3(953.54f, 844.73f, 178.41f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(568, Terminal.Constructor(Vector3(956.79f, 837.39f, 178.38f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(569, Terminal.Constructor(Vector3(963.51f, 855.72f, 183.88f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(570, Terminal.Constructor(Vector3(967.12f, 849.74f, 189.34f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(571, Terminal.Constructor(Vector3(979.19f, 862.66f, 241.45f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(572, Terminal.Constructor(Vector3(979.19f, 873.02f, 241.48f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(575, Terminal.Constructor(Vector3(989f, 872.94f, 235.95f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(582, Terminal.Constructor(Vector3(1008.85f, 1236.36f, 246.4f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(583, Terminal.Constructor(Vector3(1057.9f, 849.87f, 253.23f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(584, Terminal.Constructor(Vector3(1076.5f, 869.5f, 253.22f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(585, Terminal.Constructor(Vector3(1113.28f, 798.92f, 197.92f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(587, Terminal.Constructor(Vector3(1143.84f, 850.5f, 158.69f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(588, Terminal.Constructor(Vector3(1144.35f, 798.89f, 197.92f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(589, Terminal.Constructor(Vector3(1171.79f, 847.49f, 158.69f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(591, Terminal.Constructor(Vector3(1187.06f, 1054.3f, 230.13f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(592, Terminal.Constructor(Vector3(1207.07f, 1027.25f, 230.13f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(15, ProximityTerminal.Constructor(Vector3(974.48f, 848.12f, 235.98f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(16, ProximityTerminal.Constructor(Vector3(1111.91f, 984.81f, 150.41f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(498, ProximityTerminal.Constructor(Vector3(951.89f, 848.7f, 189.55f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(499, ProximityTerminal.Constructor(Vector3(1058.51f, 849.13f, 258.04f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("NW_Redoubt", "NW_ATPlant")
+      LatticeLink("NW_Stasis", "Core")
+      LatticeLink("SE_Stasis", "Core")
+      LatticeLink("SE_ATPlant", "SE_Stasis")
+      LatticeLink("NW_ATPlant", "NW_Stasis")
+      LatticeLink("SE_Redoubt", "SE_ATPlant")
+      LatticeLink("NW_Redoubt", "NW_Stasis")
+      LatticeLink("SE_Redoubt", "SE_Stasis")
+      LatticeLink("NW_Redoubt", "SE_Redoubt")
+      LatticeLink("GW_Cavern5_W", "NW_Redoubt")
+      LatticeLink("GW_Cavern5_N", "NW_ATPlant")
+      LatticeLink("GW_Cavern5_S", "SE_Redoubt")
+      LatticeLink("GW_Cavern5_E", "SE_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, false, List(Vector3(836.538f, 971.683f, 284.533f), Vector3(847.701f, 992.693f, 286.866f), Vector3(858.864f, 1013.704f, 281.7f), Vector3(888.189f, 1055.323f, 278.792f), Vector3(903.14f, 1076.54f, 276.458f))))
+      ZipLinePaths(new ZipLinePath(2, false, List(Vector3(891.205f, 996.755f, 333.27f), Vector3(915.423f, 1041.517f, 331.172f), Vector3(934.891f, 1077.502f, 329.469f))))
+      ZipLinePaths(new ZipLinePath(3, false, List(Vector3(914.981f, 1087.151f, 329.469f), Vector3(900.695f, 1039.306f, 331.566f), Vector3(887.839f, 996.247f, 333.27f))))
+      ZipLinePaths(new ZipLinePath(4, false, List(Vector3(933.653f, 971.335f, 168.794f), Vector3(937.301f, 1022.074f, 165.936f), Vector3(938.446f, 1037.992f, 163.681f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(934.919f, 1077.717f, 266.709f), Vector3(961.063f, 1120.966f, 259.938f), Vector3(987.208f, 1164.215f, 253.129f), Vector3(1007.713f, 1198.136f, 247.251f))))
+      ZipLinePaths(new ZipLinePath(6, false, List(Vector3(938.361f, 988.199f, 311.465f), Vector3(923.02f, 985.78f, 329.386f), Vector3(915.349f, 984.57f, 332.477f), Vector3(907.679f, 983.361f, 333.269f))))
+      ZipLinePaths(new ZipLinePath(7, true, List(Vector3(939.932f, 1041.648f, 266.204f), Vector3(940.903f, 1041.5f, 298.33f))))
+      ZipLinePaths(new ZipLinePath(8, false, List(Vector3(943.877f, 1037.999f, 298.844f), Vector3(952.428f, 1001.712f, 290.08f))))
+      ZipLinePaths(new ZipLinePath(9, true, List(Vector3(954.385f, 849.776f, 184.25f), Vector3(955.581f, 843.708f, 189.734f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(963.215f, 1070.363f, 195.797f), Vector3(973.055f, 987.338f, 186.251f), Vector3(982.896f, 904.313f, 169.711f))))
+      ZipLinePaths(new ZipLinePath(11, false, List(Vector3(966.382f, 981.995f, 161.207f), Vector3(1015.066f, 995.9f, 155.835f), Vector3(1044.658f, 1004.352f, 151.164f))))
+      ZipLinePaths(new ZipLinePath(12, false, List(Vector3(974.465f, 889.406f, 242.321f), Vector3(982.997f, 939.684f, 243.607f), Vector3(988.779f, 964.53f, 243.502f))))
+      ZipLinePaths(new ZipLinePath(13, false, List(Vector3(977.059f, 975.908f, 243.599f), Vector3(955.688f, 987.508f, 259.673f), Vector3(934.317f, 999.109f, 266.758f))))
+      ZipLinePaths(new ZipLinePath(14, false, List(Vector3(978.289f, 856.17f, 190.258f), Vector3(1014.241f, 891.248f, 199.82f), Vector3(1050.194f, 926.326f, 208.633f), Vector3(1086.147f, 961.404f, 217.447f), Vector3(1122.1f, 996.482f, 226.26f), Vector3(1158.052f, 1031.559f, 235.073f), Vector3(1162.987f, 1036.374f, 235.778f))))
+      ZipLinePaths(new ZipLinePath(15, false, List(Vector3(979.631f, 833.334f, 184.752f), Vector3(1026.998f, 815.027f, 190.209f), Vector3(1074.362f, 796.721f, 194.915f), Vector3(1095.651f, 787.956f, 198.196f), Vector3(1116.94f, 779.191f, 198.779f))))
+      ZipLinePaths(new ZipLinePath(16, false, List(Vector3(985.905f, 1139.875f, 185.717f), Vector3(1035.448f, 1151.71f, 183.938f), Vector3(1084.991f, 1163.545f, 181.413f), Vector3(1199.62f, 1190.927f, 173.376f))))
+      ZipLinePaths(new ZipLinePath(17, false, List(Vector3(990.859f, 893.127f, 243.457f), Vector3(1015.97f, 937.469f, 246.208f), Vector3(1041.079f, 981.81f, 248.211f), Vector3(1066.187f, 1026.152f, 250.214f), Vector3(1091.295f, 1070.491f, 252.217f), Vector3(1112.956f, 1108.744f, 251.464f))))
+      ZipLinePaths(new ZipLinePath(18, false, List(Vector3(993.026f, 1140.513f, 163.68f), Vector3(1043.97f, 1138.533f, 167.62f), Vector3(1094.914f, 1136.553f, 167.313f), Vector3(1138.865f, 1134.845f, 159.356f))))
+      ZipLinePaths(new ZipLinePath(19, false, List(Vector3(995.568f, 812.403f, 230.182f), Vector3(1041.682f, 791.189f, 235.778f), Vector3(1087.887f, 771.408f, 238.747f))))
+      ZipLinePaths(new ZipLinePath(20, false, List(Vector3(992.183f, 1215.784f, 247.281f), Vector3(981.853f, 1198.469f, 247.506f), Vector3(967.423f, 1179.655f, 230.129f), Vector3(938.562f, 1142.027f, 214.269f), Vector3(914.896f, 1111.172f, 198.717f))))
+      ZipLinePaths(new ZipLinePath(21, true, List(Vector3(1008.642f, 1065.179f, 390.74f), Vector3(1007.733f, 1064.686f, 397.4f))))
+      ZipLinePaths(new ZipLinePath(22, false, List(Vector3(1012.554f, 945.371f, 374.294f), Vector3(1015.582f, 995.593f, 382.861f), Vector3(1018.849f, 1049.753f, 391.246f))))
+      ZipLinePaths(new ZipLinePath(23, true, List(Vector3(1013.884f, 1025.019f, 142.543f), Vector3(1020.3f, 1023.318f, 175.782f))))
+      ZipLinePaths(new ZipLinePath(24, false, List(Vector3(1016.788f, 976.956f, 290.079f), Vector3(1037.293f, 987.803f, 297.838f), Vector3(1052.799f, 987.151f, 298.604f))))
+      ZipLinePaths(new ZipLinePath(25, true, List(Vector3(1017.555f, 1209.063f, 246.75f), Vector3(1026.884f, 1205.121f, 278.991f))))
+      ZipLinePaths(new ZipLinePath(26, true, List(Vector3(1028.886f, 1103.328f, 286.367f), Vector3(1055.503f, 1125.922f, 275.57f))))
+      ZipLinePaths(new ZipLinePath(27, false, List(Vector3(1022.812f, 888.35f, 314.685f), Vector3(1017.773f, 897.973f, 313.941f), Vector3(1012.734f, 907.596f, 309.402f), Vector3(1002.656f, 926.842f, 298.124f), Vector3(995.734f, 936.909f, 290.113f))))
+      ZipLinePaths(new ZipLinePath(28, false, List(Vector3(1036.004f, 936.681f, 386.369f), Vector3(1059.533f, 929.476f, 395.648f), Vector3(1127.297f, 908.725f, 403.708f))))
+      ZipLinePaths(new ZipLinePath(29, false, List(Vector3(1037.586f, 1219.441f, 247.248f), Vector3(1094.923f, 1205.287f, 251.306f), Vector3(1144.261f, 1193.533f, 256.623f), Vector3(1172.316f, 1186.849f, 258.35f))))
+      ZipLinePaths(new ZipLinePath(30, false, List(Vector3(1046.508f, 1118.947f, 329.469f), Vector3(1060.289f, 1101.823f, 351.796f), Vector3(1072.008f, 1099.988f, 353.752f))))
+      ZipLinePaths(new ZipLinePath(31, false, List(Vector3(1048.769f, 877.431f, 258.896f), Vector3(1025.9f, 919.197f, 256.184f), Vector3(1004.233f, 963.463f, 243.602f))))
+      ZipLinePaths(new ZipLinePath(32, false, List(Vector3(1056.116f, 1209.807f, 279.498f), Vector3(1081.23f, 1208.288f, 281.785f), Vector3(1106.344f, 1206.769f, 271.873f), Vector3(1156.572f, 1203.731f, 263.593f), Vector3(1178.239f, 1202.421f, 258.356f))))
+      ZipLinePaths(new ZipLinePath(33, false, List(Vector3(1052.422f, 1061.776f, 402.752f), Vector3(1070.817f, 1049.448f, 400.654f), Vector3(1089.212f, 1037.22f, 382.509f), Vector3(1139.78f, 998.768f, 343.26f), Vector3(1190.349f, 960.317f, 322.483f))))
+      ZipLinePaths(new ZipLinePath(34, false, List(Vector3(1055.905f, 1160.678f, 276.088f), Vector3(1045.246f, 1178.08f, 272.165f), Vector3(1034.588f, 1195.482f, 249.548f), Vector3(1026.775f, 1204.718f, 247.268f))))
+      ZipLinePaths(new ZipLinePath(35, false, List(Vector3(1064.229f, 937.492f, 177.28f), Vector3(1046.544f, 929.061f, 185.858f), Vector3(945.523f, 879.87f, 179.25f))))
+      ZipLinePaths(new ZipLinePath(36, true, List(Vector3(1065.916f, 938.66f, 141.799f), Vector3(1067.133f, 939.027f, 176.78f))))
+      ZipLinePaths(new ZipLinePath(37, false, List(Vector3(1072.997f, 941.22f, 177.28f), Vector3(1109.124f, 932.355f, 212.906f), Vector3(1145.251f, 923.49f, 247.789f), Vector3(1160.018f, 920.113f, 270.727f), Vector3(1174.786f, 916.736f, 276.061f))))
+      ZipLinePaths(new ZipLinePath(38, true, List(Vector3(1070.568f, 856.858f, 246.887f), Vector3(1082.745f, 845f, 253.59f))))
+      ZipLinePaths(new ZipLinePath(39, false, List(Vector3(1079.844f, 944.446f, 298.543f), Vector3(1073.849f, 937.71f, 296.436f), Vector3(1067.854f, 930.974f, 291.128f), Vector3(1058.565f, 910.402f, 271.726f), Vector3(1053.718f, 878.816f, 258.901f))))
+      ZipLinePaths(new ZipLinePath(40, true, List(Vector3(1079.369f, 865.469f, 314.138f), Vector3(1080.588f, 868.474f, 346.32f))))
+      ZipLinePaths(new ZipLinePath(41, false, List(Vector3(1084.523f, 1069.966f, 353.759f), Vector3(1081.809f, 1063.602f, 357.778f), Vector3(1034.51f, 952.682f, 374.294f))))
+      ZipLinePaths(new ZipLinePath(42, false, List(Vector3(1085.074f, 1117.049f, 329.482f), Vector3(1126.078f, 1090.896f, 340.496f), Vector3(1158.06f, 1070.496f, 369.607f), Vector3(1190.043f, 1050.096f, 358.773f))))
+      ZipLinePaths(new ZipLinePath(43, false, List(Vector3(1098.34f, 1019.147f, 303.582f), Vector3(1119.333f, 1053.316f, 306.9f), Vector3(1136.027f, 1072.485f, 308.32f), Vector3(1164.178f, 1104.808f, 310.373f))))
+      ZipLinePaths(new ZipLinePath(44, false, List(Vector3(1105.737f, 792.054f, 198.806f), Vector3(1070.649f, 827.286f, 214.8f), Vector3(1054.607f, 839.119f, 226.703f), Vector3(1038.566f, 850.953f, 230.21f))))
+      ZipLinePaths(new ZipLinePath(45, true, List(Vector3(1116.13f, 1100.883f, 144.66f), Vector3(1110.411f, 1100.113f, 158.152f))))
+      ZipLinePaths(new ZipLinePath(46, true, List(Vector3(1114.444f, 979.815f, 293.08f), Vector3(1109.115f, 962.793f, 308.08f))))
+      ZipLinePaths(new ZipLinePath(47, true, List(Vector3(1116.152f, 1049.326f, 142.011f), Vector3(1115.709f, 1049.785f, 176.78f))))
+      ZipLinePaths(new ZipLinePath(48, false, List(Vector3(1117.339f, 1055.876f, 177.28f), Vector3(1086.425f, 1067.357f, 215.618f), Vector3(1055.51f, 1078.838f, 253.203f), Vector3(1041.598f, 1084.004f, 287.634f), Vector3(1027.687f, 1089.171f, 286.868f))))
+      ZipLinePaths(new ZipLinePath(49, false, List(Vector3(1122.141f, 828.5f, 238.746f), Vector3(1122.477f, 879.466f, 236.861f), Vector3(1122.813f, 930.432f, 235.059f), Vector3(1123.15f, 981.397f, 233.257f), Vector3(1123.486f, 1032.363f, 231.454f), Vector3(1123.822f, 1083.325f, 229.652f), Vector3(1123.901f, 1095.316f, 226.948f))))
+      ZipLinePaths(new ZipLinePath(50, false, List(Vector3(1134.036f, 816.858f, 247.409f), Vector3(1151.499f, 864.219f, 255.407f), Vector3(1168.962f, 911.58f, 262.664f), Vector3(1186.424f, 958.942f, 275.422f), Vector3(1200.805f, 997.945f, 273.992f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(1139.77f, 957.718f, 176.286f), Vector3(1132.14f, 908.884f, 185.036f), Vector3(1124.511f, 860.05f, 192.594f), Vector3(1115.539f, 816.446f, 198.783f))))
+      ZipLinePaths(new ZipLinePath(52, true, List(Vector3(1142.063f, 961.706f, 141.954f), Vector3(1141.833f, 962.65f, 175.78f))))
+      ZipLinePaths(new ZipLinePath(53, false, List(Vector3(1145.255f, 912.243f, 322.464f), Vector3(1103.666f, 923.587f, 370.23f), Vector3(1044.747f, 939.657f, 374.346f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(1146.629f, 1086.09f, 159.359f), Vector3(1139.974f, 1061.468f, 161.182f), Vector3(1133.32f, 1036.847f, 154.174f), Vector3(1127.272f, 1018.487f, 151.164f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(1147.433f, 952.501f, 403.715f), Vector3(1174.421f, 980.424f, 402.039f), Vector3(1196.024f, 997.07f, 385.462f), Vector3(1217.428f, 1021.717f, 379.623f))))
+      ZipLinePaths(new ZipLinePath(56, false, List(Vector3(1146.091f, 1104.1f, 226.953f), Vector3(1153.881f, 1075.162f, 231.716f), Vector3(1157.777f, 1060.694f, 233.893f), Vector3(1161.672f, 1046.225f, 235.775f))))
+      ZipLinePaths(new ZipLinePath(57, false, List(Vector3(1155.908f, 799.632f, 198.811f), Vector3(1168.474f, 810.457f, 198.687f), Vector3(1189.041f, 833.683f, 180.751f))))
+      ZipLinePaths(new ZipLinePath(58, false, List(Vector3(1166.637f, 1138.424f, 172.501f), Vector3(1141.554f, 1141.091f, 174.082f), Vector3(1116.472f, 1143.758f, 176.164f), Vector3(1066.306f, 1149.092f, 177.327f), Vector3(963.976f, 1160.06f, 175.154f))))
+      ZipLinePaths(new ZipLinePath(59, false, List(Vector3(1174.081f, 905.841f, 276.08f), Vector3(1130.6f, 885.114f, 263.381f), Vector3(1087.118f, 864.386f, 249.969f), Vector3(1085.379f, 863.557f, 247.451f))))
+      ZipLinePaths(new ZipLinePath(60, false, List(Vector3(1187.233f, 1047.423f, 288.282f), Vector3(1137.464f, 1046.202f, 284.343f), Vector3(1087.696f, 1044.981f, 279.663f), Vector3(1037.928f, 1043.76f, 274.983f), Vector3(988.16f, 1042.54f, 270.303f), Vector3(957.304f, 1041.783f, 266.706f))))
+      ZipLinePaths(new ZipLinePath(61, true, List(Vector3(1195.866f, 1024.645f, 358.26f), Vector3(1196.547f, 1025.43f, 364.697f))))
+      ZipLinePaths(new ZipLinePath(62, false, List(Vector3(1202.279f, 1065.203f, 379.973f), Vector3(1158.316f, 1091.763f, 366.789f), Vector3(1087.976f, 1134.259f, 329.503f))))
+      ZipLinePaths(new ZipLinePath(63, false, List(Vector3(1218.329f, 982.117f, 322.441f), Vector3(1167.462f, 1031.49f, 333.463f), Vector3(1135.987f, 1060.504f, 343.613f), Vector3(1120.25f, 1075.012f, 352.689f), Vector3(1107.313f, 1084.519f, 353.763f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(1205.974f, 885.662f, 276.074f), Vector3(1174.101f, 851.537f, 258.901f), Vector3(1142.229f, 817.412f, 238.784f))))
+      ZipLinePaths(new ZipLinePath(65, false, List(Vector3(1209.137f, 1025.929f, 379.998f), Vector3(1164.331f, 1045.57f, 370.44f), Vector3(1098.915f, 1074.246f, 353.764f))))
+      ZipLinePaths(new ZipLinePath(66, false, List(Vector3(1210.968f, 1035.861f, 159.356f), Vector3(1220.734f, 986.826f, 159.704f), Vector3(1229.132f, 944.655f, 157.68f))))
+      ZipLinePaths(new ZipLinePath(67, false, List(Vector3(1211.43f, 918.994f, 193.301f), Vector3(1162.516f, 912.134f, 181.339f), Vector3(1113.603f, 905.273f, 173.561f), Vector3(1064.689f, 898.413f, 165.783f), Vector3(1038.276f, 894.708f, 161.212f))))
+      ZipLinePaths(new ZipLinePath(68, false, List(Vector3(1212.954f, 1184.48f, 258.387f), Vector3(1241.887f, 1146.113f, 277.704f), Vector3(1267.32f, 1107.245f, 296.218f), Vector3(1292.754f, 1068.378f, 314.731f), Vector3(1305.725f, 1048.556f, 330.249f), Vector3(1318.696f, 1028.734f, 333.772f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(1223.233f, 1112.938f, 190.58f), Vector3(1231.772f, 1063.768f, 188.214f), Vector3(1240.31f, 1014.599f, 187.788f), Vector3(1248.849f, 965.432f, 185.763f), Vector3(1257.388f, 916.265f, 183.037f), Vector3(1259.362f, 898.065f, 180.716f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(1230.107f, 1045.135f, 235.77f), Vector3(1244.028f, 1094.167f, 238.081f), Vector3(1257.948f, 1143.2f, 239.652f), Vector3(1264.226f, 1165.313f, 237.807f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(1231.002f, 1035.87f, 235.822f), Vector3(1254.525f, 996.863f, 257.139f), Vector3(1271.932f, 967.997f, 272.932f))))
+      ZipLinePaths(new ZipLinePath(72, false, List(Vector3(1234.91f, 912.664f, 157.928f), Vector3(1250.804f, 960.648f, 165.181f), Vector3(1266.698f, 1008.632f, 171.942f), Vector3(1270.75f, 1020.863f, 172.504f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(1255.485f, 1182.81f, 237.946f), Vector3(1206.913f, 1195.741f, 241.873f), Vector3(1195.984f, 1200.291f, 246.675f), Vector3(1144.741f, 1209.557f, 249.088f), Vector3(1096.169f, 1221.288f, 250.963f), Vector3(1047.598f, 1233.019f, 251.938f), Vector3(1032.812f, 1235.4f, 247.246f))))
+      ZipLinePaths(new ZipLinePath(74, true, List(Vector3(1265.476f, 927.817f, 279.476f), Vector3(1239.733f, 924.791f, 275.521f))))
+      ZipLinePaths(new ZipLinePath(75, false, List(Vector3(1313.487f, 1015.418f, 333.739f), Vector3(1293.092f, 1007.868f, 334.409f), Vector3(1270.097f, 998.818f, 326.879f), Vector3(1241.583f, 987.596f, 322.436f))))
+      ZipLinePaths(new ZipLinePath(76, true, List(Vector3(845.661f, 953.94f, 284.032f), Vector3(833.71f, 937.902f, 284.032f))))
+      ZipLinePaths(new ZipLinePath(77, false, List(Vector3(1101.112f, 1092.318f, 158.581f), Vector3(1043.9f, 1067.37f, 165.921f), Vector3(986.689f, 1042.422f, 164.515f))))
+      ZipLinePaths(new ZipLinePath(78, false, List(Vector3(1053.642f, 972.17f, 298.563f), Vector3(1016.137f, 939.284f, 295.811f), Vector3(988.785f, 915.864f, 290.753f))))
+      ZipLinePaths(new ZipLinePath(79, true, List(Vector3(1074.661f, 994.089f, 303.08f), Vector3(1074.232f, 994.714f, 308.08f))))
+      ZipLinePaths(new ZipLinePath(80, true, List(Vector3(1104.434f, 964.517f, 298.08f), Vector3(1104.444f, 964.415f, 303.08f))))
+      ZipLinePaths(new ZipLinePath(81, false, List(Vector3(1208.005f, 939.596f, 276.045f), Vector3(1208.715f, 962.582f, 276.316f), Vector3(1209.426f, 985.568f, 273.988f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(1179.915f, 1003.14f, 273.987f), Vector3(1160.46f, 995.32f, 293.853f), Vector3(1141.005f, 987.5f, 305.972f), Vector3(1127.232f, 982.307f, 308.622f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(1127.071f, 968.872f, 308.503f), Vector3(1123.104f, 919.425f, 315.516f), Vector3(1121.438f, 898.657f, 314.64f))))
+      ZipLinePaths(new ZipLinePath(84, false, List(Vector3(1046.507f, 915.223f, 314.639f), Vector3(1025.3f, 953.238f, 318.323f), Vector3(1014.696f, 972.745f, 314.793f), Vector3(1002.593f, 984.253f, 311.55f))))
+      ZipLinePaths(new ZipLinePath(85, false, List(Vector3(1096.244f, 942.801f, 298.563f), Vector3(1099.948f, 933.29f, 297.281f), Vector3(1103.653f, 921.579f, 289.539f), Vector3(1111.063f, 900.358f, 272.895f), Vector3(1125.882f, 857.914f, 247.906f), Vector3(1133.885f, 834.994f, 238.784f))))
+      ZipLinePaths(new ZipLinePath(86, false, List(Vector3(1097.66f, 942.464f, 303.601f), Vector3(1135.823f, 912.095f, 324.74f), Vector3(1147.795f, 902.568f, 322.452f))))
+      ZipLinePaths(new ZipLinePath(87, false, List(Vector3(1082.528f, 1018.227f, 303.597f), Vector3(1079.498f, 1050.159f, 301.494f), Vector3(1075.269f, 1067.092f, 291.668f), Vector3(1066.51f, 1121.357f, 276.083f))))
+      ZipLinePaths(new ZipLinePath(88, false, List(Vector3(1098.415f, 1019.645f, 308.636f), Vector3(1117.982f, 1034.342f, 306.546f), Vector3(1137.549f, 1046.439f, 290.602f), Vector3(1150.978f, 1055.634f, 280.545f), Vector3(1164.406f, 1064.828f, 274.032f))))
+      ZipLinePaths(new ZipLinePath(89, false, List(Vector3(1178.956f, 772.235f, 282.489f), Vector3(1204.251f, 811.257f, 304.124f), Vector3(1229.045f, 845.879f, 324.961f), Vector3(1231.033f, 852.574f, 322.473f))))
+      ZipLinePaths(new ZipLinePath(90, false, List(Vector3(1112.743f, 751.134f, 282.462f), Vector3(1088.902f, 756.732f, 284.043f), Vector3(1065.062f, 762.33f, 273.139f), Vector3(1017.381f, 773.527f, 263.073f), Vector3(969.701f, 784.724f, 253.007f), Vector3(951.396f, 782.683f, 243.001f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(943.422f, 797.726f, 243.265f), Vector3(916.11f, 837.921f, 259.473f), Vector3(888.799f, 878.117f, 281.944f), Vector3(868.449f, 908.066f, 284.555f))))
+      ZipLinePaths(new ZipLinePath(92, false, List(Vector3(879.92f, 943.053f, 284.535f), Vector3(902.968f, 950.268f, 293.299f), Vector3(926.016f, 957.483f, 290.07f))))
+      ZipLinePaths(new ZipLinePath(93, false, List(Vector3(1315.471f, 956.81f, 322.442f), Vector3(1332.853f, 1004.046f, 316.074f), Vector3(1347.126f, 1047.02f, 302.549f))))
+      ZipLinePaths(new ZipLinePath(94, false, List(Vector3(1319.352f, 1102.721f, 302.539f), Vector3(1274.436f, 1124.169f, 308.086f), Vector3(1251.978f, 1134.893f, 312.979f), Vector3(1229.521f, 1145.617f, 310.373f))))
+      ZipLinePaths(new ZipLinePath(95, false, List(Vector3(1174.169f, 1166.809f, 310.388f), Vector3(1131.408f, 1190.417f, 300.433f), Vector3(1088.647f, 1214.025f, 289.744f), Vector3(1067.266f, 1225.83f, 279.474f))))
+      ZipLinePaths(new ZipLinePath(96, false, List(Vector3(975.449f, 1215.112f, 279.493f), Vector3(951.71f, 1171.246f, 280.186f), Vector3(927.97f, 1127.38f, 273.129f), Vector3(907.554f, 1089.655f, 266.706f))))
+      ZipLinePaths(new ZipLinePath(97, false, List(Vector3(1310.139f, 1087.265f, 302.549f), Vector3(1262.453f, 1075.564f, 293.844f), Vector3(1245.285f, 1071.352f, 288.291f))))
+      ZipLinePaths(new ZipLinePath(98, true, List(Vector3(837.962f, 950.527f, 284.032f), Vector3(839.502f, 937.417f, 297.199f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(1107.188f, 867.405f, 157.685f), Vector3(1057.731f, 866.462f, 167.734f), Vector3(1033.002f, 865.991f, 168.798f))))
+      ZipLinePaths(new ZipLinePath(100, false, List(Vector3(1034.19f, 1151.24f, 276.07f), Vector3(1027.155f, 1171.499f, 282.137f), Vector3(1020.12f, 1186.259f, 279.493f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(1182.343f, 1165.265f, 258.349f), Vector3(1182.153f, 1158.271f, 259.739f), Vector3(1181.964f, 1151.276f, 257.847f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(1188.742f, 1150.284f, 226.948f), Vector3(1191.712f, 1126.486f, 218.923f), Vector3(1194.683f, 1102.689f, 201.903f), Vector3(1197.654f, 1078.891f, 176.509f), Vector3(1200.624f, 1055.093f, 159.356f))))
+      ZipLinePaths(new ZipLinePath(103, true, List(Vector3(845.985f, 940.029f, 284.032f), Vector3(857.812f, 940.784f, 284.032f))))
+      ZipLinePaths(new ZipLinePath(104, true, List(Vector3(913.217f, 1126.673f, 167.8f), Vector3(905.95f, 1128.761f, 185.226f))))
+      ZipLinePaths(new ZipLinePath(105, true, List(Vector3(985.057f, 1117.279f, 185.226f), Vector3(977.383f, 1119.22f, 167.8f))))
+      ZipLinePaths(new ZipLinePath(106, true, List(Vector3(1194.756f, 855.428f, 162.8f), Vector3(1186.752f, 855.411f, 180.226f))))
+      ZipLinePaths(new ZipLinePath(107, true, List(Vector3(1266.08f, 858.242f, 180.226f), Vector3(1258.221f, 859.327f, 162.8f))))
+      ZipLinePaths(new ZipLinePath(108, false, List(Vector3(1022.699f, 1016.759f, 176.299f), Vector3(1059.517f, 982.522f, 168.496f), Vector3(1096.335f, 948.284f, 159.955f), Vector3(1133.154f, 914.047f, 150.468f))))
+      ZipLinePaths(new ZipLinePath(109, true, List(Vector3(999.063f, 970.346f, 243.032f), Vector3(992.956f, 976.089f, 248.532f))))
+      ZipLinePaths(new ZipLinePath(110, true, List(Vector3(1213.98f, 1136.817f, 257.332f), Vector3(1205.284f, 1135.873f, 262.831f))))
+      ZipLinePaths(new ZipLinePath(111, false, List(Vector3(1195.134f, 1025.819f, 224.31f), Vector3(1196.763f, 1005.379f, 221.528f), Vector3(1198.393f, 984.938f, 196.447f), Vector3(1201.652f, 944.057f, 167.843f), Vector3(1202.63f, 931.792f, 157.68f))))
+      ZipLinePaths(new ZipLinePath(112, false, List(Vector3(1195.142f, 1055.611f, 224.31f), Vector3(1176.148f, 1102.906f, 226.827f), Vector3(1167.582f, 1124.236f, 226.948f))))
+      ZipLinePaths(new ZipLinePath(113, true, List(Vector3(1187.101f, 1041.722f, 223.81f), Vector3(1187.004f, 1030.267f, 230.47f))))
+      ZipLinePaths(new ZipLinePath(114, false, List(Vector3(1007.547f, 268.934f, 243.11f), Vector3(1007.527f, 292.646f, 244.644f), Vector3(1018.508f, 316.357f, 244.279f), Vector3(1024.908f, 330.77f, 243.857f), Vector3(1035.909f, 347.383f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(1068.89f, 344.904f, 243.148f), Vector3(1070.937f, 349.779f, 243.278f), Vector3(1072.784f, 354.654f, 243.921f), Vector3(1074.728f, 380.202f, 237.744f), Vector3(1075.073f, 405.551f, 231.566f), Vector3(1072.861f, 425.05f, 229.663f), Vector3(1073.449f, 444.349f, 228.36f), Vector3(1075.437f, 463.847f, 225.656f), Vector3(1075.625f, 483.346f, 225.553f), Vector3(1076.013f, 534.043f, 210.998f), Vector3(1075.593f, 583.763f, 198.865f), Vector3(1072.743f, 599.762f, 185.09f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(1049.463f, 621.931f, 183.136f), Vector3(1053.439f, 640.477f, 184.404f), Vector3(1058.226f, 649.75f, 184.889f), Vector3(1063.214f, 659.024f, 185.773f), Vector3(1070.682f, 677.638f, 184.48f), Vector3(1070.351f, 696.253f, 182.787f), Vector3(1075.419f, 712.467f, 181.094f), Vector3(1072.688f, 730.282f, 177.102f))))
+      ZipLinePaths(new ZipLinePath(117, false, List(Vector3(993.254f, 456.81f, 223.2f), Vector3(1005.741f, 456.241f, 223.7f), Vector3(1011.984f, 455.957f, 223.7f), Vector3(1018.228f, 455.673f, 223.201f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(960.308f, 504.697f, 218.191f), Vector3(938.836f, 502.633f, 219.836f), Vector3(929.464f, 487.568f, 219.381f), Vector3(919.607f, 494.021f, 219.521f), Vector3(919.542f, 520.634f, 222.656f), Vector3(919.478f, 547.248f, 223.79f), Vector3(938.214f, 551.461f, 223.725f), Vector3(967.915f, 554.863f, 223.617f), Vector3(967.766f, 571.564f, 223.363f), Vector3(966.692f, 580.615f, 223.236f), Vector3(952.817f, 588.865f, 223.202f))))
+      ZipLinePaths(new ZipLinePath(119, false, List(Vector3(941.828f, 613.476f, 223.231f), Vector3(925.918f, 616.335f, 223.995f), Vector3(920.563f, 629.564f, 227.029f), Vector3(921.008f, 642.794f, 228.864f), Vector3(934.83f, 647.518f, 228.224f))))
+      ZipLinePaths(new ZipLinePath(120, false, List(Vector3(948.435f, 649.569f, 228.256f), Vector3(952.455f, 664.02f, 228.749f), Vector3(956.475f, 678.47f, 228.243f))))
+      ZipLinePaths(new ZipLinePath(121, false, List(Vector3(942.908f, 710.963f, 233.188f), Vector3(936.267f, 720.101f, 235.096f), Vector3(936.451f, 734.912f, 237.896f), Vector3(922.235f, 750.819f, 238.936f), Vector3(922.627f, 767.772f, 243.356f), Vector3(922.219f, 784.725f, 243.576f), Vector3(921.702f, 787.641f, 243.208f))))
+      ZipLinePaths(new ZipLinePath(122, false, List(Vector3(1111.15f, 207.047f, 243.135f), Vector3(1157.929f, 227.358f, 243.888f), Vector3(1204.708f, 247.669f, 243.885f), Vector3(1209.294f, 249.66f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(1198.789f, 297.547f, 243.146f), Vector3(1197.337f, 322.502f, 247.098f), Vector3(1197.485f, 347.457f, 249.86f), Vector3(1197.781f, 397.368f, 264.825f), Vector3(1197.277f, 447.279f, 277.09f), Vector3(1197.109f, 463.915f, 281.276f), Vector3(1197.37f, 477.616f, 283.749f), Vector3(1196.881f, 486.424f, 283.146f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(1202.583f, 536.019f, 283.135f), Vector3(1204.13f, 561.193f, 285.171f), Vector3(1204.677f, 586.368f, 286.707f), Vector3(1202.824f, 611.543f, 287.818f), Vector3(1191.372f, 636.718f, 288.528f), Vector3(1179.116f, 659.424f, 288.253f), Vector3(1170.564f, 676.207f, 286.677f), Vector3(1170.612f, 692.99f, 284.7f), Vector3(1173.108f, 726.557f, 282.447f))))
+      ZipLinePaths(new ZipLinePath(125, false, List(Vector3(1769.642f, 876.984f, 243.134f), Vector3(1724.537f, 898.566f, 244.689f), Vector3(1701.985f, 909.357f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(126, false, List(Vector3(1687.12f, 945.911f, 241.987f), Vector3(1635.308f, 946.216f, 228.89f), Vector3(1608.802f, 954.568f, 229.295f), Vector3(1583.497f, 970.921f, 230.9f), Vector3(1575.821f, 972.773f, 223.142f))))
+      ZipLinePaths(new ZipLinePath(127, false, List(Vector3(1574.066f, 944.007f, 223.145f), Vector3(1564.26f, 943.102f, 223.317f), Vector3(1539.255f, 940.054f, 217.963f), Vector3(1514.25f, 939.205f, 212.809f), Vector3(1501.992f, 941.023f, 209.431f), Vector3(1489.735f, 940.042f, 206.053f), Vector3(1464.82f, 941.279f, 198.096f), Vector3(1440.505f, 942.916f, 190.639f), Vector3(1416.191f, 944.553f, 188.783f), Vector3(1367.161f, 943.427f, 184.27f), Vector3(1349.51f, 950.758f, 178.695f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(1844.368f, 962.199f, 243.288f), Vector3(1843.209f, 986.147f, 246.165f), Vector3(1826.049f, 1030.095f, 248.742f), Vector3(1813.796f, 1045.782f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(129, false, List(Vector3(1770.828f, 1066.209f, 243.135f), Vector3(1726.199f, 1088.756f, 243.877f), Vector3(1703.885f, 1100.029f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(130, false, List(Vector3(1706.104f, 1133.887f, 243.154f), Vector3(1681.993f, 1139.631f, 252.471f), Vector3(1657.881f, 1141.375f, 259.707f), Vector3(1609.657f, 1136.062f, 277.52f), Vector3(1593.98f, 1137.395f, 283.015f), Vector3(1577.906f, 1137.772f, 284.225f), Vector3(1561.433f, 1132.349f, 283.154f))))
+      ZipLinePaths(new ZipLinePath(131, false, List(Vector3(1551.103f, 1093.186f, 283.14f), Vector3(1526.704f, 1077.822f, 287.951f), Vector3(1502.305f, 1068.658f, 289.866f), Vector3(1480.834f, 1067.718f, 294.486f), Vector3(1459.363f, 1067.777f, 299.906f), Vector3(1443.772f, 1069.81f, 303.887f), Vector3(1399.83f, 1066.129f, 303.655f))))
+      ZipLinePaths(new ZipLinePath(132, false, List(Vector3(1222.883f, 1155.354f, 310.372f), Vector3(1233.227f, 1169.735f, 309.998f), Vector3(1229.371f, 1162.916f, 262.124f), Vector3(1235.989f, 1170.63f, 212.147f), Vector3(1240.919f, 1176.377f, 172.5f))))
+      ZipLinePaths(new ZipLinePath(133, false, List(Vector3(1175.587f, 1239.146f, 173.631f), Vector3(1171.886f, 1262.498f, 181.983f), Vector3(1171.393f, 1276.12f, 185.559f), Vector3(1170.751f, 1301.419f, 189.13f), Vector3(1171.108f, 1326.718f, 195.702f), Vector3(1171.043f, 1376.342f, 206.614f), Vector3(1172.179f, 1425.966f, 221.727f), Vector3(1170.049f, 1436.669f, 223.181f), Vector3(1171.12f, 1447.372f, 223.149f))))
+      ZipLinePaths(new ZipLinePath(134, false, List(Vector3(1166.209f, 1497.571f, 223.137f), Vector3(1166.17f, 1547.911f, 226.843f), Vector3(1170.072f, 1588.874f, 234.821f), Vector3(1168.974f, 1629.837f, 243.999f), Vector3(1189.267f, 1681.165f, 247.254f), Vector3(1198.153f, 1698.932f, 244.947f), Vector3(1193.839f, 1716.699f, 243.141f))))
+      ZipLinePaths(new ZipLinePath(135, false, List(Vector3(1158.399f, 1784.486f, 243.843f), Vector3(1111.506f, 1772.128f, 245.649f), Vector3(1065.55f, 1750.117f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(1045.72f, 1705.07f, 243.135f), Vector3(1022.973f, 1660.539f, 243.887f), Vector3(1014.33f, 1643.617f, 243.135f))))
+      ZipLinePaths(new ZipLinePath(137, false, List(Vector3(978.861f, 1641.87f, 243.153f), Vector3(970.657f, 1593.573f, 258.04f), Vector3(971.092f, 1584.88f, 260.944f), Vector3(973.55f, 1521.127f, 280.863f), Vector3(973.104f, 1507.604f, 283.349f), Vector3(979.459f, 1494.081f, 283.153f))))
+      ZipLinePaths(new ZipLinePath(138, false, List(Vector3(1027.608f, 1471.856f, 283.135f), Vector3(1044.922f, 1421.966f, 285.242f), Vector3(1042.036f, 1372.076f, 292.602f), Vector3(1042.75f, 1322.185f, 291.763f), Vector3(1040.202f, 1282.273f, 281.511f))))
+      ZipLinePaths(new ZipLinePath(139, false, List(Vector3(1140.673f, 973.599f, 176.313f), Vector3(1138.394f, 1020.478f, 196.964f), Vector3(1136.116f, 1067.357f, 216.913f), Vector3(1135.446f, 1081.145f, 225.28f), Vector3(1134.776f, 1094.932f, 226.989f))))
+      ZipLinePaths(new ZipLinePath(140, false, List(Vector3(1150.479f, 968.34f, 176.29f), Vector3(1170.472f, 984.147f, 176.49f), Vector3(1190.466f, 999.954f, 176.39f), Vector3(1230.453f, 1031.568f, 174.132f), Vector3(1253.974f, 1050.164f, 172.501f))))
+      ZipLinePaths(new ZipLinePath(141, false, List(Vector3(1106.342f, 1106.197f, 226.95f), Vector3(1054.565f, 1048.43f, 236.347f), Vector3(1002.788f, 990.663f, 243.55f))))
+      ZipLinePaths(new ZipLinePath(142, false, List(Vector3(984.255f, 1002.808f, 243.547f), Vector3(985.338f, 1010.52f, 242.265f), Vector3(986.422f, 1018.232f, 227.484f), Vector3(988.588f, 1033.656f, 203.92f), Vector3(992.666f, 1062.689f, 163.68f))))
+      ZipLinePaths(new ZipLinePath(143, false, List(Vector3(1116.114f, 1046.375f, 177.28f), Vector3(1147.41f, 1042.571f, 218.111f), Vector3(1153.853f, 1041.788f, 233.89f), Vector3(1160.296f, 1041.005f, 235.77f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(991.811f, 888.539f, 243.475f), Vector3(1039.377f, 875.966f, 257.645f), Vector3(1046.137f, 873.294f, 258.908f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(1098.527f, 830.352f, 258.89f), Vector3(1102.497f, 826.527f, 258.518f), Vector3(1106.468f, 822.701f, 238.745f))))
+      ZipLinePaths(new ZipLinePath(146, false, List(Vector3(1094.341f, 828.58f, 258.89f), Vector3(1089.367f, 823.039f, 258.018f), Vector3(1085.594f, 827.098f, 235.645f), Vector3(1076.848f, 825.616f, 212.9f), Vector3(1059.355f, 822.653f, 166.153f), Vector3(1055.157f, 821.942f, 152.602f))))
+      ZipLinePaths(new ZipLinePath(147, false, List(Vector3(1101.107f, 835.443f, 258.89f), Vector3(1105.861f, 841.292f, 255.843f), Vector3(1108.616f, 842.741f, 235.297f), Vector3(1115.326f, 847.639f, 212.204f), Vector3(1129.545f, 859.835f, 164.77f), Vector3(1130.939f, 861.031f, 157.68f))))
+      ZipLinePaths(new ZipLinePath(148, false, List(Vector3(1118.348f, 875.124f, 150.465f), Vector3(1118.914f, 870.112f, 157.173f), Vector3(1119.479f, 865.099f, 157.68f))))
+      ZipLinePaths(new ZipLinePath(149, false, List(Vector3(1205.55f, 1041.13f, 224.344f), Vector3(1217.347f, 1039.221f, 223.849f), Vector3(1229.145f, 1037.313f, 222.554f), Vector3(1252.74f, 1033.497f, 207.297f), Vector3(1299.93f, 1025.864f, 189.531f), Vector3(1336.016f, 1020.029f, 174.385f))))
+      ZipLinePaths(new ZipLinePath(150, false, List(Vector3(1122.96f, 1201.699f, 226.948f), Vector3(1121.853f, 1205.357f, 226.351f), Vector3(1120.746f, 1209.015f, 223.454f), Vector3(1118.532f, 1215.13f, 206.461f), Vector3(1114.104f, 1228.561f, 186.473f), Vector3(1111.624f, 1236.082f, 172.915f))))
+      ZipLinePaths(new ZipLinePath(151, false, List(Vector3(1058.953f, 1136.079f, 226.996f), Vector3(1036.782f, 1130.339f, 224.438f), Vector3(1014.612f, 1124.599f, 207.629f), Vector3(999.536f, 1120.695f, 199.391f))))
+      ZipLinePaths(new ZipLinePath(152, false, List(Vector3(980.433f, 1115.376f, 198.361f), Vector3(969.648f, 1109.169f, 197.774f), Vector3(958.864f, 1102.962f, 195.794f))))
+      ZipLinePaths(new ZipLinePath(153, false, List(Vector3(904.04f, 1103.835f, 185.723f), Vector3(892.316f, 1095.63f, 184.78f), Vector3(886.454f, 1091.528f, 183.762f), Vector3(883.524f, 1089.477f, 183.053f), Vector3(880.593f, 1087.427f, 182.544f), Vector3(876.55f, 1084.598f, 182.144f), Vector3(835.315f, 1055.742f, 171.252f))))
+      ZipLinePaths(new ZipLinePath(154, false, List(Vector3(1133.265f, 778.345f, 198.777f), Vector3(1131.568f, 771.562f, 198.189f), Vector3(1129.872f, 764.779f, 194.804f), Vector3(1126.478f, 751.214f, 169.036f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(1108.775f, 811.315f, 198.776f), Vector3(1106.722f, 813.77f, 198.054f), Vector3(1104.669f, 816.226f, 175.432f), Vector3(1102.963f, 817.937f, 153.088f))))
+      ZipLinePaths(new ZipLinePath(156, false, List(Vector3(306.846f, 1041.014f, 233.036f), Vector3(305.881f, 1023.7f, 236.553f), Vector3(342.015f, 951.186f, 234.539f), Vector3(393.984f, 925.058f, 236.511f), Vector3(405.219f, 918.196f, 233.135f))))
+      ZipLinePaths(new ZipLinePath(157, false, List(Vector3(422.655f, 878.634f, 234.823f), Vector3(462.703f, 878.635f, 252.642f), Vector3(512.448f, 879.331f, 268.067f), Vector3(537.916f, 878.972f, 272.078f))))
+      ZipLinePaths(new ZipLinePath(158, false, List(Vector3(550.586f, 914.859f, 273.135f), Vector3(609.031f, 945.539f, 276.386f), Vector3(648.677f, 946.718f, 274.915f), Vector3(662.14f, 946.656f, 273.135f))))
+      ZipLinePaths(new ZipLinePath(159, false, List(Vector3(675.759f, 912.206f, 273.905f), Vector3(733.511f, 909.282f, 296.348f), Vector3(785.289f, 906.66f, 296.654f), Vector3(816.157f, 905.097f, 284.534f))))
+      ZipLinePaths(new ZipLinePath(160, false, List(Vector3(336.043f, 1137.71f, 233.109f), Vector3(351.767f, 1137.575f, 237.165f), Vector3(416.64f, 1106.569f, 235.944f), Vector3(456.726f, 1105.644f, 223.541f), Vector3(470.089f, 1105.336f, 215.777f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(487.928f, 1066.814f, 213.142f), Vector3(543.338f, 1039.103f, 216.896f), Vector3(599.192f, 1039.599f, 194.845f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(616.478f, 1073.332f, 192.31f), Vector3(671.491f, 1073.589f, 177.53f), Vector3(736.004f, 1042.347f, 176.388f), Vector3(809.069f, 1041.654f, 174.357f))))
+      ZipLinePaths(new ZipLinePath(163, true, List(Vector3(1201.936f, 910.752f, 325.469f), Vector3(1222.351f, 877.804f, 341.059f))))
+      ZipLinePaths(new ZipLinePath(164, true, List(Vector3(1201.024f, 928.787f, 344.577f), Vector3(1248.519f, 941.266f, 331.252f), Vector3(1257.731f, 943.513f, 327.969f))))
+      ZipLinePaths(new ZipLinePath(165, true, List(Vector3(964.275f, 1096.252f, 332.469f), Vector3(992.303f, 1071.769f, 345.489f))))
+      ZipLinePaths(new ZipLinePath(166, true, List(Vector3(961.598f, 1106.636f, 349.565f), Vector3(1008.607f, 1122.679f, 338.887f), Vector3(1021.012f, 1127.083f, 334.969f))))
+    }
+
+    ZipLines()
+
+  }
+}

--- a/pslogin/src/main/scala/zonemaps/Ugd06.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd06.scala
@@ -14,7 +14,7 @@ import net.psforever.types.Vector3
 object Ugd06 { // Drugaskan
   val ZoneMap = new ZoneMap("ugd06") {
     Scale = MapScale.Dim2560
-    Checksum = 0L
+    Checksum = 4274683970L
 
     Building10077()
 

--- a/pslogin/src/main/scala/zonemaps/Ugd06.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd06.scala
@@ -1,0 +1,775 @@
+package zonemaps
+
+import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.objects.serverobject.pad.VehicleSpawnPad
+import net.psforever.objects.serverobject.painbox.Painbox
+import net.psforever.objects.serverobject.structures.{Building, FoundationBuilder, StructureType, WarpGate}
+import net.psforever.objects.serverobject.terminals.{CaptureTerminal, ProximityTerminal, Terminal}
+import net.psforever.objects.serverobject.tube.SpawnTube
+import net.psforever.objects.serverobject.zipline.ZipLinePath
+import net.psforever.objects.zones.{MapScale, ZoneMap}
+import net.psforever.types.Vector3
+
+object Ugd06 { // Drugaskan
+  val ZoneMap = new ZoneMap("ugd06") {
+    Scale = MapScale.Dim2560
+    Checksum = 0L
+
+    Building10077()
+
+    def Building10077(): Unit = { // Name: ceiling_bldg_a_10077 Type: ceiling_bldg_a GUID: 1, MapID: 10077
+      LocalBuilding("ceiling_bldg_a_10077", 1, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.11f, 1049.16f, 170.44f), ceiling_bldg_a)))
+      LocalObject(666, Door.Constructor(Vector3(1241.352f, 1050.759f, 177.725f)), owning_building_guid = 1)
+      LocalObject(668, Door.Constructor(Vector3(1247.792f, 1037.129f, 172.219f)), owning_building_guid = 1)
+      LocalObject(669, Door.Constructor(Vector3(1253.713f, 1030.187f, 177.725f)), owning_building_guid = 1)
+      LocalObject(676, Door.Constructor(Vector3(1276.061f, 1049.765f, 172.219f)), owning_building_guid = 1)
+    }
+
+    Building10079()
+
+    def Building10079(): Unit = { // Name: ceiling_bldg_b_10079 Type: ceiling_bldg_b GUID: 2, MapID: 10079
+      LocalBuilding("ceiling_bldg_b_10079", 2, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1014.06f, 873.97f, 162.94f), ceiling_bldg_b)))
+      LocalObject(608, Door.Constructor(Vector3(997.8083f, 877.4145f, 164.719f)), owning_building_guid = 2)
+      LocalObject(611, Door.Constructor(Vector3(1015.59f, 879.8751f, 164.719f)), owning_building_guid = 2)
+    }
+
+    Building10241()
+
+    def Building10241(): Unit = { // Name: ceiling_bldg_c_10241 Type: ceiling_bldg_c GUID: 3, MapID: 10241
+      LocalBuilding("ceiling_bldg_c_10241", 3, 10241, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1125.87f, 1035.29f, 171.46f), ceiling_bldg_c)))
+      LocalObject(638, Door.Constructor(Vector3(1122.978f, 1038.418f, 173.239f)), owning_building_guid = 3)
+      LocalObject(649, Door.Constructor(Vector3(1161.197f, 1070.605f, 173.239f)), owning_building_guid = 3)
+      LocalObject(651, Door.Constructor(Vector3(1172.81f, 1041.863f, 173.239f)), owning_building_guid = 3)
+    }
+
+    Building10006()
+
+    def Building10006(): Unit = { // Name: ceiling_bldg_d_10006 Type: ceiling_bldg_d GUID: 4, MapID: 10006
+      LocalBuilding("ceiling_bldg_d_10006", 4, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1196.16f, 965.32f, 165.44f), ceiling_bldg_d)))
+      LocalObject(653, Door.Constructor(Vector3(1182.001f, 955.0526f, 167.175f)), owning_building_guid = 4)
+      LocalObject(656, Door.Constructor(Vector3(1185.893f, 979.4791f, 167.175f)), owning_building_guid = 4)
+      LocalObject(659, Door.Constructor(Vector3(1206.465f, 951.1635f, 167.175f)), owning_building_guid = 4)
+      LocalObject(660, Door.Constructor(Vector3(1210.317f, 975.6251f, 167.175f)), owning_building_guid = 4)
+      LocalObject(729, Painbox.Constructor(Vector3(1196.204f, 965.1011f, 173.748f), painbox_continuous), owning_building_guid = 4)
+    }
+
+    Building10081()
+
+    def Building10081(): Unit = { // Name: ceiling_bldg_e_10081 Type: ceiling_bldg_e GUID: 5, MapID: 10081
+      LocalBuilding("ceiling_bldg_e_10081", 5, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.06f, 914.38f, 179.45f), ceiling_bldg_e)))
+      LocalObject(635, Door.Constructor(Vector3(1108.343f, 940.5333f, 186.729f)), owning_building_guid = 5)
+      LocalObject(636, Door.Constructor(Vector3(1120.104f, 905.3209f, 181.229f)), owning_building_guid = 5)
+      LocalObject(637, Door.Constructor(Vector3(1122.273f, 947.7385f, 181.229f)), owning_building_guid = 5)
+      LocalObject(642, Door.Constructor(Vector3(1140.482f, 937.5197f, 186.729f)), owning_building_guid = 5)
+    }
+
+    Building10080()
+
+    def Building10080(): Unit = { // Name: ceiling_bldg_f_10080 Type: ceiling_bldg_f GUID: 6, MapID: 10080
+      LocalBuilding("ceiling_bldg_f_10080", 6, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1059.44f, 1115.66f, 174.49f), ceiling_bldg_f)))
+      LocalObject(618, Door.Constructor(Vector3(1028.562f, 1113.933f, 176.269f)), owning_building_guid = 6)
+      LocalObject(633, Door.Constructor(Vector3(1086.384f, 1106.004f, 176.269f)), owning_building_guid = 6)
+    }
+
+    Building10078()
+
+    def Building10078(): Unit = { // Name: ceiling_bldg_g_10078 Type: ceiling_bldg_g GUID: 7, MapID: 10078
+      LocalBuilding("ceiling_bldg_g_10078", 7, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.34f, 1023.68f, 163.71f), ceiling_bldg_g)))
+      LocalObject(565, Door.Constructor(Vector3(820.356f, 1007.17f, 165.489f)), owning_building_guid = 7)
+      LocalObject(567, Door.Constructor(Vector3(828.356f, 1041.17f, 165.489f)), owning_building_guid = 7)
+    }
+
+    Building10007()
+
+    def Building10007(): Unit = { // Name: ceiling_bldg_h_10007 Type: ceiling_bldg_h GUID: 8, MapID: 10007
+      LocalBuilding("ceiling_bldg_h_10007", 8, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(904.92f, 964.1f, 173.54f), ceiling_bldg_h)))
+      LocalObject(581, Door.Constructor(Vector3(888.43f, 960.116f, 175.319f)), owning_building_guid = 8)
+      LocalObject(591, Door.Constructor(Vector3(908.904f, 980.61f, 175.319f)), owning_building_guid = 8)
+      LocalObject(593, Door.Constructor(Vector3(916.005f, 952.912f, 177.819f)), owning_building_guid = 8)
+    }
+
+    Building10008()
+
+    def Building10008(): Unit = { // Name: ceiling_bldg_i_10008 Type: ceiling_bldg_i GUID: 9, MapID: 10008
+      LocalBuilding("ceiling_bldg_i_10008", 9, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(971.61f, 1193.75f, 179.41f), ceiling_bldg_i)))
+      LocalObject(597, Door.Constructor(Vector3(946.8376f, 1186.718f, 181.189f)), owning_building_guid = 9)
+      LocalObject(607, Door.Constructor(Vector3(996.351f, 1193.677f, 181.189f)), owning_building_guid = 9)
+    }
+
+    Building10238()
+
+    def Building10238(): Unit = { // Name: ceiling_bldg_z_10238 Type: ceiling_bldg_z GUID: 10, MapID: 10238
+      LocalBuilding("ceiling_bldg_z_10238", 10, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(925.94f, 1113.67f, 188.72f), ceiling_bldg_z)))
+      LocalObject(590, Door.Constructor(Vector3(904.9026f, 1088.561f, 190.499f)), owning_building_guid = 10)
+      LocalObject(596, Door.Constructor(Vector3(946.5898f, 1127.435f, 190.499f)), owning_building_guid = 10)
+    }
+
+    Building10009()
+
+    def Building10009(): Unit = { // Name: ground_bldg_a_10009 Type: ground_bldg_a GUID: 34, MapID: 10009
+      LocalBuilding("ground_bldg_a_10009", 34, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.99f, 1151.14f, 89.94f), ground_bldg_a)))
+      LocalObject(681, Door.Constructor(Vector3(1339.435f, 1163.506f, 91.719f)), owning_building_guid = 34)
+      LocalObject(686, Door.Constructor(Vector3(1366.754f, 1149.312f, 91.719f)), owning_building_guid = 34)
+    }
+
+    Building10003()
+
+    def Building10003(): Unit = { // Name: ground_bldg_b_10003 Type: ground_bldg_b GUID: 35, MapID: 10003
+      LocalBuilding("ground_bldg_b_10003", 35, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(985.91f, 922.1f, 92.93f), ground_bldg_b)))
+      LocalObject(600, Door.Constructor(Vector3(986.4801f, 938.7028f, 94.709f)), owning_building_guid = 35)
+      LocalObject(603, Door.Constructor(Vector3(991.9911f, 921.6182f, 94.709f)), owning_building_guid = 35)
+      LocalObject(610, Door.Constructor(Vector3(1009.814f, 930.2303f, 100.209f)), owning_building_guid = 35)
+    }
+
+    Building10004()
+
+    def Building10004(): Unit = { // Name: ground_bldg_b_10004 Type: ground_bldg_b GUID: 36, MapID: 10004
+      LocalBuilding("ground_bldg_b_10004", 36, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.48f, 1145.29f, 91.97f), ground_bldg_b)))
+      LocalObject(604, Door.Constructor(Vector3(994.1558f, 1123.253f, 99.249f)), owning_building_guid = 36)
+      LocalObject(609, Door.Constructor(Vector3(1001.638f, 1141.579f, 93.749f)), owning_building_guid = 36)
+      LocalObject(612, Door.Constructor(Vector3(1017.166f, 1132.57f, 93.749f)), owning_building_guid = 36)
+    }
+
+    Building10034()
+
+    def Building10034(): Unit = { // Name: ground_bldg_c_10034 Type: ground_bldg_c GUID: 37, MapID: 10034
+      LocalBuilding("ground_bldg_c_10034", 37, 10034, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(825.03f, 1055.17f, 89.45f), ground_bldg_c)))
+      LocalObject(566, Door.Constructor(Vector3(822.3052f, 1058.445f, 91.229f)), owning_building_guid = 37)
+      LocalObject(571, Door.Constructor(Vector3(862.1569f, 1088.588f, 91.229f)), owning_building_guid = 37)
+      LocalObject(576, Door.Constructor(Vector3(872.2495f, 1059.277f, 91.229f)), owning_building_guid = 37)
+    }
+
+    Building10088()
+
+    def Building10088(): Unit = { // Name: ground_bldg_d_10088 Type: ground_bldg_d GUID: 38, MapID: 10088
+      LocalBuilding("ground_bldg_d_10088", 38, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(975.7f, 689.58f, 94.32f), ground_bldg_d)))
+      LocalObject(598, Door.Constructor(Vector3(962.0821f, 700.587f, 96.055f)), owning_building_guid = 38)
+      LocalObject(599, Door.Constructor(Vector3(964.6931f, 675.9621f, 96.055f)), owning_building_guid = 38)
+      LocalObject(601, Door.Constructor(Vector3(986.7192f, 703.1622f, 96.055f)), owning_building_guid = 38)
+      LocalObject(602, Door.Constructor(Vector3(989.2822f, 678.5608f, 96.055f)), owning_building_guid = 38)
+    }
+
+    Building10304()
+
+    def Building10304(): Unit = { // Name: ground_bldg_d_10304 Type: ground_bldg_d GUID: 39, MapID: 10304
+      LocalBuilding("ground_bldg_d_10304", 39, 10304, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.42f, 1071.61f, 100.3f), ground_bldg_d)))
+      LocalObject(620, Door.Constructor(Vector3(1038.179f, 1068.554f, 102.035f)), owning_building_guid = 39)
+      LocalObject(624, Door.Constructor(Vector3(1052.364f, 1088.851f, 102.035f)), owning_building_guid = 39)
+      LocalObject(627, Door.Constructor(Vector3(1058.441f, 1054.383f, 102.035f)), owning_building_guid = 39)
+      LocalObject(631, Door.Constructor(Vector3(1072.647f, 1074.631f, 102.035f)), owning_building_guid = 39)
+    }
+
+    Building10015()
+
+    def Building10015(): Unit = { // Name: ground_bldg_e_10015 Type: ground_bldg_e GUID: 40, MapID: 10015
+      LocalBuilding("ground_bldg_e_10015", 40, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1033.29f, 654.74f, 94.57f), ground_bldg_e)))
+      LocalObject(617, Door.Constructor(Vector3(1027.727f, 629.0727f, 101.849f)), owning_building_guid = 40)
+      LocalObject(621, Door.Constructor(Vector3(1038.441f, 665.6412f, 96.349f)), owning_building_guid = 40)
+      LocalObject(622, Door.Constructor(Vector3(1048.048f, 624.2689f, 96.349f)), owning_building_guid = 40)
+      LocalObject(628, Door.Constructor(Vector3(1059.453f, 635.0347f, 101.849f)), owning_building_guid = 40)
+    }
+
+    Building10386()
+
+    def Building10386(): Unit = { // Name: ground_bldg_f_10386 Type: ground_bldg_f GUID: 41, MapID: 10386
+      LocalBuilding("ground_bldg_f_10386", 41, 10386, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1007.11f, 851.17f, 96.4f), ground_bldg_f)))
+      LocalObject(605, Door.Constructor(Vector3(995.3392f, 877.2592f, 98.179f)), owning_building_guid = 41)
+      LocalObject(619, Door.Constructor(Vector3(1029.802f, 830.1577f, 98.179f)), owning_building_guid = 41)
+    }
+
+    Building10032()
+
+    def Building10032(): Unit = { // Name: ground_bldg_g_10032 Type: ground_bldg_g GUID: 42, MapID: 10032
+      LocalBuilding("ground_bldg_g_10032", 42, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1263.21f, 1006.27f, 98.33f), ground_bldg_g)))
+      LocalObject(671, Door.Constructor(Vector3(1255.226f, 989.76f, 100.109f)), owning_building_guid = 42)
+      LocalObject(673, Door.Constructor(Vector3(1263.226f, 1023.76f, 100.109f)), owning_building_guid = 42)
+    }
+
+    Building10242()
+
+    def Building10242(): Unit = { // Name: ground_bldg_h_10242 Type: ground_bldg_h GUID: 43, MapID: 10242
+      LocalBuilding("ground_bldg_h_10242", 43, 10242, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.36f, 1197.96f, 104.38f), ground_bldg_h)))
+      LocalObject(623, Door.Constructor(Vector3(1050.501f, 1207.053f, 108.659f)), owning_building_guid = 43)
+      LocalObject(629, Door.Constructor(Vector3(1062.303f, 1181.009f, 106.159f)), owning_building_guid = 43)
+      LocalObject(632, Door.Constructor(Vector3(1078.908f, 1204.747f, 106.159f)), owning_building_guid = 43)
+    }
+
+    Building10340()
+
+    def Building10340(): Unit = { // Name: ground_bldg_i_10340 Type: ground_bldg_i GUID: 44, MapID: 10340
+      LocalBuilding("ground_bldg_i_10340", 44, 10340, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(781.58f, 1112.31f, 97.55f), ground_bldg_i)))
+      LocalObject(558, Door.Constructor(Vector3(760.7067f, 1097.229f, 99.329f)), owning_building_guid = 44)
+      LocalObject(564, Door.Constructor(Vector3(804.8541f, 1120.703f, 99.329f)), owning_building_guid = 44)
+    }
+
+    Building10035()
+
+    def Building10035(): Unit = { // Name: ground_bldg_j_10035 Type: ground_bldg_j GUID: 45, MapID: 10035
+      LocalBuilding("ground_bldg_j_10035", 45, 10035, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(853.9f, 1131.82f, 87.35f), ground_bldg_j)))
+      LocalObject(568, Door.Constructor(Vector3(841.6863f, 1134.432f, 89.129f)), owning_building_guid = 45)
+      LocalObject(573, Door.Constructor(Vector3(866.14f, 1129.235f, 89.129f)), owning_building_guid = 45)
+    }
+
+    Building10005()
+
+    def Building10005(): Unit = { // Name: ground_bldg_j_10005 Type: ground_bldg_j GUID: 46, MapID: 10005
+      LocalBuilding("ground_bldg_j_10005", 46, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1062.19f, 885.69f, 92.65f), ground_bldg_j)))
+      LocalObject(626, Door.Constructor(Vector3(1055.949f, 874.848f, 94.429f)), owning_building_guid = 46)
+      LocalObject(630, Door.Constructor(Vector3(1068.449f, 896.4987f, 94.429f)), owning_building_guid = 46)
+    }
+
+    Building10229()
+
+    def Building10229(): Unit = { // Name: ground_bldg_z_10229 Type: ground_bldg_z GUID: 47, MapID: 10229
+      LocalBuilding("ground_bldg_z_10229", 47, 10229, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.59f, 1275.13f, 89.54f), ground_bldg_z)))
+      LocalObject(569, Door.Constructor(Vector3(856.4307f, 1292.347f, 91.319f)), owning_building_guid = 47)
+      LocalObject(570, Door.Constructor(Vector3(856.5692f, 1271.095f, 102.319f)), owning_building_guid = 47)
+      LocalObject(572, Door.Constructor(Vector3(863.3589f, 1296.347f, 107.819f)), owning_building_guid = 47)
+      LocalObject(577, Door.Constructor(Vector3(874.7871f, 1292.553f, 96.819f)), owning_building_guid = 47)
+      LocalObject(578, Door.Constructor(Vector3(876.4307f, 1257.706f, 96.819f)), owning_building_guid = 47)
+      LocalObject(579, Door.Constructor(Vector3(887.8589f, 1253.912f, 107.819f)), owning_building_guid = 47)
+      LocalObject(585, Door.Constructor(Vector3(894.6122f, 1279.203f, 102.319f)), owning_building_guid = 47)
+      LocalObject(586, Door.Constructor(Vector3(894.7871f, 1257.912f, 91.319f)), owning_building_guid = 47)
+    }
+
+    Building10082()
+
+    def Building10082(): Unit = { // Name: ground_bldg_z_10082 Type: ground_bldg_z GUID: 48, MapID: 10082
+      LocalBuilding("ground_bldg_z_10082", 48, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1207.32f, 852.88f, 95.64f), ground_bldg_z)))
+      LocalObject(654, Door.Constructor(Vector3(1182.81f, 844.864f, 97.419f)), owning_building_guid = 48)
+      LocalObject(655, Door.Constructor(Vector3(1182.81f, 852.864f, 113.919f)), owning_building_guid = 48)
+      LocalObject(657, Door.Constructor(Vector3(1191.81f, 860.864f, 102.919f)), owning_building_guid = 48)
+      LocalObject(658, Door.Constructor(Vector3(1201.336f, 834.37f, 108.419f)), owning_building_guid = 48)
+      LocalObject(661, Door.Constructor(Vector3(1213.336f, 871.37f, 108.419f)), owning_building_guid = 48)
+      LocalObject(662, Door.Constructor(Vector3(1222.81f, 844.864f, 102.919f)), owning_building_guid = 48)
+      LocalObject(663, Door.Constructor(Vector3(1231.81f, 852.864f, 113.919f)), owning_building_guid = 48)
+      LocalObject(664, Door.Constructor(Vector3(1231.81f, 860.864f, 97.419f)), owning_building_guid = 48)
+    }
+
+    Building10257()
+
+    def Building10257(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 49, MapID: 10257
+      LocalBuilding("N_Redoubt", 49, 10257, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(760.72f, 1359.42f, 99.62f), redoubt)))
+      LocalObject(791, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 49)
+      LocalObject(557, Door.Constructor(Vector3(748.8035f, 1372.222f, 101.355f)), owning_building_guid = 49)
+      LocalObject(559, Door.Constructor(Vector3(761.1804f, 1376.637f, 111.399f)), owning_building_guid = 49)
+      LocalObject(560, Door.Constructor(Vector3(766.8094f, 1370.595f, 111.379f)), owning_building_guid = 49)
+      LocalObject(561, Door.Constructor(Vector3(772.3025f, 1364.752f, 111.379f)), owning_building_guid = 49)
+      LocalObject(562, Door.Constructor(Vector3(772.6735f, 1346.625f, 101.355f)), owning_building_guid = 49)
+      LocalObject(563, Door.Constructor(Vector3(777.9285f, 1358.726f, 111.399f)), owning_building_guid = 49)
+      LocalObject(799, Terminal.Constructor(Vector3(747.0984f, 1346.889f, 99.57581f), vanu_equipment_term), owning_building_guid = 49)
+      LocalObject(802, Terminal.Constructor(Vector3(774.4174f, 1372.171f, 99.5735f), vanu_equipment_term), owning_building_guid = 49)
+      LocalObject(739, SpawnTube.Constructor(Vector3(760.72f, 1359.42f, 99.62f), Vector3(0, 0, 227)), owning_building_guid = 49)
+      LocalObject(726, Painbox.Constructor(Vector3(760.9607f, 1359.588f, 107.409f), painbox_continuous), owning_building_guid = 49)
+    }
+
+    Building10259()
+
+    def Building10259(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 50, MapID: 10259
+      LocalBuilding("S_Redoubt", 50, 10259, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1253.48f, 805.8f, 85.1f), redoubt)))
+      LocalObject(794, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 50)
+      LocalObject(665, Door.Constructor(Vector3(1237.635f, 813.2061f, 86.835f)), owning_building_guid = 50)
+      LocalObject(667, Door.Constructor(Vector3(1247.457f, 821.9362f, 96.879f)), owning_building_guid = 50)
+      LocalObject(670, Door.Constructor(Vector3(1254.94f, 818.4426f, 96.859f)), owning_building_guid = 50)
+      LocalObject(672, Door.Constructor(Vector3(1262.222f, 815.0822f, 96.859f)), owning_building_guid = 50)
+      LocalObject(674, Door.Constructor(Vector3(1269.356f, 798.4144f, 86.835f)), owning_building_guid = 50)
+      LocalObject(675, Door.Constructor(Vector3(1269.696f, 811.6027f, 96.879f)), owning_building_guid = 50)
+      LocalObject(839, Terminal.Constructor(Vector3(1245.545f, 789.0786f, 85.0558f), vanu_equipment_term), owning_building_guid = 50)
+      LocalObject(842, Terminal.Constructor(Vector3(1261.403f, 822.7539f, 85.0535f), vanu_equipment_term), owning_building_guid = 50)
+      LocalObject(740, SpawnTube.Constructor(Vector3(1253.48f, 805.8f, 85.1f), Vector3(0, 0, 205)), owning_building_guid = 50)
+      LocalObject(730, Painbox.Constructor(Vector3(1253.64f, 806.0459f, 92.889f), painbox_continuous), owning_building_guid = 50)
+    }
+
+    Building10001()
+
+    def Building10001(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 203, MapID: 10001
+      LocalBuilding("S_Stasis", 203, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.15f, 874.23f, 93.26f), vanu_control_point)))
+      LocalObject(792, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 203)
+      LocalObject(574, Door.Constructor(Vector3(867.9634f, 853.3779f, 95.039f)), owning_building_guid = 203)
+      LocalObject(575, Door.Constructor(Vector3(871.7762f, 899.1088f, 95.039f)), owning_building_guid = 203)
+      LocalObject(580, Door.Constructor(Vector3(888.4708f, 862.9407f, 125.039f)), owning_building_guid = 203)
+      LocalObject(582, Door.Constructor(Vector3(889.0839f, 875.7824f, 99.98f)), owning_building_guid = 203)
+      LocalObject(583, Door.Constructor(Vector3(891.4683f, 870.6323f, 125.019f)), owning_building_guid = 203)
+      LocalObject(584, Door.Constructor(Vector3(894.1799f, 878.179f, 125.019f)), owning_building_guid = 203)
+      LocalObject(587, Door.Constructor(Vector3(896.2295f, 860.4051f, 99.98f)), owning_building_guid = 203)
+      LocalObject(588, Door.Constructor(Vector3(896.8278f, 885.9948f, 125.039f)), owning_building_guid = 203)
+      LocalObject(589, Door.Constructor(Vector3(904.438f, 882.9578f, 99.98f)), owning_building_guid = 203)
+      LocalObject(592, Door.Constructor(Vector3(911.6068f, 867.5507f, 99.98f)), owning_building_guid = 203)
+      LocalObject(594, Door.Constructor(Vector3(933.7072f, 833.9666f, 95.039f)), owning_building_guid = 203)
+      LocalObject(595, Door.Constructor(Vector3(942.624f, 894.8666f, 95.039f)), owning_building_guid = 203)
+      LocalObject(808, Terminal.Constructor(Vector3(890.2345f, 869.1371f, 98.277f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(809, Terminal.Constructor(Vector3(891.9105f, 865.5347f, 98.273f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(810, Terminal.Constructor(Vector3(894.1234f, 880.0321f, 98.273f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(811, Terminal.Constructor(Vector3(897.7258f, 881.7081f, 98.277f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(813, Terminal.Constructor(Vector3(902.9813f, 861.585f, 98.277f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(814, Terminal.Constructor(Vector3(906.5131f, 863.2601f, 98.273f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(815, Terminal.Constructor(Vector3(908.7975f, 877.7581f, 98.273f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(816, Terminal.Constructor(Vector3(910.4735f, 874.1556f, 98.277f), vanu_equipment_term), owning_building_guid = 203)
+      LocalObject(860, SpawnTube.Constructor(Vector3(900.3454f, 871.6666f, 98.399f), Vector3(0, 0, 200)), owning_building_guid = 203)
+      LocalObject(727, Painbox.Constructor(Vector3(899.9723f, 871.4819f, 107.6018f), painbox_continuous), owning_building_guid = 203)
+      LocalObject(731, Painbox.Constructor(Vector3(886.9322f, 876.6623f, 101.55f), painbox_door_radius_continuous), owning_building_guid = 203)
+      LocalObject(732, Painbox.Constructor(Vector3(895.3766f, 858.9249f, 102.15f), painbox_door_radius_continuous), owning_building_guid = 203)
+      LocalObject(733, Painbox.Constructor(Vector3(905.1611f, 884.7763f, 102.15f), painbox_door_radius_continuous), owning_building_guid = 203)
+      LocalObject(734, Painbox.Constructor(Vector3(914.3688f, 866.9739f, 102.15f), painbox_door_radius_continuous), owning_building_guid = 203)
+    }
+
+    Building10002()
+
+    def Building10002(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 204, MapID: 10002
+      LocalBuilding("N_Stasis", 204, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1149.27f, 1132.96f, 107.22f), vanu_control_point)))
+      LocalObject(793, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 204)
+      LocalObject(634, Door.Constructor(Vector3(1101.842f, 1109.17f, 108.999f)), owning_building_guid = 204)
+      LocalObject(639, Door.Constructor(Vector3(1136.562f, 1139.138f, 113.94f)), owning_building_guid = 204)
+      LocalObject(640, Door.Constructor(Vector3(1136.582f, 1168.265f, 108.999f)), owning_building_guid = 204)
+      LocalObject(641, Door.Constructor(Vector3(1139.776f, 1122.489f, 113.94f)), owning_building_guid = 204)
+      LocalObject(643, Door.Constructor(Vector3(1140.9f, 1146.053f, 138.999f)), owning_building_guid = 204)
+      LocalObject(644, Door.Constructor(Vector3(1147.638f, 1141.284f, 138.979f)), owning_building_guid = 204)
+      LocalObject(645, Door.Constructor(Vector3(1153.212f, 1142.351f, 113.94f)), owning_building_guid = 204)
+      LocalObject(646, Door.Constructor(Vector3(1154.304f, 1136.827f, 138.979f)), owning_building_guid = 204)
+      LocalObject(647, Door.Constructor(Vector3(1156.459f, 1125.718f, 113.94f)), owning_building_guid = 204)
+      LocalObject(648, Door.Constructor(Vector3(1158.776f, 1085.785f, 108.999f)), owning_building_guid = 204)
+      LocalObject(650, Door.Constructor(Vector3(1161.247f, 1132.367f, 138.999f)), owning_building_guid = 204)
+      LocalObject(652, Door.Constructor(Vector3(1180.032f, 1153.502f, 108.999f)), owning_building_guid = 204)
+      LocalObject(826, Terminal.Constructor(Vector3(1136.074f, 1132.302f, 112.237f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(827, Terminal.Constructor(Vector3(1136.845f, 1128.469f, 112.233f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(828, Terminal.Constructor(Vector3(1142.584f, 1142.088f, 112.233f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(829, Terminal.Constructor(Vector3(1146.458f, 1121.991f, 112.237f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(830, Terminal.Constructor(Vector3(1146.485f, 1142.843f, 112.237f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(831, Terminal.Constructor(Vector3(1150.359f, 1122.745f, 112.233f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(832, Terminal.Constructor(Vector3(1156.116f, 1136.434f, 112.233f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(833, Terminal.Constructor(Vector3(1156.87f, 1132.533f, 112.237f), vanu_equipment_term), owning_building_guid = 204)
+      LocalObject(861, SpawnTube.Constructor(Vector3(1146.494f, 1132.42f, 112.359f), Vector3(0, 0, 304)), owning_building_guid = 204)
+      LocalObject(728, Painbox.Constructor(Vector3(1146.405f, 1132.827f, 121.5618f), painbox_continuous), owning_building_guid = 204)
+      LocalObject(735, Painbox.Constructor(Vector3(1135.332f, 1140.324f, 116.11f), painbox_door_radius_continuous), owning_building_guid = 204)
+      LocalObject(736, Painbox.Constructor(Vector3(1138.548f, 1119.949f, 116.11f), painbox_door_radius_continuous), owning_building_guid = 204)
+      LocalObject(737, Painbox.Constructor(Vector3(1154.586f, 1144.226f, 115.51f), painbox_door_radius_continuous), owning_building_guid = 204)
+      LocalObject(738, Painbox.Constructor(Vector3(1158.049f, 1124.576f, 116.11f), painbox_door_radius_continuous), owning_building_guid = 204)
+    }
+
+    Building10000()
+
+    def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 205, MapID: 10000
+      LocalBuilding("Core", 205, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1028.8f, 1012.78f, 165.78f), vanu_core)))
+      LocalObject(606, Door.Constructor(Vector3(996.3071f, 1000.802f, 172.568f)), owning_building_guid = 205)
+      LocalObject(613, Door.Constructor(Vector3(1024.778f, 972.287f, 172.568f)), owning_building_guid = 205)
+      LocalObject(614, Door.Constructor(Vector3(1024.778f, 972.287f, 177.568f)), owning_building_guid = 205)
+      LocalObject(615, Door.Constructor(Vector3(1024.822f, 1029.273f, 177.568f)), owning_building_guid = 205)
+      LocalObject(616, Door.Constructor(Vector3(1024.822f, 1029.273f, 182.568f)), owning_building_guid = 205)
+      LocalObject(625, Door.Constructor(Vector3(1053.293f, 1000.758f, 182.568f)), owning_building_guid = 205)
+    }
+
+    Building10246()
+
+    def Building10246(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 231, MapID: 10246
+      LocalBuilding("N_ATPlant", 231, 10246, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(739.86f, 1264.38f, 82.47f), vanu_vehicle_station)))
+      LocalObject(790, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 231)
+      LocalObject(549, Door.Constructor(Vector3(684.2806f, 1258.55f, 114.249f)), owning_building_guid = 231)
+      LocalObject(550, Door.Constructor(Vector3(688.5319f, 1265.615f, 114.229f)), owning_building_guid = 231)
+      LocalObject(551, Door.Constructor(Vector3(692.6342f, 1272.507f, 114.229f)), owning_building_guid = 231)
+      LocalObject(552, Door.Constructor(Vector3(696.8887f, 1279.533f, 114.249f)), owning_building_guid = 231)
+      LocalObject(553, Door.Constructor(Vector3(710.3329f, 1224.244f, 84.249f)), owning_building_guid = 231)
+      LocalObject(554, Door.Constructor(Vector3(714.447f, 1231.091f, 104.173f)), owning_building_guid = 231)
+      LocalObject(555, Door.Constructor(Vector3(718.8141f, 1284.958f, 104.161f)), owning_building_guid = 231)
+      LocalObject(556, Door.Constructor(Vector3(743.5565f, 1279.537f, 84.249f)), owning_building_guid = 231)
+      LocalObject(687, Door.Constructor(Vector3(675.4597f, 1282.781f, 89.103f)), owning_building_guid = 231)
+      LocalObject(785, Terminal.Constructor(Vector3(705.5295f, 1244.009f, 102.387f), vanu_air_vehicle_term), owning_building_guid = 231)
+      LocalObject(863, VehicleSpawnPad.Constructor(Vector3(713.2993f, 1248.321f, 102.386f), vanu_vehicle_creation_pad, Vector3(0, 0, 121)), owning_building_guid = 231, terminal_guid = 785)
+      LocalObject(786, Terminal.Constructor(Vector3(723.7557f, 1274.36f, 102.387f), vanu_air_vehicle_term), owning_building_guid = 231)
+      LocalObject(864, VehicleSpawnPad.Constructor(Vector3(723.6083f, 1265.478f, 102.386f), vanu_vehicle_creation_pad, Vector3(0, 0, 121)), owning_building_guid = 231, terminal_guid = 786)
+      LocalObject(796, Terminal.Constructor(Vector3(702.5449f, 1252.534f, 84.97f), vanu_equipment_term), owning_building_guid = 231)
+      LocalObject(797, Terminal.Constructor(Vector3(714.9058f, 1273.106f, 84.97f), vanu_equipment_term), owning_building_guid = 231)
+      LocalObject(868, Terminal.Constructor(Vector3(703.9712f, 1265.516f, 87.47f), vanu_vehicle_term), owning_building_guid = 231)
+      LocalObject(862, VehicleSpawnPad.Constructor(Vector3(691.0519f, 1273.405f, 84.875f), vanu_vehicle_creation_pad, Vector3(0, 0, -59)), owning_building_guid = 231, terminal_guid = 868)
+    }
+
+    Building10248()
+
+    def Building10248(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 232, MapID: 10248
+      LocalBuilding("S_ATPlant", 232, 10248, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1304.12f, 799.11f, 83.07f), vanu_vehicle_station)))
+      LocalObject(795, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 232)
+      LocalObject(677, Door.Constructor(Vector3(1298.604f, 784.5164f, 84.849f)), owning_building_guid = 232)
+      LocalObject(678, Door.Constructor(Vector3(1322.501f, 776.121f, 104.761f)), owning_building_guid = 232)
+      LocalObject(679, Door.Constructor(Vector3(1333.401f, 829.0539f, 104.773f)), owning_building_guid = 232)
+      LocalObject(680, Door.Constructor(Vector3(1338.318f, 835.3486f, 84.849f)), owning_building_guid = 232)
+      LocalObject(682, Door.Constructor(Vector3(1344.924f, 778.8329f, 114.849f)), owning_building_guid = 232)
+      LocalObject(683, Door.Constructor(Vector3(1350.003f, 785.2883f, 114.829f)), owning_building_guid = 232)
+      LocalObject(684, Door.Constructor(Vector3(1354.915f, 791.6285f, 114.829f)), owning_building_guid = 232)
+      LocalObject(685, Door.Constructor(Vector3(1359.996f, 798.1234f, 114.849f)), owning_building_guid = 232)
+      LocalObject(688, Door.Constructor(Vector3(1365.798f, 772.9979f, 89.703f)), owning_building_guid = 232)
+      LocalObject(787, Terminal.Constructor(Vector3(1318.888f, 787.242f, 102.987f), vanu_air_vehicle_term), owning_building_guid = 232)
+      LocalObject(865, VehicleSpawnPad.Constructor(Vector3(1320.117f, 796.0395f, 102.986f), vanu_vehicle_creation_pad, Vector3(0, 0, -52)), owning_building_guid = 232, terminal_guid = 787)
+      LocalObject(788, Terminal.Constructor(Vector3(1340.677f, 815.1455f, 102.987f), vanu_air_vehicle_term), owning_building_guid = 232)
+      LocalObject(866, VehicleSpawnPad.Constructor(Vector3(1332.44f, 811.8123f, 102.986f), vanu_vehicle_creation_pad, Vector3(0, 0, -52)), owning_building_guid = 232, terminal_guid = 788)
+      LocalObject(846, Terminal.Constructor(Vector3(1327.825f, 787.4082f, 85.57f), vanu_equipment_term), owning_building_guid = 232)
+      LocalObject(847, Terminal.Constructor(Vector3(1342.601f, 806.3204f, 85.57f), vanu_equipment_term), owning_building_guid = 232)
+      LocalObject(869, Terminal.Constructor(Vector3(1339.603f, 793.6083f, 88.07f), vanu_vehicle_term), owning_building_guid = 232)
+      LocalObject(867, VehicleSpawnPad.Constructor(Vector3(1351.464f, 784.2039f, 85.475f), vanu_vehicle_creation_pad, Vector3(0, 0, 128)), owning_building_guid = 232, terminal_guid = 869)
+    }
+
+    Building10225()
+
+    def Building10225(): Unit = { // Name: GW_Cavern6_W Type: warpgate_cavern GUID: 233, MapID: 10225
+      LocalBuilding("GW_Cavern6_W", 233, 10225, FoundationBuilder(WarpGate.Structure(Vector3(281.98f, 637.77f, 60.83f))))
+    }
+
+    Building10224()
+
+    def Building10224(): Unit = { // Name: GW_Cavern6_N Type: warpgate_cavern GUID: 234, MapID: 10224
+      LocalBuilding("GW_Cavern6_N", 234, 10224, FoundationBuilder(WarpGate.Structure(Vector3(1093.93f, 2082.3f, 80.82f))))
+    }
+
+    Building10226()
+
+    def Building10226(): Unit = { // Name: GW_Cavern6_S Type: warpgate_cavern GUID: 235, MapID: 10226
+      LocalBuilding("GW_Cavern6_S", 235, 10226, FoundationBuilder(WarpGate.Structure(Vector3(1218.27f, 218.05f, 100.82f))))
+    }
+
+    Building10227()
+
+    def Building10227(): Unit = { // Name: GW_Cavern6_E Type: warpgate_cavern GUID: 236, MapID: 10227
+      LocalBuilding("GW_Cavern6_E", 236, 10227, FoundationBuilder(WarpGate.Structure(Vector3(1986.27f, 922.08f, 20.82f))))
+    }
+
+    ZoneOwnedObjects()
+
+    def ZoneOwnedObjects(): Unit = {
+      LocalObject(798, Terminal.Constructor(Vector3(746.59f, 1360.06f, 99.58f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(800, Terminal.Constructor(Vector3(760.13f, 1345.53f, 99.58f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(801, Terminal.Constructor(Vector3(761.34f, 1373.51f, 99.58f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(803, Terminal.Constructor(Vector3(774.88f, 1358.94f, 99.58f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(804, Terminal.Constructor(Vector3(867.18f, 1080.28f, 89.45f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(805, Terminal.Constructor(Vector3(871.23f, 1068f, 89.45f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(806, Terminal.Constructor(Vector3(873.46f, 1273.87f, 100.52f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(807, Terminal.Constructor(Vector3(877.77f, 1276.37f, 100.52f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(812, Terminal.Constructor(Vector3(901.33f, 949.3f, 176.04f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(817, Terminal.Constructor(Vector3(919.88f, 968.41f, 176.04f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(818, Terminal.Constructor(Vector3(968.73f, 1210.66f, 179.41f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(819, Terminal.Constructor(Vector3(974.72f, 1169.48f, 179.41f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(820, Terminal.Constructor(Vector3(996.15f, 1132.13f, 97.47f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(821, Terminal.Constructor(Vector3(1007.58f, 1125.96f, 91.97f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(822, Terminal.Constructor(Vector3(1015.53f, 643.92f, 94.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(823, Terminal.Constructor(Vector3(1048.62f, 890.34f, 92.65f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(824, Terminal.Constructor(Vector3(1050.16f, 654.59f, 94.56f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(825, Terminal.Constructor(Vector3(1075.73f, 880.84f, 92.65f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(834, Terminal.Constructor(Vector3(1193.54f, 969.01f, 167.4f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(835, Terminal.Constructor(Vector3(1198.76f, 961.62f, 167.4f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(836, Terminal.Constructor(Vector3(1207.29f, 837.52f, 116.64f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(837, Terminal.Constructor(Vector3(1207.35f, 868.13f, 116.64f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(838, Terminal.Constructor(Vector3(1240.36f, 801.01f, 85.06f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(840, Terminal.Constructor(Vector3(1248.79f, 818.76f, 85.06f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(841, Terminal.Constructor(Vector3(1258.22f, 792.85f, 85.06f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(843, Terminal.Constructor(Vector3(1263.08f, 997.75f, 100.83f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(844, Terminal.Constructor(Vector3(1263.42f, 1014.84f, 100.83f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(845, Terminal.Constructor(Vector3(1266.79f, 810.47f, 85.06f), vanu_equipment_term), owning_building_guid = 0)
+      LocalObject(12, ProximityTerminal.Constructor(Vector3(1172.58f, 709.8f, 81.4f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(703, ProximityTerminal.Constructor(Vector3(857.28f, 1126.68f, 87.35f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(704, ProximityTerminal.Constructor(Vector3(978.1f, 685.44f, 96.28f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(705, ProximityTerminal.Constructor(Vector3(997.47f, 936.4f, 98.43f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(706, ProximityTerminal.Constructor(Vector3(1144.78f, 920.28f, 179.44f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(707, ProximityTerminal.Constructor(Vector3(1207.19f, 849.69f, 106.62f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(708, ProximityTerminal.Constructor(Vector3(1256.2f, 1050.93f, 170.44f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(709, ProximityTerminal.Constructor(Vector3(1350.98f, 1147.12f, 89.94f), crystals_health_a), owning_building_guid = 0)
+      LocalObject(710, ProximityTerminal.Constructor(Vector3(828.19f, 1024.07f, 166.21f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(711, ProximityTerminal.Constructor(Vector3(887.15f, 1281.71f, 110.54f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(712, ProximityTerminal.Constructor(Vector3(1055.56f, 1071.61f, 102.26f), crystals_health_b), owning_building_guid = 0)
+      LocalObject(713, ProximityTerminal.Constructor(Vector3(1069.99f, 1127.29f, 174.49f), crystals_health_b), owning_building_guid = 0)
+    }
+
+    def Lattice(): Unit = {
+      LatticeLink("N_Redoubt", "N_ATPlant")
+      LatticeLink("GW_Cavern6_W", "N_ATPlant")
+      LatticeLink("N_Stasis", "Core")
+      LatticeLink("S_Stasis", "Core")
+      LatticeLink("S_Redoubt", "S_ATPlant")
+      LatticeLink("N_Redoubt", "N_Stasis")
+      LatticeLink("S_Redoubt", "S_Stasis")
+      LatticeLink("S_Stasis", "N_ATPlant")
+      LatticeLink("N_Stasis", "S_ATPlant")
+      LatticeLink("GW_Cavern6_N", "N_Redoubt")
+      LatticeLink("GW_Cavern6_E", "S_Redoubt")
+      LatticeLink("GW_Cavern6_S", "S_ATPlant")
+    }
+
+    Lattice()
+
+    def ZipLines(): Unit = {
+      ZipLinePaths(new ZipLinePath(1, true, List(Vector3(736.484f, 1292.551f, 102.746f), Vector3(733.296f, 1284.238f, 85.32f))))
+      ZipLinePaths(new ZipLinePath(2, false, List(Vector3(797.258f, 1095.976f, 107.883f), Vector3(821.79f, 1046.854f, 164.56f))))
+      ZipLinePaths(new ZipLinePath(3, false, List(Vector3(830.324f, 1048.307f, 164.563f), Vector3(930.348f, 1184.376f, 180.261f))))
+      ZipLinePaths(new ZipLinePath(4, false, List(Vector3(831.267f, 1000.379f, 164.567f), Vector3(878.283f, 967.178f, 174.45f))))
+      ZipLinePaths(new ZipLinePath(5, false, List(Vector3(850.911f, 1030.282f, 164.806f), Vector3(851.274f, 1033.241f, 164.292f), Vector3(862.522f, 1124.985f, 97.195f))))
+      ZipLinePaths(new ZipLinePath(6, true, List(Vector3(872.544f, 1280.257f, 106.39f), Vector3(873.173f, 1280.791f, 100.874f))))
+      ZipLinePaths(new ZipLinePath(7, false, List(Vector3(877.178f, 991.846f, 175.71f), Vector3(851.866f, 1023.792f, 167.996f))))
+      ZipLinePaths(new ZipLinePath(8, true, List(Vector3(877.484f, 1269.249f, 100.874f), Vector3(879.568f, 1268.493f, 106.39f))))
+      ZipLinePaths(new ZipLinePath(9, false, List(Vector3(890.759f, 1249.269f, 106.891f), Vector3(929.721f, 1191.344f, 180.248f), Vector3(930.978f, 1189.476f, 180.258f))))
+      ZipLinePaths(new ZipLinePath(10, false, List(Vector3(906.216f, 993.369f, 174.363f), Vector3(904.343f, 1081.134f, 189.577f))))
+      ZipLinePaths(new ZipLinePath(11, false, List(Vector3(897.3f, 1088.55f, 189.596f), Vector3(893.393f, 1085.86f, 189.107f), Vector3(834.797f, 1045.518f, 164.587f))))
+      ZipLinePaths(new ZipLinePath(12, false, List(Vector3(919.03f, 892.661f, 124.113f), Vector3(946.681f, 941.791f, 118.324f))))
+      ZipLinePaths(new ZipLinePath(13, false, List(Vector3(935.446f, 1097.096f, 178.111f), Vector3(987.271f, 1008.196f, 171.632f))))
+      ZipLinePaths(new ZipLinePath(14, false, List(Vector3(931.487f, 1179.55f, 180.267f), Vector3(945.998f, 1134.391f, 189.579f))))
+      ZipLinePaths(new ZipLinePath(15, false, List(Vector3(941.35f, 952.9f, 118.301f), Vector3(997.19f, 982.882f, 116.193f))))
+      ZipLinePaths(new ZipLinePath(16, true, List(Vector3(979.744f, 928.34f, 93.272f), Vector3(979.439f, 928.257f, 98.779f))))
+      ZipLinePaths(new ZipLinePath(17, false, List(Vector3(988.07f, 993.856f, 171.603f), Vector3(930.176f, 982.283f, 174.075f))))
+      ZipLinePaths(new ZipLinePath(18, false, List(Vector3(991.738f, 887.327f, 163.802f), Vector3(925.305f, 953.451f, 176.895f))))
+      ZipLinePaths(new ZipLinePath(19, false, List(Vector3(1004.142f, 905.185f, 163.947f), Vector3(1015.49f, 963.547f, 171.569f))))
+      ZipLinePaths(new ZipLinePath(20, false, List(Vector3(1005.402f, 1400.078f, 123.017f), Vector3(864.789f, 1301.178f, 106.891f))))
+      ZipLinePaths(new ZipLinePath(21, true, List(Vector3(1006.212f, 1018.303f, 176.13f), Vector3(1006.335f, 1018.239f, 181.13f))))
+      ZipLinePaths(new ZipLinePath(22, true, List(Vector3(1006.301f, 869.097f, 163.281f), Vector3(1006.262f, 868.834f, 168.788f))))
+      ZipLinePaths(new ZipLinePath(23, true, List(Vector3(1007.402f, 983.651f, 171.13f), Vector3(1007.46f, 983.67f, 176.13f))))
+      ZipLinePaths(new ZipLinePath(24, true, List(Vector3(1008.926f, 1018.168f, 166.13f), Vector3(1008.886f, 1018.146f, 171.13f))))
+      ZipLinePaths(new ZipLinePath(25, false, List(Vector3(1006.662f, 832.842f, 112.39f), Vector3(918.117f, 946.097f, 176.938f))))
+      ZipLinePaths(new ZipLinePath(26, false, List(Vector3(1012.99f, 1201.236f, 180.278f), Vector3(1020.024f, 1402.671f, 123.084f))))
+      ZipLinePaths(new ZipLinePath(27, false, List(Vector3(1014.401f, 1192.4f, 180.259f), Vector3(1024.248f, 1120.21f, 175.306f))))
+      ZipLinePaths(new ZipLinePath(28, true, List(Vector3(1015.772f, 1144.392f, 92.312f), Vector3(1015.304f, 1144.907f, 97.818f))))
+      ZipLinePaths(new ZipLinePath(29, false, List(Vector3(1018.083f, 962.352f, 176.63f), Vector3(1015.899f, 960.875f, 176.124f), Vector3(948.199f, 915.089f, 102.837f))))
+      ZipLinePaths(new ZipLinePath(30, false, List(Vector3(1019.599f, 1038.769f, 181.6f), Vector3(1026.673f, 1104.455f, 175.304f))))
+      ZipLinePaths(new ZipLinePath(31, false, List(Vector3(1019.603f, 1108.067f, 175.312f), Vector3(957.962f, 1127.949f, 189.078f), Vector3(953.853f, 1129.275f, 189.58f))))
+      ZipLinePaths(new ZipLinePath(32, false, List(Vector3(1028.221f, 1036.732f, 176.631f), Vector3(1014.174f, 1136.949f, 112.501f))))
+      ZipLinePaths(new ZipLinePath(33, false, List(Vector3(1029.711f, 964.586f, 176.63f), Vector3(1030.75f, 962.27f, 176.113f), Vector3(1062.96f, 890.468f, 102.494f))))
+      ZipLinePaths(new ZipLinePath(34, false, List(Vector3(1030.361f, 963.633f, 171.579f), Vector3(1102.77f, 942.405f, 185.802f))))
+      ZipLinePaths(new ZipLinePath(35, true, List(Vector3(1041.412f, 1017.873f, 166.13f), Vector3(1041.577f, 1018.02f, 176.13f))))
+      ZipLinePaths(new ZipLinePath(36, true, List(Vector3(1042.555f, 983.339f, 176.13f), Vector3(1042.784f, 983.227f, 181.13f))))
+      ZipLinePaths(new ZipLinePath(37, true, List(Vector3(1042.968f, 984.255f, 166.13f), Vector3(1043.026f, 984.175f, 171.13f))))
+      ZipLinePaths(new ZipLinePath(38, false, List(Vector3(1049.448f, 1122.065f, 106.348f), Vector3(925.736f, 986.791f, 174.108f))))
+      ZipLinePaths(new ZipLinePath(39, false, List(Vector3(1050.181f, 996.471f, 116.194f), Vector3(1094.395f, 1021.971f, 119.888f), Vector3(1100.711f, 1025.614f, 119.731f))))
+      ZipLinePaths(new ZipLinePath(40, false, List(Vector3(1062.232f, 1012.159f, 181.756f), Vector3(1108.189f, 1029.232f, 172.319f))))
+      ZipLinePaths(new ZipLinePath(41, false, List(Vector3(1064.671f, 626.333f, 102.048f), Vector3(1150.823f, 607.773f, 107.952f))))
+      ZipLinePaths(new ZipLinePath(42, false, List(Vector3(1080.843f, 1098.006f, 175.309f), Vector3(1033.702f, 1041.054f, 181.641f))))
+      ZipLinePaths(new ZipLinePath(43, false, List(Vector3(1094.15f, 1103.925f, 175.33f), Vector3(1131.292f, 1068.319f, 169.536f))))
+      ZipLinePaths(new ZipLinePath(44, false, List(Vector3(1100.778f, 938.989f, 185.807f), Vector3(1021.232f, 892.206f, 163.757f))))
+      ZipLinePaths(new ZipLinePath(45, false, List(Vector3(1111.653f, 1051.984f, 172.311f), Vector3(1086.377f, 1100.131f, 175.317f))))
+      ZipLinePaths(new ZipLinePath(46, false, List(Vector3(1119.839f, 953.53f, 180.529f), Vector3(1064.102f, 992.538f, 181.578f))))
+      ZipLinePaths(new ZipLinePath(47, false, List(Vector3(1122.09f, 1126.956f, 138.079f), Vector3(1100.116f, 1034.584f, 119.739f))))
+      ZipLinePaths(new ZipLinePath(48, false, List(Vector3(1154.562f, 615.219f, 107.973f), Vector3(1060.824f, 665.928f, 95.423f))))
+      ZipLinePaths(new ZipLinePath(49, false, List(Vector3(1173.53f, 947.864f, 166.273f), Vector3(1146.927f, 940.176f, 185.27f), Vector3(1145.154f, 939.664f, 185.791f))))
+      ZipLinePaths(new ZipLinePath(50, false, List(Vector3(1177.347f, 857.502f, 112.991f), Vector3(1134.971f, 902.085f, 179.808f), Vector3(1133.604f, 903.523f, 180.296f))))
+      ZipLinePaths(new ZipLinePath(51, false, List(Vector3(1177.818f, 984.919f, 166.285f), Vector3(1171.66f, 1033.014f, 172.314f))))
+      ZipLinePaths(new ZipLinePath(52, true, List(Vector3(1202.167f, 852.92f, 112.49f), Vector3(1201.179f, 854.737f, 106.974f))))
+      ZipLinePaths(new ZipLinePath(53, true, List(Vector3(1213.359f, 851.26f, 106.974f), Vector3(1212.823f, 852.659f, 112.49f))))
+      ZipLinePaths(new ZipLinePath(54, false, List(Vector3(1213.7f, 680.904f, 133.639f), Vector3(1210.939f, 676.835f, 133.114f), Vector3(1169.527f, 615.806f, 108.011f))))
+      ZipLinePaths(new ZipLinePath(55, false, List(Vector3(1224.856f, 696.306f, 132.937f), Vector3(1237.086f, 848.842f, 112.994f))))
+      ZipLinePaths(new ZipLinePath(56, false, List(Vector3(1251.865f, 1025.854f, 176.802f), Vector3(1221.815f, 988.86f, 166.322f))))
+      ZipLinePaths(new ZipLinePath(57, false, List(Vector3(1280.512f, 1055.381f, 171.316f), Vector3(1376.507f, 1189.917f, 117.236f))))
+      ZipLinePaths(new ZipLinePath(58, true, List(Vector3(1304.143f, 770.517f, 103.346f), Vector3(1307.887f, 777.753f, 85.92f))))
+      ZipLinePaths(new ZipLinePath(59, true, List(Vector3(1346.959f, 827.541f, 85.92f), Vector3(1351.629f, 834.391f, 103.346f))))
+      ZipLinePaths(new ZipLinePath(60, true, List(Vector3(1373.997f, 1180.755f, 83.698f), Vector3(1376.644f, 1197.211f, 116.71f))))
+      ZipLinePaths(new ZipLinePath(61, false, List(Vector3(1376.099f, 1104.824f, 108.05f), Vector3(1271.454f, 1067.596f, 170.802f), Vector3(1269.793f, 1067.005f, 171.301f))))
+      ZipLinePaths(new ZipLinePath(62, true, List(Vector3(1381.237f, 1195.832f, 116.71f), Vector3(1384.165f, 1181.39f, 83.698f))))
+      ZipLinePaths(new ZipLinePath(63, false, List(Vector3(1381.497f, 1187.474f, 117.214f), Vector3(1389.994f, 1112.664f, 107.947f))))
+      ZipLinePaths(new ZipLinePath(64, false, List(Vector3(627.092f, 916.732f, 118.239f), Vector3(822.396f, 868.007f, 92.658f))))
+      ZipLinePaths(new ZipLinePath(65, false, List(Vector3(854.65f, 866.898f, 124.13f), Vector3(816.091f, 1002.187f, 164.58f))))
+      ZipLinePaths(new ZipLinePath(66, true, List(Vector3(1260.882f, 821.364f, 85.406f), Vector3(1240.71f, 805.898f, 95.45f))))
+      ZipLinePaths(new ZipLinePath(67, true, List(Vector3(1260.807f, 798f, 95.45f), Vector3(1246.127f, 790.09f, 85.406f))))
+      ZipLinePaths(new ZipLinePath(68, false, List(Vector3(993.401f, 705.41f, 95.203f), Vector3(1117.34f, 894.464f, 180.386f), Vector3(1119.307f, 897.465f, 180.316f))))
+      ZipLinePaths(new ZipLinePath(69, false, List(Vector3(1231.631f, 873.279f, 101.99f), Vector3(1252.107f, 977.047f, 99.195f))))
+      ZipLinePaths(new ZipLinePath(70, false, List(Vector3(1297.144f, 960.064f, 110.671f), Vector3(1230.772f, 978.768f, 166.333f), Vector3(1226.347f, 980.015f, 166.311f))))
+      ZipLinePaths(new ZipLinePath(71, false, List(Vector3(1184.828f, 1039.951f, 169.627f), Vector3(1238.524f, 1034.453f, 171.286f))))
+      ZipLinePaths(new ZipLinePath(72, false, List(Vector3(1300.449f, 972.002f, 110.737f), Vector3(1183.438f, 1032.292f, 173.593f), Vector3(1175.637f, 1036.312f, 172.356f))))
+      ZipLinePaths(new ZipLinePath(73, false, List(Vector3(1216.71f, 879.307f, 107.531f), Vector3(1241.241f, 1027.486f, 170.833f), Vector3(1242.032f, 1032.266f, 171.265f))))
+      ZipLinePaths(new ZipLinePath(74, false, List(Vector3(1176.666f, 1142.367f, 138.11f), Vector3(1168.297f, 1081.591f, 171.87f), Vector3(1167.739f, 1077.54f, 172.35f))))
+      ZipLinePaths(new ZipLinePath(75, false, List(Vector3(1152.799f, 1174.853f, 138.109f), Vector3(1103.141f, 1132.14f, 174.215f), Vector3(1099.831f, 1129.292f, 174.744f))))
+      ZipLinePaths(new ZipLinePath(76, false, List(Vector3(1123.628f, 1194.305f, 107.551f), Vector3(1020.93f, 1196.254f, 180.315f), Vector3(1014.084f, 1196.384f, 180.259f))))
+      ZipLinePaths(new ZipLinePath(77, true, List(Vector3(747.901f, 1347.392f, 99.926f), Vector3(749.063f, 1364.266f, 109.97f))))
+      ZipLinePaths(new ZipLinePath(78, true, List(Vector3(764.978f, 1349.413f, 109.97f), Vector3(773.404f, 1371.263f, 99.926f))))
+      ZipLinePaths(new ZipLinePath(79, false, List(Vector3(832.845f, 1322.466f, 92.854f), Vector3(852.713f, 1315.965f, 90.02f))))
+      ZipLinePaths(new ZipLinePath(80, false, List(Vector3(827.617f, 1279.218f, 92.551f), Vector3(811.451f, 1305.666f, 92.85f))))
+      ZipLinePaths(new ZipLinePath(81, false, List(Vector3(735.485f, 1339.063f, 99.673f), Vector3(715.854f, 1302.093f, 103.238f))))
+      ZipLinePaths(new ZipLinePath(82, false, List(Vector3(767.646f, 1325.436f, 99.674f), Vector3(782.281f, 1261.401f, 92.453f))))
+      ZipLinePaths(new ZipLinePath(83, false, List(Vector3(854.91f, 1298.24f, 106.892f), Vector3(794.221f, 1358.634f, 99.673f))))
+      ZipLinePaths(new ZipLinePath(84, false, List(Vector3(833.177f, 1339.31f, 92.853f), Vector3(855.999f, 1333.167f, 90.019f))))
+      ZipLinePaths(new ZipLinePath(85, false, List(Vector3(909.731f, 849.693f, 124.164f), Vector3(990.096f, 872.508f, 163.851f))))
+      ZipLinePaths(new ZipLinePath(86, false, List(Vector3(980.443f, 931.687f, 114.255f), Vector3(892.726f, 938.268f, 173.636f), Vector3(886.878f, 938.707f, 174.076f))))
+      ZipLinePaths(new ZipLinePath(87, false, List(Vector3(1202.692f, 861.073f, 121.781f), Vector3(1207.235f, 934.6f, 165.81f), Vector3(1207.537f, 939.502f, 166.299f))))
+      ZipLinePaths(new ZipLinePath(88, false, List(Vector3(1236.684f, 860.28f, 112.99f), Vector3(1300.068f, 959.856f, 110.671f))))
+      ZipLinePaths(new ZipLinePath(89, true, List(Vector3(1314.086f, 962.603f, 87.15f), Vector3(1305.694f, 964.636f, 110.181f))))
+      ZipLinePaths(new ZipLinePath(90, true, List(Vector3(1310.533f, 963.493f, 110.206f), Vector3(1305.583f, 964.179f, 87.15f))))
+      ZipLinePaths(new ZipLinePath(91, false, List(Vector3(1183.282f, 855.405f, 102.024f), Vector3(1020.01f, 874.695f, 163.806f))))
+      ZipLinePaths(new ZipLinePath(92, false, List(Vector3(1074.935f, 889.632f, 101.685f), Vector3(1160.119f, 949.134f, 165.832f), Vector3(1165.798f, 953.101f, 166.268f))))
+      ZipLinePaths(new ZipLinePath(93, false, List(Vector3(1007.636f, 845.108f, 113.11f), Vector3(1013.388f, 849.192f, 112.44f), Vector3(1053.653f, 877.782f, 102.503f))))
+      ZipLinePaths(new ZipLinePath(94, false, List(Vector3(992.283f, 891.888f, 163.798f), Vector3(991.451f, 896.417f, 163.742f), Vector3(985.627f, 928.117f, 113.461f))))
+      ZipLinePaths(new ZipLinePath(95, false, List(Vector3(985.317f, 826.497f, 110.014f), Vector3(943.562f, 831.141f, 107.768f))))
+      ZipLinePaths(new ZipLinePath(96, false, List(Vector3(1002.807f, 925.681f, 108.385f), Vector3(1046.205f, 892.296f, 102.497f))))
+      ZipLinePaths(new ZipLinePath(97, false, List(Vector3(1018.81f, 2027.017f, 92.44f), Vector3(992.566f, 2029.269f, 96.041f), Vector3(927.929f, 2030.134f, 96.384f), Vector3(863.292f, 1998.2f, 96.728f), Vector3(852.6f, 1989.914f, 93.135f))))
+      ZipLinePaths(new ZipLinePath(98, false, List(Vector3(816.912f, 1988.393f, 93.135f), Vector3(795.001f, 1943.548f, 95.243f), Vector3(772.69f, 1898.803f, 94.692f), Vector3(753.502f, 1860.322f, 93.135f))))
+      ZipLinePaths(new ZipLinePath(99, false, List(Vector3(761.037f, 1809.202f, 93.135f), Vector3(738.964f, 1764.341f, 94.477f), Vector3(725.537f, 1735.63f, 93.135f))))
+      ZipLinePaths(new ZipLinePath(100, false, List(Vector3(808.409f, 1678.306f, 92.894f), Vector3(758.409f, 1678.177f, 94.519f), Vector3(742.409f, 1678.136f, 93.135f))))
+      ZipLinePaths(new ZipLinePath(101, false, List(Vector3(850.044f, 1661.524f, 93.131f), Vector3(817.963f, 1601.012f, 96.672f), Vector3(817.205f, 1534.27f, 76.708f), Vector3(794.955f, 1487.474f, 75.549f), Vector3(791.099f, 1479.906f, 73.138f))))
+      ZipLinePaths(new ZipLinePath(102, false, List(Vector3(849.551f, 1730.123f, 93.131f), Vector3(825.82f, 1775.918f, 94.548f), Vector3(806.79f, 1821.714f, 93.938f), Vector3(800.292f, 1830.693f, 93.135f))))
+      ZipLinePaths(new ZipLinePath(103, false, List(Vector3(875f, 1703.396f, 88.662f), Vector3(886.523f, 1699.949f, 88.08f), Vector3(888.484f, 1673.276f, 88.04f), Vector3(900.146f, 1672.403f, 88.525f))))
+      ZipLinePaths(new ZipLinePath(104, false, List(Vector3(923.115f, 1671.849f, 88.633f), Vector3(934.566f, 1676.01f, 87.893f), Vector3(939.217f, 1685.07f, 88.753f), Vector3(953.325f, 1687.438f, 88.211f))))
+      ZipLinePaths(new ZipLinePath(105, false, List(Vector3(1024.561f, 1703.441f, 88.18f), Vector3(1042.067f, 1704.672f, 84.078f), Vector3(1048.72f, 1715.187f, 83.93f), Vector3(1056.773f, 1719.103f, 83.186f))))
+      ZipLinePaths(new ZipLinePath(106, false, List(Vector3(1084.358f, 1704.206f, 78.452f), Vector3(1093.939f, 1707.391f, 78.598f), Vector3(1097.02f, 1731.276f, 78.245f), Vector3(1112.424f, 1742.594f, 79.008f), Vector3(1112.125f, 1762.854f, 78.739f), Vector3(1109.527f, 1770.413f, 73.671f))))
+      ZipLinePaths(new ZipLinePath(107, false, List(Vector3(1000.29f, 1625.633f, 98.859f), Vector3(1000.181f, 1617.133f, 103.185f), Vector3(999.672f, 1597.633f, 103.259f), Vector3(984.842f, 1588.277f, 104.119f), Vector3(984.027f, 1574.749f, 107.048f), Vector3(983.612f, 1563.521f, 108.283f))))
+      ZipLinePaths(new ZipLinePath(108, false, List(Vector3(996.661f, 1495.754f, 113.22f), Vector3(1021.481f, 1495.402f, 118.224f), Vector3(1035.501f, 1495.85f, 118.262f))))
+      ZipLinePaths(new ZipLinePath(109, false, List(Vector3(1036.79f, 1464.458f, 118.185f), Vector3(1018.161f, 1461.497f, 118.106f), Vector3(1016.947f, 1438.117f, 118.333f))))
+      ZipLinePaths(new ZipLinePath(110, false, List(Vector3(1070.138f, 1989.771f, 93.138f), Vector3(1069.612f, 1920.429f, 96.74f), Vector3(1070.374f, 1855.956f, 78.424f), Vector3(1086.804f, 1820.319f, 73.139f))))
+      ZipLinePaths(new ZipLinePath(111, false, List(Vector3(1117.331f, 1840.065f, 73.142f), Vector3(1183.426f, 1841.149f, 97.117f), Vector3(1215.745f, 1828.174f, 97.599f), Vector3(1232.464f, 1793.299f, 98.381f), Vector3(1191.496f, 1745.11f, 93.142f))))
+      ZipLinePaths(new ZipLinePath(112, false, List(Vector3(1134.661f, 1721.993f, 93.137f), Vector3(1134.547f, 1663.691f, 98.085f), Vector3(1135.071f, 1607.797f, 80.745f), Vector3(1140.725f, 1579.552f, 76.669f), Vector3(1191.406f, 1546.395f, 79.469f), Vector3(1216.006f, 1501.982f, 80.37f), Vector3(1225.64f, 1482.405f, 73.137f))))
+      ZipLinePaths(new ZipLinePath(113, true, List(Vector3(1228.182f, 1476.191f, 72.635f), Vector3(1222.636f, 1475.527f, 151.831f), Vector3(1141.796f, 1450.049f, 163.334f), Vector3(1095.336f, 1435.407f, 174.611f), Vector3(1048.876f, 1420.764f, 185.888f), Vector3(1013.488f, 1415.158f, 122.539f))))
+      ZipLinePaths(new ZipLinePath(114, false, List(Vector3(1251.686f, 1518.522f, 73.137f), Vector3(1276.598f, 1564.053f, 77.383f), Vector3(1294.51f, 1597.684f, 77.847f), Vector3(1293.755f, 1663.148f, 97.995f), Vector3(1303.481f, 1693.585f, 97.716f), Vector3(1337.207f, 1713.821f, 93.137f))))
+      ZipLinePaths(new ZipLinePath(115, false, List(Vector3(1394.471f, 1732.147f, 93.138f), Vector3(1394.459f, 1791.418f, 97.651f), Vector3(1426.63f, 1857.554f, 99.082f), Vector3(1426.438f, 1911.439f, 74.996f))))
+      ZipLinePaths(new ZipLinePath(116, false, List(Vector3(1379.692f, 1934.355f, 73.137f), Vector3(1313.917f, 1933.904f, 96.93f), Vector3(1251.132f, 1933.473f, 117.324f), Vector3(1186.307f, 1933.425f, 98.423f), Vector3(1130.546f, 1932.646f, 93.137f))))
+      ZipLinePaths(new ZipLinePath(117, true, List(Vector3(1025.864f, 1409.726f, 122.407f), Vector3(1070.85f, 1431.534f, 113.042f), Vector3(1208.454f, 1498.242f, 148.385f), Vector3(1244.62f, 1515.774f, 72.635f))))
+      ZipLinePaths(new ZipLinePath(118, false, List(Vector3(1202.008f, 297.806f, 113.226f), Vector3(1202.584f, 322.137f, 118.691f), Vector3(1235.36f, 389.367f, 113.135f))))
+      ZipLinePaths(new ZipLinePath(119, false, List(Vector3(1242.126f, 432.375f, 113.151f), Vector3(1274.428f, 433.633f, 111.467f), Vector3(1315.73f, 433.691f, 98.599f), Vector3(1376.535f, 434.707f, 78.133f), Vector3(1389.545f, 446.139f, 77.8f), Vector3(1386.464f, 499.904f, 73.151f))))
+      ZipLinePaths(new ZipLinePath(120, false, List(Vector3(1131.491f, 241.737f, 113.146f), Vector3(1053.841f, 241.809f, 118.259f), Vector3(1003.713f, 241.856f, 103.067f), Vector3(954.568f, 241.902f, 88.559f), Vector3(924.097f, 241.93f, 73.144f))))
+      ZipLinePaths(new ZipLinePath(121, false, List(Vector3(879.356f, 250.391f, 73.135f), Vector3(877.875f, 322.009f, 75.591f), Vector3(865.652f, 333.714f, 76.216f), Vector3(800.368f, 333.08f, 76.774f), Vector3(770.187f, 344.511f, 76.742f), Vector3(753.401f, 374.752f, 73.135f))))
+      ZipLinePaths(new ZipLinePath(122, false, List(Vector3(724.372f, 439.993f, 73.135f), Vector3(702.543f, 484.976f, 75.034f), Vector3(695.558f, 499.37f, 73.135f))))
+      ZipLinePaths(new ZipLinePath(123, false, List(Vector3(927.581f, 302.259f, 73.066f), Vector3(941.583f, 316.887f, 77.329f), Vector3(941.783f, 375.246f, 79.629f), Vector3(963.228f, 424.3f, 76.137f), Vector3(965.963f, 433.919f, 73.135f))))
+      ZipLinePaths(new ZipLinePath(124, false, List(Vector3(1160.627f, 580.379f, 108.277f), Vector3(1161.721f, 570.879f, 108.041f), Vector3(1189.315f, 566.479f, 108.504f), Vector3(1191.699f, 543.808f, 108.218f))))
+      ZipLinePaths(new ZipLinePath(125, false, List(Vector3(1207.802f, 538.221f, 113.201f), Vector3(1208.144f, 548.124f, 113.056f), Vector3(1210.215f, 566.825f, 108.333f), Vector3(1234.185f, 567.526f, 113.811f), Vector3(1237.758f, 564.185f, 113.25f))))
+      ZipLinePaths(new ZipLinePath(126, false, List(Vector3(1224.007f, 664.636f, 133.221f), Vector3(1223.934f, 652.419f, 133.673f), Vector3(1223.16f, 636.401f, 128.433f), Vector3(1208.114f, 626.266f, 129.353f), Vector3(1208.169f, 613.814f, 123.77f))))
+      ZipLinePaths(new ZipLinePath(127, false, List(Vector3(1225.626f, 600.261f, 123.186f), Vector3(1228.418f, 600.63f, 123.819f), Vector3(1251.711f, 599.7f, 118.858f), Vector3(1258.795f, 586.139f, 118.536f), Vector3(1272.363f, 579.017f, 118.191f), Vector3(1271.831f, 575.195f, 118.569f), Vector3(1272.099f, 565.373f, 113.706f))))
+      ZipLinePaths(new ZipLinePath(128, false, List(Vector3(1271.691f, 531.861f, 108.485f), Vector3(1271.658f, 509.334f, 108.41f), Vector3(1271.644f, 502.251f, 103.845f))))
+      ZipLinePaths(new ZipLinePath(129, false, List(Vector3(1287.978f, 474.746f, 103.686f), Vector3(1288.009f, 467.239f, 107.927f), Vector3(1286.339f, 457.632f, 108.568f), Vector3(1251.901f, 455.918f, 108.65f), Vector3(1242.902f, 456.115f, 108.661f))))
+      ZipLinePaths(new ZipLinePath(130, true, List(Vector3(969.919f, 441.728f, 72.635f), Vector3(1009.025f, 473.71f, 80.954f), Vector3(1048.129f, 505.692f, 87.942f), Vector3(1087.232f, 537.674f, 94.93f), Vector3(1126.335f, 569.654f, 101.918f), Vector3(1162.137f, 599.373f, 107.659f))))
+      ZipLinePaths(new ZipLinePath(131, true, List(Vector3(1387.976f, 507.419f, 72.636f), Vector3(1385.3f, 510.225f, 74.718f), Vector3(1383.962f, 511.628f, 76.512f), Vector3(1381.955f, 513.733f, 137.228f), Vector3(1381.286f, 514.435f, 137.473f), Vector3(1322.408f, 576.175f, 149.977f), Vector3(1261.523f, 640.021f, 162.48f), Vector3(1227.4f, 675.802f, 174.983f), Vector3(1226.262f, 680.206f, 132.59f))))
+      ZipLinePaths(new ZipLinePath(132, true, List(Vector3(1234.923f, 685.242f, 132.733f), Vector3(1267.406f, 649.47f, 121.373f), Vector3(1305.087f, 607.973f, 108.519f), Vector3(1337.569f, 572.201f, 95.665f), Vector3(1377.848f, 527.842f, 82.811f), Vector3(1388.443f, 517.526f, 72.656f))))
+      ZipLinePaths(new ZipLinePath(133, true, List(Vector3(1153.869f, 604.137f, 107.796f), Vector3(1116.755f, 572.207f, 101.227f), Vector3(1107.583f, 564.663f, 117.562f), Vector3(1068.605f, 532.605f, 110.2f), Vector3(1030.391f, 501.175f, 102.982f), Vector3(992.177f, 469.747f, 95.765f), Vector3(972.07f, 453.432f, 72.607f))))
+      ZipLinePaths(new ZipLinePath(134, true, List(Vector3(694.353f, 506.02f, 72.635f), Vector3(693.408f, 510.898f, 75.838f), Vector3(683.572f, 561.632f, 81.593f), Vector3(673.925f, 611.39f, 87.237f), Vector3(664.279f, 661.148f, 92.88f), Vector3(654.632f, 710.906f, 98.524f), Vector3(644.986f, 760.664f, 104.168f), Vector3(635.339f, 810.422f, 109.812f), Vector3(625.693f, 860.18f, 115.456f), Vector3(620.397f, 887.498f, 134.035f), Vector3(618.538f, 904.381f, 117.681f))))
+      ZipLinePaths(new ZipLinePath(135, true, List(Vector3(627.84f, 909.247f, 117.827f), Vector3(636.839f, 859.105f, 112.711f), Vector3(644.838f, 810.063f, 107.141f), Vector3(652.836f, 761.022f, 101.57f), Vector3(660.835f, 711.98f, 96f), Vector3(668.834f, 662.938f, 90.43f), Vector3(676.832f, 613.896f, 84.86f), Vector3(684.831f, 564.855f, 79.29f), Vector3(692.51f, 517.775f, 72.71f))))
+      ZipLinePaths(new ZipLinePath(136, false, List(Vector3(861.866f, 1183.37f, 77.95f), Vector3(853.767f, 1165.099f, 77.75f))))
+      ZipLinePaths(new ZipLinePath(137, false, List(Vector3(862.428f, 1129.783f, 97.194f), Vector3(986.978f, 1119.254f, 98.247f))))
+      ZipLinePaths(new ZipLinePath(138, false, List(Vector3(844.896f, 1130.823f, 97.194f), Vector3(811.383f, 1125.083f, 98.4f))))
+      ZipLinePaths(new ZipLinePath(139, false, List(Vector3(851.715f, 1113.668f, 97.231f), Vector3(856.403f, 1096.555f, 90.295f))))
+      ZipLinePaths(new ZipLinePath(140, true, List(Vector3(1094.656f, 1028.66f, 85.95f), Vector3(1101.679f, 1029.985f, 119.23f))))
+      ZipLinePaths(new ZipLinePath(141, true, List(Vector3(1105.375f, 1032.63f, 119.23f), Vector3(1102.402f, 1030.171f, 85.95f))))
+      ZipLinePaths(new ZipLinePath(142, true, List(Vector3(933.254f, 939.081f, 92.25f), Vector3(941.062f, 944.592f, 117.812f))))
+      ZipLinePaths(new ZipLinePath(143, true, List(Vector3(935.9f, 940.753f, 117.811f), Vector3(938.783f, 942.43f, 92.25f))))
+      ZipLinePaths(new ZipLinePath(144, false, List(Vector3(872.334f, 1048.719f, 90.263f), Vector3(933.133f, 967.339f, 92.651f))))
+      ZipLinePaths(new ZipLinePath(145, false, List(Vector3(982.409f, 729.272f, 86.85f), Vector3(992.811f, 822.687f, 88.85f))))
+      ZipLinePaths(new ZipLinePath(146, true, List(Vector3(922.643f, 850.812f, 96.109f), Vector3(909.595f, 831.634f, 113.284f))))
+      ZipLinePaths(new ZipLinePath(147, true, List(Vector3(929.96f, 861.944f, 117.749f), Vector3(868.055f, 887.015f, 98.609f))))
+      ZipLinePaths(new ZipLinePath(148, true, List(Vector3(1120.997f, 1115.475f, 110.069f), Vector3(1119.491f, 1123.132f, 126.696f), Vector3(1117.841f, 1135.263f, 129.177f))))
+      ZipLinePaths(new ZipLinePath(149, true, List(Vector3(1155.227f, 1098.523f, 123.089f), Vector3(1169.031f, 1159.746f, 112.569f))))
+      ZipLinePaths(new ZipLinePath(150, false, List(Vector3(1004.971f, 1143.408f, 111.496f), Vector3(880.245f, 1250.32f, 95.892f))))
+      ZipLinePaths(new ZipLinePath(151, true, List(Vector3(1019.69f, 1007.623f, 115.693f), Vector3(1000.005f, 1001.177f, 166.13f))))
+      ZipLinePaths(new ZipLinePath(152, true, List(Vector3(1050.232f, 1000.81f, 166.13f), Vector3(1021.86f, 1002.474f, 115.693f))))
+      ZipLinePaths(new ZipLinePath(153, false, List(Vector3(1891.956f, 942.414f, 33.135f), Vector3(1821.932f, 977.7f, 35.084f), Vector3(1811.37f, 987.494f, 36.308f), Vector3(1778.408f, 1055.287f, 37.532f), Vector3(1776.673f, 1083.246f, 33.135f))))
+      ZipLinePaths(new ZipLinePath(154, false, List(Vector3(1742.077f, 1117.64f, 33.158f), Vector3(1743.128f, 1166.486f, 50.314f), Vector3(1742.632f, 1178.937f, 52.387f))))
+      ZipLinePaths(new ZipLinePath(155, false, List(Vector3(1730.829f, 1199.918f, 53.138f), Vector3(1665.225f, 1198.474f, 77.439f), Vector3(1599.621f, 1197.031f, 76.243f), Vector3(1552.051f, 1172.147f, 73.138f))))
+      ZipLinePaths(new ZipLinePath(156, true, List(Vector3(1539.981f, 1165.92f, 72.635f), Vector3(1535.523f, 1163.592f, 75.147f), Vector3(1515.908f, 1154.668f, 145.491f), Vector3(1470.436f, 1133.98f, 155.771f), Vector3(1425.856f, 1113.698f, 165.85f), Vector3(1386.517f, 1096.256f, 107.574f))))
+      ZipLinePaths(new ZipLinePath(157, false, List(Vector3(952.148f, 897.258f, 92.851f), Vector3(922.937f, 946.221f, 176.437f), Vector3(920.99f, 949.486f, 176.89f))))
+      ZipLinePaths(new ZipLinePath(158, false, List(Vector3(932.443f, 806.082f, 92.651f), Vector3(991.259f, 862.472f, 163.374f), Vector3(993.156f, 864.292f, 163.797f))))
+      ZipLinePaths(new ZipLinePath(159, false, List(Vector3(879.015f, 930.909f, 92.708f), Vector3(932.22f, 1092.636f, 178.167f))))
+      ZipLinePaths(new ZipLinePath(160, false, List(Vector3(1243f, 987.886f, 99.197f), Vector3(1174.26f, 1066.841f, 107.552f))))
+      ZipLinePaths(new ZipLinePath(161, false, List(Vector3(1103.05f, 1078.253f, 107.708f), Vector3(1180.178f, 992.405f, 165.77f), Vector3(1182.666f, 989.636f, 166.342f))))
+      ZipLinePaths(new ZipLinePath(162, false, List(Vector3(722.901f, 1218.822f, 103.265f), Vector3(912.849f, 1117.522f, 178.139f))))
+      ZipLinePaths(new ZipLinePath(163, false, List(Vector3(1331.164f, 1158.065f, 90.792f), Vector3(1248.261f, 1136.533f, 99.005f))))
+      ZipLinePaths(new ZipLinePath(164, true, List(Vector3(1210.313f, 1084.792f, 100.121f), Vector3(1199.343f, 1073.476f, 106.5f), Vector3(1196.969f, 1072.153f, 106.85f))))
+      ZipLinePaths(new ZipLinePath(165, true, List(Vector3(1220.939f, 1186.566f, 98.502f), Vector3(1213.099f, 1184.104f, 106.75f))))
+      ZipLinePaths(new ZipLinePath(166, true, List(Vector3(1172.896f, 1233.173f, 103.636f), Vector3(1162.954f, 1227.012f, 106.95f))))
+      ZipLinePaths(new ZipLinePath(167, true, List(Vector3(1199.205f, 1200.656f, 103.636f), Vector3(1196.948f, 1196.556f, 106.95f))))
+      ZipLinePaths(new ZipLinePath(168, true, List(Vector3(1222.933f, 1107.801f, 98.138f), Vector3(1216.995f, 1100.217f, 100.121f))))
+      ZipLinePaths(new ZipLinePath(169, true, List(Vector3(884.118f, 939.871f, 85.012f), Vector3(877.122f, 945.369f, 86.745f))))
+      ZipLinePaths(new ZipLinePath(170, true, List(Vector3(835.184f, 956.37f, 82.33f), Vector3(845.422f, 955.435f, 86.745f))))
+      ZipLinePaths(new ZipLinePath(171, true, List(Vector3(798.088f, 933.249f, 82.33f), Vector3(801.227f, 929.672f, 85.391f))))
+      ZipLinePaths(new ZipLinePath(172, true, List(Vector3(817.542f, 872.74f, 85.391f), Vector3(821.367f, 877.892f, 91.804f), Vector3(824.646f, 882.308f, 92.154f))))
+      ZipLinePaths(new ZipLinePath(173, true, List(Vector3(809.042f, 966.006f, 72.637f), Vector3(806.015f, 962.745f, 81.98f), Vector3(804.286f, 960.882f, 82.33f))))
+      ZipLinePaths(new ZipLinePath(174, true, List(Vector3(782.321f, 946.101f, 72.637f), Vector3(782.209f, 943.098f, 81.216f), Vector3(782.096f, 940.095f, 82.33f))))
+      ZipLinePaths(new ZipLinePath(175, true, List(Vector3(771.194f, 921.372f, 72.637f), Vector3(773.573f, 922.573f, 78.9f), Vector3(775.951f, 923.774f, 79.25f))))
+      ZipLinePaths(new ZipLinePath(176, true, List(Vector3(785.799f, 928.492f, 79.25f), Vector3(787.866f, 933.334f, 82.33f))))
+      ZipLinePaths(new ZipLinePath(177, true, List(Vector3(773.105f, 877.692f, 72.637f), Vector3(776f, 883.044f, 85.041f), Vector3(776.762f, 884.99f, 85.391f))))
+      ZipLinePaths(new ZipLinePath(178, true, List(Vector3(1260.095f, 1122.392f, 72.637f), Vector3(1248.111f, 1131.053f, 98.152f), Vector3(1246.528f, 1132.553f, 98.502f))))
+      ZipLinePaths(new ZipLinePath(179, true, List(Vector3(1247.407f, 1189.7f, 72.637f), Vector3(1242.866f, 1188.597f, 85.416f), Vector3(1237.21f, 1185.933f, 98.152f), Vector3(1235.197f, 1185.562f, 98.502f))))
+      ZipLinePaths(new ZipLinePath(180, true, List(Vector3(1227.751f, 1204.986f, 85.766f), Vector3(1230.308f, 1198.845f, 97.468f), Vector3(1231.522f, 1197.036f, 98.502f))))
+      ZipLinePaths(new ZipLinePath(181, true, List(Vector3(1217.513f, 1218.632f, 85.766f), Vector3(1214.723f, 1224.759f, 89.205f))))
+      ZipLinePaths(new ZipLinePath(182, true, List(Vector3(1229.038f, 1246.627f, 72.637f), Vector3(1230.799f, 1238.957f, 85.421f), Vector3(1231.386f, 1236.401f, 85.767f))))
+      ZipLinePaths(new ZipLinePath(183, true, List(Vector3(1150.235f, 1233.13f, 89.205f), Vector3(1145.005f, 1230.417f, 91.211f))))
+      ZipLinePaths(new ZipLinePath(184, true, List(Vector3(1143.722f, 1247.649f, 72.637f), Vector3(1150.984f, 1246.704f, 88.641f), Vector3(1154.614f, 1246.232f, 89.205f))))
+      ZipLinePaths(new ZipLinePath(185, true, List(Vector3(1093.149f, 1249.843f, 72.637f), Vector3(1092.856f, 1240.249f, 90.861f), Vector3(1092.764f, 1237.251f, 91.211f))))
+      ZipLinePaths(new ZipLinePath(186, true, List(Vector3(1042.911f, 1261.351f, 72.637f), Vector3(1044.372f, 1257.098f, 80f), Vector3(1049.484f, 1242.212f, 91.146f))))
+      ZipLinePaths(new ZipLinePath(187, true, List(Vector3(837.728f, 828.382f, 82.742f), Vector3(840.4f, 833.819f, 91.804f), Vector3(841.491f, 837.298f, 92.154f))))
+      ZipLinePaths(new ZipLinePath(188, true, List(Vector3(873.715f, 759.255f, 84.319f), Vector3(867.275f, 761.983f, 86.937f))))
+      ZipLinePaths(new ZipLinePath(189, true, List(Vector3(814.836f, 852.508f, 72.637f), Vector3(823.482f, 854.756f, 91.804f), Vector3(825.644f, 855.318f, 92.154f))))
+      ZipLinePaths(new ZipLinePath(190, true, List(Vector3(901.862f, 755.126f, 72.637f), Vector3(903.995f, 759.861f, 83.969f), Vector3(905.077f, 762.454f, 84.319f))))
+      ZipLinePaths(new ZipLinePath(191, true, List(Vector3(836.436f, 790.696f, 72.637f), Vector3(836.032f, 796.342f, 82.392f), Vector3(835.897f, 798.223f, 82.742f))))
+      ZipLinePaths(new ZipLinePath(192, true, List(Vector3(842.566f, 807.217f, 82.742f), Vector3(845.266f, 803.584f, 86.394f), Vector3(846.346f, 802.131f, 86.937f))))
+      ZipLinePaths(new ZipLinePath(193, true, List(Vector3(840.797f, 960.721f, 72.637f), Vector3(837.499f, 957.71f, 81.98f), Vector3(830.352f, 951.186f, 86.745f))))
+      ZipLinePaths(new ZipLinePath(194, true, List(Vector3(861.487f, 756.065f, 72.637f), Vector3(861.344f, 761.414f, 86.484f), Vector3(861.273f, 764.088f, 86.937f))))
+      ZipLinePaths(new ZipLinePath(195, false, List(Vector3(1064.899f, 1048.02f, 101.15f), Vector3(1120.375f, 956.607f, 179.814f), Vector3(1122.165f, 953.658f, 180.287f))))
+      ZipLinePaths(new ZipLinePath(196, false, List(Vector3(1163.953f, 891.526f, 94.91f), Vector3(1188.363f, 882.792f, 92.952f))))
+      ZipLinePaths(new ZipLinePath(197, true, List(Vector3(701.124f, 1230.701f, 85.32f), Vector3(696.653f, 1222.976f, 102.746f))))
+      ZipLinePaths(new ZipLinePath(198, true, List(Vector3(1393.029f, 1101.697f, 107.755f), Vector3(1438.339f, 1122.279f, 97.577f), Vector3(1452.554f, 1128.736f, 156.164f), Vector3(1497.864f, 1149.318f, 148.448f), Vector3(1528.959f, 1163.443f, 72.797f))))
+      ZipLinePaths(new ZipLinePath(199, false, List(Vector3(306.221f, 763.282f, 73.135f), Vector3(306.698f, 800.603f, 76.521f), Vector3(340.381f, 872.043f, 73.135f))))
+      ZipLinePaths(new ZipLinePath(200, false, List(Vector3(345.801f, 912.178f, 73.135f), Vector3(363.505f, 919.044f, 73.324f), Vector3(381.408f, 931.811f, 74.014f), Vector3(408.416f, 942.444f, 75.392f), Vector3(429.031f, 949.809f, 75.579f), Vector3(455.238f, 969.842f, 75.672f), Vector3(481.246f, 977.475f, 75.765f), Vector3(528.556f, 979.943f, 73.135f))))
+      ZipLinePaths(new ZipLinePath(201, true, List(Vector3(539.196f, 980.064f, 72.635f), Vector3(574.053f, 948.591f, 93.851f), Vector3(608.91f, 917.118f, 113.732f), Vector3(618.311f, 910.212f, 117.698f))))
+      ZipLinePaths(new ZipLinePath(202, true, List(Vector3(607.495f, 909.335f, 117.666f), Vector3(578.291f, 944.643f, 96.61f), Vector3(549.087f, 979.952f, 72.716f))))
+      ZipLinePaths(new ZipLinePath(203, false, List(Vector3(614.076f, 918.037f, 118.092f), Vector3(648.718f, 955.203f, 114.812f), Vector3(682.681f, 991.641f, 110.851f))))
+      ZipLinePaths(new ZipLinePath(204, false, List(Vector3(716.336f, 1022.474f, 110.856f), Vector3(755.976f, 1089.243f, 98.406f))))
+      ZipLinePaths(new ZipLinePath(205, false, List(Vector3(730.061f, 994.571f, 110.85f), Vector3(808.623f, 1005.013f, 164.303f), Vector3(813.861f, 1005.709f, 164.56f))))
+      ZipLinePaths(new ZipLinePath(206, true, List(Vector3(1021.601f, 1075.097f, 91.155f), Vector3(1015.346f, 1066.557f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(207, true, List(Vector3(998.898f, 1042.539f, 97.276f), Vector3(995.256f, 1040.166f, 101.431f), Vector3(993.799f, 1039.216f, 101.794f))))
+      ZipLinePaths(new ZipLinePath(208, true, List(Vector3(987.398f, 1053.149f, 91.156f), Vector3(994.469f, 1055.576f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(209, true, List(Vector3(1056.106f, 1034.411f, 91.25f), Vector3(1051.638f, 1035.824f, 96.926f), Vector3(1049.649f, 1036.895f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(210, true, List(Vector3(979.786f, 1011.902f, 101.811f), Vector3(980.707f, 1006.752f, 107.616f), Vector3(981.167f, 1004.177f, 107.966f))))
+      ZipLinePaths(new ZipLinePath(211, true, List(Vector3(960.739f, 1004.397f, 92.05f), Vector3(966.398f, 997.912f, 101.464f), Vector3(967.427f, 996.733f, 101.82f))))
+      ZipLinePaths(new ZipLinePath(212, true, List(Vector3(986.563f, 956.368f, 89.55f), Vector3(983.367f, 961.629f, 101.444f), Vector3(982.204f, 963.542f, 101.794f))))
+      ZipLinePaths(new ZipLinePath(213, true, List(Vector3(983.637f, 981.525f, 101.794f), Vector3(989.245f, 975.315f, 107.966f))))
+      ZipLinePaths(new ZipLinePath(214, true, List(Vector3(988.599f, 996.118f, 107.966f), Vector3(991.802f, 995.824f, 114.824f), Vector3(994.365f, 995.59f, 115.693f))))
+      ZipLinePaths(new ZipLinePath(215, true, List(Vector3(1066.595f, 1027.52f, 91.25f), Vector3(1069.864f, 1017.647f, 96.926f), Vector3(1071.349f, 1013.159f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(216, true, List(Vector3(1074.69f, 990.196f, 97.276f), Vector3(1071.034f, 992.737f, 104.342f), Vector3(1068.596f, 994.432f, 104.692f))))
+      ZipLinePaths(new ZipLinePath(217, true, List(Vector3(1091.584f, 998.45f, 89.35f), Vector3(1087.866f, 993.893f, 96.728f), Vector3(1086.472f, 992.184f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(218, true, List(Vector3(1068.438f, 954.245f, 89.351f), Vector3(1062.46f, 953.254f, 96.926f), Vector3(1060.965f, 953.006f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(219, true, List(Vector3(1066.35f, 973.397f, 97.276f), Vector3(1058.251f, 973.884f, 104.692f))))
+      ZipLinePaths(new ZipLinePath(220, true, List(Vector3(1032.003f, 936.282f, 89.55f), Vector3(1038.859f, 936.207f, 96.926f), Vector3(1042.287f, 936.169f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(221, true, List(Vector3(1019.28f, 950.5f, 89.55f), Vector3(1026.949f, 951.393f, 97.276f))))
+      ZipLinePaths(new ZipLinePath(222, true, List(Vector3(1042.968f, 954.078f, 97.276f), Vector3(1044.525f, 958.776f, 104.342f), Vector3(1045.563f, 961.908f, 104.692f))))
+      ZipLinePaths(new ZipLinePath(223, true, List(Vector3(1043.88f, 975.722f, 104.692f), Vector3(1041.782f, 981.626f, 115.343f), Vector3(1041.083f, 983.594f, 115.693f))))
+      ZipLinePaths(new ZipLinePath(224, true, List(Vector3(1058.822f, 1006.575f, 104.692f), Vector3(1054.133f, 1008.733f, 115.343f), Vector3(1052.375f, 1009.542f, 115.693f))))
+      ZipLinePaths(new ZipLinePath(225, true, List(Vector3(1001.752f, 1027.373f, 107.966f), Vector3(1004.216f, 1023.209f, 115.343f), Vector3(1005.42f, 1021.419f, 115.693f))))
+      ZipLinePaths(new ZipLinePath(226, false, List(Vector3(1391.743f, 1080.478f, 108.201f), Vector3(1398.365f, 1079.972f, 107.639f), Vector3(1412.786f, 1079.466f, 102.885f), Vector3(1416.622f, 1072.662f, 103.533f), Vector3(1416.958f, 1050.859f, 97.981f), Vector3(1430.894f, 1044.656f, 98.029f), Vector3(1431.862f, 1036.555f, 97.553f), Vector3(1432.946f, 1018.004f, 93.115f), Vector3(1440.43f, 1017.453f, 93.186f))))
+      ZipLinePaths(new ZipLinePath(227, false, List(Vector3(1519.21f, 999.864f, 83.184f), Vector3(1540.844f, 1000.889f, 78.393f), Vector3(1548.161f, 1015.301f, 78.498f), Vector3(1558.54f, 1015.504f, 77.025f), Vector3(1568.92f, 1015.707f, 73.351f), Vector3(1576.299f, 1006.71f, 73.177f), Vector3(1566.244f, 999.461f, 73.309f), Vector3(1560.188f, 992.212f, 73.44f), Vector3(1560.333f, 976.463f, 69.522f), Vector3(1566.478f, 967.713f, 68.203f))))
+      ZipLinePaths(new ZipLinePath(228, false, List(Vector3(1626.306f, 967.026f, 58.235f), Vector3(1639.898f, 967.223f, 61.771f), Vector3(1653.49f, 967.419f, 63.507f), Vector3(1655.783f, 957.315f, 62.743f), Vector3(1657.975f, 938.211f, 58.578f), Vector3(1671.203f, 932.356f, 58.341f), Vector3(1673.016f, 905.329f, 53.772f), Vector3(1688.03f, 904.501f, 53.203f))))
+      ZipLinePaths(new ZipLinePath(229, false, List(Vector3(1711.197f, 924.758f, 53.139f), Vector3(1710.369f, 942.404f, 54.049f), Vector3(1709.94f, 990.049f, 36.063f), Vector3(1740.884f, 1044.941f, 35.233f), Vector3(1742.134f, 1084.117f, 33.139f))))
+      ZipLinePaths(new ZipLinePath(230, false, List(Vector3(1897.005f, 909.845f, 33.139f), Vector3(1890.302f, 910.029f, 36.637f), Vector3(1877.651f, 905.72f, 35.937f), Vector3(1847.499f, 885.412f, 36.038f), Vector3(1832.994f, 880.879f, 36.882f), Vector3(1761.44f, 877.355f, 56.523f), Vector3(1741.073f, 885.183f, 54.579f), Vector3(1724.506f, 898.41f, 53.139f))))
+      ZipLinePaths(new ZipLinePath(231, false, List(Vector3(607.175f, 888.218f, 118.163f), Vector3(570.208f, 886.839f, 108.58f), Vector3(566.924f, 874.849f, 108.339f), Vector3(553.182f, 869.605f, 108.219f), Vector3(552.912f, 851.132f, 112.959f), Vector3(552.641f, 832.66f, 113.199f))))
+      ZipLinePaths(new ZipLinePath(232, false, List(Vector3(551.781f, 772.243f, 103.542f), Vector3(550.899f, 762.266f, 103.537f), Vector3(523.357f, 759.878f, 102.185f), Vector3(508.587f, 758.684f, 98.309f), Vector3(501.216f, 744.69f, 98.033f), Vector3(481.289f, 744.323f, 98.193f))))
+      ZipLinePaths(new ZipLinePath(233, false, List(Vector3(435.564f, 775.856f, 83.45f), Vector3(410.779f, 775.127f, 83.255f), Vector3(405.683f, 761.182f, 83.307f), Vector3(378.802f, 758.763f, 83.249f), Vector3(372.661f, 744.254f, 83.519f), Vector3(361.876f, 744.126f, 82.212f), Vector3(351.091f, 743.999f, 78.805f), Vector3(330.306f, 745.471f, 73.448f), Vector3(329.521f, 752.744f, 73.19f))))
+      ZipLinePaths(new ZipLinePath(234, false, List(Vector3(694.79f, 533.179f, 73.154f), Vector3(704.33f, 582.022f, 88.963f), Vector3(713.871f, 630.865f, 102.305f), Vector3(723.412f, 679.708f, 113.447f), Vector3(732.953f, 728.55f, 119.589f), Vector3(734.636f, 737.17f, 115.86f))))
+      ZipLinePaths(new ZipLinePath(235, false, List(Vector3(1227.559f, 1464.788f, 73.065f), Vector3(1204.683f, 1422.484f, 98.524f), Vector3(1181.807f, 1380.181f, 111.615f), Vector3(1170.369f, 1359.029f, 112.1f), Vector3(1167.167f, 1353.107f, 110.872f))))
+      ZipLinePaths(new ZipLinePath(236, false, List(Vector3(1151.041f, 1307.142f, 110.85f), Vector3(1149.808f, 1257.197f, 109.965f), Vector3(1148.896f, 1220.238f, 107.451f))))
+      ZipLinePaths(new ZipLinePath(237, false, List(Vector3(1119.158f, 1351.924f, 110.853f), Vector3(1075.835f, 1376.326f, 117.478f), Vector3(1032.512f, 1400.728f, 122.747f), Vector3(1025.581f, 1404.632f, 122.843f))))
+      ZipLinePaths(new ZipLinePath(238, false, List(Vector3(1120.059f, 1320.54f, 110.862f), Vector3(1095.096f, 1278.566f, 101.21f), Vector3(1074.626f, 1244.147f, 91.658f))))
+      ZipLinePaths(new ZipLinePath(239, false, List(Vector3(1168.393f, 1314.06f, 110.852f), Vector3(1209.694f, 1284.47f, 109.355f), Vector3(1250.994f, 1254.88f, 104.931f), Vector3(1292.295f, 1225.29f, 100.507f), Vector3(1297.964f, 1221.228f, 96.852f))))
+      ZipLinePaths(new ZipLinePath(240, false, List(Vector3(1520.99f, 1163.069f, 73.227f), Vector3(1471.094f, 1163.271f, 87.591f), Vector3(1421.197f, 1163.472f, 92.633f), Vector3(1385.272f, 1163.617f, 84.199f))))
+      ZipLinePaths(new ZipLinePath(241, false, List(Vector3(1352.209f, 1198.899f, 87.497f), Vector3(1352.861f, 1204.463f, 96.7f), Vector3(1352.762f, 1206.433f, 96.85f))))
+      ZipLinePaths(new ZipLinePath(242, false, List(Vector3(1370.127f, 1176.595f, 84.198f), Vector3(1368.367f, 1178.316f, 87.247f), Vector3(1366.677f, 1179.496f, 87.498f))))
+      ZipLinePaths(new ZipLinePath(243, false, List(Vector3(1132.846f, 1216.479f, 91.711f), Vector3(1142.058f, 1210.391f, 107.329f), Vector3(1143.9f, 1209.173f, 107.451f))))
+      ZipLinePaths(new ZipLinePath(244, false, List(Vector3(1078.17f, 1148.271f, 91.351f), Vector3(1090.02f, 1146.1f, 107.634f), Vector3(1091.414f, 1145.844f, 107.751f))))
+      ZipLinePaths(new ZipLinePath(245, false, List(Vector3(1081.421f, 1072.106f, 101.202f), Vector3(1088.084f, 1079.606f, 107.87f), Vector3(1089.901f, 1081.652f, 107.702f))))
+      ZipLinePaths(new ZipLinePath(246, false, List(Vector3(1136.448f, 1054.578f, 91.95f), Vector3(1141.153f, 1061.864f, 107.3f), Vector3(1143.254f, 1063.402f, 107.55f))))
+      ZipLinePaths(new ZipLinePath(247, false, List(Vector3(1390.277f, 526.009f, 73.06f), Vector3(1380.297f, 575.581f, 84.344f), Vector3(1370.318f, 625.152f, 92.475f), Vector3(1360.338f, 674.723f, 99.805f), Vector3(1350.358f, 724.294f, 104.935f), Vector3(1344.879f, 751.51f, 103.84f))))
+      ZipLinePaths(new ZipLinePath(248, false, List(Vector3(971.093f, 460.616f, 73.02f), Vector3(987.394f, 508.286f, 87.196f), Vector3(1003.696f, 555.955f, 98.121f), Vector3(1019.998f, 603.624f, 102.646f), Vector3(1026.39f, 622.318f, 100.918f))))
+      ZipLinePaths(new ZipLinePath(249, false, List(Vector3(763.983f, 784.294f, 115.871f), Vector3(792.938f, 823.826f, 131.416f), Vector3(821.893f, 863.359f, 145.548f), Vector3(850.849f, 902.891f, 159.679f), Vector3(879.804f, 942.424f, 173.81f), Vector3(880.939f, 943.974f, 174.096f))))
+      ZipLinePaths(new ZipLinePath(250, false, List(Vector3(749.571f, 785.971f, 115.85f), Vector3(714.337f, 822.839f, 117.331f), Vector3(679.103f, 859.707f, 117.868f), Vector3(643.87f, 896.575f, 118.406f), Vector3(628.671f, 912.479f, 118.29f))))
+      ZipLinePaths(new ZipLinePath(251, false, List(Vector3(779.486f, 745.268f, 115.853f), Vector3(827.456f, 732.543f, 111.557f), Vector3(875.427f, 719.817f, 105.484f), Vector3(923.398f, 707.091f, 99.411f), Vector3(952.18f, 699.456f, 95.173f))))
+      ZipLinePaths(new ZipLinePath(252, false, List(Vector3(780.058f, 775.855f, 115.868f), Vector3(787.884f, 785.361f, 116.604f), Vector3(811.364f, 813.881f, 108.464f), Vector3(834.689f, 842.214f, 92.672f))))
+      ZipLinePaths(new ZipLinePath(253, false, List(Vector3(555.581f, 981.167f, 73.266f), Vector3(603.655f, 991.018f, 94.61f), Vector3(651.729f, 1000.87f, 107.893f), Vector3(684.721f, 1007.632f, 110.87f))))
+      ZipLinePaths(new ZipLinePath(254, false, List(Vector3(702.522f, 1030.162f, 110.85f), Vector3(699.16f, 1081.037f, 109.82f), Vector3(695.798f, 1131.913f, 108.875f), Vector3(695.205f, 1140.891f, 107.779f))))
+      ZipLinePaths(new ZipLinePath(255, false, List(Vector3(696.454f, 1171.992f, 107.781f), Vector3(715.169f, 1212.74f, 103.239f))))
+      ZipLinePaths(new ZipLinePath(256, false, List(Vector3(787.305f, 1465.731f, 73.517f), Vector3(781.021f, 1442.654f, 86.618f), Vector3(774.737f, 1419.577f, 95.82f), Vector3(770.59f, 1404.345f, 99.458f), Vector3(766.443f, 1389.114f, 99.697f))))
+      ZipLinePaths(new ZipLinePath(257, false, List(Vector3(728.914f, 969.705f, 110.895f), Vector3(739.989f, 966.686f, 110.459f), Vector3(790.937f, 952.799f, 82.875f))))
+      ZipLinePaths(new ZipLinePath(258, false, List(Vector3(1302.013f, 1185.204f, 96.853f), Vector3(1252.343f, 1186.784f, 102.446f), Vector3(1205.652f, 1188.27f, 107.253f))))
+      ZipLinePaths(new ZipLinePath(259, false, List(Vector3(1078.239f, 1125.433f, 107.751f), Vector3(1035.593f, 1046.301f, 176.325f), Vector3(1032.75f, 1041.026f, 176.63f))))
+      ZipLinePaths(new ZipLinePath(260, false, List(Vector3(1168.453f, 1061.073f, 107.351f), Vector3(1236.382f, 1044.695f, 175.95f), Vector3(1240.911f, 1043.603f, 176.79f))))
+      ZipLinePaths(new ZipLinePath(261, false, List(Vector3(1031.964f, 828.333f, 110.751f), Vector3(1082.946f, 827.829f, 109.239f), Vector3(1133.927f, 827.324f, 108.222f), Vector3(1184.908f, 826.82f, 107.205f), Vector3(1197.904f, 826.692f, 107.49f))))
+      ZipLinePaths(new ZipLinePath(262, false, List(Vector3(1337.353f, 851.122f, 83.075f), Vector3(1219.221f, 945.439f, 165.999f), Vector3(1217.346f, 946.937f, 166.325f))))
+      ZipLinePaths(new ZipLinePath(263, false, List(Vector3(1284.797f, 766.939f, 81.981f), Vector3(1234.37f, 700.07f, 132.568f), Vector3(1231.008f, 695.612f, 132.959f))))
+      ZipLinePaths(new ZipLinePath(264, false, List(Vector3(1330.746f, 755.47f, 103.852f), Vector3(1290.194f, 728.822f, 116.781f), Vector3(1249.642f, 702.174f, 128.861f), Vector3(1235.044f, 692.581f, 133.139f))))
+      ZipLinePaths(new ZipLinePath(265, false, List(Vector3(1218.624f, 694.117f, 133.015f), Vector3(1214.347f, 744.806f, 129.669f), Vector3(1210.07f, 795.495f, 126.036f), Vector3(1206.463f, 838.232f, 121.775f))))
+      ZipLinePaths(new ZipLinePath(266, false, List(Vector3(704.794f, 1142.453f, 107.813f), Vector3(817.239f, 1046.672f, 164.281f), Vector3(819.024f, 1045.152f, 164.594f))))
+      ZipLinePaths(new ZipLinePath(267, false, List(Vector3(690.815f, 1208.531f, 83.177f), Vector3(690.381f, 1191.88f, 101.623f), Vector3(690.055f, 1179.392f, 107.984f), Vector3(689.946f, 1175.229f, 107.779f))))
+      ZipLinePaths(new ZipLinePath(268, false, List(Vector3(758.955f, 1305.325f, 80.95f), Vector3(763.554f, 1322.557f, 99.347f), Vector3(764.154f, 1325.222f, 99.671f))))
+      ZipLinePaths(new ZipLinePath(269, false, List(Vector3(799.991f, 1259.203f, 92.603f), Vector3(910.702f, 1128.801f, 178.363f), Vector3(918.083f, 1120.108f, 178.162f))))
+      ZipLinePaths(new ZipLinePath(270, false, List(Vector3(1034.138f, 973.675f, 116.193f), Vector3(1105.112f, 948.65f, 185.221f), Vector3(1107.402f, 947.843f, 185.796f))))
+      ZipLinePaths(new ZipLinePath(271, false, List(Vector3(1010.579f, 1029.295f, 116.193f), Vector3(941.146f, 1096.884f, 177.675f), Vector3(938.906f, 1099.064f, 178.11f))))
+      ZipLinePaths(new ZipLinePath(272, false, List(Vector3(988.457f, 921.752f, 112.454f), Vector3(993.639f, 872.029f, 111.752f), Vector3(994.158f, 867.057f, 111.196f))))
+      ZipLinePaths(new ZipLinePath(273, false, List(Vector3(976.528f, 927.49f, 114.256f), Vector3(941.289f, 893.713f, 109.631f))))
+    }
+
+    ZipLines()
+
+  }
+}


### PR DESCRIPTION
This work initially started off as just being fixes for zipline paths being the wrong way around, and zipline teleporters not working at all.

However, after fixing those two I figured I might as well just get caverns working for basic gameplay.

Facilities can be captured, terminals (equipment and vehicle), doors and spawn points work. As mentioned above, ziplines and teleporters also work.

**Known bugs:**
- Some amenities are not centered on the base properly. This is a client side issue
- ~~GUID ordering may be off by one for S_Redoubt in Supai. Needs investigation~~
- ~~Whilst health crystals are defined in the map file and are set up in GlobalDefinitions they don't seem to actually do anything. Further investigation is needed. This may be related to the above GUID 0 workaround.~~
- Health crystals have no use animation. This is due to them expecting to have a ZoneAware owner object. As they don't, the UseProximityTerminal packet gets directed to the `nowhere` zone.
- ~~Equipment terminals in non-facility buildings do not fill orders properly~~
- ~~Map checksums are not known due to us never packet capturing them. This means you'll get the old warning about the client files being out of date when zoning into caves~~
- Capture flags don't show on facilities when the CC is hacked

**Notes:**
- Redoubt buildings are apparently considered to be Towers by the client (and are defined as so in the map file). This is likely to allow a spawn selection of either a Module building or Redoubt building as Nick mentioned
- The caverns do not follow the same logic as above-ground continents in defining their contained objects. Almost everything is in the groundcover files and there is no mpo files. There are all kinds of oddities in this new groundcover syntax including overriding GUID ordering. This also leads to amenities that have no owner, as such they have been assigned to GUID 0 and initialized separately in the map file. A change was added to allow all factions to access order terminals of this type.
- Other crystal types have not been looked at (yet)
- Modules are non-functional
- BFR imprinting is non-functional
- Vanu turrets are non-functional
- Cavern lock benefits are non-functional
- Other unspecified functionality that I can't think of right now is likely non-functional