### PR TITLE
Silly Uses

### DIFF
--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -158,10 +158,12 @@ class PlayerControl(player : Player) extends Actor
           }
         }
 
-      case CommonMessages.Use(user, Some(item : Tool)) if item.Definition == GlobalDefinitions.medicalapplicator && !player.isAlive =>
+      case CommonMessages.Use(user, Some(item : Tool)) if item.Definition == GlobalDefinitions.medicalapplicator =>
         //revive
-        if(user != player && user.isAlive && !user.isMoving &&
-          !player.isBackpack &&
+        if(user != player &&
+          user.Faction == player.Faction &&
+          user.isAlive && !user.isMoving &&
+          !player.isAlive && !player.isBackpack &&
           item.Magazine >= 25) {
           sender ! CommonMessages.Progress(
             4,


### PR DESCRIPTION
Sometimes, equipment didn't do what it was supposed to.  The following instances of tools - medical applicators and banks mainly - acting funky have been tied up:
- using a tool on a corpse caused the corpses's inventory to flicker open and closed
- using a medical applicator on a dead enemy soldier began the revival process and would, if completed, revive them
- using a tool on a deployed telepad would attempt to transport the user to the router's end if the connection was established

In addition, the base case "take a shot in the dark" has been removed so trying to operate on something the main `UseItemMessage` case doesn't know about won't inadvertantly cause the world to come to an end.

I can not stop the medical applicator or the bank from visually trying to act on whatever it gets waved towards, not safely, anyway; but I can stop it from causing any weird behaviors.