### PR TITLE
Fix hacking speed returning an integer, not a float

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/hackable/GenericHackables.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/hackable/GenericHackables.scala
@@ -27,7 +27,7 @@ object GenericHackables {
       case hackable : Hackable => hackable.HackDuration(playerHackLevel)
       case _ =>
         log.warn(s"${player.Name} tried to hack an object that has no hack time defined - ${obj.Definition.Name}#${obj.GUID} on ${obj.Zone.Id}")
-        0
+        0f
     }
     if(timeToHack == 0) {
       log.warn(s"${player.Name} tried to hack an object that they don't have the correct hacking level for - ${obj.Definition.Name}#${obj.GUID} on ${obj.Zone.Id}")
@@ -35,7 +35,7 @@ object GenericHackables {
     }
     else {
       //timeToHack is in seconds; progress is measured in quarters of a second (250ms)
-      (100 / timeToHack) / 4
+      (100f / timeToHack) / 4
     }
   }
 


### PR DESCRIPTION
Int / Int = Int, for example: (100 / 15) / 4 = 1
Float / Int = Float, for example (100 / 15) / 4 = 1.66666