### PR TITLE
Persistence

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Avatar.scala
+++ b/common/src/main/scala/net/psforever/objects/Avatar.scala
@@ -53,6 +53,8 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
     */
   private var lfs : Boolean = false
 
+  private var vehicleOwned : Option[PlanetSideGUID] = None
+
   def CharId : Long = char_id
 
   def BEP : Long = bep
@@ -195,6 +197,15 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
   def LFS_=(looking : Boolean) : Boolean = {
     lfs = looking
     LFS
+  }
+
+  def VehicleOwned : Option[PlanetSideGUID] = vehicleOwned
+
+  def VehicleOwned_=(guid : PlanetSideGUID) : Option[PlanetSideGUID] = VehicleOwned_=(Some(guid))
+
+  def VehicleOwned_=(guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
+    vehicleOwned = guid
+    VehicleOwned
   }
 
   def Definition : AvatarDefinition = GlobalDefinitions.avatar

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -51,7 +51,6 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
   private var cloaked : Boolean = false
 
   private var vehicleSeated : Option[PlanetSideGUID] = None
-  private var vehicleOwned : Option[PlanetSideGUID] = None
 
   Continent = "home2" //the zone id
 
@@ -605,14 +604,11 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
     VehicleSeated
   }
 
-  def VehicleOwned : Option[PlanetSideGUID] = vehicleOwned
+  def VehicleOwned : Option[PlanetSideGUID] = core.VehicleOwned
 
-  def VehicleOwned_=(guid : PlanetSideGUID) : Option[PlanetSideGUID] = VehicleOwned_=(Some(guid))
+  def VehicleOwned_=(guid : PlanetSideGUID) : Option[PlanetSideGUID] = core.VehicleOwned_=(Some(guid))
 
-  def VehicleOwned_=(guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
-    vehicleOwned = guid
-    VehicleOwned
-  }
+  def VehicleOwned_=(guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = core.VehicleOwned_=(guid)
 
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]
 
@@ -658,7 +654,6 @@ object Player {
   def Respawn(player : Player) : Player = {
     if(player.Release) {
       val obj = new Player(player.core)
-      obj.VehicleOwned = player.VehicleOwned
       obj.Continent = player.Continent
       obj
     }

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -102,6 +102,9 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends AmenityOwner
     */
   private var mountedIn : Option[PlanetSideGUID] = None
 
+  private var vehicleGatingManifest : Option[VehicleManifest] = None
+  private var previousVehicleGatingManifest : Option[VehicleManifest] = None
+
   //init
   LoadDefinition()
 
@@ -522,6 +525,23 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends AmenityOwner
     * @return the current access value for the `Vehicle` `Trunk`
     */
   def TrunkLockState :  VehicleLockState.Value = groupPermissions(3)
+
+  def PrepareGatingManifest() : VehicleManifest = {
+    val manifest = VehicleManifest(this)
+    seats.collect { case (index, seat) if index > 0 => seat.Occupant = None }
+    vehicleGatingManifest = Some(manifest)
+    previousVehicleGatingManifest = None
+    manifest
+  }
+
+  def PublishGatingManifest() : Option[VehicleManifest] = {
+    val out = vehicleGatingManifest
+    previousVehicleGatingManifest = vehicleGatingManifest
+    vehicleGatingManifest = None
+    out
+  }
+
+  def PreviousGatingManifest() : Option[VehicleManifest] = previousVehicleGatingManifest
 
   def DamageModel = Definition.asInstanceOf[DamageResistanceModel]
 

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects
+
+import net.psforever.objects.vehicles.VehicleLockState
+import net.psforever.objects.zones.Zone
+import net.psforever.types.PlanetSideGUID
+import services.avatar.{AvatarAction, AvatarServiceMessage}
+import services.vehicle.{VehicleAction, VehicleServiceMessage}
+
+object Vehicles {
+  /**
+    * Disassociate a player from a vehicle that he owns.
+    * The vehicle must exist in the game world on the specified continent.
+    * This is similar but unrelated to the natural exchange of ownership when someone else sits in the vehicle's driver seat.
+    * This is the player side of vehicle ownership removal.
+    * @param player the player
+    */
+  def Disown(player : Player, zone : Zone) : Option[Vehicle] = Disown(player, Some(zone))
+  /**
+    * Disassociate a player from a vehicle that he owns.
+    * The vehicle must exist in the game world on the specified continent.
+    * This is similar but unrelated to the natural exchange of ownership when someone else sits in the vehicle's driver seat.
+    * This is the player side of vehicle ownership removal.
+    * @param player the player
+    */
+  def Disown(player : Player, zoneOpt : Option[Zone]) : Option[Vehicle] = {
+    player.VehicleOwned match {
+      case Some(vehicle_guid) =>
+        player.VehicleOwned = None
+        zoneOpt.getOrElse(player.Zone).GUID(vehicle_guid) match {
+          case Some(vehicle : Vehicle) =>
+            Disown(player, vehicle)
+          case _ =>
+            None
+        }
+      case None =>
+        None
+    }
+  }
+
+  /**
+    * Disassociate a player from a vehicle that he owns without associating a different player as the owner.
+    * Set the vehicle's driver seat permissions and passenger and gunner seat permissions to "allow empire,"
+    * then reload them for all clients.
+    * This is the vehicle side of vehicle ownership removal.
+    * @param player the player
+    */
+  def Disown(player : Player, vehicle : Vehicle) : Option[Vehicle] = {
+    val pguid = player.GUID
+    if(vehicle.Owner.contains(pguid)) {
+      vehicle.AssignOwnership(None)
+      val factionChannel = s"${vehicle.Faction}"
+      vehicle.Zone.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.Ownership(pguid, PlanetSideGUID(0)))
+      val vguid = vehicle.GUID
+      val empire = VehicleLockState.Empire.id
+      (0 to 2).foreach(group => {
+        vehicle.PermissionGroup(group, empire)
+        vehicle.Zone.VehicleEvents ! VehicleServiceMessage(factionChannel, VehicleAction.SeatPermissions(pguid, vguid, group, empire))
+      })
+      ReloadAccessPermissions(vehicle, player.Name)
+      Some(vehicle)
+    }
+    else {
+      None
+    }
+  }
+  /**
+    * Uterate over vehicle permissions and turn them into `PlanetsideAttributeMessage` packets.<br>
+    * <br>
+    * For the purposes of ensuring that other players are always aware of the proper permission state of the trunk and seats,
+    * packets are intentionally dispatched to the current client to update the states.
+    * Perform this action just after any instance where the client would initially gain awareness of the vehicle.
+    * The most important examples include either the player or the vehicle itself spawning in for the first time.
+    * @param vehicle the `Vehicle`
+    */
+  def ReloadAccessPermissions(vehicle : Vehicle, toChannel : String) : Unit = {
+    val vehicle_guid = vehicle.GUID
+    (0 to 3).foreach(group => {
+      vehicle.Zone.AvatarEvents ! AvatarServiceMessage(
+        toChannel,
+        AvatarAction.PlanetsideAttributeToAll(vehicle_guid, group + 10, vehicle.PermissionGroup(group).get.id)
+      )
+    })
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -27,7 +27,6 @@ object Vehicles {
       case Some(tplayer) =>
         tplayer.VehicleOwned = vehicle.GUID
         vehicle.AssignOwnership(playerOpt)
-
         vehicle.Zone.VehicleEvents ! VehicleServiceMessage(vehicle.Zone.Id, VehicleAction.Ownership(tplayer.GUID, vehicle.GUID))
         Vehicles.ReloadAccessPermissions(vehicle, tplayer.Name)
         Some(vehicle)

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -9,6 +9,34 @@ import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 object Vehicles {
   /**
+    * na
+    * @param vehicle na
+    * @param tplayer na
+    * @return na
+    */
+  def Own(vehicle : Vehicle, tplayer : Player) : Option[Vehicle] = Own(vehicle, Some(tplayer))
+
+  /**
+    * na
+    * @param vehicle na
+    * @param playerOpt na
+    * @return na
+    */
+  def Own(vehicle : Vehicle, playerOpt : Option[Player]) : Option[Vehicle] = {
+    playerOpt match {
+      case Some(tplayer) =>
+        tplayer.VehicleOwned = vehicle.GUID
+        vehicle.AssignOwnership(playerOpt)
+
+        vehicle.Zone.VehicleEvents ! VehicleServiceMessage(vehicle.Zone.Id, VehicleAction.Ownership(tplayer.GUID, vehicle.GUID))
+        Vehicles.ReloadAccessPermissions(vehicle, tplayer.Name)
+        Some(vehicle)
+      case None =>
+        None
+    }
+  }
+
+  /**
     * Disassociate a player from a vehicle that he owns.
     * The vehicle must exist in the game world on the specified continent.
     * This is similar but unrelated to the natural exchange of ownership when someone else sits in the vehicle's driver seat.

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -92,8 +92,9 @@ object Vehicles {
       None
     }
   }
+
   /**
-    * Uterate over vehicle permissions and turn them into `PlanetsideAttributeMessage` packets.<br>
+    * Iterate over vehicle permissions and turn them into `PlanetsideAttributeMessage` packets.<br>
     * <br>
     * For the purposes of ensuring that other players are always aware of the proper permission state of the trunk and seats,
     * packets are intentionally dispatched to the current client to update the states.

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -22,6 +22,9 @@ class PlayerControl(player : Player) extends Actor
   with JammableBehavior {
   def JammableObject = player
 
+  private [this] val log = org.log4s.getLogger(player.Name)
+  private [this] val damageLog = org.log4s.getLogger("DamageResolution")
+
   def receive : Receive = jammableBehavior.orElse {
     case Player.Die() =>
       PlayerControl.HandleDestructionAwareness(player, player.GUID, None)
@@ -40,8 +43,7 @@ class PlayerControl(player : Player) extends Actor
         val damageToCapacitor = originalCapacitor - capacitor
         PlayerControl.HandleDamageResolution(player, cause, damageToHealth, damageToArmor, damageToCapacitor)
         if(damageToHealth != 0 || damageToArmor != 0 || damageToCapacitor != 0) {
-          org.log4s.getLogger("DamageResolution")
-            .info(s"${player.Name}-infantry: BEFORE=$originalHealth/$originalArmor/$originalCapacitor, AFTER=$health/$armor/$capacitor, CHANGE=$damageToHealth/$damageToArmor/$damageToCapacitor")
+          damageLog.info(s"${player.Name}-infantry: BEFORE=$originalHealth/$originalArmor/$originalCapacitor, AFTER=$health/$armor/$capacitor, CHANGE=$damageToHealth/$damageToArmor/$damageToCapacitor")
         }
       }
     case _ => ;

--- a/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -183,7 +183,7 @@ class GridInventory extends Container {
     val starth : Int = starty + h - 1
     if(actualSlot < 0 || actualSlot >= grid.length || startw >= width || starth >= height) {
       val bounds : String = if(startx < 0) { "left" } else if(startw >= width) { "right" } else { "bottom" }
-      Failure(new IndexOutOfBoundsException(s"requested region escapes the $bounds edge of the grid inventory - $startx, $starty; $w x $h"))
+      Failure(new IndexOutOfBoundsException(s"requested region escapes the $bounds edge of the grid inventory - $startx + $w, $starty + $h"))
     }
     else {
       val collisions : mutable.Set[InventoryItem] = mutable.Set[InventoryItem]()
@@ -220,22 +220,31 @@ class GridInventory extends Container {
       val starty : Int = actualSlot / width
       val startw : Int = startx + w - 1
       val bounds : String = if(startx < 0) { "left" } else if(startw >= width) { "right" } else { "bottom" }
-      Failure(new IndexOutOfBoundsException(s"requested region escapes the $bounds edge of the grid inventory - $startx, $starty; $w x $h"))
+      Failure(new IndexOutOfBoundsException(s"requested region escapes the $bounds edge of the grid inventory - $startx + $w, $starty + $h"))
     }
     else {
       val collisions : mutable.Set[InventoryItem] = mutable.Set[InventoryItem]()
       var curr = actualSlot
       val fixedItems = items.toMap
       val fixedGrid = grid.toList
-      for(_ <- 0 until h) {
-        for(col <- 0 until w) {
-          if(fixedGrid(curr + col) > -1) {
-            collisions += fixedItems(fixedGrid(curr + col))
+      try {
+        for(_ <- 0 until h) {
+          for(col <- 0 until w) {
+            val itemIndex = fixedGrid(curr + col)
+            if(itemIndex > -1) {
+              collisions += fixedItems(itemIndex)
+            }
           }
+          curr += width
         }
-        curr += width
+        Success(collisions.toList)
       }
-      Success(collisions.toList)
+      catch {
+        case e : NoSuchElementException =>
+          Failure(InventoryDisarrayException(s"inventory contained old item data", e))
+        case e : Exception =>
+          Failure(e)
+      }
     }
   }
 
@@ -305,7 +314,7 @@ class GridInventory extends Container {
       val starty : Int = start / width
       val startw : Int = startx + w - 1
       val bounds : String = if(startx < 0) { "left" } else if(startw >= width) { "right" } else { "bottom" }
-      throw new IndexOutOfBoundsException(s"requested region escapes the $bounds of the grid inventory - $startx, $starty; $w x $h")
+      throw new IndexOutOfBoundsException(s"requested region escapes the $bounds of the grid inventory - $startx + $w, $starty + $h")
     }
     else {
       var curr = start

--- a/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -289,6 +289,7 @@ class GridInventory extends Container {
 
   /**
     * Define a region of inventory grid cells and set them to a given value.
+    * @see `SetCellsNoOffset`
     * @param start the initial inventory index
     * @param w the width of the region
     * @param h the height of the region
@@ -296,19 +297,22 @@ class GridInventory extends Container {
     *              defaults to -1 (which is "nothing")
     */
   def SetCells(start : Int, w : Int, h : Int, value : Int = -1) : Unit = {
-    SetCellsOffset(math.max(start - offset, 0), w, h, value)
+    grid = SetCellsNoOffset(start - offset, w, h, value)
   }
 
   /**
     * Define a region of inventory grid cells and set them to a given value.
+    * Perform basic boundary checking for the current inventory dimensions.
+    * @see `SetCellsOnlyNoOffset`
     * @param start the initial inventory index, without the inventory offset (required)
     * @param w the width of the region
     * @param h the height of the region
     * @param value the value to set all the cells in the defined region;
     *              defaults to -1 (which is "nothing")
+    * @return a copy of the inventory as a grid, with the anticipated modifications
     * @throws IndexOutOfBoundsException if the region extends outside of the grid boundaries
     */
-  def SetCellsOffset(start : Int, w : Int, h : Int, value : Int = -1) : Unit = {
+  def SetCellsNoOffset(start : Int, w : Int, h : Int, value : Int = -1) : Array[Int] = {
     if(start < 0 || start > grid.length || (start % width) + w - 1 > width || (start / width) + h- 1 > height) {
       val startx : Int = start % width
       val starty : Int = start / width
@@ -316,57 +320,113 @@ class GridInventory extends Container {
       val bounds : String = if(startx < 0) { "left" } else if(startw >= width) { "right" } else { "bottom" }
       throw new IndexOutOfBoundsException(s"requested region escapes the $bounds of the grid inventory - $startx + $w, $starty + $h")
     }
-    else {
-      var curr = start
-      for(_ <- 0 until h) {
-        for(col <- 0 until w) {
-          grid(curr + col) = value
-        }
-        curr += width
+    SetCellsOnlyNoOffset(start, w, h, value)
+  }
+
+  /**
+    * Define a region of inventory grid cells and set them to a given value.
+    * Ignore inventory boundary checking and just set the appropriate cell values.
+    * Do not use this unless boundary checking was already performed.
+    * @param start the initial inventory index, without the inventory offset (required)
+    * @param w the width of the region
+    * @param h the height of the region
+    * @param value the value to set all the cells in the defined region;
+    *              defaults to -1 (which is "nothing")
+    * @return a copy of the inventory as a grid, with the anticipated modifications
+    */
+  private def SetCellsOnlyNoOffset(start : Int, w : Int, h : Int, value : Int = -1) : Array[Int] = {
+    val out : Array[Int] = grid.clone()
+    var curr = start
+    for(_ <- 0 until h) {
+      for(col <- 0 until w) {
+        out(curr + col) = value
       }
+      curr += width
     }
+    out
   }
 
   def Insert(start : Int, obj : Equipment) : Boolean = {
     val key : Int = entryIndex.getAndIncrement()
     items.get(key) match {
-      case None => //no redundant insertions or other collisions
+      case None => //no redundant insertions
         Insertion_CheckCollisions(start, obj, key)
       case _ =>
         false
     }
   }
 
+  /**
+    * Perform a collisions check and, if it passes, perform the insertion.
+    * @param start the starting slot
+    * @param obj the `Equipment` item to be inserted
+    * @param key the internal numeric identifier for this item
+    * @return the success or the failure of the insertion process
+    */
   def Insertion_CheckCollisions(start : Int, obj : Equipment, key : Int) : Boolean = {
     CheckCollisions(start, obj) match {
       case Success(Nil) =>
-        InsertQuickly(start, obj, key)
+        val tile = obj.Tile
+        grid = SetCellsOnlyNoOffset(start - offset, tile.Width, tile.Height, key)
+        val card = InventoryItem(obj, start)
+        items += key -> card
+        true
       case _ =>
         false
     }
   }
 
+  /**
+    * Just insert an item into the inventory without checking for item collisions.
+    * @param start the starting slot
+    * @param obj the `Equipment` item to be inserted
+    * @return whether the insertion succeeded
+    */
   def InsertQuickly(start : Int, obj : Equipment) : Boolean = InsertQuickly(start, obj, entryIndex.getAndIncrement())
 
+  /**
+    * Just insert an item into the inventory without checking for item collisions.
+    * Inventory boundary checking still occurs but the `Exception` is caught and discarded.
+    * Discarding the `Exception` is normally bad practice; the result is the only thing we care about here.
+    * @param start the starting slot
+    * @param obj the `Equipment` item to be inserted
+    * @param key the internal numeric identifier for this item
+    * @return whether the insertion succeeded
+    */
   private def InsertQuickly(start : Int, obj : Equipment, key : Int) : Boolean = {
-    val card = InventoryItem(obj, start)
-    items += key -> card
-    val tile = obj.Tile
-    SetCells(start, tile.Width, tile.Height, key)
-    true
+    try {
+      val tile = obj.Tile
+      val updated = SetCellsNoOffset(start - offset, tile.Width, tile.Height, key)
+      val card = InventoryItem(obj, start)
+      items += key -> card
+      grid = updated
+      true
+    }
+    catch {
+      case _ : Exception =>
+        false
+    }
   }
 
   def +=(kv : (Int, Equipment)) : Boolean = Insert(kv._1, kv._2)
 
   def Remove(index : Int) : Boolean = {
-    val key = grid(index - Offset)
-    items.remove(key) match {
-      case Some(item) =>
-        val tile = item.obj.Tile
-        SetCells(item.start, tile.Width, tile.Height)
-        true
-      case None =>
-        false
+    val keyVal = index - offset
+    if(keyVal > -1 && keyVal < grid.length) {
+      val key = grid(index - offset)
+      items.get(key) match {
+        case Some(item) =>
+          val tile = item.obj.Tile
+          val updated = SetCellsNoOffset(item.start - offset, tile.Width, tile.Height)
+          items.remove(key)
+          grid = updated
+          true
+        case None =>
+          false
+      }
+    }
+    else {
+      false
     }
   }
 
@@ -374,10 +434,12 @@ class GridInventory extends Container {
 
   def Remove(guid : PlanetSideGUID) : Boolean = {
     recursiveFindIdentifiedObject(items.keys.iterator, guid) match {
-      case Some(index) =>
-        val item = items.remove(index).get
+      case Some(key) =>
+        val item = items(key)
         val tile = item.obj.Tile
-        SetCells(item.start, tile.Width, tile.Height)
+        val updated = SetCellsNoOffset(item.start - offset, tile.Width, tile.Height)
+        items.remove(key)
+        grid = updated
         true
       case None =>
         false
@@ -416,13 +478,107 @@ class GridInventory extends Container {
   }
 
   /**
+    * Align the "inventory as a grid" with the "inventory as a list."
+    * The grid is a faux-two-dimensional map of object identifiers that should point to items in the list.
+    * (Not the same as the global unique identifier number.)
+    * The objects in the list are considered actually being in the inventory.
+    * Only the references to those objects in grid-space can be considered out of alignment
+    * by not pointing to objects in the list.
+    * The inventory as a grid can be repaired but only a higher authority can perform inventory synchronization.
+    * @see `InventoryDisarrayException`
+    * @return the number of stale object references found and corrected
+    */
+  def ElementsOnGridMatchList() : Int = {
+    var misses : Int = 0
+    grid = grid.map {
+      case n if items.get(n).nonEmpty => n
+      case -1 => -1
+      case _ =>
+        misses += 1
+        -1
+    }
+    misses
+  }
+
+  /**
+    * Check whether any items in the "inventory as a list" datastructure would overlap in the "inventory as a grid".
+    * Most likely, if an overlap is discovered,
+    * the grid-space is already compromised by having lost a section of some item's `Tile`.
+    * The inventory system actually lacks mechanics to properly resolve any discovered issues.
+    * For that reason, it will return a list of overlap issues that need to be resolved by a higher authority.
+    * @see `InventoryDisarrayException`
+    * @see `recursiveRelatedListCollisions`
+    * @return a list of item overlap collision combinations
+    */
+  def ElementsInListCollideInGrid() : List[List[InventoryItem]] = {
+    val testGrid : mutable.Map[Int, List[Int]] = mutable.Map[Int, List[Int]]()
+    //on average this will run the same number of times as capacity
+    items.foreach {
+      case (itemId, item) =>
+        var start = item.start
+        val wide = item.obj.Tile.Width
+        val high = item.obj.Tile.Height
+        //allocate all of the slots that comprise this item's tile
+        (0 until high).foreach { _ =>
+          (0 until wide).foreach { w =>
+            val slot = start + w
+            testGrid(slot) = testGrid.getOrElse(slot, Nil) :+ itemId
+          }
+          start += width
+        }
+    }
+    //lists with multiple entries represent a group of items that collide
+    //perform a specific distinct on the list of lists of numeric id overlaps
+    //THEN map each list of list's item id to an item
+    val out = testGrid.collect {
+      case (_, list) if list.size > 1 => list.sortWith(_ < _)
+    }
+    recursiveRelatedListCollisions(out.iterator, out.toList).map { list => list.map { items } }
+  }
+
+  /**
+    * Filter out element overlap combinations until only unique overlap combinations remain.
+    * The filtration operation not only removes exact duplicates, leaving but one of an entry's kind,
+    * but also removes that very entry if another element contains the entry as a subset of itself.
+    * For example:
+    * if A overlaps B and B overlaps C, but A doesn't overlap C, the output will be A-B and B-C;
+    * if A and C do overlap, however, the output will be A-B-C, eliminating both A-B and B-C in the process.
+    * @see `ElementsInListCollideInGrid`
+    * @see `SeqLike.containsSlice`
+    * @see `tailrec`
+    * @param original an iterator of the original list of overlapping elements
+    * @param updated an list of overlapping elements not filtered out of the original list
+    * @return the final list of unique overlapping element combinations
+    */
+  @tailrec private def recursiveRelatedListCollisions(original : Iterator[List[Int]], updated : List[List[Int]]) : List[List[Int]] = {
+    if(original.hasNext) {
+      val target = original.next
+      val filtered = updated.filterNot(item => item.equals(target))
+      val newupdated = if(filtered.size == updated.size) {
+        updated //the lists are the same size, nothing was filtered
+      }
+      else if(updated.exists(test => test.containsSlice(target) && !test.equals(target))) {
+        filtered //some element that is not the target element contains the target element as a subset
+      }
+      else {
+        filtered :+ target //restore one entry for the target element
+      }
+      recursiveRelatedListCollisions(original, newupdated)
+    }
+    else {
+      updated
+    }
+  }
+
+  /**
     * Clear the inventory by removing all of its items.
     * @return a `List` of the previous items in the inventory as their `InventoryItemData` tiles
     */
   def Clear() : List[InventoryItem] = {
     val list = items.values.toList
     items.clear
-    SetCellsOffset(0, width, height)
+    //entryIndex.set(0)
+    grid = SetCellsOnlyNoOffset(0, width, height)
     list
   }
 

--- a/common/src/main/scala/net/psforever/objects/inventory/InventoryDisarrayException.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/InventoryDisarrayException.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects.inventory
+
+/**
+  * Some data in the grid portion of a `GridInventory`
+  * does not match against data that is expected to be found in the "list" portion of `GridInventory`.
+  * While merely eliminating the old data is possible,
+  * the discovery of this errant data could be hiding significantly greater issues,
+  * and these greater issues must be explored at a higher level of governance.
+  * @param message the explanation of why the exception was thrown
+  * @param cause any prior `Exception` that was thrown then wrapped in this one
+  */
+final case class InventoryDisarrayException(private val message: String = "", private val cause: Throwable)
+  extends Exception(message, cause)
+
+object InventoryDisarrayException {
+  /**
+    * Overloaded constructor that constructs the `Exception` without nesting any prior `Exceptions`.
+    * Just the custom error message is included.
+    * @param message the explanation of why the exception was thrown
+    * @return an `InventoryDisarrayException` object
+    */
+  def apply(message : String) : InventoryDisarrayException =
+    InventoryDisarrayException(message, None.orNull)
+}

--- a/common/src/main/scala/net/psforever/objects/inventory/InventoryEquipmentSlot.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/InventoryEquipmentSlot.scala
@@ -35,7 +35,7 @@ class InventoryEquipmentSlot(private val slot : Int, private val inv : GridInven
         val tile = equip.Definition.Tile
         inv.CheckCollisionsVar(slot, tile.Width, tile.Height) match {
           case Success(Nil) => inv.InsertQuickly(slot, equip)
-          case _ => ;
+          case _ => ; //TODO we should handle the exception
         }
 
       case None =>

--- a/common/src/main/scala/net/psforever/objects/serverobject/structures/Amenity.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/structures/Amenity.scala
@@ -31,7 +31,7 @@ abstract class Amenity extends PlanetSideServerObject with ZoneAware {
     */
   def Owner : AmenityOwner = {
     if(owner == Building.NoBuilding) {
-      log.warn(s"Amenity $GUID in zone $Zone tried to access owner, but doesn't have one.")
+      log.warn(s"Amenity $GUID in zone ${Zone.Id} tried to access owner, but doesn't have one.")
     }
     owner
   }

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleManifest.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleManifest.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects.vehicles
+
+import net.psforever.objects.Vehicle
+import net.psforever.objects.zones.Zone
+
+/**
+  * na
+  * @param file the id of this manifest entry;
+  *             used as the channel name for summoning passengers to the vehicle
+  *             after it has been loaded to a new location or to a new zone;
+  *             this channel name should be unique to the vehicle for at least the duration of the transition;
+  *             the vehicle-specific channel with which all passengers are coordinated back to the original vehicle
+  * @param vehicle na
+  * @param origin na
+  * @param driverName na
+  * @param passengers na
+  * @param cargo na
+  */
+/**
+  * The channel name for summoning passengers to the vehicle
+  * after it has been loaded to a new location or to a new zone.
+  * This channel name should be unique to the vehicle for at least the duration of the transition.
+  * The vehicle-specific channel with which all passengers are coordinated back to the original vehicle.
+  * @param vehicle the vehicle being moved (or having been moved)
+  * @return the channel name
+  */
+final case class VehicleManifest(file : String,
+                                 vehicle : Vehicle,
+                                 origin : Zone,
+                                 driverName : String,
+                                 passengers : List[(String, Int)],
+                                 cargo : List[(String, Int)])
+
+object VehicleManifest {
+  def apply(vehicle : Vehicle) : VehicleManifest = {
+    val driverName = vehicle.Seats(0).Occupant match {
+      case Some(driver) => driver.Name
+      case None => "MISSING_DRIVER"
+    }
+    val passengers = vehicle.Seats.collect { case (index, seat) if index > 0 && seat.isOccupied =>
+      (seat.Occupant.get.Name, index)
+    }
+    val cargo = vehicle.CargoHolds.collect { case (index, hold) if hold.Occupant.nonEmpty =>
+      hold.Occupant.get.Seats(0).Occupant match {
+        case Some(driver) =>
+          (driver.Name, index)
+        case None =>
+          ("MISSING_DRIVER", index)
+      }
+    }
+    VehicleManifest(ManifestChannelName(vehicle), vehicle, vehicle.Zone, driverName, passengers.toList, cargo.toList)
+  }
+
+  def ManifestChannelName(vehicle : Vehicle) : String = {
+    s"transport-vehicle-channel-${vehicle.GUID.guid}"
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
@@ -47,7 +47,7 @@ class ZonePopulationActor(zone : Zone, playerMap : TrieMap[Avatar, Option[Player
             sender ! Zone.Population.PlayerAlreadySpawned(zone, player)
           }
           else if(newToZone) {
-            player.Actor = context.actorOf(Props(classOf[PlayerControl], player),  s"${player.Name}_${player.GUID.guid}_${System.currentTimeMillis}")
+            player.Actor = context.actorOf(Props(classOf[PlayerControl], player),  s"${player.CharId}_${player.GUID.guid}_${System.currentTimeMillis}")
             player.Zone = zone
           }
         case None =>

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -347,7 +347,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     */
   def DisownVehicle(player : Player) : Unit = {
     Vehicles.Disown(player, inZone) match {
-      case Some(vehicle) if vehicle.Health == 0 || vehicle.Seats.values.forall(seat => !seat.isOccupied) =>
+      case Some(vehicle) if vehicle.Health == 0 || (vehicle.Seats.values.forall(seat => !seat.isOccupied) && vehicle.Owner.isEmpty) =>
         inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), inZone))
         inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, inZone,
           if(vehicle.Flying) {

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -2,12 +2,12 @@
 package services.account
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
+
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import net.psforever.objects.guid.GUIDTask
-import net.psforever.objects.{Avatar, DefaultCancellable, Deployables, Player, Vehicle, Vehicles}
+import net.psforever.objects._
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.zones.Zone
 import net.psforever.types.Vector3
@@ -328,7 +328,9 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     */
   def AvatarLogout(avatar : Avatar) : Unit = {
     val parent = context.parent
-    squadService.tell(Service.Leave(Some(avatar.CharId.toString)), parent)
+    val charId = avatar.CharId
+    LivePlayerList.Remove(charId)
+    squadService.tell(Service.Leave(Some(charId.toString)), parent)
     Deployables.Disown(inZone, avatar, parent)
     inZone.Population.tell(Zone.Population.Leave(avatar), parent)
   }

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -2,35 +2,77 @@
 package services.account
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
-import net.psforever.objects.guid.GUIDTask
-import net.psforever.objects.serverobject.mount.Mountable
-
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-import net.psforever.objects._
+
+import net.psforever.objects.guid.GUIDTask
+import net.psforever.objects.{Avatar, DefaultCancellable, Deployables, Player, Vehicle, Vehicles}
+import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.zones.Zone
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.Vector3
 import services.{RemoverActor, Service, ServiceManager}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.vehicle.VehicleServiceMessage
 
+/**
+  * A global service that manages user behavior as divided into the following three categories:
+  * persistence (ongoing participation in the game world),
+  * relogging (short-term client connectivity issue resolution), and
+  * logout (end-of-life conditions involving the separation of a user from the game world).<br>
+  * <br>
+  * A user polls this service and the services either creates a new `PersistenceMonitor` entity
+  * or returns whatever `PersistenceMonitor` entity currently exists.
+  * Performing informative pdates to the monitor about the user's eventual player avatar instance
+  * (which can be performed by messaging the service indirectly,
+  * though sending directly to the monitor is recommended)
+  * facilitate the management of persistence.
+  * If connectivity isssues with the client are encountered by the user,
+  * within a reasonable amount of time to connection restoration,
+  * the user may regain control of their existing persistence monitor and, thus, the same player avatar.
+  * End of life is mainly managed by the monitors internally
+  * and the monitors only communicate up to this service when executing their "end-of-life" operations.
+  */
 class AccountPersistenceService extends Actor {
-  val log = org.log4s.getLogger
-  var accountIndex : Long = 0
+  /** an association of user text descriptors - player names - and their current monitor indices<br>
+    * key - player name, value - monitor index
+    */
+  var userIndices : mutable.Map[String, Int] = mutable.Map[String, Int]()
+  /**
+    * an association of user test descriptors - player names - and their current monitor<br>
+    * key - player name, value - player monitor
+    */
   val accounts : mutable.Map[String, ActorRef] = mutable.Map[String, ActorRef]()
-
+  /** squad service event hook */
   var squad : ActorRef = ActorRef.noSender
+  /** task resolver service event hook */
   var resolver : ActorRef = ActorRef.noSender
+  /** log, for trace and warnings only */
+  val log = org.log4s.getLogger
 
-  override def preStart = {
+  /**
+    * Retrieve the required system event service hooks.
+    * @see `ServiceManager.LookupResult`
+    */
+  override def preStart : Unit = {
     ServiceManager.serviceManager ! ServiceManager.Lookup("squad")
     ServiceManager.serviceManager ! ServiceManager.Lookup("taskResolver")
-    log.trace("Starting; awaiting system hooks ...")
+    log.trace("Awaiting system service hooks ...")
+  }
+
+  override def postStop : Unit = {
+    accounts.foreach { case (_, monitor) => context.stop(monitor) }
+    accounts.clear
   }
 
   def receive : Receive = Setup
 
+  /**
+    * Entry point for persistence monitoring setup.
+    * Primarily intended to deal with the initial condition of verifying/assuring of an enqueued persistence monitor.
+    * Updates to persistence can be received and will be distributed, if possible;
+    * but, updating should be reserved for individual persistence monitor callback (by the user who is being monitored).
+    */
   val Started : Receive = {
     case msg @ AccountPersistenceService.Login(name) =>
       (accounts.get(name) match {
@@ -38,21 +80,25 @@ class AccountPersistenceService extends Actor {
         case None => CreateNewPlayerToken(name)
       }).tell(msg, sender)
 
-    case msg @ AccountPersistenceService.Update(name, _, _, _) =>
+    case msg @ AccountPersistenceService.Update(name, _, _) =>
       accounts.get(name) match {
         case Some(ref) =>
           ref ! msg
         case None =>
           log.warn(s"tried to update a player entry ($name) that did not yet exist; rebuilding entry ...")
-          CreateNewPlayerToken(name).tell(AccountPersistenceService.Login(name), sender)
+          CreateNewPlayerToken(name).tell(msg, sender)
       }
 
-    case PlayerToken.LogoutInfo(target) =>
+    case Logout(target) => //TODO use context.watch and Terminated?
       accounts.remove(target)
 
     case _ => ;
   }
 
+  /**
+    * Process the system event service hooks when they arrive, before starting proper persistence monitoring.
+    * @see `ServiceManager.LookupResult`
+    */
   val Setup : Receive = {
     case ServiceManager.LookupResult(id, endpoint) =>
       id match {
@@ -63,80 +109,145 @@ class AccountPersistenceService extends Actor {
       }
       if(squad != ActorRef.noSender &&
         resolver != ActorRef.noSender) {
-        log.trace("Hooks obtained.  Continuing with standard operation.")
+        log.trace("Service hooks obtained.  Continuing with standard operation.")
         context.become(Started)
       }
-    case _ => ;
+
+    case msg =>
+      log.warn(s"Not yet started; received a $msg that will go unhandled")
   }
 
+  /**
+    * Enqueue a new persistency monitor object for this player.
+    * @param name the unique name of the player
+    * @return the persistence monitor object
+    */
   def CreateNewPlayerToken(name : String) : ActorRef = {
-    val ref = context.actorOf(Props(classOf[PlayerToken], name, squad, resolver), s"$name-$accountIndex")
-    accountIndex += 1
+    val ref = context.actorOf(Props(classOf[PersistenceMonitor], name, squad, resolver), s"$name-${NextPlayerIndex(name)}")
     accounts += name -> ref
     ref
+  }
+
+  /**
+    * Get the next account unique login index.
+    * The index suggests the number of times the player has logged into the game.
+    * The main purpose is to give each player a meaninfgul ordinal number of logging agencies
+    * whose names did not interfere with each other (`Actor` name uniqueness).
+    * @param name the text personal descriptor used by the player
+    * @return the next index for this player, starting at 0
+    */
+  def NextPlayerIndex(name : String) : Int = {
+    userIndices.get(name) match {
+      case Some(n) =>
+        val p = n + 1
+        userIndices += name -> p
+        p
+      case None =>
+        userIndices += name -> 0
+        0
+    }
   }
 }
 
 object AccountPersistenceService {
+  /**
+    * Message to begin persistence monitoring of user with this text descriptor (player name).
+    * If the persistence monitor already exists, use that instead and synchronize the data.
+    * @param name the unique name of the player
+    */
   final case class Login(name : String)
 
   /**
-    * na
-    * Corpses become ineligible.
+    * Update the persistence monitor that was setup for a user with the given text descriptor (player name).
     * The player's name should be able to satisfy the condition:<br>
     * `zone.LivePlayers.exists(p => p.Name.equals(name))`<br>
-    * If the player is in a facility SOI, record that facility's faction affinity.
-    * If the player is in the wilderness, always list as `NEUTRAL`.
-    * The zone's affinity is `NEUTRAL` unless it is empire locked.
     * @param name the unique name of the player
-    * @param zone the current zone the player is in;
-    * @param regionAffinity the last reported faction affinity of the surrounding region
-    * @param zoneAffinity the last reported faction affinity of the zone
+    * @param zone the current zone the player is in
+    * @param position the location of the player in game world coordinates
     */
-  final case class Update(name : String, zone : Zone, regionAffinity : PlanetSideEmpire.Value, zoneAffinity : PlanetSideEmpire.Value)
+  final case class Update(name : String, zone : Zone, position : Vector3)
 }
 
-class PlayerToken(name : String, squadService : ActorRef, taskResolver : ActorRef) extends Actor {
-  val log = org.log4s.getLogger(s"Logout-$name")
+/**
+  * Observe and manage the persistence of a single named player avatar entity in the game world,
+  * with special care to the conditions of short interruption in connectivity (relogging)
+  * and end-of-life operations.
+  * Upon login, the monitor will echo all of the current information about the user's (recent) login back to the `sender`.
+  * With a zone and a coordinate position in that zone, a user's player avatar can be properly reconnected
+  * or can be reconstructed.
+  * Without actual recent activity,
+  * the default information about the zone is an indication that the user must start this player avatar from scratch.
+  * The monitor expects a reliable update messaging (heartbeat) to keep track of the important information
+  * and to determine the conditions for end-of-life activity.
+  * @param name the unique name of the player
+  * @param squadService a hook into the `SquadService` event system
+  * @param taskResolver a hook into the `TaskResolver` event system;
+  *                     used for object unregistering
+  */
+class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : ActorRef) extends Actor {
+  /** the last-reported zone of this player */
   var inZone : Zone = Zone.Nowhere
-  var regionAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
-  var zoneAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
+  /** the last-reported game coordinate position of this player */
+  var lastPosition : Vector3 = Vector3.Zero
+  /** the ongoing amount of permissible inactivity */
   var timer : Cancellable = DefaultCancellable.obj
-  var timeup : Boolean = false
-  UpdateTimer()
+  /** the sparingly-used log */
+  val log = org.log4s.getLogger
 
+  /**
+    * Perform logout operations before the persistence monitor finally stops.
+    */
   override def postStop() : Unit = {
-    super.postStop
     timer.cancel
-    context.parent ! PlayerToken.LogoutInfo(name)
-    performLogout()
+    PerformLogout()
   }
 
   def receive : Receive = {
-    case PlayerToken.Logout(_) =>
-      timeup = timer.cancel
-      context.stop(self)
-
     case AccountPersistenceService.Login(_) =>
-      sender ! PlayerToken.LoginInfo(name, inZone, regionAffinity, zoneAffinity)
-
-    case AccountPersistenceService.Update(_, z, rf, zf) =>
-      inZone = z
-      regionAffinity = rf
-      zoneAffinity = zf
+      sender ! PlayerToken.LoginInfo(name, inZone, lastPosition)
       UpdateTimer()
+
+    case AccountPersistenceService.Update(_, z, p) =>
+      inZone = z
+      lastPosition = p
+      UpdateTimer()
+
+    case Logout(_) =>
+      context.parent ! Logout(name)
+      context.stop(self)
 
     case _ => ;
   }
 
+  /**
+    * Restart the minimum activity timer.
+    */
   def UpdateTimer() : Unit = {
-    if(!timeup) {
-      timer.cancel
-      timer = context.system.scheduler.scheduleOnce(90000 milliseconds, self, PlayerToken.Logout(name))
-    }
+    timer.cancel
+    timer = context.system.scheduler.scheduleOnce(60 seconds, self, Logout(name))
   }
 
-  def performLogout() : Unit = {
+  /**
+    * When the sustenance updates of the persistence monitor come to an end,
+    * and the persistence monitor itself is about to clean itself up,
+    * the player and avatar combination that has been associated with it will also undergo independent end of life activity.
+    * This is the true purpose of the persistence object - to perform a proper logout.<br>
+    * <br>
+    * The updates have been providing the zone
+    * and the basic information about the user (player name) has been provided since the beginning
+    * and it's a trivial matter to find where the avatar and player and asess their circumstances.
+    * The four important vectors are:
+    * the player avatar is in a vehicle,
+    * the player avatar is standing,
+    * only the avatar exists and the player released,
+    * and neither the avatar nor the player exist.
+    * It does not matter whether the player, if encountered, is alive or dead,
+    * only if they have been rendered a corpse and did not respawn.
+    * The fourth condition is not technically a failure condition,
+    * and can arise during normal transitional gameplay,
+    * but should be uncommon.
+    */
+  def PerformLogout() : Unit = {
     log.info(s"logout of $name")
     (inZone.Players.find(p => p.name == name), inZone.LivePlayers.find(p => p.Name == name)) match {
       case (Some(avatar), Some(player)) if player.VehicleSeated.nonEmpty =>
@@ -144,45 +255,31 @@ class PlayerToken(name : String, squadService : ActorRef, taskResolver : ActorRe
         //if the avatar is dead while in a vehicle, they haven't released yet
         //TODO perform any last minute saving now ...
         (inZone.GUID(player.VehicleSeated) match {
-          case Some(vehicle : Mountable) =>
-            (Some(vehicle), vehicle.Seat(vehicle.PassengerInSeat(player).getOrElse(-1)))
+          case Some(obj : Mountable) =>
+            (Some(obj), obj.Seat(obj.PassengerInSeat(player).getOrElse(-1)))
           case _ => (None, None) //bad data?
         }) match {
-          case (Some(vehicle : Vehicle), Some(seat)) =>
-            seat.Occupant = None //unseat
-            if(vehicle.Health == 0 || vehicle.Seats.values.forall(seat => !seat.isOccupied)) {
-              inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), inZone))
-              inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, inZone, if(vehicle.Flying) {
-                //TODO gravity
-                Some(0 seconds) //immediate deconstruction
-              }
-              else {
-                vehicle.Definition.DeconstructionTime //normal deconstruction
-              }))
-            }
           case (Some(_), Some(seat)) =>
             seat.Occupant = None //unseat
           case _ => ;
         }
-        StandardLogout(avatar, player)
+        PlayerAvatarLogout(avatar, player)
 
       case (Some(avatar), Some(player)) =>
-        //alive or dead, as Infantry; may be waiting for respawn
+        //alive or dead, as standard Infantry
         //TODO perform any last minute saving now ...
-        StandardLogout(avatar, player)
+        PlayerAvatarLogout(avatar, player)
 
       case (Some(avatar), None) =>
         //player has released
         //our last body was turned into a corpse; just the avatar remains
         //TODO perform any last minute saving now ...
-        squadService.tell(Service.Leave(Some(avatar.CharId.toString)), context.parent)
-        Deployables.Disown(inZone, avatar, context.parent)
+        AvatarLogout(avatar)
         inZone.GUID(avatar.VehicleOwned) match {
           case Some(obj : Vehicle) if obj.OwnerName.contains(avatar.name) =>
             obj.AssignOwnership(None)
           case _ => ;
         }
-        inZone.Population.tell(Zone.Population.Release(avatar), context.parent)
         taskResolver.tell(GUIDTask.UnregisterLocker(avatar.Locker)(inZone.GUID), context.parent)
 
       case _ =>
@@ -190,24 +287,65 @@ class PlayerToken(name : String, squadService : ActorRef, taskResolver : ActorRe
     }
   }
 
-  def StandardLogout(avatar : Avatar, player : Player) : Unit = {
+  /**
+    * A common set of actions to perform in the course of logging out a player avatar.
+    * Of the four scenarios described - in transport, on foot, released, missing - two of them utilize these operations.
+    * One of the other two uses a modified version of some of these activities to facilitate its log out.
+    * As this persistence monitor is about to become invalid,
+    * any messages sent in response to what we are sending are received by the monitor's parent.
+    * @see `Avatar`
+    * @see `AvatarAction.ObjectDelete`
+    * @see `AvatarServiceMessage`
+    * @see `DisownVehicle`
+    * @see `GUIDTask.UnregisterAvatar`
+    * @see `Player`
+    * @see `Zone.AvatarEvents`
+    * @see `Zone.Population.Release`
+    * @param avatar the avatar
+    * @param player the player
+    */
+  def PlayerAvatarLogout(avatar : Avatar, player : Player) : Unit = {
     val pguid = player.GUID
+    val parent = context.parent
     player.Position = Vector3.Zero
     player.Health = 0
-    squadService.tell(Service.Leave(Some(player.CharId.toString)), context.parent)
-    Deployables.Disown(inZone, avatar, context.parent)
-    inZone.Population.tell(Zone.Population.Release(avatar), context.parent)
-    inZone.AvatarEvents.tell(AvatarServiceMessage(inZone.Id, AvatarAction.ObjectDelete(pguid, pguid)), context.parent)
     DisownVehicle(player)
-    taskResolver.tell(GUIDTask.UnregisterAvatar(player)(inZone.GUID), context.parent)
+    inZone.Population.tell(Zone.Population.Release(avatar), parent)
+    inZone.AvatarEvents.tell(AvatarServiceMessage(inZone.Id, AvatarAction.ObjectDelete(pguid, pguid)), parent)
+    AvatarLogout(avatar)
+    taskResolver.tell(GUIDTask.UnregisterAvatar(player)(inZone.GUID), parent)
+  }
+
+  /**
+    * A common set of actions to perform in the course of logging out an avatar.
+    * Of the four scenarios described - in transport, on foot, released, missing - three of them utilize these operations.
+    * The avatar will virtually always be in an existential position, one that needs to be handled at logout
+    * @see `Avatar`
+    * @see `Deployables.Disown`
+    * @see `Service.Leave`
+    * @see `Zone.Population.Leave`
+    * @param avatar the avatar
+    */
+  def AvatarLogout(avatar : Avatar) : Unit = {
+    val parent = context.parent
+    squadService.tell(Service.Leave(Some(avatar.CharId.toString)), parent)
+    Deployables.Disown(inZone, avatar, parent)
+    inZone.Population.tell(Zone.Population.Leave(avatar), parent)
   }
 
   /**
     * Vehicle cleanup that is specific to log out behavior.
+    * @see `Vehicles.Disown`
+    * @see `RemoverActor.AddTask`
+    * @see `RemoverActor.ClearSpecific`
+    * @see `Vehicle.Flying`
+    * @see `VehicleDefinition.DeconstructionTime`
+    * @see `VehicleServiceMessage.Decon`
+    * @see `Zone.VehicleEvents`
     */
   def DisownVehicle(player : Player) : Unit = {
     Vehicles.Disown(player, inZone) match {
-      case Some(vehicle) if vehicle.Seats.values.forall(seat => !seat.isOccupied) =>
+      case Some(vehicle) if vehicle.Health == 0 || vehicle.Seats.values.forall(seat => !seat.isOccupied) =>
         inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), inZone))
         inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, inZone,
           if(vehicle.Flying) {
@@ -218,13 +356,26 @@ class PlayerToken(name : String, squadService : ActorRef, taskResolver : ActorRe
             vehicle.Definition.DeconstructionTime //normal deconstruction
           }
         ))
-      case None => ;
+      case _ => ;
     }
   }
 }
 
+/**
+  * Internal message that flags that the player has surpassed the maximum amount of inactivity allowable
+  * and should stop existing.
+  * @param name the unique name of the player
+  */
+private[this] case class Logout(name : String)
+
 object PlayerToken {
-  final case class LoginInfo(name : String, zone : Zone, regionAffinity : PlanetSideEmpire.Value, zoneAffinity : PlanetSideEmpire.Value)
-  private case class Logout(name : String)
-  final case class LogoutInfo(name : String)
+  /**
+    * Message dispatched to confirm that a player with given locational attributes exists.
+    * Agencies outside of the `AccountPersistanceService`/`PlayerToken` system make use of this message.
+    * ("Exists" does not imply an ongoing process and can also mean "just joined the game" here.)
+    * @param name the name of the player
+    * @param zone the zone in which the player is location
+    * @param position where in the zone the player is located
+    */
+  final case class LoginInfo(name : String, zone : Zone, position : Vector3)
 }

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -2,27 +2,35 @@
 package services.account
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import net.psforever.objects.guid.GUIDTask
+import net.psforever.objects.inventory.InventoryItem
+import net.psforever.objects.serverobject.mount.Mountable
+
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
-
-import net.psforever.objects.DefaultCancellable
+import net.psforever.objects._
 import net.psforever.objects.zones.Zone
-import net.psforever.types.PlanetSideEmpire
-import services.ServiceManager
+import net.psforever.types.{PlanetSideEmpire, Vector3}
+import services.{RemoverActor, Service, ServiceManager}
+import services.avatar.{AvatarAction, AvatarServiceMessage}
+import services.vehicle.VehicleServiceMessage
 
 class AccountPersistenceService extends Actor {
   val log = org.log4s.getLogger
   var accountIndex : Long = 0
   val accounts : mutable.Map[String, ActorRef] = mutable.Map[String, ActorRef]()
 
-  var taskResolver : ActorRef = ActorRef.noSender
+  var squad : ActorRef = ActorRef.noSender
+  var resolver : ActorRef = ActorRef.noSender
 
   override def preStart = {
+    ServiceManager.serviceManager ! ServiceManager.Lookup("squad")
+    ServiceManager.serviceManager ! ServiceManager.Lookup("taskResolver")
     log.trace("Starting; awaiting system hooks ...")
   }
 
-  def receive : Receive = Initial
+  def receive : Receive = Setup
 
   val Started : Receive = {
     case msg @ AccountPersistenceService.Login(name) =>
@@ -49,23 +57,21 @@ class AccountPersistenceService extends Actor {
   val Setup : Receive = {
     case ServiceManager.LookupResult(id, endpoint) =>
       id match {
+        case "squad" =>
+          squad = endpoint
         case "taskResolver" =>
-          taskResolver = endpoint
+          resolver = endpoint
       }
-      if(taskResolver != Actor.noSender) {
+      if(squad != ActorRef.noSender &&
+        resolver != ActorRef.noSender) {
         log.trace("Hooks obtained.  Continuing with standard operation.")
         context.become(Started)
       }
+    case _ => ;
   }
 
-  val Initial : Receive = Setup
-    .orElse(Started)
-    .orElse {
-      case _ => ;
-    }
-
   def CreateNewPlayerToken(name : String) : ActorRef = {
-    val ref = context.actorOf(Props(classOf[PlayerToken], name), s"$name-$accountIndex")
+    val ref = context.actorOf(Props(classOf[PlayerToken], name, squad, resolver), s"$name-$accountIndex")
     accountIndex += 1
     accounts += name -> ref
     ref
@@ -91,7 +97,8 @@ object AccountPersistenceService {
   final case class Update(name : String, zone : Zone, regionAffinity : PlanetSideEmpire.Value, zoneAffinity : PlanetSideEmpire.Value)
 }
 
-class PlayerToken(name : String) extends Actor {
+class PlayerToken(name : String, squadService : ActorRef, taskResolver : ActorRef) extends Actor {
+  val log = org.log4s.getLogger(s"Logout-$name")
   var inZone : Zone = Zone.Nowhere
   var regionAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
   var zoneAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
@@ -103,7 +110,7 @@ class PlayerToken(name : String) extends Actor {
     super.postStop
     timer.cancel
     context.parent ! PlayerToken.LogoutInfo(name)
-    //todo handle logout
+    performLogout()
   }
 
   def receive : Receive = {
@@ -126,7 +133,118 @@ class PlayerToken(name : String) extends Actor {
   def UpdateTimer() : Unit = {
     if(!timeup) {
       timer.cancel
-      timer = context.system.scheduler.scheduleOnce(600000 milliseconds, self, PlayerToken.Logout(name))
+      timer = context.system.scheduler.scheduleOnce(60000 milliseconds, self, PlayerToken.Logout(name))
+    }
+  }
+
+  def performLogout() : Unit = {
+    log.info(s"attempting logout of $name")
+    val parent = context.parent
+    (inZone.Players.find(p => p.name == name), inZone.LivePlayers.find(p => p.Name == name)) match {
+      case (Some(avatar), Some(player)) if player.VehicleSeated.nonEmpty =>
+        log.error("unhandled vehicle condition")
+        //...
+
+      case (Some(avatar), Some(player)) =>
+        log.info(s"HANDLED infantry condition")
+        val pguid = player.GUID
+        player.Position = Vector3.Zero
+        player.Health = 0
+        squadService.tell(Service.Leave(Some(player.CharId.toString)), parent)
+        Deployables.Disown(inZone, avatar, parent)
+        inZone.Population.tell(Zone.Population.Release(avatar), parent)
+        inZone.AvatarEvents.tell(AvatarServiceMessage(inZone.Id, AvatarAction.ObjectDelete(pguid, pguid)), parent)
+        DisownVehicle(player)
+        taskResolver.tell(GUIDTask.UnregisterAvatar(player)(inZone.GUID), parent)
+
+      case (Some(avatar), None) =>
+        log.error("unhandled dead condition")
+        //...
+
+      case _ =>
+        log.error("unhandled unforeseen condition")
+    }
+  //    if(player != null && player.HasGUID) {
+  //      PlayerActionsToCancel()
+  //      val player_guid = player.GUID
+  //      //handle orphaned deployables
+  //      Disown()
+  //      //clean up boomer triggers and telepads
+  //      val equipment = (
+  //        player.Holsters()
+  //          .zipWithIndex
+  //          .collect({ case (slot, index) if slot.Equipment.nonEmpty => InventoryItem(slot.Equipment.get, index) }) ++
+  //          player.Inventory.Items
+  //        )
+  //        .filterNot({ case InventoryItem(obj, _) => obj.isInstanceOf[BoomerTrigger] || obj.isInstanceOf[Telepad] })
+  //      //put any temporary value back into the avatar
+  //      //TODO final character save before doing any of this (use equipment)
+  //      continent.Population ! Zone.Population.Release(avatar)
+  //      if(player.isAlive) {
+  //        //actually being alive or manually deconstructing
+  //        player.Position = Vector3.Zero
+  //        //if seated, dismount
+  //        player.VehicleSeated match {
+  //          case Some(_) =>
+  //            //quickly and briefly kill player to avoid disembark animation?
+  //            continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(player_guid, 0, 0))
+  //            DismountVehicleOnLogOut()
+  //          case _ => ;
+  //        }
+  //        continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(player_guid, player_guid))
+  //        taskResolver ! GUIDTask.UnregisterAvatar(player)(continent.GUID)
+  //        //TODO normally, the actual player avatar persists a minute or so after the user disconnects
+  //      }
+  //      else if(continent.LivePlayers.contains(player) && !continent.Corpses.contains(player)) {
+  //        //player disconnected while waiting for a revive, maybe
+  //        //similar to handling ReleaseAvatarRequestMessage
+  //        player.Release
+  //        player.VehicleSeated match {
+  //          case None =>
+  //            FriskCorpse(player) //TODO eliminate dead letters
+  //            if(!WellLootedCorpse(player)) {
+  //              continent.Population ! Zone.Corpse.Add(player)
+  //              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.Release(player, continent))
+  //              taskResolver ! GUIDTask.UnregisterLocker(player.Locker)(continent.GUID) //rest of player will be cleaned up with corpses
+  //            }
+  //            else {
+  //              //no items in inventory; leave no corpse
+  //              val player_guid = player.GUID
+  //              player.Position = Vector3.Zero //save character before doing this
+  //              continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(player_guid, player_guid))
+  //              taskResolver ! GUIDTask.UnregisterAvatar(player)(continent.GUID)
+  //            }
+  //
+  //          case Some(_) =>
+  //            val player_guid = player.GUID
+  //            player.Position = Vector3.Zero //save character before doing this
+  //            continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(player_guid, player_guid))
+  //            taskResolver ! GUIDTask.UnregisterAvatar(player)(continent.GUID)
+  //            DismountVehicleOnLogOut()
+  //        }
+  //      }
+  //      //disassociate and start the deconstruction timer for any currently owned vehicle
+  //      SpecialCaseDisownVehicle()
+  //      continent.Population ! Zone.Population.Leave(avatar)
+  }
+
+  /**
+    * Vehicle cleanup that is specific to log out behavior.
+    */
+  def DisownVehicle(player : Player) : Unit = {
+    Vehicles.Disown(player, inZone) match {
+      case out @ Some(vehicle) =>
+        inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), inZone))
+        inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, inZone,
+          if(vehicle.Flying) {
+            //TODO gravity
+            Some(0 seconds) //immediate deconstruction
+          }
+          else {
+            vehicle.Definition.DeconstructionTime //normal deconstruction
+          }
+        ))
+      case None => ;
     }
   }
 }

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2020 PSForever
+package services.account
+
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import net.psforever.objects.DefaultCancellable
+import net.psforever.objects.zones.Zone
+import net.psforever.types.PlanetSideEmpire
+import services.ServiceManager
+
+class AccountPersistenceService extends Actor {
+  val log = org.log4s.getLogger
+  var accountIndex : Long = 0
+  val accounts : mutable.Map[String, ActorRef] = mutable.Map[String, ActorRef]()
+
+  var taskResolver : ActorRef = ActorRef.noSender
+
+  override def preStart = {
+    log.trace("Starting; awaiting system hooks ...")
+  }
+
+  def receive : Receive = Initial
+
+  val Started : Receive = {
+    case msg @ AccountPersistenceService.Login(name) =>
+      (accounts.get(name) match {
+        case Some(ref) => ref
+        case None => CreateNewPlayerToken(name)
+      }).tell(msg, sender)
+
+    case msg @ AccountPersistenceService.Update(name, _, _, _) =>
+      accounts.get(name) match {
+        case Some(ref) =>
+          ref ! msg
+        case None =>
+          log.warn(s"tried to update a player entry ($name) that did not yet exist; capable of recovery")
+          CreateNewPlayerToken(name).tell(AccountPersistenceService.Login(name), sender)
+      }
+
+    case PlayerToken.LogoutInfo(target) =>
+      accounts.remove(target)
+
+    case _ => ;
+  }
+
+  val Setup : Receive = {
+    case ServiceManager.LookupResult(id, endpoint) =>
+      id match {
+        case "taskResolver" =>
+          taskResolver = endpoint
+      }
+      if(taskResolver != Actor.noSender) {
+        log.trace("Hooks obtained.  Continuing with standard operation.")
+        context.become(Started)
+      }
+  }
+
+  val Initial : Receive = Setup
+    .orElse(Started)
+    .orElse {
+      case _ => ;
+    }
+
+  def CreateNewPlayerToken(name : String) : ActorRef = {
+    val ref = context.actorOf(Props(classOf[PlayerToken], name), s"$name-$accountIndex")
+    accountIndex += 1
+    accounts += name -> ref
+    ref
+  }
+}
+
+object AccountPersistenceService {
+  final case class Login(name : String)
+
+  /**
+    * na
+    * Corpses become ineligible.
+    * The player's name should be able to satisfy the condition:<br>
+    * `zone.LivePlayers.exists(p => p.Name.equals(name))`<br>
+    * If the player is in a facility SOI, record that facility's faction affinity.
+    * If the player is in the wilderness, always list as `NEUTRAL`.
+    * The zone's affinity is `NEUTRAL` unless it is empire locked.
+    * @param name the unique name of the player
+    * @param zone the current zone the player is in;
+    * @param regionAffinity the last reported faction affinity of the surrounding region
+    * @param zoneAffinity the last reported faction affinity of the zone
+    */
+  final case class Update(name : String, zone : Zone, regionAffinity : PlanetSideEmpire.Value, zoneAffinity : PlanetSideEmpire.Value)
+}
+
+class PlayerToken(name : String) extends Actor {
+  var inZone : Zone = Zone.Nowhere
+  var regionAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
+  var zoneAffinity : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
+  var timer : Cancellable = DefaultCancellable.obj
+  var timeup : Boolean = false
+  UpdateTimer()
+
+  override def postStop() : Unit = {
+    super.postStop
+    timer.cancel
+    context.parent ! PlayerToken.LogoutInfo(name)
+    //todo handle logout
+  }
+
+  def receive : Receive = {
+    case PlayerToken.Logout(_) =>
+      timeup = timer.cancel
+      context.stop(self)
+
+    case AccountPersistenceService.Login(_) =>
+      sender ! PlayerToken.LoginInfo(name, inZone, regionAffinity, zoneAffinity)
+
+    case AccountPersistenceService.Update(_, z, rf, zf) =>
+      inZone = z
+      regionAffinity = rf
+      zoneAffinity = zf
+      UpdateTimer()
+
+    case _ => ;
+  }
+
+  def UpdateTimer() : Unit = {
+    if(!timeup) {
+      timer.cancel
+      timer = context.system.scheduler.scheduleOnce(600000 milliseconds, self, PlayerToken.Logout(name))
+    }
+  }
+}
+
+object PlayerToken {
+  final case class LoginInfo(name : String, zone : Zone, regionAffinity : PlanetSideEmpire.Value, zoneAffinity : PlanetSideEmpire.Value)
+  private case class Logout(name : String)
+  final case class LogoutInfo(name : String)
+}

--- a/common/src/main/scala/services/avatar/AvatarService.scala
+++ b/common/src/main/scala/services/avatar/AvatarService.scala
@@ -229,6 +229,11 @@ class AvatarService(zone : Zone) extends Actor {
             AvatarServiceResponse(s"/$forChannel/Avatar", target_guid, AvatarResponse.Revive(target_guid))
           )
 
+        case AvatarAction.TeardownConnection() =>
+          AvatarEvents.publish(
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.TeardownConnection())
+          )
+
         case _ => ;
     }
 

--- a/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
@@ -62,6 +62,7 @@ object AvatarAction {
   final case class SendResponse(player_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
   final case class SendResponseTargeted(target_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
 
+  final case class TeardownConnection() extends Action
   //  final case class PlayerStateShift(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
   //  final case class DestroyDisplay(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action
 }

--- a/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
@@ -54,5 +54,7 @@ object AvatarResponse {
 
   final case class SendResponse(msg: PlanetSideGamePacket) extends Response
   final case class SendResponseTargeted(target_guid : PlanetSideGUID, msg: PlanetSideGamePacket) extends Response
+
+  final case class TeardownConnection() extends Response
   //  final case class PlayerStateShift(itemID : PlanetSideGUID) extends Response
 }

--- a/common/src/main/scala/services/galaxy/GalaxyService.scala
+++ b/common/src/main/scala/services/galaxy/GalaxyService.scala
@@ -53,9 +53,9 @@ class GalaxyService extends Actor {
             GalaxyServiceResponse(s"/Galaxy", GalaxyResponse.MapUpdate(msg))
           )
 
-        case GalaxyAction.TransferPassenger(player_guid, temp_channel, vehicle, vehicle_to_delete) =>
+        case GalaxyAction.TransferPassenger(player_guid, temp_channel, vehicle, vehicle_to_delete, manifest) =>
           GalaxyEvents.publish(
-            GalaxyServiceResponse(s"/$forChannel/Galaxy", GalaxyResponse.TransferPassenger(temp_channel, vehicle, vehicle_to_delete))
+            GalaxyServiceResponse(s"/$forChannel/Galaxy", GalaxyResponse.TransferPassenger(temp_channel, vehicle, vehicle_to_delete, manifest))
           )
         case _ => ;
       }

--- a/common/src/main/scala/services/galaxy/GalaxyServiceMessage.scala
+++ b/common/src/main/scala/services/galaxy/GalaxyServiceMessage.scala
@@ -2,6 +2,7 @@
 package services.galaxy
 
 import net.psforever.objects.Vehicle
+import net.psforever.objects.vehicles.VehicleManifest
 import net.psforever.packet.game.BuildingInfoUpdateMessage
 import net.psforever.types.PlanetSideGUID
 
@@ -16,5 +17,5 @@ object GalaxyAction {
 
   final case class MapUpdate(msg: BuildingInfoUpdateMessage) extends Action
 
-  final case class TransferPassenger(player_guid : PlanetSideGUID, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Action
+  final case class TransferPassenger(player_guid : PlanetSideGUID, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID, manifest : VehicleManifest) extends Action
 }

--- a/common/src/main/scala/services/galaxy/GalaxyServiceResponse.scala
+++ b/common/src/main/scala/services/galaxy/GalaxyServiceResponse.scala
@@ -2,6 +2,7 @@
 package services.galaxy
 
 import net.psforever.objects.Vehicle
+import net.psforever.objects.vehicles.VehicleManifest
 import net.psforever.objects.zones.HotSpotInfo
 import net.psforever.packet.game.BuildingInfoUpdateMessage
 import net.psforever.types.PlanetSideGUID
@@ -17,5 +18,5 @@ object GalaxyResponse {
   final case class HotSpotUpdate(zone_id : Int, priority : Int, host_spot_info : List[HotSpotInfo]) extends Response
   final case class MapUpdate(msg: BuildingInfoUpdateMessage) extends Response
 
-  final case class TransferPassenger(temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Response
+  final case class TransferPassenger(temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID, manifest : VehicleManifest) extends Response
 }

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -133,9 +133,9 @@ class VehicleService(zone : Zone) extends Actor {
         case VehicleAction.UpdateAmsSpawnPoint(zone : Zone) =>
           sender ! VehicleServiceResponse(s"/$forChannel/Vehicle", Service.defaultPlayerGUID, VehicleResponse.UpdateAmsSpawnPoint(AmsSpawnPoints(zone)))
 
-        case VehicleAction.TransferPassengerChannel(player_guid, old_channel, temp_channel, vehicle) =>
+        case VehicleAction.TransferPassengerChannel(player_guid, old_channel, temp_channel, vehicle, vehicle_to_delete) =>
           VehicleEvents.publish(
-            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.TransferPassengerChannel(old_channel, temp_channel, vehicle))
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.TransferPassengerChannel(old_channel, temp_channel, vehicle, vehicle_to_delete))
           )
 
         case VehicleAction.ForceDismountVehicleCargo(player_guid, vehicle_guid, bailed, requestedByPassenger, kicked) =>

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -44,7 +44,7 @@ object VehicleAction {
   final case class SendResponse(player_guid: PlanetSideGUID, msg : PlanetSideGamePacket) extends Action
   final case class UpdateAmsSpawnPoint(zone : Zone) extends Action
 
-  final case class TransferPassengerChannel(player_guid : PlanetSideGUID, temp_channel : String, new_channel : String, vehicle : Vehicle) extends Action
+  final case class TransferPassengerChannel(player_guid : PlanetSideGUID, temp_channel : String, new_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Action
 
   final case class ForceDismountVehicleCargo(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Action
   final case class KickCargo(player_guid : PlanetSideGUID, cargo : Vehicle, speed : Int, delay : Long) extends Action

--- a/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
@@ -50,7 +50,7 @@ object VehicleResponse {
   final case class ResetSpawnPad(pad_guid : PlanetSideGUID) extends Response
   final case class PeriodicReminder(reason : Reminders.Value, data : Option[Any] = None) extends Response
 
-  final case class TransferPassengerChannel(old_channel : String, temp_channel : String, vehicle : Vehicle) extends Response
+  final case class TransferPassengerChannel(old_channel : String, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Response
 
   final case class ForceDismountVehicleCargo(vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Response
   final case class KickCargo(cargo : Vehicle, speed : Int, delay : Long) extends Response

--- a/common/src/test/scala/objects/InventoryTest.scala
+++ b/common/src/test/scala/objects/InventoryTest.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2017 PSForever
 package objects
 
-import net.psforever.objects.{AmmoBox, SimpleItem}
+import net.psforever.objects.{AmmoBox, SimpleItem, Tool}
 import net.psforever.objects.definition.SimpleItemDefinition
-import net.psforever.objects.inventory._
-import net.psforever.objects.GlobalDefinitions._
+import net.psforever.objects.inventory.{GridInventory, InventoryDisarrayException, InventoryItem, InventoryTile}
+import net.psforever.objects.GlobalDefinitions.{bullet_9mm, suppressor}
 import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
 
@@ -42,18 +42,6 @@ class InventoryTest extends Specification {
       val obj : GridInventory = GridInventory(9, 6)
       obj.TotalCapacity mustEqual 54
       obj.Capacity mustEqual 54
-      obj.Size mustEqual 0
-    }
-
-    "insert item" in {
-      val obj : GridInventory = GridInventory(9, 6)
-      obj.CheckCollisions(23, bullet9mmBox1) mustEqual Success(Nil)
-      obj += 2 -> bullet9mmBox1
-      obj.TotalCapacity mustEqual 54
-      obj.Capacity mustEqual 45
-      obj.Size mustEqual 1
-      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
-      obj.Clear()
       obj.Size mustEqual 0
     }
 
@@ -287,6 +275,36 @@ class InventoryTest extends Specification {
       ok
     }
 
+    "insert item" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      obj.CheckCollisions(23, bullet9mmBox1) mustEqual Success(Nil)
+      obj += 2 -> bullet9mmBox1
+      obj.TotalCapacity mustEqual 54
+      obj.Capacity mustEqual 45
+      obj.Size mustEqual 1
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
+      obj.Clear()
+      obj.Size mustEqual 0
+    }
+
+    "not insert into an invalid slot (n < 0)" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      obj.Capacity mustEqual 54
+      obj.Size mustEqual 0
+      obj.Insert(-1, bullet9mmBox1) must throwA[IndexOutOfBoundsException]
+      obj.Capacity mustEqual 54
+      obj.Size mustEqual 0
+    }
+
+    "not insert into an invalid slot (n > capacity)" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      obj.Capacity mustEqual 54
+      obj.Size mustEqual 0
+      obj.Insert(55, bullet9mmBox1) must throwA[IndexOutOfBoundsException]
+      obj.Capacity mustEqual 54
+      obj.Size mustEqual 0
+    }
+
     "block insertion if item collision" in {
       val obj : GridInventory = GridInventory(9, 6)
       obj += 0 -> bullet9mmBox1
@@ -294,8 +312,53 @@ class InventoryTest extends Specification {
       obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj += 2 -> bullet9mmBox2
       obj.hasItem(PlanetSideGUID(2)).isEmpty mustEqual true
+    }
+
+    "insert items quickly (risk overwriting entries)" in {
+      val obj : GridInventory = GridInventory(6, 6)
+      (obj += 0 -> bullet9mmBox1) mustEqual true
+      val collision1 = obj.CheckCollisions(0,1,1)
+      obj.CheckCollisions(1,1,1) mustEqual collision1
+      obj.CheckCollisions(2,1,1) mustEqual collision1
+      obj.CheckCollisions(6,1,1) mustEqual collision1
+      obj.CheckCollisions(7,1,1) mustEqual collision1
+      obj.CheckCollisions(8,1,1) mustEqual collision1
+      obj.CheckCollisions(12,1,1) mustEqual collision1
+      obj.CheckCollisions(13,1,1) mustEqual collision1
+      obj.CheckCollisions(14,1,1) mustEqual collision1
+
+      (obj += 7 -> bullet9mmBox2) mustEqual false //can not insert overlapping object
+      obj.CheckCollisions(0,1,1) mustEqual collision1
+      obj.CheckCollisions(1,1,1) mustEqual collision1
+      obj.CheckCollisions(2,1,1) mustEqual collision1
+      obj.CheckCollisions(6,1,1) mustEqual collision1
+      obj.CheckCollisions(7,1,1) mustEqual collision1
+      obj.CheckCollisions(8,1,1) mustEqual collision1
+      obj.CheckCollisions(12,1,1) mustEqual collision1
+      obj.CheckCollisions(13,1,1) mustEqual collision1
+      obj.CheckCollisions(14,1,1) mustEqual collision1
+
+      obj.InsertQuickly(7, bullet9mmBox2) mustEqual true //overwrite
+      val collision2 = obj.CheckCollisions(7,1,1)
+      obj.CheckCollisions(0,1,1) mustEqual collision1
+      obj.CheckCollisions(1,1,1) mustEqual collision1
+      obj.CheckCollisions(2,1,1) mustEqual collision1
+      obj.CheckCollisions(6,1,1) mustEqual collision1
+      obj.CheckCollisions(7,1,1) mustEqual collision2
+      obj.CheckCollisions(8,1,1) mustEqual collision2
+      obj.CheckCollisions(12,1,1) mustEqual collision1
+      obj.CheckCollisions(13,1,1) mustEqual collision2
+      obj.CheckCollisions(14,1,1) mustEqual collision2
+    }
+
+    "clear all items" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      obj += 2 -> bullet9mmBox1
+      obj.Size mustEqual 1
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj.Clear()
-      ok
+      obj.Size mustEqual 0
+      obj.hasItem(PlanetSideGUID(1)).isEmpty mustEqual true
     }
 
     "remove item" in {
@@ -306,6 +369,16 @@ class InventoryTest extends Specification {
       obj.hasItem(PlanetSideGUID(1)).isEmpty mustEqual true
       obj.Clear()
       ok
+    }
+
+    "fail to remove from an invalid slot (n < 0)" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      (obj -= -1) mustEqual false
+    }
+
+    "fail to remove from an invalid slot (n > capacity)" in {
+      val obj : GridInventory = GridInventory(9, 6)
+      (obj -= 55) mustEqual false
     }
 
     "unblock insertion on item removal" in {
@@ -374,41 +447,82 @@ class InventoryTest extends Specification {
       ok
     }
 
-    "insert items quickly (risk overwriting entries)" in {
+    "confirm integrity of inventory as a grid" in {
       val obj : GridInventory = GridInventory(6, 6)
       (obj += 0 -> bullet9mmBox1) mustEqual true
-      val collision1 = obj.CheckCollisions(0,1,1)
-      obj.CheckCollisions(1,1,1) mustEqual collision1
-      obj.CheckCollisions(2,1,1) mustEqual collision1
-      obj.CheckCollisions(6,1,1) mustEqual collision1
-      obj.CheckCollisions(7,1,1) mustEqual collision1
-      obj.CheckCollisions(8,1,1) mustEqual collision1
-      obj.CheckCollisions(12,1,1) mustEqual collision1
-      obj.CheckCollisions(13,1,1) mustEqual collision1
-      obj.CheckCollisions(14,1,1) mustEqual collision1
+      (obj += 21 -> bullet9mmBox2) mustEqual true
+      //artificially pollute the inventory grid-space
+      obj.SetCells(10, 1, 1, 3)
+      obj.SetCells(19, 2, 2, 4)
+      obj.ElementsOnGridMatchList() mustEqual 5 //number of misses repaired
+    }
 
-      (obj += 7 -> bullet9mmBox2) mustEqual false //can not insert overlapping object
-      obj.CheckCollisions(0,1,1) mustEqual collision1
-      obj.CheckCollisions(1,1,1) mustEqual collision1
-      obj.CheckCollisions(2,1,1) mustEqual collision1
-      obj.CheckCollisions(6,1,1) mustEqual collision1
-      obj.CheckCollisions(7,1,1) mustEqual collision1
-      obj.CheckCollisions(8,1,1) mustEqual collision1
-      obj.CheckCollisions(12,1,1) mustEqual collision1
-      obj.CheckCollisions(13,1,1) mustEqual collision1
-      obj.CheckCollisions(14,1,1) mustEqual collision1
+    "confirm integrity of inventory as a list (no overlap)" in {
+      val obj : GridInventory = GridInventory(9, 9)
+      val gun = Tool(suppressor)
+      obj.InsertQuickly(0, gun)
+      obj.InsertQuickly(33, bullet9mmBox1)
+      //nothing should overlap
+      val lists = obj.ElementsInListCollideInGrid()
+      lists.size mustEqual 0
+    }
 
-      obj.InsertQuickly(7, bullet9mmBox2) mustEqual true //overwrite
-      val collision2 = obj.CheckCollisions(7,1,1)
-      obj.CheckCollisions(0,1,1) mustEqual collision1
-      obj.CheckCollisions(1,1,1) mustEqual collision1
-      obj.CheckCollisions(2,1,1) mustEqual collision1
-      obj.CheckCollisions(6,1,1) mustEqual collision1
-      obj.CheckCollisions(7,1,1) mustEqual collision2
-      obj.CheckCollisions(8,1,1) mustEqual collision2
-      obj.CheckCollisions(12,1,1) mustEqual collision1
-      obj.CheckCollisions(13,1,1) mustEqual collision2
-      obj.CheckCollisions(14,1,1) mustEqual collision2
+    "confirm integrity of inventory as a list (normal overlap)" in {
+      val obj : GridInventory = GridInventory(9, 9)
+      val gun = Tool(suppressor)
+      val bullet9mmBox3 = AmmoBox(bullet_9mm)
+      obj.InsertQuickly(0, gun)
+      obj.InsertQuickly(18, bullet9mmBox1)
+      obj.InsertQuickly(38, bullet9mmBox2)
+      obj.InsertQuickly(33, bullet9mmBox3)
+      //gun and box1 should overlap
+      //box1 and box2 should overlap
+      //box3 should not overlap with anything
+      val lists = obj.ElementsInListCollideInGrid()
+      lists.size mustEqual 2
+      lists.foreach { list =>
+        val out = list.map { _.obj }
+        if(out.size == 2 && out.contains(gun) && out.contains(bullet9mmBox1)) {
+          ok
+        }
+        else if(out.size == 2 && out.contains(bullet9mmBox1) && out.contains(bullet9mmBox2)) {
+          ok
+        }
+        else {
+          ko
+        }
+      }
+      ok
+    }
+
+    "confirm integrity of inventory as a list (triple overlap)" in {
+      val obj : GridInventory = GridInventory(9, 9)
+      val gun = Tool(suppressor)
+      val bullet9mmBox3 = AmmoBox(bullet_9mm)
+      val bullet9mmBox4 = AmmoBox(bullet_9mm)
+      obj.InsertQuickly(0, gun)
+      obj.InsertQuickly(18, bullet9mmBox1)
+      obj.InsertQuickly(36, bullet9mmBox2)
+      obj.InsertQuickly(38, bullet9mmBox3)
+      obj.InsertQuickly(33, bullet9mmBox4)
+      //gun and box1 should overlap
+      //box1, box2, and box3 should overlap
+      //box4 should not overlap with anything
+      val lists = obj.ElementsInListCollideInGrid()
+      lists.size mustEqual 2
+      lists.foreach { list =>
+        val out = list.map { _.obj }
+        if(out.size == 2 && out.contains(gun) && out.contains(bullet9mmBox1)) {
+          ok
+        }
+        else if(out.size == 3 && out.contains(bullet9mmBox1) && out.contains(bullet9mmBox2) && out.contains(bullet9mmBox3)) {
+          ok
+        }
+        else {
+          ko
+        }
+      }
+      ok
     }
   }
 }

--- a/common/src/test/scala/objects/InventoryTest.scala
+++ b/common/src/test/scala/objects/InventoryTest.scala
@@ -3,7 +3,7 @@ package objects
 
 import net.psforever.objects.{AmmoBox, SimpleItem}
 import net.psforever.objects.definition.SimpleItemDefinition
-import net.psforever.objects.inventory.{GridInventory, InventoryItem, InventoryTile}
+import net.psforever.objects.inventory._
 import net.psforever.objects.GlobalDefinitions._
 import net.psforever.types.PlanetSideGUID
 import org.specs2.mutable._
@@ -18,6 +18,18 @@ class InventoryTest extends Specification {
   val
   bullet9mmBox2 = AmmoBox(bullet_9mm)
   bullet9mmBox2.GUID = PlanetSideGUID(2)
+
+  "InventoryDisarrayException" should {
+    "construct" in {
+      InventoryDisarrayException("slot out of bounds")
+      ok
+    }
+
+    "construct (with Throwable)" in {
+      InventoryDisarrayException("slot out of bounds", new Throwable())
+      ok
+    }
+  }
 
   "GridInventory" should {
     "construct" in {
@@ -40,7 +52,7 @@ class InventoryTest extends Specification {
       obj.TotalCapacity mustEqual 54
       obj.Capacity mustEqual 45
       obj.Size mustEqual 1
-      obj.hasItem(PlanetSideGUID(1)) mustEqual Some(bullet9mmBox1)
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj.Clear()
       obj.Size mustEqual 0
     }
@@ -50,11 +62,23 @@ class InventoryTest extends Specification {
       //safe
       obj.CheckCollisionsAsList(0, 3, 3) mustEqual Success(Nil)
       //right
-      obj.CheckCollisionsAsList(-1, 3, 3).isFailure mustEqual true
+      obj.CheckCollisionsAsList(-1, 3, 3) match {
+        case scala.util.Failure(fail) =>
+          fail.isInstanceOf[IndexOutOfBoundsException] mustEqual true
+        case _ => ko
+      }
       //left
-      obj.CheckCollisionsAsList(1, 3, 3).isFailure mustEqual true
+      obj.CheckCollisionsAsList(1, 3, 3) match {
+        case scala.util.Failure(fail) =>
+          fail.isInstanceOf[IndexOutOfBoundsException] mustEqual true
+        case _ => ko
+      }
       //bottom
-      obj.CheckCollisionsAsList(3, 3, 3).isFailure mustEqual true
+      obj.CheckCollisionsAsList(3, 3, 3) match {
+        case scala.util.Failure(fail) =>
+          fail.isInstanceOf[IndexOutOfBoundsException] mustEqual true
+        case _ => ko
+      }
     }
 
     "check for item collision (right insert)" in {
@@ -64,7 +88,7 @@ class InventoryTest extends Specification {
       val w = bullet9mmBox2.Tile.Width
       val h = bullet9mmBox2.Tile.Height
       val list0 = obj.CheckCollisionsAsList(0, w, h)
-      list0 match {
+      obj.CheckCollisionsAsList(0, w, h) match {
         case scala.util.Success(list) => list.length mustEqual 1
         case scala.util.Failure(_) => ko
       }
@@ -267,9 +291,9 @@ class InventoryTest extends Specification {
       val obj : GridInventory = GridInventory(9, 6)
       obj += 0 -> bullet9mmBox1
       obj.Capacity mustEqual 45
-      obj.hasItem(PlanetSideGUID(1)) mustEqual Some(bullet9mmBox1)
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj += 2 -> bullet9mmBox2
-      obj.hasItem(PlanetSideGUID(2)) mustEqual None
+      obj.hasItem(PlanetSideGUID(2)).isEmpty mustEqual true
       obj.Clear()
       ok
     }
@@ -277,9 +301,9 @@ class InventoryTest extends Specification {
     "remove item" in {
       val obj : GridInventory = GridInventory(9, 6)
       obj += 0 -> bullet9mmBox1
-      obj.hasItem(PlanetSideGUID(1)) mustEqual Some(bullet9mmBox1)
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj -= PlanetSideGUID(1)
-      obj.hasItem(PlanetSideGUID(1)) mustEqual None
+      obj.hasItem(PlanetSideGUID(1)).isEmpty mustEqual true
       obj.Clear()
       ok
     }
@@ -288,10 +312,10 @@ class InventoryTest extends Specification {
       val obj : GridInventory = GridInventory(9, 6)
       obj.CheckCollisions(23, bullet9mmBox1) mustEqual Success(Nil)
       obj += 23 -> bullet9mmBox1
-      obj.hasItem(PlanetSideGUID(1)) mustEqual Some(bullet9mmBox1)
+      obj.hasItem(PlanetSideGUID(1)).contains(bullet9mmBox1) mustEqual true
       obj.CheckCollisions(23, bullet9mmBox1) mustEqual Success(1 :: Nil)
       obj -= PlanetSideGUID(1)
-      obj.hasItem(PlanetSideGUID(1)) mustEqual None
+      obj.hasItem(PlanetSideGUID(1)).isEmpty mustEqual true
       obj.CheckCollisions(23, bullet9mmBox1) mustEqual Success(Nil)
       obj.Clear()
       ok

--- a/common/src/test/scala/objects/ZoneTest.scala
+++ b/common/src/test/scala/objects/ZoneTest.scala
@@ -357,6 +357,7 @@ class ZonePopulationTest extends ActorTest {
       val zone = new Zone("test", new ZoneMap(""), 0) { override def SetupNumberPools() = { } }
       val avatar = Avatar("Chord", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Voice5)
       val player = Player(avatar)
+      player.GUID = PlanetSideGUID(1)
       zone.Actor = system.actorOf(Props(classOf[ZoneActor], zone), ZoneTest.TestName)
       zone.Actor ! Zone.Init()
       expectNoMsg(200 milliseconds)

--- a/common/src/test/scala/service/VehicleServiceTest.scala
+++ b/common/src/test/scala/service/VehicleServiceTest.scala
@@ -261,8 +261,8 @@ class TransferPassengerChannelTest extends ActorTest {
       val service = system.actorOf(Props(classOf[VehicleService], Zone.Nowhere), "v-service")
       val fury = Vehicle(GlobalDefinitions.fury)
       service ! Service.Join("test")
-      service ! VehicleServiceMessage("test", VehicleAction.TransferPassengerChannel(PlanetSideGUID(10), "old_channel", "new_channel", fury))
-      expectMsg(VehicleServiceResponse("/test/Vehicle", PlanetSideGUID(10), VehicleResponse.TransferPassengerChannel("old_channel", "new_channel", fury)))
+      service ! VehicleServiceMessage("test", VehicleAction.TransferPassengerChannel(PlanetSideGUID(10), "old_channel", "new_channel", fury, PlanetSideGUID(11)))
+      expectMsg(VehicleServiceResponse("/test/Vehicle", PlanetSideGUID(10), VehicleResponse.TransferPassengerChannel("old_channel", "new_channel", fury, PlanetSideGUID(11))))
     }
   }
 }

--- a/pslogin/src/main/scala/PsLogin.scala
+++ b/pslogin/src/main/scala/PsLogin.scala
@@ -11,7 +11,7 @@ import ch.qos.logback.core.joran.spi.JoranException
 import ch.qos.logback.core.status._
 import ch.qos.logback.core.util.StatusPrinter
 import com.typesafe.config.ConfigFactory
-import net.psforever.config.{Valid, Invalid}
+import net.psforever.config.{Invalid, Valid}
 import net.psforever.crypto.CryptoInterface
 import net.psforever.objects.zones._
 import net.psforever.objects.guid.TaskResolver
@@ -19,7 +19,7 @@ import org.slf4j
 import org.fusesource.jansi.Ansi._
 import org.fusesource.jansi.Ansi.Color._
 import services.ServiceManager
-import services.account.AccountIntermediaryService
+import services.account.{AccountIntermediaryService, AccountPersistenceService}
 import services.chat.ChatService
 import services.galaxy.GalaxyService
 import services.teamwork.SquadService
@@ -275,6 +275,7 @@ object PsLogin {
     serviceManager ! ServiceManager.Register(Props[GalaxyService], "galaxy")
     serviceManager ! ServiceManager.Register(Props[SquadService], "squad")
     serviceManager ! ServiceManager.Register(Props(classOf[InterstellarCluster], continentList), "cluster")
+    serviceManager ! ServiceManager.Register(Props[AccountPersistenceService], "accountPersistence")
 
     logger.info("Initializing loginRouter & worldRouter")
     /** Create two actors for handling the login and world server endpoints */

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -198,16 +198,18 @@ class WorldSessionActor extends Actor
     antDischargingTick.cancel
     chatService ! Service.Leave()
     galaxyService ! Service.Leave()
-    squadService ! Service.Leave(Some(s"${avatar.faction}"))
     continent.AvatarEvents ! Service.Leave()
     continent.LocalEvents ! Service.Leave()
     continent.VehicleEvents ! Service.Leave()
-    if(player != null && player.HasGUID) {
+    if(avatar != null) {
       //TODO put any temporary values back into the avatar
-      prefire.orElse(shooting) match {
-        case Some(guid) =>
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ChangeFireState_Stop(player.GUID, guid))
-        case None => ;
+      squadService ! Service.Leave(Some(s"${avatar.faction}"))
+      if(player != null && player.HasGUID) {
+        prefire.orElse(shooting) match {
+          case Some(guid) =>
+            continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ChangeFireState_Stop(player.GUID, guid))
+          case None => ;
+        }
       }
     }
   }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1348,7 +1348,7 @@ class WorldSessionActor extends Actor
         case _ =>
           //fall back to sanctuary/prior?
           log.error(s"LoginInfo: player $playerName could not be found in game world")
-          self ! PlayerToken.LoginInfo(playerName, Zone.Nowhere, player.Position)
+          self ! PlayerToken.LoginInfo(playerName, Zone.Nowhere, pos)
       }
 
     case default =>
@@ -3371,8 +3371,12 @@ class WorldSessionActor extends Actor
       loadConfZone = false
     }
 
-    if (noSpawnPointHere) {
+    if(noSpawnPointHere) {
       RequestSanctuaryZoneSpawn(player, continent.Number)
+    }
+    else if(player.Health == 0) {
+      //player died during setup; probably a relog
+      player.Actor ! Player.Die()
     }
   }
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -716,7 +716,7 @@ class WorldSessionActor extends Actor
                 val converter : CharacterSelectConverter = new CharacterSelectConverter
 
                 result.rows foreach { row =>
-                  log.info(s"char list : ${row.toString()}")
+                  log.trace(s"char list : ${row.toString()}")
                   val nowTimeInSeconds = System.currentTimeMillis() / 1000
                   var avatarArray : Array[Avatar] = Array.ofDim(row.length)
                   var playerArray : Array[Player] = Array.ofDim(row.length)
@@ -2412,7 +2412,13 @@ class WorldSessionActor extends Actor
         continent.AvatarEvents ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ArmorChanged(tplayer.GUID, nextSuit, nextSubtype))
         if(nextSuit == ExoSuitType.MAX) {
           val (maxWeapons, otherWeapons) = afterHolsters.partition(entry => { entry.obj.Size == EquipmentSize.Max })
-          taskResolver ! DelayedObjectHeld(tplayer, 0, List(PutEquipmentInSlot(tplayer, maxWeapons.head.obj, 0)))
+          val weapon = maxWeapons.headOption match {
+            case Some(mweapon) =>
+              mweapon.obj
+            case None =>
+              Tool(GlobalDefinitions.MAXArms(nextSubtype, tplayer.Faction))
+          }
+          taskResolver ! DelayedObjectHeld(tplayer, 0, List(PutEquipmentInSlot(tplayer, weapon, 0)))
           otherWeapons
         }
         else {
@@ -10973,6 +10979,8 @@ class WorldSessionActor extends Actor
           obj.Seats.values.collect { case seat if seat.isOccupied => seat.Occupant.get.Name }
         case Some(obj : Player) if obj.ExoSuit == ExoSuitType.MAX =>
           Seq(obj.Name)
+        case _ =>
+          Seq.empty[String]
       }
   }
 


### PR DESCRIPTION
The documentation of the class in question explains succinctly:
> A global service that manages user behavior as divided into the following three categories:
>* persistence (ongoing participation in the game world),
>* relogging (short-term client connectivity issue resolution), and
>* logout (end-of-life conditions involving the separation of a user from the game world).

Following the squad update, it was reported that players quitting out of the game and joining back in using the same player character too soon would cause issues.  The main result were doubly-logged players, phantoms who could see another of themselves for a short time, and, when that doppelgänger unloaded as a product of that user's `WorldSessionActor` going out of scope, the game world went crosseyed when trying to depict their own character(s) correctly.  This issue really persisted for quite some time before the squad update.  Directly-related to that update, however, the hot-off-the-truck squad interaction system would completely collapse upon quick relogging, though that was only the start of a really impressive desynchronization of the character and the game.

Lifetime of `WorldSessionActor` is controlled indirectly by a feature deeper in the session pipeline called the `SessionReaper` that triggers to clean up an inactive, decaying connection.  The `SessionReaper` is useful for the lifetime of the connection but presents a rock hard limitation for player persistence.  Once it goes off, that pipeline has come to its end.  Players and avatars were previously products local to `WorldSessionActor` due to the relationship between `WorldSessionActor` and clients.  Player avatars were loaned out to `Zone` entities and the nearly deprecated `LivePlayerList` singleton, then died when their pipeline died.  But, `LivePlayerList` is a static component that only deals with the `Avatar` component, and `Zone` objects' population management systems, while being more suitable for the kind of activity necessary to detect an end of life situation, are already performing one task that does not necessarily need to be compounded.  For this reason, the new global service system was devised, and end of life control of players and avatars was stripped away from `WorldSessionActor` and the `SessionReaper`.

___Features___:
__`PersistenceMonitor`__
Token unit that keeps track of individual users in terms of avatar name, avatar zone, and avatar coordinate position in that zone.  Receives updated information frequently from `WSA` and, when `WSA` has lapsed into nonexistence, and even its internal update timer has expired, plans for end of life operations to ensure that all (other) users see the retirement of this monitored user.  Also takes care of related paraphrenalia such as driven vehicles, owned vehicles, deployables, and lingering subscriptions (such as to `SquadService`).  Manages its own lifetime, in general.

__`AccountPersistenceService`__
Maintains monitors for individual users and mainly controls creation of those monitor tokens.

__`WorldSessionActor`__
Greatly scaled back manipulation of the user's avatar object and the user's player object during `postStop`.  The process of bisecting normal login operations to check for user player relogging (the same character already in the game world, still in the game world, when the user attempts to load that character again) created what would have been a multiple path split without the use of function literals to redirect key operations, mainly, avatar creation (`ObjectCreateDetailedMessage`) and avatar designation (`SetCurrentAvatarMessage`).  Due to the requirements of the database interactions, some rewriting was performed to utilize `Promise`s and `Future`s.

___Caveats___:
1.  Players classically persist in the game world for about a minute after their user has broken the connection (logged out, errored, etc.).  Due to the `SessionReaper` previously serving a dual purpose of maintaining a connection through latency (proper) and formerly being set to time a proper logout (inheritted), the time it expires is currently one minute.  The persistence monitoring system is also set to activate logout after one minute of inactivity, but that one minute expires after `SessionReaper`'s one minute.  The result is that players will endure in the game world for **two minutes** when no longer associated with a client instead of just one.
2. End of life management of a vehicle that is being submitted for deconstruction may encounter issues due to overlapping deconstruction clear/submission orders.
3. Thought mostly deprecated now, since it serves no purpose save for reporting server population, `LivePlayerList` continues to exist.
4. No database solution is enacted to keep track of a player's zone and position information for longer than the decay of its persistence monitor.  Once a user has been disconnected from the game's server for long enough, that user is required to start their next session with the same character from the character's faction's sanctuary continent.
5.  While it has always been possible to log into the same game session twice with the same player character, the persistence system will only help synchronize the subsequent logins with (one) of the earlier player characters.  The server will still not stop two of the same player avatars from logging in with the saem character simultaneously, and will still go crosseyed from the experience.

___Addenda___:
1. If a unique login attempt is detected, a player will be sent to a random HART campus on their sanctuary continent.  This is the first time a player will be sent to their own sanctuary rather than a static continent and is significant enough of a change in test planning that it warrants mention.
2. Some vehicle functionality and deployable functionality originally located in `WorldSessionActor` has been moved out of the class and into their own feature-related classes.