### PR TITLE
Vanu turret actor message spam reduction

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurret.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurret.scala
@@ -26,6 +26,7 @@ object FacilityTurret {
   }
 
   final case class RechargeAmmo()
+  final case class WeaponDischarged()
 
   import akka.actor.ActorContext
   /**

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -265,7 +265,7 @@ class WorldSessionActor extends Actor
   def ValidObject(id : Option[PlanetSideGUID]) : Option[PlanetSideGameObject] = continent.GUID(id) match {
     case out@Some(obj) if obj.HasGUID =>
       out
-    case None if id.nonEmpty =>
+    case None if id.nonEmpty && id.get != PlanetSideGUID(0) =>
       //delete stale entity reference from client
       log.warn(s"Player ${player.Name} has an invalid reference to GUID ${id.get} in zone ${continent.Id}.")
       //sendResponse(ObjectDeleteMessage(id.get, 0))

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -5850,6 +5850,12 @@ class WorldSessionActor extends Actor
                 })
               }
               projectilesToCleanUp(projectileIndex) = false
+
+              obj match {
+                case turret : FacilityTurret if turret.Definition == GlobalDefinitions.vanu_sentry_turret =>
+                  turret.Actor ! FacilityTurret.WeaponDischarged()
+                case _ => ;
+              }
             }
             else {
               log.warn(s"WeaponFireMessage: $player's ${tool.Definition.Name} projectile is too far from owner position at time of discharge ($distanceToOwner > $acceptableDistanceToOwner); suspect")


### PR DESCRIPTION
So, one of the things plugging in Kamon.io flagged up almost immediately was this:

![image](https://user-images.githubusercontent.com/809719/80649151-6346b980-8a69-11ea-8495-bc0d09fd1c9f.png)

62.1k messages for FacilityTurretControl per minute? That can't be right...

![image](https://user-images.githubusercontent.com/809719/80649194-79547a00-8a69-11ea-9457-431ba4c999c2.png)

Oh, Right.... I forgot about that.

So this PR addresses that. Vanu turrets will be notified when their weapon is discharged, and will begin the recharge timer at that point, and subsequently cancel the timer when the ammo is fully recharged. No more actor message spam

Also included is a quick fix that stops a log warning from firing when a splash damage hits the world itself.