### PR TITLE
Spawn Pad Fix

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnControl.scala
@@ -112,6 +112,8 @@ class VehicleSpawnControl(pad : VehicleSpawnPad) extends VehicleSpawnControlBase
         case None => ;
       }
       trackedOrder = None
+      handleOrderFunc = NewTasking
+      pad.Zone.VehicleEvents ! VehicleSpawnPad.ResetSpawnPad(pad) //cautious animation reset
       concealPlayer ! akka.actor.Kill //should cause the actor to restart, which will abort any trapped messages
 
     case _ => ;

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
@@ -26,7 +26,7 @@ class VehicleSpawnControlConcealPlayer(pad : VehicleSpawnPad) extends VehicleSpa
   def receive : Receive = {
     case order @ VehicleSpawnControl.Order(driver, _) =>
       //TODO how far can the driver stray from the Terminal before his order is cancelled?
-      if(driver.Continent == pad.Continent && driver.VehicleSeated.isEmpty) {
+      if(driver.Continent == pad.Continent && driver.VehicleSeated.isEmpty && driver.isAlive) {
         trace(s"hiding ${driver.Name}")
         pad.Zone.VehicleEvents ! VehicleSpawnPad.ConcealPlayer(driver.GUID)
         context.system.scheduler.scheduleOnce(2000 milliseconds, loadVehicle, order)

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
@@ -28,6 +28,7 @@ class VehicleSpawnControlDriverControl(pad : VehicleSpawnPad) extends VehicleSpa
       else {
         trace(s"${driver.Name} is not seated in ${vehicle.Definition.Name}; vehicle controls might have been locked")
       }
+      vehicle.MountedIn = None
       finalClear ! order
 
     case msg @ (VehicleSpawnControl.ProcessControl.Reminder | VehicleSpawnControl.ProcessControl.GetNewOrder) =>

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -28,7 +28,7 @@ class VehicleSpawnControlLoadVehicle(pad : VehicleSpawnPad) extends VehicleSpawn
 
   def receive : Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      if(driver.Continent == pad.Continent && vehicle.Health > 0) {
+      if(driver.Continent == pad.Continent && vehicle.Health > 0 && driver.isAlive) {
         trace(s"loading the ${vehicle.Definition.Name}")
         vehicle.Position = vehicle.Position - Vector3.z(if(GlobalDefinitions.isFlightVehicle(vehicle.Definition)) 9 else 5) //appear below the trench and doors
         vehicle.Cloaked = vehicle.Definition.CanCloak && driver.Cloaked

--- a/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
@@ -26,6 +26,7 @@ class VehicleSpawnControlRailJack(pad : VehicleSpawnPad) extends VehicleSpawnCon
 
   def receive : Receive = {
     case order @ VehicleSpawnControl.Order(_, vehicle) =>
+      vehicle.MountedIn = pad.GUID
       pad.Zone.VehicleEvents ! VehicleSpawnPad.AttachToRails(vehicle, pad)
       context.system.scheduler.scheduleOnce(10 milliseconds, seatDriver, order)
 

--- a/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
+++ b/pslogin/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
@@ -218,7 +218,7 @@ object VehicleSpawnPadControlTest {
     val vehicle = Vehicle(GlobalDefinitions.two_man_assault_buggy)
     val weapon = vehicle.WeaponControlledFromSeat(1).get.asInstanceOf[Tool]
     val guid : NumberPoolHub = new NumberPoolHub(LimitedNumberSource(5))
-    guid.AddPool("test-pool", (0 to 3).toList)
+    guid.AddPool("test-pool", (0 to 5).toList)
     guid.register(vehicle, "test-pool")
     guid.register(weapon, "test-pool")
     guid.register(weapon.AmmoSlot.Box, "test-pool")
@@ -241,6 +241,7 @@ object VehicleSpawnPadControlTest {
     pad.Owner = new Building("Building", building_guid = 0, map_id = 0, zone, StructureType.Building, GlobalDefinitions.building)
     pad.Owner.Faction = faction
     pad.Zone = zone
+    guid.register(pad, "test-pool")
     val player = Player(Avatar("test", faction, CharacterGender.Male, 0, CharacterVoice.Mute))
     guid.register(player, "test-pool")
     player.Zone = zone


### PR DESCRIPTION
Vehicle order queueing restored in the event of a hard reset of the spawn process for a given terminal.

Lock the user in their vehicle until it is free from the spawn pad's control.