### PR TITLE
Destruction

### DIFF
--- a/common/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
@@ -45,7 +45,7 @@ class ExplosiveDeployableDefinition(private val objectId : Int) extends ComplexD
   }
 
   override def Initialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {
-    obj.Actor = context.actorOf(Props(classOf[ExplosiveDeployableControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    obj.Actor = context.actorOf(Props(classOf[ExplosiveDeployableControl], obj), PlanetSideServerObject.UniqueActorName(obj))
   }
 
   override def Uninitialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {

--- a/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
@@ -30,7 +30,7 @@ class SensorDeployableDefinition(private val objectId : Int) extends ComplexDepl
   Packet = new SmallDeployableConverter
 
   override def Initialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {
-    obj.Actor = context.actorOf(Props(classOf[SensorDeployableControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    obj.Actor = context.actorOf(Props(classOf[SensorDeployableControl], obj), PlanetSideServerObject.UniqueActorName(obj))
   }
 
   override def Uninitialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {

--- a/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/SensorDeployable.scala
@@ -126,7 +126,7 @@ object SensorDeployableControl {
     target.Actor ! JammableUnit.ClearJammeredSound()
     target.Actor ! JammableUnit.ClearJammeredStatus()
     val zone = target.Zone
-    Deployables.AnnounceDestroyDeployable(target, Some(0 seconds))
+    Deployables.AnnounceDestroyDeployable(target, None)
     zone.LocalEvents ! LocalServiceMessage(zone.Id, LocalAction.TriggerEffectInfo(Service.defaultPlayerGUID, "on", target.GUID, false, 1000))
     zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.Destroy(target.GUID, attribution, attribution, target.Position))
   }

--- a/common/src/main/scala/net/psforever/objects/ShieldGeneratorDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/ShieldGeneratorDeployable.scala
@@ -25,7 +25,7 @@ class ShieldGeneratorDefinition extends ComplexDeployableDefinition(240) {
   DeployCategory = DeployableCategory.ShieldGenerators
 
   override def Initialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {
-    obj.Actor = context.actorOf(Props(classOf[ShieldGeneratorControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    obj.Actor = context.actorOf(Props(classOf[ShieldGeneratorControl], obj), PlanetSideServerObject.UniqueActorName(obj))
   }
 
   override def Uninitialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {

--- a/common/src/main/scala/net/psforever/objects/TurretDeployable.scala
+++ b/common/src/main/scala/net/psforever/objects/TurretDeployable.scala
@@ -49,7 +49,7 @@ class TurretDeployableDefinition(private val objectId : Int) extends ComplexDepl
   override def MaxHealth_=(max : Int) : Int = super[ComplexDeployableDefinition].MaxHealth_=(max)
 
   override def Initialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {
-    obj.Actor = context.actorOf(Props(classOf[TurretControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    obj.Actor = context.actorOf(Props(classOf[TurretControl], obj), PlanetSideServerObject.UniqueActorName(obj))
   }
 
   override def Uninitialize(obj : PlanetSideServerObject with Deployable, context : ActorContext) = {

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -49,6 +49,10 @@ object TelepadLike {
     */
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     obj.asInstanceOf[TelepadLike].Router = obj.Owner.GUID
+    import akka.actor.{ActorRef, Props}
+    if(obj.Actor == ActorRef.noSender) {
+      obj.Actor = context.actorOf(Props(classOf[TelepadControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+    }
   }
 
   /**
@@ -81,5 +85,18 @@ object TelepadLike {
       case _ =>
         None
     }
+  }
+}
+
+/**
+  * Telepad-like components don't actually use control agents right now, but,
+  * since the `trait` is used for a `Vehicle` `Utility` entity as well as a `Deployable` entity,
+  * and all utilities are supposed to have control agents with which to interface,
+  * a placeholder like this is easy to reason around.
+  * @param obj an entity that extends `TelepadLike`
+  */
+class TelepadControl(obj : TelepadLike) extends akka.actor.Actor {
+  def receive : akka.actor.Actor.Receive = {
+    case _ => ;
   }
 }

--- a/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/common/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -2,6 +2,7 @@
 package net.psforever.objects.ce
 
 import akka.actor.ActorContext
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.objects.vehicles.Utility
@@ -51,7 +52,7 @@ object TelepadLike {
     obj.asInstanceOf[TelepadLike].Router = obj.Owner.GUID
     import akka.actor.{ActorRef, Props}
     if(obj.Actor == ActorRef.noSender) {
-      obj.Actor = context.actorOf(Props(classOf[TelepadControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+      obj.Actor = context.actorOf(Props(classOf[TelepadControl], obj), PlanetSideServerObject.UniqueActorName(obj))
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/PlanetSideServerObject.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/PlanetSideServerObject.scala
@@ -3,6 +3,7 @@ package net.psforever.objects.serverobject
 
 import akka.actor.ActorRef
 import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.entity.NoGUIDException
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.zones.ZoneAware
 
@@ -32,5 +33,28 @@ abstract class PlanetSideServerObject extends PlanetSideGameObject
       actor = control
     }
     actor
+  }
+}
+
+object PlanetSideServerObject {
+  /**
+    * `Actor` entities require unique names over the course of the lifetime of the `ActorSystem` object.
+    * To produce this name, a composition of three strings separated by underscores is assembled.<br>
+    * - the entity's object name;
+    * uniqueness is very low, less than 50, but helps to identify the object<br>
+    * - the entity's globally unique identifier number;
+    * its uniqueness is much greater but still falls within less than 66535 possible integers;
+    * useful for locating that entity;
+    * an `Exception` can be thrown if this field was never set,
+    * but that is a condition for which it is worth throwing the `Exception`<br>
+    * - the current POSIX time in milliseconds;
+    * results will remain reasonably unique;
+    * useful for taking a rough estimation of how long the entity has existed
+    * @throws `NoGUIDException` if the entity has never been registered to a unique identifier system
+    * @param obj the entity for whom the `Actor` object will be created
+    * @return the unique name
+    */
+  def UniqueActorName(obj : PlanetSideGameObject) : String = {
+    s"${obj.Definition.Name}_${obj.GUID.guid}_${System.currentTimeMillis}"
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/MatrixTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/MatrixTerminalDefinition.scala
@@ -3,6 +3,7 @@ package net.psforever.objects.serverobject.terminals
 
 import akka.actor.ActorContext
 import net.psforever.objects.Player
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.structures.Amenity
 
 /**
@@ -29,7 +30,7 @@ object MatrixTerminalDefinition {
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     import akka.actor.{ActorRef, Props}
     if(obj.Actor == ActorRef.noSender) {
-      obj.Actor = context.actorOf(Props(classOf[TerminalControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+      obj.Actor = context.actorOf(Props(classOf[TerminalControl], obj), PlanetSideServerObject.UniqueActorName(obj))
     }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
@@ -7,6 +7,7 @@ import net.psforever.objects.{Player, Vehicle}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.loadouts.{InfantryLoadout, VehicleLoadout}
 import net.psforever.objects.inventory.InventoryItem
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.packet.game.ItemTransactionMessage
 import net.psforever.objects.serverobject.terminals.EquipmentTerminalDefinition._
@@ -341,7 +342,7 @@ object OrderTerminalDefinition {
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     import akka.actor.{ActorRef, Props}
     if(obj.Actor == ActorRef.noSender) {
-      obj.Actor = context.actorOf(Props(classOf[TerminalControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+      obj.Actor = context.actorOf(Props(classOf[TerminalControl], obj), PlanetSideServerObject.UniqueActorName(obj))
     }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminal.scala
@@ -2,7 +2,7 @@
 package net.psforever.objects.serverobject.terminals
 
 import net.psforever.objects.Player
-import net.psforever.objects.serverobject.CommonMessages
+import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.types.Vector3
 import services.Service
@@ -76,7 +76,7 @@ object ProximityTerminal {
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     import akka.actor.{ActorRef, Props}
     if(obj.Actor == ActorRef.noSender) {
-      obj.Actor = context.actorOf(Props(classOf[ProximityTerminalControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+      obj.Actor = context.actorOf(Props(classOf[ProximityTerminalControl], obj), PlanetSideServerObject.UniqueActorName(obj))
       obj.Actor ! Service.Startup()
     }
   }

--- a/common/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeDefinition.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorContext
 import net.psforever.objects.SpawnPointDefinition
 import net.psforever.objects.definition.ObjectDefinition
 import net.psforever.objects.definition.converter.SpawnTubeConverter
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.structures.Amenity
 
 /**
@@ -25,7 +26,7 @@ object SpawnTubeDefinition {
   def Setup(obj : Amenity, context : ActorContext) : Unit = {
     import akka.actor.{ActorRef, Props}
     if(obj.Actor == ActorRef.noSender) {
-      obj.Actor = context.actorOf(Props(classOf[SpawnTubeControl], obj), s"${obj.Definition.Name}_${obj.GUID.guid}")
+      obj.Actor = context.actorOf(Props(classOf[SpawnTubeControl], obj), PlanetSideServerObject.UniqueActorName(obj))
     }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/teamwork/SquadFeatures.scala
+++ b/common/src/main/scala/net/psforever/objects/teamwork/SquadFeatures.scala
@@ -67,7 +67,7 @@ class SquadFeatures(val Squad : Squad) {
   private lazy val channel : String = s"${Squad.Faction}-Squad${Squad.GUID.guid}"
 
   def Start(implicit context : ActorContext) : SquadFeatures = {
-    switchboard = context.actorOf(Props[SquadSwitchboard], s"squad${Squad.GUID.guid}")
+    switchboard = context.actorOf(Props[SquadSwitchboard], s"squad_${Squad.GUID.guid}_${System.currentTimeMillis}")
     waypoints = Array.fill[WaypointData](SquadWaypoints.values.size)(new WaypointData())
     this
   }

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -53,32 +53,13 @@ class VehicleControl(vehicle : Vehicle) extends Actor
 
   def Enabled : Receive = checkBehavior
     .orElse(deployBehavior)
-    .orElse(dismountBehavior)
     .orElse(jammableBehavior)
     .orElse {
-      case Mountable.TryMount(user, seat_num) =>
-        val exosuit = user.ExoSuit
-        val restriction = vehicle.Seats(seat_num).ArmorRestriction
-        val seatGroup = vehicle.SeatPermissionGroup(seat_num).getOrElse(AccessPermissionGroup.Passenger)
-        val permission = vehicle.PermissionGroup(seatGroup.id).getOrElse(VehicleLockState.Empire)
-        if(
-          (if(seatGroup == AccessPermissionGroup.Driver) {
-              vehicle.Owner.contains(user.GUID) || vehicle.Owner.isEmpty || permission != VehicleLockState.Locked
-            }
-            else {
-              permission != VehicleLockState.Locked
-            }) &&
-            (exosuit match {
-              case ExoSuitType.MAX => restriction == SeatArmorRestriction.MaxOnly
-              case ExoSuitType.Reinforced => restriction == SeatArmorRestriction.NoMax
-              case _ => restriction != SeatArmorRestriction.MaxOnly
-            })
-        ) {
-          mountBehavior.apply(Mountable.TryMount(user, seat_num))
-        }
-        else {
-          sender ! Mountable.MountMessages(user, Mountable.CanNotMount(vehicle, seat_num))
-        }
+      case msg : Mountable.TryMount =>
+        tryMountBehavior.apply(msg)
+
+      case msg : Mountable.TryDismount =>
+        dismountBehavior.apply(msg)
 
       case Vitality.Damage(damage_func) =>
         if(vehicle.Health > 0) {
@@ -122,9 +103,37 @@ class VehicleControl(vehicle : Vehicle) extends Actor
       case _ => ;
     }
 
+  val tryMountBehavior : Receive = {
+    case msg @ Mountable.TryMount(user, seat_num) =>
+      val exosuit = user.ExoSuit
+      val restriction = vehicle.Seats(seat_num).ArmorRestriction
+      val seatGroup = vehicle.SeatPermissionGroup(seat_num).getOrElse(AccessPermissionGroup.Passenger)
+      val permission = vehicle.PermissionGroup(seatGroup.id).getOrElse(VehicleLockState.Empire)
+      if(
+        (if(seatGroup == AccessPermissionGroup.Driver) {
+          vehicle.Owner.contains(user.GUID) || vehicle.Owner.isEmpty || permission != VehicleLockState.Locked
+        }
+        else {
+          permission != VehicleLockState.Locked
+        }) &&
+          (exosuit match {
+            case ExoSuitType.MAX => restriction == SeatArmorRestriction.MaxOnly
+            case ExoSuitType.Reinforced => restriction == SeatArmorRestriction.NoMax
+            case _ => restriction != SeatArmorRestriction.MaxOnly
+          })
+      ) {
+        mountBehavior.apply(msg)
+      }
+      else {
+        sender ! Mountable.MountMessages(user, Mountable.CanNotMount(vehicle, seat_num))
+      }
+  }
+
   def Disabled : Receive = checkBehavior
-    .orElse(dismountBehavior)
     .orElse {
+      case msg : Mountable.TryDismount =>
+        dismountBehavior.apply(msg)
+
       case Vehicle.Reactivate() =>
         context.become(Enabled)
 

--- a/common/src/main/scala/net/psforever/objects/zones/ZoneVehicleActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZoneVehicleActor.scala
@@ -3,6 +3,7 @@ package net.psforever.objects.zones
 
 import akka.actor.{Actor, ActorRef, Props}
 import net.psforever.objects.Vehicle
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.vehicles.VehicleControl
 
 import scala.annotation.tailrec
@@ -43,7 +44,7 @@ class ZoneVehicleActor(zone : Zone, vehicleList : ListBuffer[Vehicle]) extends A
       else {
         vehicleList += vehicle
         vehicle.Zone = zone
-        vehicle.Actor = context.actorOf(Props(classOf[VehicleControl], vehicle), s"${vehicle.Definition.Name}_${vehicle.GUID.guid}")
+        vehicle.Actor = context.actorOf(Props(classOf[VehicleControl], vehicle), PlanetSideServerObject.UniqueActorName(vehicle))
       }
 
     case Zone.Vehicle.Despawn(vehicle) =>

--- a/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
+++ b/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
@@ -22,52 +22,59 @@ class VehicleRemover extends RemoverActor {
   def InitialJob(entry : RemoverActor.Entry) : Unit = { }
 
   def FirstJob(entry : RemoverActor.Entry) : Unit = {
-    val vehicle = entry.obj.asInstanceOf[Vehicle]
-    val vehicleGUID = vehicle.GUID
-    val zoneId = entry.zone.Id
-    vehicle.Actor ! Vehicle.PrepareForDeletion()
-    //escape being someone else's cargo
-    (vehicle.MountedIn match {
-      case Some(carrierGUID) =>
-        entry.zone.Vehicles.find(v => v.GUID == carrierGUID)
-      case None =>
-        None
-    }) match {
-      case Some(carrier : Vehicle) =>
-        val driverName = carrier.Seats(0).Occupant match {
-          case Some(driver) => driver.Name
-          case _ => zoneId
+    val vehicleGUID = entry.obj.GUID
+    entry.zone.GUID(vehicleGUID) match {
+      case Some(vehicle : Vehicle) if vehicle.HasGUID =>
+        val zoneId = entry.zone.Id
+        vehicle.Actor ! Vehicle.PrepareForDeletion()
+        //escape being someone else's cargo
+        (vehicle.MountedIn match {
+          case Some(carrierGUID) =>
+            entry.zone.Vehicles.find(v => v.GUID == carrierGUID)
+          case None =>
+            None
+        }) match {
+          case Some(carrier : Vehicle) =>
+            val driverName = carrier.Seats(0).Occupant match {
+              case Some(driver) => driver.Name
+              case _ => zoneId
+            }
+            context.parent ! VehicleServiceMessage(s"$driverName", VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), vehicleGUID, true, false, false))
+          case _ => ;
         }
-        context.parent ! VehicleServiceMessage(s"$driverName", VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), vehicleGUID, true, false, false))
+        //kick out all passengers
+        vehicle.Seats.values.foreach(seat => {
+          seat.Occupant match {
+            case Some(tplayer) =>
+              seat.Occupant = None
+              tplayer.VehicleSeated = None
+              if(tplayer.HasGUID) {
+                context.parent ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(tplayer.GUID, 4, false, vehicleGUID))
+              }
+            case None => ;
+          }
+          //abandon all cargo
+          vehicle.CargoHolds.values
+            .collect { case hold if hold.isOccupied =>
+              val cargo = hold.Occupant.get
+              context.parent ! VehicleServiceMessage(zoneId, VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), cargo.GUID, true, false, false))
+            }
+        })
       case _ => ;
     }
-    //kick out all passengers
-    vehicle.Seats.values.foreach(seat => {
-      seat.Occupant match {
-        case Some(tplayer) =>
-          seat.Occupant = None
-          tplayer.VehicleSeated = None
-          if(tplayer.HasGUID) {
-            context.parent ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(tplayer.GUID, 4, false, vehicleGUID))
-          }
-        case None => ;
-      }
-      //abandon all cargo
-      vehicle.CargoHolds.values
-        .collect { case hold if hold.isOccupied =>
-          val cargo = hold.Occupant.get
-          context.parent ! VehicleServiceMessage(zoneId, VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), cargo.GUID, true, false, false))
-        }
-    })
   }
 
   override def SecondJob(entry : RemoverActor.Entry) : Unit = {
-    val vehicle = entry.obj.asInstanceOf[Vehicle]
-    val zone = entry.zone
-    vehicle.DeploymentState = DriveState.Mobile
-    zone.Transport ! Zone.Vehicle.Despawn(vehicle)
-    context.parent ! VehicleServiceMessage(zone.Id, VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, zone, vehicle, vehicle.GUID))
-    super.SecondJob(entry)
+    val vehicleGUID = entry.obj.GUID
+    entry.zone.GUID(vehicleGUID) match {
+      case Some(vehicle : Vehicle) if vehicle.HasGUID =>
+        val zone = entry.zone
+        vehicle.DeploymentState = DriveState.Mobile
+        zone.Transport ! Zone.Vehicle.Despawn(vehicle)
+        context.parent ! VehicleServiceMessage(zone.Id, VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, zone, vehicle, vehicleGUID))
+        super.SecondJob(entry)
+      case _ => ;
+    }
   }
 
   def ClearanceTest(entry : RemoverActor.Entry) : Boolean = entry.obj.asInstanceOf[Vehicle].Seats.values.count(_.isOccupied) == 0

--- a/common/src/test/scala/objects/UtilityTest.scala
+++ b/common/src/test/scala/objects/UtilityTest.scala
@@ -217,7 +217,7 @@ class UtilityInternalTelepadTest extends ActorTest {
 
       system.actorOf(Props(classOf[UtilityTest.SetupControl], obj), "test") ! ""
       receiveOne(Duration.create(100, "ms")) //consume and discard
-      assert(obj().Actor == ActorRef.noSender)
+      assert(obj().Actor != ActorRef.noSender)
       assert(obj().asInstanceOf[Utility.InternalTelepad].Router.contains(veh.GUID))
     }
   }

--- a/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
+++ b/common/src/test/scala/objects/number/UniqueNumberSystemTest.scala
@@ -187,14 +187,14 @@ class UniqueNumberSystemTest5 extends ActorTest() {
       assert(src.CountUsed == 0)
 
       uns ! Register(testObj, "pool2")
-      val msg1 = receiveOne(Duration.create(500, "ms"))
+      val msg1 = receiveOne(Duration.create(2000, "ms"))
       assert(msg1.isInstanceOf[Success[_]])
       assert(testObj.HasGUID)
       assert(pool2.contains(testObj.GUID.guid))
       assert(src.CountUsed == 1)
 
       uns ! Unregister(testObj)
-      val msg2 = receiveOne(Duration.create(500, "ms"))
+      val msg2 = receiveOne(Duration.create(2000, "ms"))
       assert(msg2.isInstanceOf[Success[_]])
       assert(!testObj.HasGUID)
       assert(src.CountUsed == 0)

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3622,7 +3622,7 @@ class WorldSessionActor extends Actor
               })
               player.Inventory.Clear()
               player.ExoSuit = ExoSuitType.Standard
-              player.Slot(0).Equipment = Tool(StandardPistol(player.Faction))
+              player.Slot(0).Equipment = ConstructionItem(ace) //Tool(StandardPistol(player.Faction))
               player.Slot(2).Equipment = Tool(suppressor)
               player.Slot(4).Equipment = Tool(StandardMelee(player.Faction))
               player.Slot(6).Equipment = AmmoBox(bullet_9mm)
@@ -8691,15 +8691,15 @@ class WorldSessionActor extends Actor
   def HandleDealingDamage(target : PlanetSideGameObject with Vitality, data : ResolvedProjectile) : Unit = {
     val func = data.damage_model.Calculate(data)
     target match {
-      case obj : Player =>
+      case obj : Player if obj.Health > 0 =>
         //damage is synchronized on the target player's `WSA` (results distributed from there)
         continent.AvatarEvents ! AvatarServiceMessage(obj.Name, AvatarAction.Damage(player.GUID, obj, func))
 
-      case obj : Vehicle => obj.Actor ! Vitality.Damage(func)
-      case obj : FacilityTurret => obj.Actor ! Vitality.Damage(func)
-      case obj : ComplexDeployable => obj.Actor ! Vitality.Damage(func)
+      case obj : Vehicle if obj.Health > 0 => obj.Actor ! Vitality.Damage(func)
+      case obj : FacilityTurret if obj.Health > 0 => obj.Actor ! Vitality.Damage(func)
+      case obj : ComplexDeployable if obj.Health > 0 => obj.Actor ! Vitality.Damage(func)
 
-      case obj : SimpleDeployable =>
+      case obj : SimpleDeployable if obj.Health > 0 =>
         //damage is synchronized on `LSA` (results returned to and distributed from this `WSA`)
         continent.LocalEvents ! Vitality.DamageOn(obj, func)
       case _ => ;

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3633,11 +3633,11 @@ class WorldSessionActor extends Actor
               whenUsedLastMAXName(1) = faction+"hev_antiaircraft"
 
               (0 until 4).foreach( index => {
-                if (player.Slot(index).Equipment.isDefined) player.Slot(index).Equipment = None
+                player.Slot(index).Equipment = None
               })
               player.Inventory.Clear()
               player.ExoSuit = ExoSuitType.Standard
-              player.Slot(0).Equipment = ConstructionItem(ace) //Tool(StandardPistol(player.Faction))
+              player.Slot(0).Equipment = Tool(StandardPistol(player.Faction))
               player.Slot(2).Equipment = Tool(suppressor)
               player.Slot(4).Equipment = Tool(StandardMelee(player.Faction))
               player.Slot(6).Equipment = AmmoBox(bullet_9mm)


### PR DESCRIPTION
The handling of some issues that became apparent in our logs dealing with object destruction and, occasionally, creation.

1.  Objects that have no health never consider taking damage.  Previously, the check for this was in one or two places further up the chain of damage synchronization; now, it's right at the vestibule when allocating targets.
2.  On some occasions, it will be considered a valid operation to attempt to locally delete the unique identifier reference sent from a client if the server no longer recognizes the existence of such an entity. (The deletion is only attempted if *no* object is found.  If some object other than the one was was expected is found, deleting the reference, even if only for one client, would, of course, be a synchronization issue.)
3.  Entities with control agents now have very unique control agent names, as most "control agents" are `Actor` objects.  This is a lifetime requirement of an instance of an `ActorSystem`.  These names are generated by a function in `PlanetSideServerObject`.  The format is: "ObjectType_GUID_POSIXTime."
4.  Most objects seemed safe from any disruptions caused by the previously-explained issue, which would throw an `Exception`.  Players that were deconstructing and reconstructing in the same zone encountered this issue, however, and were thus the first instance of required uniqueness.
5.  All vehicle utilities should have control agents.  All control agents phase in and other existence as the vehicle's main control agent does.  One vehicle utility was lacking a control agent.  Kaboom.
6.  Tasking in `VehicleRemover` was given a slight modification to make it more secure and smell less.