### PR TITLE
Vehicles Must Be Destroyed

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -578,14 +578,8 @@ object Vehicle {
   final case class VehicleMessages(player : Player, response : Exchange)
 
   /**
-    * The `Vehicle` will become unresponsive to player activity.
-    * Usually, it does this to await deconstruction and clean-up.
-    * @see `VehicleControl`
-    */
-  final case class PrepareForDeletion()
-
-  /**
     * Initiate vehicle deconstruction.
+    * @see `VehicleControl`
     * @param time the delay before deconstruction should initiate;
     *             should initiate instantly when `None`
     */

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -16,6 +16,7 @@ import net.psforever.objects.vital.{DamageResistanceModel, StandardResistancePro
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.annotation.tailrec
+import scala.concurrent.duration.FiniteDuration
 
 /**
   * The server-side support object that represents a vehicle.<br>
@@ -582,6 +583,13 @@ object Vehicle {
     * @see `VehicleControl`
     */
   final case class PrepareForDeletion()
+
+  /**
+    * Initiate vehicle deconstruction.
+    * @param time the delay before deconstruction should initiate;
+    *             should initiate instantly when `None`
+    */
+  final case class Deconstruct(time : Option[FiniteDuration] = None)
 
   /**
     * The `Vehicle` will resume previous unresponsiveness to player activity.

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.vehicles.{CargoBehavior, VehicleLockState}
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.TriggeredSound
 import net.psforever.types.{DriveState, PlanetSideGUID}
-import services.{RemoverActor, Service}
+import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.local.{LocalAction, LocalServiceMessage}
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
@@ -215,8 +215,7 @@ object Vehicles {
     // If the vehicle can fly and is flying deconstruct it, and well played to whomever managed to hack a plane in mid air. I'm impressed.
     if(target.Definition.CanFly && target.Flying) {
       // todo: Should this force the vehicle to land in the same way as when a pilot bails with passengers on board?
-      zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(target), zone))
-      zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(target, zone, Some(0 seconds)))
+      target.Actor ! Vehicle.Deconstruct()
     } else { // Otherwise handle ownership transfer as normal
       // Remove ownership of our current vehicle, if we have one
       hacker.VehicleOwned match {

--- a/common/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -191,10 +191,10 @@ object Vehicles {
         case Some(cargo : Vehicle) => {
           cargo.Seats(0).Occupant match {
             case Some(cargoDriver: Player) =>
-              CargoBehavior.HandleVehicleCargoDismount(target.Zone, cargoDriver.GUID, cargo.GUID, bailed = target.Flying, requestedByPassenger = false, kicked = true )
+              CargoBehavior.HandleVehicleCargoDismount(target.Zone, cargo.GUID, bailed = target.Flying, requestedByPassenger = false, kicked = true )
             case None =>
               log.error("FinishHackingVehicle: vehicle in cargo hold missing driver")
-              CargoBehavior.HandleVehicleCargoDismount(hacker.GUID, cargo.GUID, cargo, target.GUID, target, false, false, true)
+              CargoBehavior.HandleVehicleCargoDismount(cargo.GUID, cargo, target.GUID, target, false, false, true)
           }
         }
         case None => ;

--- a/common/src/main/scala/net/psforever/objects/serverobject/damage/DamageableVehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/damage/DamageableVehicle.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.deploy.Deployment
 import net.psforever.objects.vital.resolution.ResolutionCalculations
 import net.psforever.types.{DriveState, PlanetSideGUID}
-import services.{RemoverActor, Service}
+import services.Service
 import services.local.{LocalAction, LocalServiceMessage}
 import services.vehicle.{VehicleAction, VehicleService, VehicleServiceMessage}
 
@@ -180,8 +180,7 @@ object DamageableVehicle {
       target.Shields = 0
       zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, target.GUID, 68, 0))
     }
-    zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(target), zone))
-    zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(target, zone, Some(1 minute)))
+    target.Actor ! Vehicle.Deconstruct(Some(1 minute))
     target.ClearHistory()
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
@@ -33,7 +33,7 @@ class VehicleSpawnControlConcealPlayer(pad : VehicleSpawnPad) extends VehicleSpa
       }
       else {
         trace(s"integral component lost; abort order fulfillment")
-        VehicleSpawnControl.DisposeSpawnedVehicle(order.vehicle, pad.Zone)
+        VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       }
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
@@ -21,15 +21,12 @@ class VehicleSpawnControlDriverControl(pad : VehicleSpawnPad) extends VehicleSpa
 
   def receive : Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      if(vehicle.Health == 0) {
-        trace(s"vehicle was already destroyed; but, everything is fine")
-      }
-      if(vehicle.PassengerInSeat(driver).contains(0)) {
+      if(vehicle.Health > 0 && vehicle.PassengerInSeat(driver).contains(0)) {
         trace(s"returning control of ${vehicle.Definition.Name} to ${driver.Name}")
         pad.Zone.VehicleEvents ! VehicleSpawnPad.ServerVehicleOverrideEnd(driver.Name, vehicle, pad)
       }
       else {
-        trace(s"${driver.Name} is not seated in ${vehicle.Definition.Name}; vehicle controls have been locked")
+        trace(s"${driver.Name} is not seated in ${vehicle.Definition.Name}; vehicle controls might have been locked")
       }
       finalClear ! order
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -4,6 +4,7 @@ package net.psforever.objects.serverobject.pad.process
 import akka.actor.Props
 import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
+import net.psforever.objects.zones.Zone
 import net.psforever.types.Vector3
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,7 +37,7 @@ class VehicleSpawnControlLoadVehicle(pad : VehicleSpawnPad) extends VehicleSpawn
       }
       else {
         trace("owner lost or vehicle in poor condition; abort order fulfillment")
-        VehicleSpawnControl.DisposeSpawnedVehicle(order, pad.Zone)
+        VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       }
 

--- a/common/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
@@ -231,18 +231,18 @@ object CargoBehavior {
 
   /**
     * na
-    * @param player_guid na
+    * @param zone na
     * @param cargo_guid na
     * @param bailed na
     * @param requestedByPassenger na
     * @param kicked na
     */
-  def HandleVehicleCargoDismount(zone : Zone, player_guid : PlanetSideGUID, cargo_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) : Unit = {
+  def HandleVehicleCargoDismount(zone : Zone, cargo_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) : Unit = {
     zone.GUID(cargo_guid) match {
       case Some(cargo : Vehicle) =>
         zone.GUID(cargo.MountedIn) match {
           case Some(ferry : Vehicle) =>
-            HandleVehicleCargoDismount(player_guid, cargo_guid, cargo, ferry.GUID, ferry, bailed, requestedByPassenger, kicked)
+            HandleVehicleCargoDismount(cargo_guid, cargo, ferry.GUID, ferry, bailed, requestedByPassenger, kicked)
           case _ =>
             log.warn(s"DismountVehicleCargo: target ${cargo.Definition.Name}@$cargo_guid does not know what treats it as cargo")
         }
@@ -253,7 +253,6 @@ object CargoBehavior {
 
   /**
     * na
-    * @param player_guid the target player
     * @param cargoGUID the globally unique number for the vehicle being ferried
     * @param cargo the vehicle being ferried
     * @param carrierGUID the globally unique number for the vehicle doing the ferrying
@@ -262,7 +261,7 @@ object CargoBehavior {
     * @param requestedByPassenger the ferried vehicle is being politely disembarked from the cargo hold
     * @param kicked the ferried vehicle is being kicked out of the cargo hold
     */
-  def HandleVehicleCargoDismount(player_guid : PlanetSideGUID, cargoGUID : PlanetSideGUID, cargo : Vehicle, carrierGUID : PlanetSideGUID, carrier : Vehicle, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) : Unit = {
+  def HandleVehicleCargoDismount(cargoGUID : PlanetSideGUID, cargo : Vehicle, carrierGUID : PlanetSideGUID, carrier : Vehicle, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) : Unit = {
     val zone = carrier.Zone
     carrier.CargoHolds.find({case(_, hold) => hold.Occupant.contains(cargo)}) match {
       case Some((mountPoint, hold)) =>
@@ -284,16 +283,20 @@ object CargoBehavior {
           //the lodestar's cargo hold is almost the center of the vehicle
           carrier.Position
         }
-        zone.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
-        zone.VehicleEvents ! VehicleServiceMessage(s"${cargo.Actor}", VehicleAction.SendResponse(PlanetSideGUID(0), PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
+        val GUID0 = Service.defaultPlayerGUID
+        val zoneId = zone.Id
+        val events = zone.VehicleEvents
+        val cargoActor = cargo.Actor
+        events ! VehicleServiceMessage(s"$cargoActor", VehicleAction.SendResponse(GUID0, PlanetsideAttributeMessage(cargoGUID, 0, cargo.Health)))
+        events ! VehicleServiceMessage(s"$cargoActor", VehicleAction.SendResponse(GUID0, PlanetsideAttributeMessage(cargoGUID, 68, cargo.Shields)))
         if(carrier.Flying) {
           //the carrier vehicle is flying; eject the cargo vehicle
-          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.InProgress, 0)
+          val ejectCargoMsg = CargoMountPointStatusMessage(carrierGUID, GUID0, GUID0, cargoGUID, mountPoint, CargoStatus.InProgress, 0)
           val detachCargoMsg = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition - Vector3.z(1), rotation)
-          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
-          zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(Service.defaultPlayerGUID, ejectCargoMsg))
-          zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(Service.defaultPlayerGUID, detachCargoMsg))
-          zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(Service.defaultPlayerGUID, resetCargoMsg))
+          val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, GUID0, GUID0, cargoGUID, mountPoint, CargoStatus.Empty, 0)
+          events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, ejectCargoMsg))
+          events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, detachCargoMsg))
+          events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, resetCargoMsg))
           log.debug(ejectCargoMsg.toString)
           log.debug(detachCargoMsg.toString)
           if(driverOpt.isEmpty) {
@@ -303,20 +306,20 @@ object CargoBehavior {
         }
         else {
           //the carrier vehicle is not flying; just open the door and let the cargo vehicle back out; force it out if necessary
-          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), cargoGUID, PlanetSideGUID(0), mountPoint, CargoStatus.InProgress, 0)
+          val cargoStatusMessage = CargoMountPointStatusMessage(carrierGUID, GUID0, cargoGUID, GUID0, mountPoint, CargoStatus.InProgress, 0)
           val cargoDetachMessage = ObjectDetachMessage(carrierGUID, cargoGUID, cargoHoldPosition + Vector3.z(1f), rotation)
-          zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(Service.defaultPlayerGUID, cargoStatusMessage))
-          zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(Service.defaultPlayerGUID, cargoDetachMessage))
+          events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, cargoStatusMessage))
+          events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, cargoDetachMessage))
           driverOpt match {
             case Some(driver) =>
-              zone.VehicleEvents ! VehicleServiceMessage(s"${driver.Name}", VehicleAction.KickCargo(player_guid, cargo, cargo.Definition.AutoPilotSpeed2, 2500))
+              events ! VehicleServiceMessage(s"${driver.Name}", VehicleAction.KickCargo(GUID0, cargo, cargo.Definition.AutoPilotSpeed2, 2500))
               //check every quarter second if the vehicle has moved far enough away to be considered dismounted
-              cargo.Actor ! CheckCargoDismount(carrierGUID, mountPoint, 0)
+              cargoActor ! CheckCargoDismount(carrierGUID, mountPoint, 0)
             case None =>
-              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
-              zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
+              val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, GUID0, GUID0, cargoGUID, mountPoint, CargoStatus.Empty, 0)
+              events ! VehicleServiceMessage(zoneId, VehicleAction.SendResponse(GUID0, resetCargoMsg)) //lazy
               //TODO cargo should back out like normal; until then, deconstruct it
-              cargo.Actor ! Vehicle.Deconstruct()
+              cargoActor ! Vehicle.Deconstruct()
           }
         }
 

--- a/common/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.vehicles.CargoBehavior.{CheckCargoDismount, CheckCa
 import net.psforever.packet.game.{CargoMountPointStatusMessage, ObjectAttachMessage, ObjectDetachMessage, PlanetsideAttributeMessage}
 import net.psforever.types.{CargoStatus, PlanetSideGUID, Vector3}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
-import services.{RemoverActor, Service}
+import services.Service
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.concurrent.duration._
@@ -298,8 +298,7 @@ object CargoBehavior {
           log.debug(detachCargoMsg.toString)
           if(driverOpt.isEmpty) {
             //TODO cargo should drop like a rock like normal; until then, deconstruct it
-            zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(cargo), zone))
-            zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(cargo, zone, Some(0 seconds)))
+            cargo.Actor ! Vehicle.Deconstruct()
           }
         }
         else {
@@ -317,8 +316,7 @@ object CargoBehavior {
               val resetCargoMsg = CargoMountPointStatusMessage(carrierGUID, PlanetSideGUID(0), PlanetSideGUID(0), cargoGUID, mountPoint, CargoStatus.Empty, 0)
               zone.VehicleEvents ! VehicleServiceMessage(zone.Id, VehicleAction.SendResponse(PlanetSideGUID(0), resetCargoMsg)) //lazy
               //TODO cargo should back out like normal; until then, deconstruct it
-              zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(cargo), zone))
-              zone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(cargo, zone, Some(0 seconds)))
+              cargo.Actor ! Vehicle.Deconstruct()
           }
         }
 

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -169,21 +169,9 @@ class VehicleControl(vehicle : Vehicle) extends Actor
     CancelJammeredSound(vehicle)
     CancelJammeredStatus(vehicle)
     //escape being someone else's cargo
-    (vehicle.MountedIn match {
-      case Some(carrierGUID) =>
-        zone.Vehicles.find(v => v.GUID == carrierGUID)
-      case None =>
-        None
-    }) match {
-      case Some(carrier : Vehicle) =>
-        val driverName = carrier.Seats(0).Occupant match {
-          case Some(driver) => driver.Name
-          case _ => zoneId
-        }
-        events ! VehicleServiceMessage(
-          s"$driverName",
-          VehicleAction.ForceDismountVehicleCargo(Service.defaultPlayerGUID, guid, true, false, false)
-        )
+    vehicle.MountedIn match {
+      case Some(_) =>
+        CargoBehavior.HandleVehicleCargoDismount(zone, guid, bailed = false, requestedByPassenger = false, kicked = false)
       case _ => ;
     }
     //kick all passengers
@@ -201,7 +189,7 @@ class VehicleControl(vehicle : Vehicle) extends Actor
       vehicle.CargoHolds.values
         .collect { case hold if hold.isOccupied =>
           val cargo = hold.Occupant.get
-          CargoBehavior.HandleVehicleCargoDismount(zone, cargo.GUID, bailed = false, requestedByPassenger = false, kicked = false)
+          CargoBehavior.HandleVehicleCargoDismount(cargo.GUID, cargo, guid, vehicle, bailed = false, requestedByPassenger = false, kicked = false)
         }
     })
     //unregister

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -155,6 +155,11 @@ class VehicleControl(vehicle : Vehicle) extends Actor
     val zone = vehicle.Zone
     val zoneId = zone.Id
     val events = zone.VehicleEvents
+    //driver's name
+    val driverName = vehicle.Seats(0).Occupant match {
+      case Some(driver) => driver.Name
+      case _ => zoneId
+    }
     //become disabled
     context.become(Disabled)
     //cancel jammed behavior
@@ -194,7 +199,7 @@ class VehicleControl(vehicle : Vehicle) extends Actor
         .collect { case hold if hold.isOccupied =>
           val cargo = hold.Occupant.get
           events ! VehicleServiceMessage(
-            zoneId,
+            driverName,
             VehicleAction.ForceDismountVehicleCargo(Service.defaultPlayerGUID, cargo.GUID, true, false, false)
           )
         }

--- a/common/src/main/scala/services/RemoverActor.scala
+++ b/common/src/main/scala/services/RemoverActor.scala
@@ -61,7 +61,7 @@ abstract class RemoverActor extends SupportActor[RemoverActor.Entry] {
     */
   override def preStart() : Unit = {
     super.preStart()
-    self ! Service.Startup()
+    ServiceManager.serviceManager ! ServiceManager.Lookup("taskResolver") //ask for a resolver to deal with the GUID system
   }
 
   /**
@@ -84,9 +84,6 @@ abstract class RemoverActor extends SupportActor[RemoverActor.Entry] {
   }
 
   def receive : Receive = {
-    case Service.Startup() =>
-      ServiceManager.serviceManager ! ServiceManager.Lookup("taskResolver") //ask for a resolver to deal with the GUID system
-
     case ServiceManager.LookupResult("taskResolver", endpoint) =>
       taskResolver = endpoint
       context.become(Processing)

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -351,7 +351,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
         vehicle.Actor ! Vehicle.Deconstruct(
           if(vehicle.Flying) {
             //TODO gravity
-            Some(0 seconds) //immediate deconstruction
+            None //immediate deconstruction
           }
           else {
             vehicle.Definition.DeconstructionTime //normal deconstruction

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -348,8 +348,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
   def DisownVehicle(player : Player) : Unit = {
     Vehicles.Disown(player, inZone) match {
       case Some(vehicle) if vehicle.Health == 0 || (vehicle.Seats.values.forall(seat => !seat.isOccupied) && vehicle.Owner.isEmpty) =>
-        inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), inZone))
-        inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, inZone,
+        vehicle.Actor ! Vehicle.Deconstruct(
           if(vehicle.Flying) {
             //TODO gravity
             Some(0 seconds) //immediate deconstruction
@@ -357,7 +356,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
           else {
             vehicle.Definition.DeconstructionTime //normal deconstruction
           }
-        ))
+        )
       case _ => ;
     }
   }

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -137,11 +137,6 @@ class VehicleService(zone : Zone) extends Actor {
           VehicleEvents.publish(
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.TransferPassengerChannel(old_channel, temp_channel, vehicle, vehicle_to_delete))
           )
-
-        case VehicleAction.ForceDismountVehicleCargo(player_guid, vehicle_guid, bailed, requestedByPassenger, kicked) =>
-          VehicleEvents.publish(
-            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.ForceDismountVehicleCargo(vehicle_guid, bailed, requestedByPassenger, kicked))
-          )
         case VehicleAction.KickCargo(player_guid, cargo, speed, delay) =>
           VehicleEvents.publish(
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.KickCargo(cargo, speed, delay))

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -216,12 +216,6 @@ class VehicleService(zone : Zone) extends Actor {
       VehicleEvents.publish(
         VehicleServiceResponse(s"/${zone.Id}/Vehicle", Service.defaultPlayerGUID, VehicleResponse.LoadVehicle(vehicle, vtype, vguid, vdata))
       )
-      //avoid unattended vehicle spawning blocking the pad; user should mount (and does so normally) to reset decon timer
-      vehicleDecon forward RemoverActor.AddTask(vehicle, zone, Some(30 seconds))
-
-    case VehicleSpawnPad.DisposeVehicle(vehicle) =>
-      vehicleDecon forward RemoverActor.AddTask(vehicle, zone, Some(0 seconds))
-      vehicleDecon forward RemoverActor.HurrySpecific(List(vehicle), zone)
 
     //correspondence from WorldSessionActor
     case VehicleServiceMessage.AMSDeploymentChange(_) =>

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -46,6 +46,5 @@ object VehicleAction {
 
   final case class TransferPassengerChannel(player_guid : PlanetSideGUID, temp_channel : String, new_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Action
 
-  final case class ForceDismountVehicleCargo(player_guid : PlanetSideGUID, vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Action
   final case class KickCargo(player_guid : PlanetSideGUID, cargo : Vehicle, speed : Int, delay : Long) extends Action
 }

--- a/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
@@ -52,6 +52,5 @@ object VehicleResponse {
 
   final case class TransferPassengerChannel(old_channel : String, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Response
 
-  final case class ForceDismountVehicleCargo(vehicle_guid : PlanetSideGUID, bailed : Boolean, requestedByPassenger : Boolean, kicked : Boolean) extends Response
   final case class KickCargo(cargo : Vehicle, speed : Int, delay : Long) extends Response
 }

--- a/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
+++ b/common/src/main/scala/services/vehicle/support/VehicleRemover.scala
@@ -1,88 +1,31 @@
-// Copyright (c) 2017 PSForever
+// Copyright (c) 2017-2020 PSForever
 package services.vehicle.support
 
-import akka.actor.ActorRef
+import akka.actor.{Actor, ActorRef}
 import net.psforever.objects.Vehicle
-import net.psforever.objects.guid.{GUIDTask, TaskResolver}
-import net.psforever.objects.zones.Zone
-import net.psforever.types.{DriveState, PlanetSideGUID}
-import services.{RemoverActor, Service}
-import services.vehicle.{VehicleAction, VehicleServiceMessage}
+import net.psforever.objects.guid.GUIDTask.UnregisterVehicle
+import services.{RemoverActor, ServiceManager}
 
-import scala.concurrent.duration._
+class VehicleRemover extends Actor {
+  var taskResolver : ActorRef = Actor.noSender
 
-class VehicleRemover extends RemoverActor {
-  final val FirstStandardDuration : FiniteDuration = 5 minutes
-
-  final val SecondStandardDuration : FiniteDuration = 5 seconds
-
-  def InclusionTest(entry : RemoverActor.Entry) : Boolean = {
-    entry.obj.isInstanceOf[Vehicle]
+  override def preStart() : Unit = {
+    super.preStart()
+    ServiceManager.serviceManager ! ServiceManager.Lookup("taskResolver") //ask for a resolver to deal with the GUID system
   }
 
-  def InitialJob(entry : RemoverActor.Entry) : Unit = { }
+  def receive : Receive = {
+    case ServiceManager.LookupResult("taskResolver", endpoint) =>
+      taskResolver = endpoint
+      context.become(Processing)
 
-  def FirstJob(entry : RemoverActor.Entry) : Unit = {
-    val vehicleGUID = entry.obj.GUID
-    entry.zone.GUID(vehicleGUID) match {
-      case Some(vehicle : Vehicle) if vehicle.HasGUID =>
-        val zoneId = entry.zone.Id
-        if(vehicle.Actor != ActorRef.noSender) {
-          vehicle.Actor ! Vehicle.PrepareForDeletion()
-        }
-        //escape being someone else's cargo
-        (vehicle.MountedIn match {
-          case Some(carrierGUID) =>
-            entry.zone.Vehicles.find(v => v.GUID == carrierGUID)
-          case None =>
-            None
-        }) match {
-          case Some(carrier : Vehicle) =>
-            val driverName = carrier.Seats(0).Occupant match {
-              case Some(driver) => driver.Name
-              case _ => zoneId
-            }
-            context.parent ! VehicleServiceMessage(s"$driverName", VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), vehicleGUID, true, false, false))
-          case _ => ;
-        }
-        //kick out all passengers
-        vehicle.Seats.values.foreach(seat => {
-          seat.Occupant match {
-            case Some(tplayer) =>
-              seat.Occupant = None
-              tplayer.VehicleSeated = None
-              if(tplayer.HasGUID) {
-                context.parent ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(tplayer.GUID, 4, false, vehicleGUID))
-              }
-            case None => ;
-          }
-          //abandon all cargo
-          vehicle.CargoHolds.values
-            .collect { case hold if hold.isOccupied =>
-              val cargo = hold.Occupant.get
-              context.parent ! VehicleServiceMessage(zoneId, VehicleAction.ForceDismountVehicleCargo(PlanetSideGUID(0), cargo.GUID, true, false, false))
-            }
-        })
-      case _ => ;
-    }
+    case _ => ;
   }
 
-  override def SecondJob(entry : RemoverActor.Entry) : Unit = {
-    val vehicleGUID = entry.obj.GUID
-    entry.zone.GUID(vehicleGUID) match {
-      case Some(vehicle : Vehicle) if vehicle.HasGUID =>
-        val zone = entry.zone
-        vehicle.DeploymentState = DriveState.Mobile
-        zone.Transport ! Zone.Vehicle.Despawn(vehicle)
-        context.parent ! VehicleServiceMessage(zone.Id, VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, zone, vehicle, vehicleGUID))
-        super.SecondJob(entry)
-      case _ => ;
-    }
-  }
+  def Processing : Receive = {
+    case RemoverActor.AddTask(obj : Vehicle, zone, _) =>
+      taskResolver ! UnregisterVehicle(obj)(zone.GUID)
 
-  def ClearanceTest(entry : RemoverActor.Entry) : Boolean = entry.obj.asInstanceOf[Vehicle].Seats.values.count(_.isOccupied) == 0
-
-  def DeletionTask(entry : RemoverActor.Entry) : TaskResolver.GiveTask = {
-    GUIDTask.UnregisterVehicle(entry.obj.asInstanceOf[Vehicle])(entry.zone.GUID)
+    case _ => ;
   }
 }

--- a/common/src/test/scala/base/FreedContextActorTest.scala
+++ b/common/src/test/scala/base/FreedContextActorTest.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 PSForever
+package base
+
+import akka.actor.{Actor, ActorContext, ActorRef, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+/**
+  * Create an `ActorTest` environment that has an `ActorContext` object.
+  */
+abstract class FreedContextActorTest extends ActorTest {
+  /*
+  Never do this in actual production code!
+  ActorSystem and ActorContext offer similar mechanisms for instantiating actors.
+  This is a consequence of their shared inheritance of the ActorRefFactory trait.
+  They are not equivalent enough to be able to pass one as the other as a parameter.
+  Because the ActorSystem has no context of its own,
+  various bizarre mechanisms have to be developed to use any methods that would pass in a context object.
+  We create a middleman Actor whose main purpose is to surrender its context object to the test environment directly
+  and then direct all messages sent to that object to the test environment.
+  */
+  private val _testContextHandler = system.actorOf(Props(classOf[ContextSensitive]), "actor-test-cs")
+  private implicit val timeout = Timeout(5 seconds)
+  private val _testContextHandlerResult = ask(_testContextHandler, message = "", self)
+  implicit val context = Await.result(_testContextHandlerResult, timeout.duration).asInstanceOf[ActorContext]
+}
+
+/**
+  * Surrender your `context` object for a greater good!
+  */
+private class ContextSensitive extends Actor {
+  var output : ActorRef = ActorRef.noSender
+
+  def receive : Receive = {
+    case _ =>
+      context.become(PassThroughBehavior)
+      output = sender
+      sender ! context
+  }
+
+  /**
+    * Once the `context` object has been leased,
+    * this `Actor` becomes transparent.
+    * Calling `context.parent` from whatever `Actor` was spurned by the previously provided `context`,
+    * will now refer to whatever was the contact to gain access to it - the test environment.
+    * @return something to `become`
+    */
+  def PassThroughBehavior : Receive = {
+    case msg => output forward msg
+  }
+}

--- a/common/src/test/scala/objects/DamageableTest.scala
+++ b/common/src/test/scala/objects/DamageableTest.scala
@@ -21,7 +21,7 @@ import net.psforever.objects.vital.Vitality
 import net.psforever.objects.zones.{Zone, ZoneMap}
 import net.psforever.packet.game.DamageWithPositionMessage
 import net.psforever.types._
-import services.{RemoverActor, Service}
+import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 import services.support.SupportActor
 import services.vehicle.support.TurretUpgrader
@@ -1307,7 +1307,6 @@ class DamageableVehicleDestroyTest extends ActorTest {
       atv.Actor ! Vitality.Damage(applyDamageTo)
       val msg124 = avatarProbe.receiveN(3, 500 milliseconds)
       val msg3 = player2Probe.receiveOne(200 milliseconds)
-      val msg567 = vehicleProbe.receiveN(2, 200 milliseconds)
       assert(
         msg124.head match {
           case AvatarServiceMessage("test", AvatarAction.PlanetsideAttributeToAll(PlanetSideGUID(1), 0, _)) => true
@@ -1329,18 +1328,6 @@ class DamageableVehicleDestroyTest extends ActorTest {
       assert(
         msg124(2) match {
           case AvatarServiceMessage("test", AvatarAction.ObjectDelete(PlanetSideGUID(0), PlanetSideGUID(4), _)) => true
-          case _ => false
-        }
-      )
-      assert(
-        msg567.head match {
-          case VehicleServiceMessage.Decon(SupportActor.ClearSpecific(List(target), _zone)) if (target eq atv) && (_zone eq zone) => true
-          case _ => false
-        }
-      )
-      assert(
-        msg567(1) match {
-          case VehicleServiceMessage.Decon(RemoverActor.AddTask(target, _zone, _)) if (target eq atv) && (_zone eq zone) => true
           case _ => false
         }
       )
@@ -1467,7 +1454,7 @@ class DamageableVehicleDestroyMountedTest extends ActorTest {
     player2Probe.expectNoMsg(10 milliseconds)
     val msg_player3 = player3Probe.receiveOne(200 milliseconds)
     player3Probe.expectNoMsg(10 milliseconds)
-    val msg_vehicle = vehicleProbe.receiveN(6, 200 milliseconds)
+    val msg_vehicle = vehicleProbe.receiveN(2, 200 milliseconds)
     vehicleProbe.expectNoMsg(10 milliseconds)
     assert(
       msg_avatar.exists( {
@@ -1510,30 +1497,6 @@ class DamageableVehicleDestroyMountedTest extends ActorTest {
         case Player.Die() => true
         case _ => false
       }
-    )
-    assert(
-      msg_vehicle.exists( {
-        case VehicleServiceMessage.Decon(SupportActor.ClearSpecific(List(target), _zone)) if (target eq lodestar) && (_zone eq zone) => true
-        case _ => false
-      })
-    )
-    assert(
-      msg_vehicle.exists( {
-        case VehicleServiceMessage.Decon(RemoverActor.AddTask(target, _zone, _)) if (target eq lodestar) && (_zone eq zone) => true
-        case _ => false
-      })
-    )
-    assert(
-      msg_vehicle.exists( {
-        case VehicleServiceMessage.Decon(SupportActor.ClearSpecific(List(target), _zone)) if (target eq atv) && (_zone eq zone) => true
-        case _ => false
-      })
-    )
-    assert(
-      msg_vehicle.exists( {
-        case VehicleServiceMessage.Decon(RemoverActor.AddTask(target, _zone, _)) if (target eq atv) && (_zone eq zone) => true
-        case _ => false
-      })
     )
     assert(
         msg_vehicle.exists( {

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1403,7 +1403,7 @@ class WorldSessionActor extends Actor
                 v.Actor ! Vehicle.Deconstruct(
                   if(v.Flying) {
                   //TODO gravity
-                  Some(0 seconds) //immediate deconstruction
+                  None //immediate deconstruction
                 }
                 else {
                   v.Definition.DeconstructionTime //normal deconstruction
@@ -3097,7 +3097,7 @@ class WorldSessionActor extends Actor
         }
 
       case VehicleResponse.ForceDismountVehicleCargo(cargo_guid, bailed, requestedByPassenger, kicked) =>
-        CargoBehavior.HandleVehicleCargoDismount(continent, tplayer_guid, cargo_guid, bailed, requestedByPassenger, kicked)
+        CargoBehavior.HandleVehicleCargoDismount(continent, cargo_guid, bailed, requestedByPassenger, kicked)
 
       case VehicleResponse.KickCargo(vehicle, speed, delay) =>
         if(player.VehicleSeated.nonEmpty && deadState == DeadState.Alive) {
@@ -3110,7 +3110,7 @@ class WorldSessionActor extends Actor
             controlled = Some(reverseSpeed)
             sendResponse(ServerVehicleOverrideMsg(true, true, true, false, 0, strafe, reverseSpeed, Some(0)))
             import scala.concurrent.ExecutionContext.Implicits.global
-            context.system.scheduler.scheduleOnce(delay milliseconds, self, VehicleServiceResponse(toChannel, tplayer_guid, VehicleResponse.KickCargo(vehicle, 0, delay)))
+            context.system.scheduler.scheduleOnce(delay milliseconds, self, VehicleServiceResponse(toChannel, PlanetSideGUID(0), VehicleResponse.KickCargo(vehicle, 0, delay)))
           }
           else {
             controlled = None
@@ -3646,7 +3646,7 @@ class WorldSessionActor extends Actor
         case Some(cargo : Vehicle) if !requestedByPassenger =>
           continent.GUID(cargo.MountedIn) match {
             case Some(carrier : Vehicle) =>
-              CargoBehavior.HandleVehicleCargoDismount(continent, player_guid, cargo_guid, bailed, requestedByPassenger, kicked)
+              CargoBehavior.HandleVehicleCargoDismount(continent, cargo_guid, bailed, requestedByPassenger, kicked)
             case _ => ;
           }
         case _ => ;
@@ -9717,7 +9717,7 @@ class WorldSessionActor extends Actor
       case ("MISSING_DRIVER", index) =>
         val cargo = vehicle.CargoHolds(index).Occupant.get
         log.error(s"LoadZoneInVehicleAsDriver: eject cargo in hold $index; vehicle missing driver")
-        CargoBehavior.HandleVehicleCargoDismount(pguid, cargo.GUID, cargo, vehicle.GUID, vehicle, false, false, true)
+        CargoBehavior.HandleVehicleCargoDismount(cargo.GUID, cargo, vehicle.GUID, vehicle, false, false, true)
       case (name, index) =>
         val cargo = vehicle.CargoHolds(index).Occupant.get
         continent.VehicleEvents ! VehicleServiceMessage(name, VehicleAction.TransferPassengerChannel(pguid, s"${cargo.Actor}", toChannel, cargo, topLevel))

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3096,9 +3096,6 @@ class WorldSessionActor extends Actor
           galaxyService ! Service.Join(temp_channel) //temporary vehicle-specific channel
         }
 
-      case VehicleResponse.ForceDismountVehicleCargo(cargo_guid, bailed, requestedByPassenger, kicked) =>
-        CargoBehavior.HandleVehicleCargoDismount(continent, cargo_guid, bailed, requestedByPassenger, kicked)
-
       case VehicleResponse.KickCargo(vehicle, speed, delay) =>
         if(player.VehicleSeated.nonEmpty && deadState == DeadState.Alive) {
           if(speed > 0) {

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1400,14 +1400,14 @@ class WorldSessionActor extends Actor
           else {
             inZone.GUID(p.VehicleSeated) match {
               case Some(v : Vehicle) if v.Destroyed =>
-                inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(v), inZone))
-                inZone.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(v, inZone, if(v.Flying) {
+                v.Actor ! Vehicle.Deconstruct(
+                  if(v.Flying) {
                   //TODO gravity
                   Some(0 seconds) //immediate deconstruction
                 }
                 else {
                   v.Definition.DeconstructionTime //normal deconstruction
-                }))
+                })
               case _ => ;
             }
           }
@@ -2283,7 +2283,6 @@ class WorldSessionActor extends Actor
           sendResponse(PlanetsideAttributeMessage(obj_guid, 113, capacitor))
         }
         if(seat_num == 0) {
-          continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(obj), continent)) //clear timer
           //simplistic vehicle ownership management
           obj.Owner match {
             case Some(owner_guid) =>
@@ -2336,8 +2335,6 @@ class WorldSessionActor extends Actor
       case Mountable.CanDismount(obj : Vehicle, seat_num) if obj.Definition == GlobalDefinitions.droppod =>
         UnAccessContents(obj)
         DismountAction(tplayer, obj, seat_num)
-        continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(obj), continent))
-        continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(obj, continent, obj.Definition.DeconstructionTime))
 
       case Mountable.CanDismount(obj : Vehicle, seat_num) =>
         val player_guid : PlanetSideGUID = tplayer.GUID
@@ -3007,9 +3004,8 @@ class WorldSessionActor extends Actor
           )
         }
 
-      case msg@VehicleResponse.KickPassenger(seat_num, wasKickedByDriver, vehicle_guid) =>
+      case VehicleResponse.KickPassenger(seat_num, wasKickedByDriver, vehicle_guid) =>
         // seat_num seems to be correct if passenger is kicked manually by driver, but always seems to return 4 if user is kicked by seat permissions
-        log.info(s"$msg")
         sendResponse(DismountVehicleMsg(guid, BailType.Kicked, wasKickedByDriver))
         if(tplayer_guid == guid) {
           continent.GUID(vehicle_guid) match {
@@ -4218,8 +4214,7 @@ class WorldSessionActor extends Actor
                 case v : Vehicle if seatNum == 0 && v.Flying =>
                   TotalDriverVehicleControl(v)
                   UnAccessContents(v)
-                  continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(obj), continent))
-                  continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(obj, continent, Some(0 seconds)))
+                  v.Actor ! Vehicle.Deconstruct()
                 case _ => ;
               }
             case _ => ; //found no vehicle where one was expected; since we're dead, let's not dwell on it
@@ -5035,8 +5030,7 @@ class WorldSessionActor extends Actor
           if((player.VehicleOwned.contains(object_guid) && vehicle.Owner.contains(player.GUID)) ||
             (player.Faction == vehicle.Faction &&
               ((vehicle.Owner.isEmpty || continent.GUID(vehicle.Owner.get).isEmpty) || vehicle.Destroyed))) {
-            continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(vehicle), continent))
-            continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(vehicle, continent, Some(0 seconds)))
+            vehicle.Actor ! Vehicle.Deconstruct()
             log.info(s"RequestDestroy: vehicle $vehicle")
           }
           else {
@@ -6024,8 +6018,7 @@ class WorldSessionActor extends Actor
                     //todo: kick cargo passengers out. To be added after PR #216 is merged
                     obj match {
                       case v : Vehicle if bailType == BailType.Bailed && seat_num == 0 && v.Flying =>
-                        continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(obj), continent))
-                        continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.AddTask(obj, continent, Some(0 seconds))) // Immediately deconstruct vehicle
+                        v.Actor ! Vehicle.Deconstruct() // Immediately deconstruct vehicle
                       case _ => ;
                     }
 
@@ -10016,8 +10009,6 @@ class WorldSessionActor extends Actor
       sendResponse(PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
       UseRouterTelepadEffect(pguid, sguid, dguid)
       StopBundlingPackets()
-      //      continent.VehicleEvents ! VehicleServiceMessage.Decon(RemoverActor.ClearSpecific(List(router), continent))
-      //      continent.VehicleEvents p! VehicleServiceMessage.Decon(RemoverActor.AddTask(router, continent, router.Definition.DeconstructionTime))
       continent.LocalEvents ! LocalServiceMessage(continent.Id, LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid))
     }
     else {

--- a/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
+++ b/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
@@ -9,6 +9,7 @@ import net.psforever.objects.serverobject.structures.StructureType
 import net.psforever.objects.{Avatar, GlobalDefinitions, Player, Vehicle}
 import net.psforever.objects.zones.Zone
 import net.psforever.types.{PlanetSideGUID, _}
+import services.RemoverActor
 import services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.concurrent.duration._
@@ -107,7 +108,13 @@ class VehicleSpawnControl4Test extends ActorTest {
 
       pad.Actor ! VehicleSpawnPad.VehicleOrder(player, vehicle) //order
 
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.DisposeVehicle])
+      val msg = probe.receiveOne(1 minute)
+      assert(
+        msg match {
+          case VehicleServiceMessage.Decon(RemoverActor.AddTask(v, z , _)) => (v == vehicle) && (z == zone)
+          case _ => false
+        }
+      )
       probe.expectNoMsg(5 seconds)
     }
   }


### PR DESCRIPTION
Originally, `VehicleRemover` was designed to be part of the ideal `RemoverActor` paradigm.  Without muddying the control agency, an external apparatus designed to handle retirement and inter entities (vehicles, in this case, of course) at the end of their life in a hands-off approach.  Sadly, this was not nearly as ideal as I desired, as often seen with how the messages to destroy vehicles came in pairs: one to clear a potential old entry, and one to add a new "destroy immediately" entry.  As "immediate" as travelling across the event system for all vehicles and then undergoing processing.  No method existed to test the waters over whether an entry existed either.  Just push the messages across the pipe blindly when you felt it was necessary, hopeful that the support service itself could filter out the chaff.  As a result, these messages were spammed wherever needed and in some cases where they were not needed.  The explosion, undramatic as one could be, occurred because an old message was being sent to an uninitialized vehicle control agent - out of date data interacting with old data and unintialized data.

The new system violates the paradigm I intended in the first place but if also hopefully much more stable.  Vehicles now keep track of their own decay and handled a bunch of post-life activities, e.g., kicking passengers, kicking its cargo, kicking itself from being cargo, before becoming unresponsive, waiting for deconstruction.  In addition, because of the expansion to global unique identification which now allows for `ValidPlanetSideGUID`'s to mutate into `StalePlanetSideGUID`'s that can still serve to reference the previous life of the entity, it's possible to eliminate the vehicles in a much more coordinated fashion.

The only difference that a user might hopefully encounter is less failure.

___Features___
__`VehicleRemover`__
Almost completely gutted, and not even a formal `RemoverActor` anymore, this specialized "remover" exists only to support the task resolver that will terminate the registration of any provided vehicle.  All of the important operations of the vehicle's end of life routine have been moved into ...

__`VehicleControl`__
As mentioned above, contains its own decay timer and keeps track of the timer in cases of mounting and unmounting.  The timer or the functionality gated behind the timer can also be directly invoked by sending the message `Vehicle.Deconstruct(Option[time])`.  The control agent will still be rendered unresponsive within the last five seconds of the vehicle's lifecycle as it is about to be deconstructed.  Most of the operations performed to get the vehicle safe for deconstruction that originally part of `VehicleRemover` now occur just as the vehicle is moving into an unresponvise mode.  It's important to note that a vehicle is unregistered before it is perfectly removed from the game environment, the list of vehicles known to a zone and the loaded model for that vehicle.  This is okay because the lack of registration means that even if a client can observe the derelict vehicle, it will never be able to "locate" the entity for that vehicle.

__`VehicleSpawnPadControl`...__
Spawn pad control contains some code involving the clean-up of vehicles that are no longer for sale - their driver has gone missing, they've died on the pad due to mysterious circumstances, they've been left to rot too close to the pad for too long, etc.  Not only was I required to handle this code, but I had planned to manipulate it.  No substantiating evidence exists but I believe that a failure of the vehicle spawn pad to clean up vehicles that have been left to rot after being spawned caused the spawn pad, that vehicle's control agent, and the former `VehicleRemover` to explode, rendering all three ineffectual.

___Caveats___
Vehicle ownership is still mostly operated external to the vehicle control agency.  An unowned vehicle, in reminder, should decay as long as no one is seated in it, and this is still mainly performed through manipulations of `WorldSessionActor`.

___Addenda___
1. One should notice the `FreedContextActorSystem`.  This is something I had wanted to create for a while to assist with testing, in the hopes of removing middlemen for gaining access to the juicy internal components of formal `Actors`, one component in particular that the `ActorSystem` lacks but that I required.  Just as the comment dictate, one should never do this in production code.
2. I was debugging cargo behaviors, as those also have functionality that intersects vehicle end of life operations, and also instigates end of life operations on vehicles.  I found what was intended to be a player character global unique identifier that was being passed around from one iteration of a message to the next, until it was ultimately dispatched in a message as a filter.  I believe at one point the reference was important.  I believe at one point that the message had a use for the player identifier.  As the methods were refined and ported, little fragments of "uses" were slowly stripped down.  The identifier kept being passed around not because it was needed anymore but because it just kept being passed around.  It was a wonderfully pointless relic of wasted effort and I followed it around the code for a few hours.