### PR TITLE
Priority Fixes (20200405)

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -4812,7 +4812,9 @@ class WorldSessionActor extends Actor
                 }
               } && indexSlot.Equipment.contains(item)) {
                 if(PermitEquipmentStow(item, destination)) {
+                  StartBundlingPackets()
                   PerformMoveItem(item, source, index, destination, dest, destItemEntry)
+                  StopBundlingPackets()
                 }
                 else {
                   log.error(s"MoveItem: $item disallowed storage in $destination")
@@ -4862,7 +4864,9 @@ class WorldSessionActor extends Actor
             }, target.Fit(item)) match {
             case (Some((source, Some(index))), Some(dest)) =>
               if(PermitEquipmentStow(item, target)) {
+                StartBundlingPackets()
                 PerformMoveItem(item, source, index, target, dest, None)
+                StopBundlingPackets()
               }
               else {
                 log.error(s"LootItem: $item disallowed storage in $target")


### PR DESCRIPTION
The following changes:
- Bundling the packets of the actual move item code.
- Removed an explicit `Option.get` call to waning message of a failed move item test (can find `None` in the slot where something was expected, though I can't say I know why).
- Adjusted loadout database save code to need to navigate to the `Equipment` entity in the slot and identify it as a `Tool` object using so many calls.
- Adjusted loadout database save code to cache the exo-suit type to avoid race case between the user playing with his loadout and the database playing with connections.

Additionally: saving a loadout with some class-inherited equipment previously resulted in improper objects that were not guaranteed to be detected by clean up code.  For example, a `Telepad` entity would be saved in the database loadout data and would get translated back into a "telepad-like" `ConstructionItem` entity (not to be confused with a `TelepadLike` object).  Now the `Telepad` entity should get properly ignored when converting loadout data from the database back into actual game object loadouts.