### PR TITLE
Painbox v2

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
@@ -1,47 +1,95 @@
 package net.psforever.objects.serverobject.painbox
 
 import akka.actor.{Actor, Cancellable}
-import net.psforever.objects.DefaultCancellable
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.structures.Building
+import net.psforever.objects.{DefaultCancellable, GlobalDefinitions}
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 class PainboxControl(painbox: Painbox) extends Actor {
   private[this] val log = org.log4s.getLogger(s"Painbox")
   var painboxTick: Cancellable = DefaultCancellable.obj
-  var nearestDoor : Option[Door] = None
+  var nearestDoor: Option[Door] = None
+  var bBoxMinCorner = Vector3.Zero
+  var bBoxMaxCorner = Vector3.Zero
+  var bBoxMidPoint = Vector3.Zero
 
-  def receive : Receive = {
+  def receive: Receive = {
     case "startup" =>
-      if(painbox.Definition.HasNearestDoorDependency) {
+      if (painbox.Definition.HasNearestDoorDependency) {
         (painbox.Owner match {
-          case obj : Building =>
+          case obj: Building =>
             obj.Amenities
-              .collect { case door : Door => door }
+              .collect { case door: Door => door }
               .sortBy(door => Vector3.DistanceSquared(painbox.Position, door.Position))
               .headOption
           case _ =>
             None
         }) match {
-          case door @ Some(_) =>
+          case door@Some(_) =>
             nearestDoor = door
-            context.become(Stopped)
           case _ =>
-            log.error(s"object #${painbox.GUID.guid} can not find a door that it needed")
+            log.error(s"Painbox ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position} can not find a door that it is dependent on")
         }
-      }
-      else {
+
         context.become(Stopped)
       }
+      else {
+        if (painbox.Definition.Radius == 0f) {
+          if (painbox.Owner.Continent.matches("c[0-9]")) {
+            // todo: handle non-radius painboxes in caverns properly
+            log.warn(s"Skipping initialization of ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position}")
+          } else {
+            painbox.Owner match {
+              case obj: Building =>
+                val planarRange = 16.5f
+                val aboveRange = 5
+                val belowRange = 5
 
+                // Find amenities within the specified range
+                val nearbyAmenities = obj.Amenities
+                  .filter(amenity =>
+                    amenity.Position != Vector3.Zero
+                      && (amenity.Definition == GlobalDefinitions.mb_locker
+                      || amenity.Definition == GlobalDefinitions.respawn_tube
+                      || amenity.Definition == GlobalDefinitions.spawn_terminal
+                      || amenity.Definition == GlobalDefinitions.order_terminal
+                      || amenity.Definition == GlobalDefinitions.door)
+                      && amenity.Position.x > painbox.Position.x - planarRange && amenity.Position.x < painbox.Position.x + planarRange
+                      && amenity.Position.y > painbox.Position.y - planarRange && amenity.Position.y < painbox.Position.y + planarRange
+                      && amenity.Position.z > painbox.Position.z - belowRange && amenity.Position.z < painbox.Position.z + aboveRange
+                  )
+
+                // Calculate bounding box of amenities
+                bBoxMinCorner = Vector3(
+                  nearbyAmenities.minBy(amenity => amenity.Position.x).Position.x,
+                  nearbyAmenities.minBy(amenity => amenity.Position.y).Position.y,
+                  nearbyAmenities.minBy(x => x.Position.z).Position.z
+                  )
+                bBoxMaxCorner = Vector3(
+                  nearbyAmenities.maxBy(amenity => amenity.Position.x).Position.x,
+                  nearbyAmenities.maxBy(amenity => amenity.Position.y).Position.y,
+                  painbox.Position.z
+                )
+                bBoxMidPoint = Vector3(
+                  (bBoxMinCorner.x + bBoxMaxCorner.x) / 2,
+                  (bBoxMinCorner.y + bBoxMaxCorner.y) / 2,
+                  (bBoxMinCorner.z + bBoxMaxCorner.z) / 2
+                )
+              case _ => None
+            }
+          }
+          context.become(Stopped)
+        }
+      }
     case _ => ;
   }
 
-  def Running : Receive = {
+  def Running: Receive = {
     case Painbox.Stop() =>
       context.become(Stopped)
       painboxTick.cancel
@@ -54,23 +102,47 @@ class PainboxControl(painbox: Painbox) extends Actor {
       val guid = painbox.GUID
       val owner = painbox.Owner.asInstanceOf[Building]
       val faction = owner.Faction
-      if(faction != PlanetSideEmpire.NEUTRAL && (nearestDoor match { case Some(door) => door.Open.nonEmpty; case _ => true })) {
+      if (faction != PlanetSideEmpire.NEUTRAL && (nearestDoor match {
+        case Some(door) => door.Open.nonEmpty;
+        case _ => true
+      })) {
         val events = painbox.Zone.AvatarEvents
         val damage = painbox.Definition.Damage
         val radius = painbox.Definition.Radius * painbox.Definition.Radius
         val position = painbox.Position
-        owner.PlayersInSOI
-          .collect { case p if p.Faction != faction
-            && p.Health > 0
-            && Vector3.DistanceSquared(p.Position, position) < radius =>
-            events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
-          }
+
+        if (painbox.Definition.Radius != 0f) {
+          // Spherical pain field
+          owner.PlayersInSOI
+            .collect { case p if p.Faction != faction
+              && p.Health > 0
+              && Vector3.DistanceSquared(p.Position, position) < radius =>
+              events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
+            }
+        } else {
+          // Bounding box pain field
+          owner.PlayersInSOI
+            .collect { case p if p.Faction != faction
+              && p.Health > 0 =>
+              /*
+                 This may be cpu intensive with a large number of players in SOI. Further performance tweaking may be required
+                 The bounding box is calculated aligned to the world XY axis, instead of rotating the painbox corners to match the base rotation
+                 we instead rotate the player's current coordinates to match the base rotation, which allows for much simplified checking of if the player is
+                 within the bounding box
+               */
+              val playerRot = Vector3.PlanarRotateAroundPoint(p.Position, bBoxMidPoint, painbox.Owner.Orientation.z.toRadians)
+              if (bBoxMinCorner.x <= playerRot.x && playerRot.x <= bBoxMaxCorner.x && bBoxMinCorner.y <= playerRot.y && playerRot.y <= bBoxMaxCorner.y
+                && playerRot.z >= bBoxMinCorner.z && playerRot.z <= bBoxMaxCorner.z) {
+                events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
+              }
+            }
+        }
       }
 
     case _ => ;
   }
 
-  def Stopped : Receive = {
+  def Stopped: Receive = {
     case Painbox.Start() =>
       context.become(Running)
       painboxTick.cancel

--- a/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxDefinition.scala
@@ -6,7 +6,7 @@ import net.psforever.types.Vector3
 class PainboxDefinition(objectId : Int) extends AmenityDefinition(objectId) {
   private var alwaysOn : Boolean = true
   private var radius : Float = 0f
-  private var damage : Int = 10
+  private var damage : Int = 5
   private var sphereOffset = Vector3(0f, 0f, -0.4f)
   private var hasNearestDoorDependency = false
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxDefinition.scala
@@ -14,11 +14,9 @@ class PainboxDefinition(objectId : Int) extends AmenityDefinition(objectId) {
     case 622 =>
       Name = "painbox"
       alwaysOn = false
-      radius = 10f // Guess - not in game_objects.adb.lst - probably not radius based but it will have to do for the moment
       damage = 0
     case 623 =>
       Name = "painbox_continuous"
-      radius = 10f // Guess - not in game_objects.adb.lst - probably not radius based but it will have to do for the moment
     case 624 =>
       Name = "painbox_door_radius"
       alwaysOn = false

--- a/common/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -281,10 +281,11 @@ object Building {
     new Building(name, guid, map_id, zone, buildingType, GlobalDefinitions.building)
   }
 
-  def Structure(buildingType : StructureType.Value, location : Vector3, definition: BuildingDefinition)(name : String, guid : Int, map_id : Int, zone : Zone, context : ActorContext) : Building = {
+  def Structure(buildingType : StructureType.Value, location : Vector3, rotation : Vector3, definition: BuildingDefinition)(name : String, guid : Int, map_id : Int, zone : Zone, context : ActorContext) : Building = {
     import akka.actor.Props
     val obj = new Building(name, guid, map_id, zone, buildingType, definition)
     obj.Position = location
+    obj.Orientation = rotation
     obj.Actor = context.actorOf(Props(classOf[BuildingControl], obj), s"$map_id-$buildingType-building")
     obj
   }

--- a/common/src/main/scala/net/psforever/types/Vector3.scala
+++ b/common/src/main/scala/net/psforever/types/Vector3.scala
@@ -326,4 +326,11 @@ object Vector3 {
       z
     )
   }
+
+  def PlanarRotateAroundPoint(point: Vector3, center: Vector3, radians : Float) : Vector3 = {
+    val x = (Math.cos(radians) * (point.x - center.x) - Math.sin(radians) * (point.y - center.y) + center.x).toFloat
+    val y = (Math.sin(radians) * (point.x - center.x) + Math.cos(radians) * (point.y - center.y) + center.y).toFloat
+
+    Vector3(x, y, point.z)
+  }
 }

--- a/pslogin/src/main/scala/zonemaps/Map01.scala
+++ b/pslogin/src/main/scala/zonemaps/Map01.scala
@@ -23,7 +23,7 @@ object Map01 { // Solsar
     Building10()
 
     def Building10(): Unit = { // Name: Mont Type: amp_station GUID: 1, MapID: 10
-      LocalBuilding("Mont", 1, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3380f, 4300f, 82.74789f), amp_station)))
+      LocalBuilding("Mont", 1, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3380f, 4300f, 82.74789f), Vector3(0f, 0f, 209f), amp_station)))
       LocalObject(153, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(121, Door.Constructor(Vector3(3376.516f, 4305.85f, 95.64989f)), owning_building_guid = 1)
       LocalObject(122, Door.Constructor(Vector3(3383.112f, 4293.944f, 95.64989f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map01 { // Solsar
     Building6()
 
     def Building6(): Unit = { // Name: Bastet Type: amp_station GUID: 4, MapID: 6
-      LocalBuilding("Bastet", 4, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5346f, 5518f, 56.43483f), amp_station)))
+      LocalBuilding("Bastet", 4, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5346f, 5518f, 56.43483f), Vector3(0f, 0f, 360f), amp_station)))
       LocalObject(160, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(123, Door.Constructor(Vector3(5346.211f, 5511.195f, 69.33682f)), owning_building_guid = 4)
       LocalObject(124, Door.Constructor(Vector3(5346.214f, 5524.805f, 69.33682f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map01 { // Solsar
     Building34()
 
     def Building34(): Unit = { // Name: bunkerg2 Type: bunker_gauntlet GUID: 7, MapID: 34
-      LocalBuilding("bunkerg2", 7, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4318f, 4604f, 59.17406f), bunker_gauntlet)))
+      LocalBuilding("bunkerg2", 7, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4318f, 4604f, 59.17406f), Vector3(0f, 0f, 335f), bunker_gauntlet)))
       LocalObject(339, Door.Constructor(Vector3(4294.626f, 4612.79f, 60.69506f)), owning_building_guid = 7)
       LocalObject(348, Door.Constructor(Vector3(4339.785f, 4591.744f, 60.69506f)), owning_building_guid = 7)
     }
@@ -287,7 +287,7 @@ object Map01 { // Solsar
     Building35()
 
     def Building35(): Unit = { // Name: bunkerg3 Type: bunker_gauntlet GUID: 8, MapID: 35
-      LocalBuilding("bunkerg3", 8, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4460f, 3330f, 53.19434f), bunker_gauntlet)))
+      LocalBuilding("bunkerg3", 8, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4460f, 3330f, 53.19434f), Vector3(0f, 0f, 62f), bunker_gauntlet)))
       LocalObject(359, Door.Constructor(Vector3(4450f, 3307.119f, 54.71534f)), owning_building_guid = 8)
       LocalObject(362, Door.Constructor(Vector3(4473.379f, 3351.113f, 54.71534f)), owning_building_guid = 8)
     }
@@ -295,7 +295,7 @@ object Map01 { // Solsar
     Building33()
 
     def Building33(): Unit = { // Name: bunkerg1 Type: bunker_gauntlet GUID: 9, MapID: 33
-      LocalBuilding("bunkerg1", 9, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4678f, 6156f, 57.799f), bunker_gauntlet)))
+      LocalBuilding("bunkerg1", 9, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4678f, 6156f, 57.799f), Vector3(0f, 0f, 263f), bunker_gauntlet)))
       LocalObject(410, Door.Constructor(Vector3(4673.076f, 6131.495f, 59.32f)), owning_building_guid = 9)
       LocalObject(411, Door.Constructor(Vector3(4679.137f, 6180.945f, 59.32f)), owning_building_guid = 9)
     }
@@ -303,49 +303,49 @@ object Map01 { // Solsar
     Building27()
 
     def Building27(): Unit = { // Name: bunker2 Type: bunker_lg GUID: 10, MapID: 27
-      LocalBuilding("bunker2", 10, 27, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3730f, 2238f, 72.89651f), bunker_lg)))
+      LocalBuilding("bunker2", 10, 27, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3730f, 2238f, 72.89651f), Vector3(0f, 0f, 220f), bunker_lg)))
       LocalObject(305, Door.Constructor(Vector3(3729.647f, 2234.366f, 74.41752f)), owning_building_guid = 10)
     }
 
     Building30()
 
     def Building30(): Unit = { // Name: bunker5 Type: bunker_lg GUID: 11, MapID: 30
-      LocalBuilding("bunker5", 11, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3846f, 5334f, 54.1717f), bunker_lg)))
+      LocalBuilding("bunker5", 11, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3846f, 5334f, 54.1717f), Vector3(0f, 0f, 45f), bunker_lg)))
       LocalObject(314, Door.Constructor(Vector3(3846.035f, 5337.651f, 55.6927f)), owning_building_guid = 11)
     }
 
     Building28()
 
     def Building28(): Unit = { // Name: bunker3 Type: bunker_sm GUID: 12, MapID: 28
-      LocalBuilding("bunker3", 12, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3068f, 2992f, 74.51704f), bunker_sm)))
+      LocalBuilding("bunker3", 12, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3068f, 2992f, 74.51704f), Vector3(0f, 0f, 96f), bunker_sm)))
       LocalObject(240, Door.Constructor(Vector3(3067.927f, 2993.224f, 76.03805f)), owning_building_guid = 12)
     }
 
     Building29()
 
     def Building29(): Unit = { // Name: bunker4 Type: bunker_sm GUID: 13, MapID: 29
-      LocalBuilding("bunker4", 13, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3376f, 4166f, 82.73873f), bunker_sm)))
+      LocalBuilding("bunker4", 13, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3376f, 4166f, 82.73873f), Vector3(0f, 0f, 130f), bunker_sm)))
       LocalObject(275, Door.Constructor(Vector3(3375.255f, 4166.974f, 84.25974f)), owning_building_guid = 13)
     }
 
     Building26()
 
     def Building26(): Unit = { // Name: bunker1 Type: bunker_sm GUID: 14, MapID: 26
-      LocalBuilding("bunker1", 14, 26, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4494f, 2102f, 68.3874f), bunker_sm)))
+      LocalBuilding("bunker1", 14, 26, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4494f, 2102f, 68.3874f), Vector3(0f, 0f, 82f), bunker_sm)))
       LocalObject(368, Door.Constructor(Vector3(4494.225f, 2103.205f, 69.9084f)), owning_building_guid = 14)
     }
 
     Building31()
 
     def Building31(): Unit = { // Name: bunker6 Type: bunker_sm GUID: 15, MapID: 31
-      LocalBuilding("bunker6", 15, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4656f, 6084f, 57.799f), bunker_sm)))
+      LocalBuilding("bunker6", 15, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4656f, 6084f, 57.799f), Vector3(0f, 0f, 200f), bunker_sm)))
       LocalObject(409, Door.Constructor(Vector3(4654.83f, 6083.633f, 59.32f)), owning_building_guid = 15)
     }
 
     Building8()
 
     def Building8(): Unit = { // Name: Hapi Type: comm_station GUID: 16, MapID: 8
-      LocalBuilding("Hapi", 16, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4276f, 4512f, 59.18149f), comm_station)))
+      LocalBuilding("Hapi", 16, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4276f, 4512f, 59.18149f), Vector3(0f, 0f, 300f), comm_station)))
       LocalObject(156, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 16)
       LocalObject(332, Door.Constructor(Vector3(4195.935f, 4515.072f, 68.89649f)), owning_building_guid = 16)
       LocalObject(333, Door.Constructor(Vector3(4205.031f, 4499.316f, 60.93249f)), owning_building_guid = 16)
@@ -464,7 +464,7 @@ object Map01 { // Solsar
     Building13()
 
     def Building13(): Unit = { // Name: Sobek Type: comm_station_dsp GUID: 19, MapID: 13
-      LocalBuilding("Sobek", 19, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3044f, 3086f, 74.5262f), comm_station_dsp)))
+      LocalBuilding("Sobek", 19, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3044f, 3086f, 74.5262f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(152, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 19)
       LocalObject(199, Door.Constructor(Vector3(3112.339f, 3156.464f, 77.9042f)), owning_building_guid = 19)
       LocalObject(230, Door.Constructor(Vector3(2984.196f, 3042.501f, 76.1772f)), owning_building_guid = 19)
@@ -605,7 +605,7 @@ object Map01 { // Solsar
     Building12()
 
     def Building12(): Unit = { // Name: Horus Type: cryo_facility GUID: 22, MapID: 12
-      LocalBuilding("Horus", 22, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3690f, 2158f, 72.89651f), cryo_facility)))
+      LocalBuilding("Horus", 22, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3690f, 2158f, 72.89651f), Vector3(0f, 0f, 265f), cryo_facility)))
       LocalObject(154, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 22)
       LocalObject(290, Door.Constructor(Vector3(3595.561f, 2134.14f, 74.41752f)), owning_building_guid = 22)
       LocalObject(291, Door.Constructor(Vector3(3605.34f, 2141.817f, 74.44752f)), owning_building_guid = 22)
@@ -753,7 +753,7 @@ object Map01 { // Solsar
     Building7()
 
     def Building7(): Unit = { // Name: Aton Type: cryo_facility GUID: 25, MapID: 7
-      LocalBuilding("Aton", 25, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3830f, 5418f, 54.14594f), cryo_facility)))
+      LocalBuilding("Aton", 25, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3830f, 5418f, 54.14594f), Vector3(0f, 0f, 90f), cryo_facility)))
       LocalObject(155, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 25)
       LocalObject(308, Door.Constructor(Vector3(3762.197f, 5375.674f, 55.69694f)), owning_building_guid = 25)
       LocalObject(309, Door.Constructor(Vector3(3762.197f, 5393.867f, 63.66094f)), owning_building_guid = 25)
@@ -901,7 +901,7 @@ object Map01 { // Solsar
     Building9()
 
     def Building9(): Unit = { // Name: Thoth Type: cryo_facility GUID: 28, MapID: 9
-      LocalBuilding("Thoth", 28, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4556f, 3338f, 53.19376f), cryo_facility)))
+      LocalBuilding("Thoth", 28, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4556f, 3338f, 53.19376f), Vector3(0f, 0f, 335f), cryo_facility)))
       LocalObject(159, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 28)
       LocalObject(377, Door.Constructor(Vector3(4504.451f, 3367.003f, 54.74476f)), owning_building_guid = 28)
       LocalObject(387, Door.Constructor(Vector3(4512.139f, 3383.492f, 62.70876f)), owning_building_guid = 28)
@@ -1061,7 +1061,7 @@ object Map01 { // Solsar
     Building11()
 
     def Building11(): Unit = { // Name: Amun Type: tech_plant GUID: 35, MapID: 11
-      LocalBuilding("Amun", 35, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4428f, 2220f, 68.3462f), tech_plant)))
+      LocalBuilding("Amun", 35, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4428f, 2220f, 68.3462f), Vector3(0f, 0f, 179f), tech_plant)))
       LocalObject(157, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 35)
       LocalObject(350, Door.Constructor(Vector3(4348.938f, 2218.272f, 69.8882f)), owning_building_guid = 35)
       LocalObject(351, Door.Constructor(Vector3(4349.255f, 2236.463f, 77.8512f)), owning_building_guid = 35)
@@ -1187,7 +1187,7 @@ object Map01 { // Solsar
     Building5()
 
     def Building5(): Unit = { // Name: Seth Type: tech_plant GUID: 38, MapID: 5
-      LocalBuilding("Seth", 38, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4566f, 6116f, 57.799f), tech_plant)))
+      LocalBuilding("Seth", 38, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4566f, 6116f, 57.799f), Vector3(0f, 0f, 265f), tech_plant)))
       LocalObject(158, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 38)
       LocalObject(361, Door.Constructor(Vector3(4469.867f, 6164.563f, 59.42f)), owning_building_guid = 38)
       LocalObject(363, Door.Constructor(Vector3(4474.748f, 6119.361f, 59.45f)), owning_building_guid = 38)
@@ -1313,7 +1313,7 @@ object Map01 { // Solsar
     Building20()
 
     def Building20(): Unit = { // Name: W_Sobek_Tower Type: tower_a GUID: 41, MapID: 20
-      LocalBuilding("W_Sobek_Tower", 41, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2600f, 3180f, 73.48247f), tower_a)))
+      LocalBuilding("W_Sobek_Tower", 41, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2600f, 3180f, 73.48247f), Vector3(0f, 0f, 256f), tower_a)))
       LocalObject(1877, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 41)
       LocalObject(222, Door.Constructor(Vector3(2589.334f, 3170.292f, 75.00347f)), owning_building_guid = 41)
       LocalObject(223, Door.Constructor(Vector3(2589.334f, 3170.292f, 95.00247f)), owning_building_guid = 41)
@@ -1350,7 +1350,7 @@ object Map01 { // Solsar
     Building21()
 
     def Building21(): Unit = { // Name: S_Mont_Tower Type: tower_a GUID: 42, MapID: 21
-      LocalBuilding("S_Mont_Tower", 42, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3124f, 3784f, 97.89117f), tower_a)))
+      LocalBuilding("S_Mont_Tower", 42, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3124f, 3784f, 97.89117f), Vector3(0f, 0f, 5f), tower_a)))
       LocalObject(1879, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 42)
       LocalObject(246, Door.Constructor(Vector3(3135.257f, 3793.015f, 99.41218f)), owning_building_guid = 42)
       LocalObject(247, Door.Constructor(Vector3(3135.257f, 3793.015f, 119.4112f)), owning_building_guid = 42)
@@ -1387,7 +1387,7 @@ object Map01 { // Solsar
     Building14()
 
     def Building14(): Unit = { // Name: NE_Amerish_Warpgate_Tower Type: tower_a GUID: 43, MapID: 14
-      LocalBuilding("NE_Amerish_Warpgate_Tower", 43, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3148f, 1398f, 56.7095f), tower_a)))
+      LocalBuilding("NE_Amerish_Warpgate_Tower", 43, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3148f, 1398f, 56.7095f), Vector3(0f, 0f, 34f), tower_a)))
       LocalObject(1880, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 43)
       LocalObject(253, Door.Constructor(Vector3(3153.475f, 1411.343f, 58.2305f)), owning_building_guid = 43)
       LocalObject(254, Door.Constructor(Vector3(3153.475f, 1411.343f, 78.22949f)), owning_building_guid = 43)
@@ -1424,7 +1424,7 @@ object Map01 { // Solsar
     Building32()
 
     def Building32(): Unit = { // Name: SW__Aton_Tower Type: tower_a GUID: 44, MapID: 32
-      LocalBuilding("SW__Aton_Tower", 44, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3572f, 4886f, 68.03491f), tower_a)))
+      LocalBuilding("SW__Aton_Tower", 44, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3572f, 4886f, 68.03491f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1883, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 44)
       LocalObject(286, Door.Constructor(Vector3(3584f, 4878f, 69.55592f)), owning_building_guid = 44)
       LocalObject(287, Door.Constructor(Vector3(3584f, 4878f, 89.55492f)), owning_building_guid = 44)
@@ -1461,7 +1461,7 @@ object Map01 { // Solsar
     Building38()
 
     def Building38(): Unit = { // Name: NE_Horus_Tower Type: tower_a GUID: 45, MapID: 38
-      LocalBuilding("NE_Horus_Tower", 45, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3862f, 2326f, 72.06335f), tower_a)))
+      LocalBuilding("NE_Horus_Tower", 45, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3862f, 2326f, 72.06335f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1885, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 45)
       LocalObject(316, Door.Constructor(Vector3(3874f, 2318f, 73.58436f)), owning_building_guid = 45)
       LocalObject(317, Door.Constructor(Vector3(3874f, 2318f, 93.58336f)), owning_building_guid = 45)
@@ -1498,7 +1498,7 @@ object Map01 { // Solsar
     Building17()
 
     def Building17(): Unit = { // Name: W_Thoth_Tower Type: tower_a GUID: 46, MapID: 17
-      LocalBuilding("W_Thoth_Tower", 46, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4290f, 3328f, 67.31162f), tower_a)))
+      LocalBuilding("W_Thoth_Tower", 46, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4290f, 3328f, 67.31162f), Vector3(0f, 0f, 25f), tower_a)))
       LocalObject(1888, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 46)
       LocalObject(342, Door.Constructor(Vector3(4297.495f, 3340.322f, 68.83263f)), owning_building_guid = 46)
       LocalObject(343, Door.Constructor(Vector3(4297.495f, 3340.322f, 88.83162f)), owning_building_guid = 46)
@@ -1535,7 +1535,7 @@ object Map01 { // Solsar
     Building36()
 
     def Building36(): Unit = { // Name: E_Tower_Seth Type: tower_a GUID: 47, MapID: 36
-      LocalBuilding("E_Tower_Seth", 47, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4828f, 6192f, 67.78428f), tower_a)))
+      LocalBuilding("E_Tower_Seth", 47, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4828f, 6192f, 67.78428f), Vector3(0f, 0f, 33f), tower_a)))
       LocalObject(1892, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 47)
       LocalObject(412, Door.Constructor(Vector3(4833.707f, 6205.245f, 69.30528f)), owning_building_guid = 47)
       LocalObject(413, Door.Constructor(Vector3(4833.707f, 6205.245f, 89.30428f)), owning_building_guid = 47)
@@ -1572,7 +1572,7 @@ object Map01 { // Solsar
     Building24()
 
     def Building24(): Unit = { // Name: E_Bastet_Tower Type: tower_a GUID: 48, MapID: 24
-      LocalBuilding("E_Bastet_Tower", 48, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5524f, 5436f, 74.02264f), tower_a)))
+      LocalBuilding("E_Bastet_Tower", 48, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5524f, 5436f, 74.02264f), Vector3(0f, 0f, 332f), tower_a)))
       LocalObject(1895, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 48)
       LocalObject(441, Door.Constructor(Vector3(5530.839f, 5423.303f, 75.54365f)), owning_building_guid = 48)
       LocalObject(442, Door.Constructor(Vector3(5530.839f, 5423.303f, 95.54265f)), owning_building_guid = 48)
@@ -1609,7 +1609,7 @@ object Map01 { // Solsar
     Building25()
 
     def Building25(): Unit = { // Name: NW_Cyssor_Warpgate_Tower Type: tower_a GUID: 49, MapID: 25
-      LocalBuilding("NW_Cyssor_Warpgate_Tower", 49, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5636f, 3622f, 162.7766f), tower_a)))
+      LocalBuilding("NW_Cyssor_Warpgate_Tower", 49, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5636f, 3622f, 162.7766f), Vector3(0f, 0f, 342f), tower_a)))
       LocalObject(1896, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 49)
       LocalObject(445, Door.Constructor(Vector3(5644.94f, 3610.683f, 164.2976f)), owning_building_guid = 49)
       LocalObject(446, Door.Constructor(Vector3(5644.94f, 3610.683f, 184.2966f)), owning_building_guid = 49)
@@ -1646,7 +1646,7 @@ object Map01 { // Solsar
     Building22()
 
     def Building22(): Unit = { // Name: S_Sobek_Tower Type: tower_b GUID: 50, MapID: 22
-      LocalBuilding("S_Sobek_Tower", 50, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3162f, 2856f, 70.09491f), tower_b)))
+      LocalBuilding("S_Sobek_Tower", 50, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3162f, 2856f, 70.09491f), Vector3(0f, 0f, 51f), tower_b)))
       LocalObject(1881, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 50)
       LocalObject(258, Door.Constructor(Vector3(3163.335f, 2870.36f, 71.61491f)), owning_building_guid = 50)
       LocalObject(259, Door.Constructor(Vector3(3163.335f, 2870.36f, 81.61491f)), owning_building_guid = 50)
@@ -1683,7 +1683,7 @@ object Map01 { // Solsar
     Building37()
 
     def Building37(): Unit = { // Name: N_Aton_Tower Type: tower_b GUID: 51, MapID: 37
-      LocalBuilding("N_Aton_Tower", 51, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3708f, 5656f, 81.34708f), tower_b)))
+      LocalBuilding("N_Aton_Tower", 51, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3708f, 5656f, 81.34708f), Vector3(0f, 0f, 302f), tower_b)))
       LocalObject(1884, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 51)
       LocalObject(297, Door.Constructor(Vector3(3707.575f, 5641.584f, 82.86708f)), owning_building_guid = 51)
       LocalObject(298, Door.Constructor(Vector3(3707.575f, 5641.584f, 92.86708f)), owning_building_guid = 51)
@@ -1720,7 +1720,7 @@ object Map01 { // Solsar
     Building41()
 
     def Building41(): Unit = { // Name: E_Hossin_Warpgate_Tower Type: tower_b GUID: 52, MapID: 41
-      LocalBuilding("E_Hossin_Warpgate_Tower", 52, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4484f, 7294f, 61.76336f), tower_b)))
+      LocalBuilding("E_Hossin_Warpgate_Tower", 52, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4484f, 7294f, 61.76336f), Vector3(0f, 0f, 337f), tower_b)))
       LocalObject(1889, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(365, Door.Constructor(Vector3(4491.92f, 7281.947f, 63.28336f)), owning_building_guid = 52)
       LocalObject(366, Door.Constructor(Vector3(4491.92f, 7281.947f, 73.28336f)), owning_building_guid = 52)
@@ -1757,7 +1757,7 @@ object Map01 { // Solsar
     Building18()
 
     def Building18(): Unit = { // Name: N_Hapi_Tower Type: tower_b GUID: 53, MapID: 18
-      LocalBuilding("N_Hapi_Tower", 53, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4494f, 4884f, 74.691f), tower_b)))
+      LocalBuilding("N_Hapi_Tower", 53, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4494f, 4884f, 74.691f), Vector3(0f, 0f, 5f), tower_b)))
       LocalObject(1890, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(378, Door.Constructor(Vector3(4505.257f, 4893.016f, 76.211f)), owning_building_guid = 53)
       LocalObject(379, Door.Constructor(Vector3(4505.257f, 4893.016f, 86.211f)), owning_building_guid = 53)
@@ -1794,7 +1794,7 @@ object Map01 { // Solsar
     Building15()
 
     def Building15(): Unit = { // Name: S_Amun_Tower Type: tower_b GUID: 54, MapID: 15
-      LocalBuilding("S_Amun_Tower", 54, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4500f, 1912f, 76.47633f), tower_b)))
+      LocalBuilding("S_Amun_Tower", 54, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4500f, 1912f, 76.47633f), Vector3(0f, 0f, 12f), tower_b)))
       LocalObject(1891, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(384, Door.Constructor(Vector3(4510.075f, 1922.32f, 77.99633f)), owning_building_guid = 54)
       LocalObject(385, Door.Constructor(Vector3(4510.075f, 1922.32f, 87.99634f)), owning_building_guid = 54)
@@ -1831,7 +1831,7 @@ object Map01 { // Solsar
     Building39()
 
     def Building39(): Unit = { // Name: E_Forseral_Warpgate_Tower Type: tower_c GUID: 55, MapID: 39
-      LocalBuilding("E_Forseral_Warpgate_Tower", 55, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2826f, 5330f, 175.1091f), tower_c)))
+      LocalBuilding("E_Forseral_Warpgate_Tower", 55, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2826f, 5330f, 175.1091f), Vector3(0f, 0f, 346f), tower_c)))
       LocalObject(1878, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(226, Door.Constructor(Vector3(2835.708f, 5319.334f, 176.6301f)), owning_building_guid = 55)
       LocalObject(227, Door.Constructor(Vector3(2835.708f, 5319.334f, 196.6291f)), owning_building_guid = 55)
@@ -1872,7 +1872,7 @@ object Map01 { // Solsar
     Building23()
 
     def Building23(): Unit = { // Name: NW_Mont_Tower Type: tower_c GUID: 56, MapID: 23
-      LocalBuilding("NW_Mont_Tower", 56, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3190f, 4412f, 105.591f), tower_c)))
+      LocalBuilding("NW_Mont_Tower", 56, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3190f, 4412f, 105.591f), Vector3(0f, 0f, 323f), tower_c)))
       LocalObject(1882, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(264, Door.Constructor(Vector3(3194.769f, 4398.389f, 107.112f)), owning_building_guid = 56)
       LocalObject(265, Door.Constructor(Vector3(3194.769f, 4398.389f, 127.111f)), owning_building_guid = 56)
@@ -1913,7 +1913,7 @@ object Map01 { // Solsar
     Building42()
 
     def Building42(): Unit = { // Name: E_Amerish_Warpgate_Tower Type: tower_c GUID: 57, MapID: 42
-      LocalBuilding("E_Amerish_Warpgate_Tower", 57, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4058f, 1262f, 68.20887f), tower_c)))
+      LocalBuilding("E_Amerish_Warpgate_Tower", 57, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4058f, 1262f, 68.20887f), Vector3(0f, 0f, 28f), tower_c)))
       LocalObject(1886, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(324, Door.Constructor(Vector3(4064.84f, 1274.697f, 69.72987f)), owning_building_guid = 57)
       LocalObject(325, Door.Constructor(Vector3(4064.84f, 1274.697f, 89.72887f)), owning_building_guid = 57)
@@ -1954,7 +1954,7 @@ object Map01 { // Solsar
     Building19()
 
     def Building19(): Unit = { // Name: NW_Seth_Tower Type: tower_c GUID: 58, MapID: 19
-      LocalBuilding("NW_Seth_Tower", 58, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4148f, 6224f, 93.21268f), tower_c)))
+      LocalBuilding("NW_Seth_Tower", 58, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4148f, 6224f, 93.21268f), Vector3(0f, 0f, 31f), tower_c)))
       LocalObject(1887, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(328, Door.Constructor(Vector3(4154.166f, 6237.038f, 94.73369f)), owning_building_guid = 58)
       LocalObject(329, Door.Constructor(Vector3(4154.166f, 6237.038f, 114.7327f)), owning_building_guid = 58)
@@ -1995,7 +1995,7 @@ object Map01 { // Solsar
     Building16()
 
     def Building16(): Unit = { // Name: E_Amun_Tower Type: tower_c GUID: 59, MapID: 16
-      LocalBuilding("E_Amun_Tower", 59, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5080f, 1796f, 76.71438f), tower_c)))
+      LocalBuilding("E_Amun_Tower", 59, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5080f, 1796f, 76.71438f), Vector3(0f, 0f, 35f), tower_c)))
       LocalObject(1893, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(416, Door.Constructor(Vector3(5085.241f, 1809.436f, 78.23538f)), owning_building_guid = 59)
       LocalObject(417, Door.Constructor(Vector3(5085.241f, 1809.436f, 98.23438f)), owning_building_guid = 59)
@@ -2036,7 +2036,7 @@ object Map01 { // Solsar
     Building40()
 
     def Building40(): Unit = { // Name: N_Bastet_Tower Type: tower_c GUID: 60, MapID: 40
-      LocalBuilding("N_Bastet_Tower", 60, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5514f, 5964f, 52.92538f), tower_c)))
+      LocalBuilding("N_Bastet_Tower", 60, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5514f, 5964f, 52.92538f), Vector3(0f, 0f, 353f), tower_c)))
       LocalObject(1894, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(437, Door.Constructor(Vector3(5524.936f, 5954.597f, 54.44638f)), owning_building_guid = 60)
       LocalObject(438, Door.Constructor(Vector3(5524.936f, 5954.597f, 74.44539f)), owning_building_guid = 60)

--- a/pslogin/src/main/scala/zonemaps/Map02.scala
+++ b/pslogin/src/main/scala/zonemaps/Map02.scala
@@ -23,7 +23,7 @@ object Map02 { // Hossin
     Building12()
 
     def Building12(): Unit = { // Name: Ixtab Type: amp_station GUID: 1, MapID: 12
-      LocalBuilding("Ixtab", 1, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3390f, 3150f, 39.97925f), amp_station)))
+      LocalBuilding("Ixtab", 1, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3390f, 3150f, 39.97925f), Vector3(0f, 0f, 315f), amp_station)))
       LocalObject(186, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(148, Door.Constructor(Vector3(3385.337f, 3145.039f, 52.88125f)), owning_building_guid = 1)
       LocalObject(149, Door.Constructor(Vector3(3394.963f, 3154.661f, 52.88125f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map02 { // Hossin
     Building46()
 
     def Building46(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 46
-      LocalBuilding("bunker_gauntlet", 4, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2598f, 3700f, 41.29307f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2598f, 3700f, 41.29307f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(307, Door.Constructor(Vector3(2596.099f, 3675.077f, 42.81407f)), owning_building_guid = 4)
       LocalObject(308, Door.Constructor(Vector3(2596.088f, 3724.898f, 42.81407f)), owning_building_guid = 4)
     }
@@ -159,7 +159,7 @@ object Map02 { // Hossin
     Building44()
 
     def Building44(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 44
-      LocalBuilding("bunker_gauntlet", 5, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3474f, 3242f, 39.97925f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3474f, 3242f, 39.97925f), Vector3(0f, 0f, 315f), bunker_gauntlet)))
       LocalObject(372, Door.Constructor(Vector3(3455.042f, 3258.254f, 41.50025f)), owning_building_guid = 5)
       LocalObject(379, Door.Constructor(Vector3(3490.279f, 3223.032f, 41.50025f)), owning_building_guid = 5)
     }
@@ -167,7 +167,7 @@ object Map02 { // Hossin
     Building47()
 
     def Building47(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 47
-      LocalBuilding("bunker_gauntlet", 6, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4580f, 3462f, 28.62407f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4580f, 3462f, 28.62407f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(450, Door.Constructor(Vector3(4578.099f, 3437.077f, 30.14507f)), owning_building_guid = 6)
       LocalObject(451, Door.Constructor(Vector3(4578.088f, 3486.898f, 30.14507f)), owning_building_guid = 6)
     }
@@ -175,7 +175,7 @@ object Map02 { // Hossin
     Building45()
 
     def Building45(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 45
-      LocalBuilding("bunker_gauntlet", 7, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5404f, 3430f, 27.68258f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5404f, 3430f, 27.68258f), Vector3(0f, 0f, 180f), bunker_gauntlet)))
       LocalObject(479, Door.Constructor(Vector3(5379.077f, 3431.901f, 29.20358f)), owning_building_guid = 7)
       LocalObject(484, Door.Constructor(Vector3(5428.898f, 3431.912f, 29.20358f)), owning_building_guid = 7)
     }
@@ -183,70 +183,70 @@ object Map02 { // Hossin
     Building36()
 
     def Building36(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 8, MapID: 36
-      LocalBuilding("bunker_lg", 8, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2234f, 3870f, 33.47842f), bunker_lg)))
+      LocalBuilding("bunker_lg", 8, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2234f, 3870f, 33.47842f), Vector3(0f, 0f, 315f), bunker_lg)))
       LocalObject(289, Door.Constructor(Vector3(2237.651f, 3869.965f, 34.99942f)), owning_building_guid = 8)
     }
 
     Building41()
 
     def Building41(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 41
-      LocalBuilding("bunker_lg", 9, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3218f, 5222f, 13.92865f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3218f, 5222f, 13.92865f), Vector3(0f, 0f, 44f), bunker_lg)))
       LocalObject(325, Door.Constructor(Vector3(3218.098f, 5225.649f, 15.44965f)), owning_building_guid = 9)
     }
 
     Building34()
 
     def Building34(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 34
-      LocalBuilding("bunker_lg", 10, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3448f, 2944f, 38.54488f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3448f, 2944f, 38.54488f), Vector3(0f, 0f, 360f), bunker_lg)))
       LocalObject(370, Door.Constructor(Vector3(3450.606f, 2946.557f, 40.06588f)), owning_building_guid = 10)
     }
 
     Building43()
 
     def Building43(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 11, MapID: 43
-      LocalBuilding("bunker_lg", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3544f, 3970f, 30.07141f), bunker_lg)))
+      LocalBuilding("bunker_lg", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3544f, 3970f, 30.07141f), Vector3(0f, 0f, 90f), bunker_lg)))
       LocalObject(382, Door.Constructor(Vector3(3541.443f, 3972.606f, 31.59241f)), owning_building_guid = 11)
     }
 
     Building35()
 
     def Building35(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 12, MapID: 35
-      LocalBuilding("bunker_lg", 12, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4028f, 3712f, 29.54496f), bunker_lg)))
+      LocalBuilding("bunker_lg", 12, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4028f, 3712f, 29.54496f), Vector3(0f, 0f, 270f), bunker_lg)))
       LocalObject(405, Door.Constructor(Vector3(4030.557f, 3709.394f, 31.06596f)), owning_building_guid = 12)
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 13, MapID: 38
-      LocalBuilding("bunker_lg", 13, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5520f, 3804f, 18.05474f), bunker_lg)))
+      LocalBuilding("bunker_lg", 13, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5520f, 3804f, 18.05474f), Vector3(0f, 0f, 270f), bunker_lg)))
       LocalObject(491, Door.Constructor(Vector3(5522.557f, 3801.394f, 19.57574f)), owning_building_guid = 13)
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 37
-      LocalBuilding("bunker_sm", 14, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3826f, 6192f, 29.88374f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3826f, 6192f, 29.88374f), Vector3(0f, 0f, 44f), bunker_sm)))
       LocalObject(393, Door.Constructor(Vector3(3826.919f, 6192.812f, 31.40474f)), owning_building_guid = 14)
     }
 
     Building39()
 
     def Building39(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 15, MapID: 39
-      LocalBuilding("bunker_sm", 15, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4678f, 3042f, 24.19964f), bunker_sm)))
+      LocalBuilding("bunker_sm", 15, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4678f, 3042f, 24.19964f), Vector3(0f, 0f, 89f), bunker_sm)))
       LocalObject(452, Door.Constructor(Vector3(4678.076f, 3043.224f, 25.72064f)), owning_building_guid = 15)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 40
-      LocalBuilding("bunker_sm", 16, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6606f, 2274f, 130.5399f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6606f, 2274f, 130.5399f), Vector3(0f, 0f, 270f), bunker_sm)))
       LocalObject(520, Door.Constructor(Vector3(6605.945f, 2272.775f, 132.0609f)), owning_building_guid = 16)
     }
 
     Building48()
 
     def Building48(): Unit = { // Name: Hurakan Type: comm_station GUID: 17, MapID: 48
-      LocalBuilding("Hurakan", 17, 48, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1904f, 2988f, 38.46553f), comm_station)))
+      LocalBuilding("Hurakan", 17, 48, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1904f, 2988f, 38.46553f), Vector3(0f, 0f, 270f), comm_station)))
       LocalObject(183, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 17)
       LocalObject(266, Door.Constructor(Vector3(1836.197f, 3012.5f, 40.21653f)), owning_building_guid = 17)
       LocalObject(267, Door.Constructor(Vector3(1836.197f, 3030.693f, 48.18053f)), owning_building_guid = 17)
@@ -365,7 +365,7 @@ object Map02 { // Hossin
     Building13()
 
     def Building13(): Unit = { // Name: Kisin Type: comm_station GUID: 20, MapID: 13
-      LocalBuilding("Kisin", 20, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3296f, 5426f, 31.04343f), comm_station)))
+      LocalBuilding("Kisin", 20, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3296f, 5426f, 31.04343f), Vector3(0f, 0f, 360f), comm_station)))
       LocalObject(185, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 20)
       LocalObject(326, Door.Constructor(Vector3(3236.196f, 5382.5f, 32.79443f)), owning_building_guid = 20)
       LocalObject(327, Door.Constructor(Vector3(3236.196f, 5400.693f, 40.75843f)), owning_building_guid = 20)
@@ -484,7 +484,7 @@ object Map02 { // Hossin
     Building5()
 
     def Building5(): Unit = { // Name: Voltan Type: comm_station GUID: 23, MapID: 5
-      LocalBuilding("Voltan", 23, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4484f, 3482f, 28.31507f), comm_station)))
+      LocalBuilding("Voltan", 23, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4484f, 3482f, 28.31507f), Vector3(0f, 0f, 360f), comm_station)))
       LocalObject(190, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 23)
       LocalObject(418, Door.Constructor(Vector3(4424.196f, 3438.5f, 30.06607f)), owning_building_guid = 23)
       LocalObject(419, Door.Constructor(Vector3(4424.196f, 3456.693f, 38.03008f)), owning_building_guid = 23)
@@ -603,7 +603,7 @@ object Map02 { // Hossin
     Building6()
 
     def Building6(): Unit = { // Name: Naum Type: comm_station_dsp GUID: 26, MapID: 6
-      LocalBuilding("Naum", 26, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5408f, 3536f, 27.71691f), comm_station_dsp)))
+      LocalBuilding("Naum", 26, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5408f, 3536f, 27.71691f), Vector3(0f, 0f, 315f), comm_station_dsp)))
       LocalObject(191, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 26)
       LocalObject(234, Door.Constructor(Vector3(5506.148f, 3537.503f, 31.09491f)), owning_building_guid = 26)
       LocalObject(471, Door.Constructor(Vector3(5329.868f, 3518.245f, 37.33191f)), owning_building_guid = 26)
@@ -744,7 +744,7 @@ object Map02 { // Hossin
     Building8()
 
     def Building8(): Unit = { // Name: Acan Type: cryo_facility GUID: 29, MapID: 8
-      LocalBuilding("Acan", 29, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3478f, 4056f, 29.82269f), cryo_facility)))
+      LocalBuilding("Acan", 29, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3478f, 4056f, 29.82269f), Vector3(0f, 0f, 269f), cryo_facility)))
       LocalObject(187, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 29)
       LocalObject(353, Door.Constructor(Vector3(3385.456f, 4025.611f, 31.34369f)), owning_building_guid = 29)
       LocalObject(357, Door.Constructor(Vector3(3394.676f, 4033.951f, 31.37369f)), owning_building_guid = 29)
@@ -892,7 +892,7 @@ object Map02 { // Hossin
     Building9()
 
     def Building9(): Unit = { // Name: Bitol Type: cryo_facility GUID: 32, MapID: 9
-      LocalBuilding("Bitol", 32, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4480f, 2570f, 30.43306f), cryo_facility)))
+      LocalBuilding("Bitol", 32, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4480f, 2570f, 30.43306f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(189, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 32)
       LocalObject(416, Door.Constructor(Vector3(4421.023f, 2574.5f, 31.98406f)), owning_building_guid = 32)
       LocalObject(417, Door.Constructor(Vector3(4421.023f, 2592.693f, 39.94806f)), owning_building_guid = 32)
@@ -1040,7 +1040,7 @@ object Map02 { // Hossin
     Building7()
 
     def Building7(): Unit = { // Name: Zotz Type: cryo_facility GUID: 35, MapID: 7
-      LocalBuilding("Zotz", 35, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6730f, 2292f, 129.2093f), cryo_facility)))
+      LocalBuilding("Zotz", 35, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6730f, 2292f, 129.2093f), Vector3(0f, 0f, 90f), cryo_facility)))
       LocalObject(193, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 35)
       LocalObject(521, Door.Constructor(Vector3(6662.197f, 2249.674f, 130.7603f)), owning_building_guid = 35)
       LocalObject(522, Door.Constructor(Vector3(6662.197f, 2267.867f, 138.7243f)), owning_building_guid = 35)
@@ -1200,7 +1200,7 @@ object Map02 { // Hossin
     Building11()
 
     def Building11(): Unit = { // Name: Ghanon Type: tech_plant GUID: 42, MapID: 11
-      LocalBuilding("Ghanon", 42, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2482f, 3762f, 41.20609f), tech_plant)))
+      LocalBuilding("Ghanon", 42, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2482f, 3762f, 41.20609f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(184, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 42)
       LocalObject(290, Door.Constructor(Vector3(2410.54f, 3691.929f, 42.74809f)), owning_building_guid = 42)
       LocalObject(291, Door.Constructor(Vector3(2410.54f, 3710.121f, 50.71109f)), owning_building_guid = 42)
@@ -1326,7 +1326,7 @@ object Map02 { // Hossin
     Building10()
 
     def Building10(): Unit = { // Name: Chac Type: tech_plant GUID: 45, MapID: 10
-      LocalBuilding("Chac", 45, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4020f, 6012f, 39.28953f), tech_plant)))
+      LocalBuilding("Chac", 45, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4020f, 6012f, 39.28953f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(188, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 45)
       LocalObject(398, Door.Constructor(Vector3(3948.54f, 5941.929f, 40.83153f)), owning_building_guid = 45)
       LocalObject(399, Door.Constructor(Vector3(3948.54f, 5960.121f, 48.79453f)), owning_building_guid = 45)
@@ -1452,7 +1452,7 @@ object Map02 { // Hossin
     Building14()
 
     def Building14(): Unit = { // Name: Mulac Type: tech_plant GUID: 48, MapID: 14
-      LocalBuilding("Mulac", 48, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5668f, 2824f, 36.97623f), tech_plant)))
+      LocalBuilding("Mulac", 48, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5668f, 2824f, 36.97623f), Vector3(0f, 0f, 268f), tech_plant)))
       LocalObject(192, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 48)
       LocalObject(496, Door.Constructor(Vector3(5569.457f, 2867.466f, 38.59723f)), owning_building_guid = 48)
       LocalObject(498, Door.Constructor(Vector3(5576.697f, 2822.581f, 38.62723f)), owning_building_guid = 48)
@@ -1578,7 +1578,7 @@ object Map02 { // Hossin
     Building15()
 
     def Building15(): Unit = { // Name: S_Ceryshen_Warpgate_Tower Type: tower_a GUID: 51, MapID: 15
-      LocalBuilding("S_Ceryshen_Warpgate_Tower", 51, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1816f, 4282f, 45.38713f), tower_a)))
+      LocalBuilding("S_Ceryshen_Warpgate_Tower", 51, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1816f, 4282f, 45.38713f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2259, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 51)
       LocalObject(262, Door.Constructor(Vector3(1828f, 4274f, 46.90813f)), owning_building_guid = 51)
       LocalObject(263, Door.Constructor(Vector3(1828f, 4274f, 66.90713f)), owning_building_guid = 51)
@@ -1615,7 +1615,7 @@ object Map02 { // Hossin
     Building17()
 
     def Building17(): Unit = { // Name: NE_Ceryshen_Warpgate_Tower Type: tower_a GUID: 52, MapID: 17
-      LocalBuilding("NE_Ceryshen_Warpgate_Tower", 52, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2196f, 5162f, 30.38423f), tower_a)))
+      LocalBuilding("NE_Ceryshen_Warpgate_Tower", 52, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2196f, 5162f, 30.38423f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2261, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(285, Door.Constructor(Vector3(2208f, 5154f, 31.90523f)), owning_building_guid = 52)
       LocalObject(286, Door.Constructor(Vector3(2208f, 5154f, 51.90423f)), owning_building_guid = 52)
@@ -1652,7 +1652,7 @@ object Map02 { // Hossin
     Building28()
 
     def Building28(): Unit = { // Name: W_Oshur_Warpgate_Tower Type: tower_a GUID: 53, MapID: 28
-      LocalBuilding("W_Oshur_Warpgate_Tower", 53, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2506f, 2050f, 30.77677f), tower_a)))
+      LocalBuilding("W_Oshur_Warpgate_Tower", 53, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2506f, 2050f, 30.77677f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2262, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(300, Door.Constructor(Vector3(2518f, 2042f, 32.29778f)), owning_building_guid = 53)
       LocalObject(301, Door.Constructor(Vector3(2518f, 2042f, 52.29678f)), owning_building_guid = 53)
@@ -1689,7 +1689,7 @@ object Map02 { // Hossin
     Building49()
 
     def Building49(): Unit = { // Name: Ixtab_tower Type: tower_a GUID: 54, MapID: 49
-      LocalBuilding("Ixtab_tower", 54, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3652f, 3042f, 38.52847f), tower_a)))
+      LocalBuilding("Ixtab_tower", 54, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3652f, 3042f, 38.52847f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2269, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(385, Door.Constructor(Vector3(3664f, 3034f, 40.04947f)), owning_building_guid = 54)
       LocalObject(386, Door.Constructor(Vector3(3664f, 3034f, 60.04847f)), owning_building_guid = 54)
@@ -1726,7 +1726,7 @@ object Map02 { // Hossin
     Building32()
 
     def Building32(): Unit = { // Name: S_Acan_Tower Type: tower_a GUID: 55, MapID: 32
-      LocalBuilding("S_Acan_Tower", 55, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3834f, 4050f, 25.81256f), tower_a)))
+      LocalBuilding("S_Acan_Tower", 55, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3834f, 4050f, 25.81256f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2271, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(394, Door.Constructor(Vector3(3846f, 4042f, 27.33356f)), owning_building_guid = 55)
       LocalObject(395, Door.Constructor(Vector3(3846f, 4042f, 47.33256f)), owning_building_guid = 55)
@@ -1763,7 +1763,7 @@ object Map02 { // Hossin
     Building50()
 
     def Building50(): Unit = { // Name: WG_Hossin_to_VSSanc_Tower Type: tower_a GUID: 56, MapID: 50
-      LocalBuilding("WG_Hossin_to_VSSanc_Tower", 56, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5238f, 1902f, 40.67507f), tower_a)))
+      LocalBuilding("WG_Hossin_to_VSSanc_Tower", 56, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5238f, 1902f, 40.67507f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2277, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(463, Door.Constructor(Vector3(5250f, 1894f, 42.19607f)), owning_building_guid = 56)
       LocalObject(464, Door.Constructor(Vector3(5250f, 1894f, 62.19507f)), owning_building_guid = 56)
@@ -1800,7 +1800,7 @@ object Map02 { // Hossin
     Building23()
 
     def Building23(): Unit = { // Name: N_Kisin_Tower Type: tower_a GUID: 57, MapID: 23
-      LocalBuilding("N_Kisin_Tower", 57, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5332f, 4112f, 18.44539f), tower_a)))
+      LocalBuilding("N_Kisin_Tower", 57, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5332f, 4112f, 18.44539f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2279, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(474, Door.Constructor(Vector3(5344f, 4104f, 19.96639f)), owning_building_guid = 57)
       LocalObject(475, Door.Constructor(Vector3(5344f, 4104f, 39.96539f)), owning_building_guid = 57)
@@ -1837,7 +1837,7 @@ object Map02 { // Hossin
     Building52()
 
     def Building52(): Unit = { // Name: E_Naum_Tower Type: tower_a GUID: 58, MapID: 52
-      LocalBuilding("E_Naum_Tower", 58, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6472f, 3562f, 46.96188f), tower_a)))
+      LocalBuilding("E_Naum_Tower", 58, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6472f, 3562f, 46.96188f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2281, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(516, Door.Constructor(Vector3(6484f, 3554f, 48.48288f)), owning_building_guid = 58)
       LocalObject(517, Door.Constructor(Vector3(6484f, 3554f, 68.48189f)), owning_building_guid = 58)
@@ -1874,7 +1874,7 @@ object Map02 { // Hossin
     Building31()
 
     def Building31(): Unit = { // Name: SW_Ghanon_Tower Type: tower_b GUID: 59, MapID: 31
-      LocalBuilding("SW_Ghanon_Tower", 59, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1994f, 3310f, 25.44633f), tower_b)))
+      LocalBuilding("SW_Ghanon_Tower", 59, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1994f, 3310f, 25.44633f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2260, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(279, Door.Constructor(Vector3(2006f, 3302f, 26.96633f)), owning_building_guid = 59)
       LocalObject(280, Door.Constructor(Vector3(2006f, 3302f, 36.96633f)), owning_building_guid = 59)
@@ -1911,7 +1911,7 @@ object Map02 { // Hossin
     Building30()
 
     def Building30(): Unit = { // Name: SW_Ixtab_Tower Type: tower_b GUID: 60, MapID: 30
-      LocalBuilding("SW_Ixtab_Tower", 60, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2950f, 2648f, 21.2714f), tower_b)))
+      LocalBuilding("SW_Ixtab_Tower", 60, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2950f, 2648f, 21.2714f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2264, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(313, Door.Constructor(Vector3(2962f, 2640f, 22.7914f)), owning_building_guid = 60)
       LocalObject(314, Door.Constructor(Vector3(2962f, 2640f, 32.7914f)), owning_building_guid = 60)
@@ -1948,7 +1948,7 @@ object Map02 { // Hossin
     Building16()
 
     def Building16(): Unit = { // Name: NW_Acan_Tower Type: tower_b GUID: 61, MapID: 16
-      LocalBuilding("NW_Acan_Tower", 61, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3086f, 4562f, 22.34565f), tower_b)))
+      LocalBuilding("NW_Acan_Tower", 61, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3086f, 4562f, 22.34565f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2265, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(319, Door.Constructor(Vector3(3098f, 4554f, 23.86565f)), owning_building_guid = 61)
       LocalObject(320, Door.Constructor(Vector3(3098f, 4554f, 33.86565f)), owning_building_guid = 61)
@@ -1985,7 +1985,7 @@ object Map02 { // Hossin
     Building19()
 
     def Building19(): Unit = { // Name: N_Naum_Tower Type: tower_b GUID: 62, MapID: 19
-      LocalBuilding("N_Naum_Tower", 62, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3306f, 5924f, 24.897f), tower_b)))
+      LocalBuilding("N_Naum_Tower", 62, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3306f, 5924f, 24.897f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2266, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(338, Door.Constructor(Vector3(3318f, 5916f, 26.417f)), owning_building_guid = 62)
       LocalObject(339, Door.Constructor(Vector3(3318f, 5916f, 36.417f)), owning_building_guid = 62)
@@ -2022,7 +2022,7 @@ object Map02 { // Hossin
     Building22()
 
     def Building22(): Unit = { // Name: SW_Solsar_Warpgate_Tower Type: tower_b GUID: 63, MapID: 22
-      LocalBuilding("SW_Solsar_Warpgate_Tower", 63, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4494f, 4096f, 26.09943f), tower_b)))
+      LocalBuilding("SW_Solsar_Warpgate_Tower", 63, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4494f, 4096f, 26.09943f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2274, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(438, Door.Constructor(Vector3(4506f, 4088f, 27.61943f)), owning_building_guid = 63)
       LocalObject(439, Door.Constructor(Vector3(4506f, 4088f, 37.61943f)), owning_building_guid = 63)
@@ -2059,7 +2059,7 @@ object Map02 { // Hossin
     Building42()
 
     def Building42(): Unit = { // Name: Voltan_Tower Type: tower_b GUID: 64, MapID: 42
-      LocalBuilding("Voltan_Tower", 64, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4780f, 3522f, 21.20083f), tower_b)))
+      LocalBuilding("Voltan_Tower", 64, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4780f, 3522f, 21.20083f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2276, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(457, Door.Constructor(Vector3(4792f, 3514f, 22.72083f)), owning_building_guid = 64)
       LocalObject(458, Door.Constructor(Vector3(4792f, 3514f, 32.72083f)), owning_building_guid = 64)
@@ -2096,7 +2096,7 @@ object Map02 { // Hossin
     Building24()
 
     def Building24(): Unit = { // Name: NE_Mulac_Tower Type: tower_b GUID: 65, MapID: 24
-      LocalBuilding("NE_Mulac_Tower", 65, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5784f, 3474f, 24.29884f), tower_b)))
+      LocalBuilding("NE_Mulac_Tower", 65, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5784f, 3474f, 24.29884f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2280, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(510, Door.Constructor(Vector3(5796f, 3466f, 25.81884f)), owning_building_guid = 65)
       LocalObject(511, Door.Constructor(Vector3(5796f, 3466f, 35.81884f)), owning_building_guid = 65)
@@ -2133,7 +2133,7 @@ object Map02 { // Hossin
     Building33()
 
     def Building33(): Unit = { // Name: SE_Ghanon_Tower Type: tower_c GUID: 66, MapID: 33
-      LocalBuilding("SE_Ghanon_Tower", 66, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2638f, 3496f, 35.68224f), tower_c)))
+      LocalBuilding("SE_Ghanon_Tower", 66, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2638f, 3496f, 35.68224f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2263, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(309, Door.Constructor(Vector3(2650f, 3488f, 37.20324f)), owning_building_guid = 66)
       LocalObject(310, Door.Constructor(Vector3(2650f, 3488f, 57.20224f)), owning_building_guid = 66)
@@ -2174,7 +2174,7 @@ object Map02 { // Hossin
     Building29()
 
     def Building29(): Unit = { // Name: NE_Oshur_Warpgate_Tower Type: tower_c GUID: 67, MapID: 29
-      LocalBuilding("NE_Oshur_Warpgate_Tower", 67, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3434f, 2144f, 25.65386f), tower_c)))
+      LocalBuilding("NE_Oshur_Warpgate_Tower", 67, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3434f, 2144f, 25.65386f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2267, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(366, Door.Constructor(Vector3(3446f, 2136f, 27.17486f)), owning_building_guid = 67)
       LocalObject(367, Door.Constructor(Vector3(3446f, 2136f, 47.17386f)), owning_building_guid = 67)
@@ -2215,7 +2215,7 @@ object Map02 { // Hossin
     Building18()
 
     def Building18(): Unit = { // Name: SE_Naum_Tower Type: tower_c GUID: 68, MapID: 18
-      LocalBuilding("SE_Naum_Tower", 68, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3456f, 5278f, 21.2775f), tower_c)))
+      LocalBuilding("SE_Naum_Tower", 68, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3456f, 5278f, 21.2775f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2268, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(373, Door.Constructor(Vector3(3468f, 5270f, 22.7985f)), owning_building_guid = 68)
       LocalObject(374, Door.Constructor(Vector3(3468f, 5270f, 42.7975f)), owning_building_guid = 68)
@@ -2256,7 +2256,7 @@ object Map02 { // Hossin
     Building27()
 
     def Building27(): Unit = { // Name: SE_Oshur_Warpgate_Tower Type: tower_c GUID: 69, MapID: 27
-      LocalBuilding("SE_Oshur_Warpgate_Tower", 69, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3716f, 1182f, 34.80941f), tower_c)))
+      LocalBuilding("SE_Oshur_Warpgate_Tower", 69, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3716f, 1182f, 34.80941f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2270, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(389, Door.Constructor(Vector3(3728f, 1174f, 36.33041f)), owning_building_guid = 69)
       LocalObject(390, Door.Constructor(Vector3(3728f, 1174f, 56.32941f)), owning_building_guid = 69)
@@ -2297,7 +2297,7 @@ object Map02 { // Hossin
     Building20()
 
     def Building20(): Unit = { // Name: E_Chac_Tower Type: tower_c GUID: 70, MapID: 20
-      LocalBuilding("E_Chac_Tower", 70, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4288f, 5776f, 26.28254f), tower_c)))
+      LocalBuilding("E_Chac_Tower", 70, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4288f, 5776f, 26.28254f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2272, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(412, Door.Constructor(Vector3(4300f, 5768f, 27.80354f)), owning_building_guid = 70)
       LocalObject(413, Door.Constructor(Vector3(4300f, 5768f, 47.80254f)), owning_building_guid = 70)
@@ -2338,7 +2338,7 @@ object Map02 { // Hossin
     Building21()
 
     def Building21(): Unit = { // Name: NW_Solsar_Warpgate_Tower Type: tower_c GUID: 71, MapID: 21
-      LocalBuilding("NW_Solsar_Warpgate_Tower", 71, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4480f, 4726f, 35.56017f), tower_c)))
+      LocalBuilding("NW_Solsar_Warpgate_Tower", 71, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4480f, 4726f, 35.56017f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2273, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(432, Door.Constructor(Vector3(4492f, 4718f, 37.08117f)), owning_building_guid = 71)
       LocalObject(433, Door.Constructor(Vector3(4492f, 4718f, 57.08017f)), owning_building_guid = 71)
@@ -2379,7 +2379,7 @@ object Map02 { // Hossin
     Building26()
 
     def Building26(): Unit = { // Name: E_Bitol_Tower Type: tower_c GUID: 72, MapID: 26
-      LocalBuilding("E_Bitol_Tower", 72, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4702f, 2460f, 28.31507f), tower_c)))
+      LocalBuilding("E_Bitol_Tower", 72, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4702f, 2460f, 28.31507f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2275, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(453, Door.Constructor(Vector3(4714f, 2452f, 29.83607f)), owning_building_guid = 72)
       LocalObject(454, Door.Constructor(Vector3(4714f, 2452f, 49.83508f)), owning_building_guid = 72)
@@ -2420,7 +2420,7 @@ object Map02 { // Hossin
     Building25()
 
     def Building25(): Unit = { // Name: NW_Mulac_Tower Type: tower_c GUID: 73, MapID: 25
-      LocalBuilding("NW_Mulac_Tower", 73, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5308f, 2976f, 27.19199f), tower_c)))
+      LocalBuilding("NW_Mulac_Tower", 73, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5308f, 2976f, 27.19199f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2278, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(467, Door.Constructor(Vector3(5320f, 2968f, 28.71299f)), owning_building_guid = 73)
       LocalObject(468, Door.Constructor(Vector3(5320f, 2968f, 48.71199f)), owning_building_guid = 73)
@@ -2461,7 +2461,7 @@ object Map02 { // Hossin
     Building51()
 
     def Building51(): Unit = { // Name: Zotz_Tower Type: tower_c GUID: 74, MapID: 51
-      LocalBuilding("Zotz_Tower", 74, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6680f, 2510f, 181.3593f), tower_c)))
+      LocalBuilding("Zotz_Tower", 74, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6680f, 2510f, 181.3593f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2282, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 74)
       LocalObject(523, Door.Constructor(Vector3(6692f, 2502f, 182.8803f)), owning_building_guid = 74)
       LocalObject(524, Door.Constructor(Vector3(6692f, 2502f, 202.8793f)), owning_building_guid = 74)

--- a/pslogin/src/main/scala/zonemaps/Map03.scala
+++ b/pslogin/src/main/scala/zonemaps/Map03.scala
@@ -23,7 +23,7 @@ object Map03 { // Cyssor
     Building1()
 
     def Building1(): Unit = { // Name: Aja Type: amp_station GUID: 1, MapID: 1
-      LocalBuilding("Aja", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(710f, 5342f, 48.41151f), amp_station)))
+      LocalBuilding("Aja", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(710f, 5342f, 48.41151f), Vector3(0f, 0f, 20f), amp_station)))
       LocalObject(279, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(216, Door.Constructor(Vector3(707.8737f, 5348.468f, 61.31351f)), owning_building_guid = 1)
       LocalObject(217, Door.Constructor(Vector3(712.5257f, 5335.678f, 61.31351f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map03 { // Cyssor
     Building12()
 
     def Building12(): Unit = { // Name: Nzame Type: amp_station GUID: 4, MapID: 12
-      LocalBuilding("Nzame", 4, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1568f, 2688f, 45.10147f), amp_station)))
+      LocalBuilding("Nzame", 4, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1568f, 2688f, 45.10147f), Vector3(0f, 0f, 325f), amp_station)))
       LocalObject(281, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(218, Door.Constructor(Vector3(1564.27f, 2682.305f, 58.00348f)), owning_building_guid = 4)
       LocalObject(219, Door.Constructor(Vector3(1572.078f, 2693.452f, 58.00348f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map03 { // Cyssor
     Building5()
 
     def Building5(): Unit = { // Name: Ekera Type: amp_station GUID: 7, MapID: 5
-      LocalBuilding("Ekera", 7, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5636f, 6622f, 50.96042f), amp_station)))
+      LocalBuilding("Ekera", 7, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5636f, 6622f, 50.96042f), Vector3(0f, 0f, 275f), amp_station)))
       LocalObject(289, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 7)
       LocalObject(220, Door.Constructor(Vector3(5629.239f, 6621.197f, 63.86242f)), owning_building_guid = 7)
       LocalObject(221, Door.Constructor(Vector3(5642.798f, 6622.38f, 63.86242f)), owning_building_guid = 7)
@@ -407,7 +407,7 @@ object Map03 { // Cyssor
     Building20()
 
     def Building20(): Unit = { // Name: Kaang Type: amp_station GUID: 10, MapID: 20
-      LocalBuilding("Kaang", 10, 20, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5846f, 3956f, 62.32429f), amp_station)))
+      LocalBuilding("Kaang", 10, 20, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5846f, 3956f, 62.32429f), Vector3(0f, 0f, 205f), amp_station)))
       LocalObject(290, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 10)
       LocalObject(222, Door.Constructor(Vector3(5842.933f, 3962.078f, 75.22629f)), owning_building_guid = 10)
       LocalObject(223, Door.Constructor(Vector3(5848.682f, 3949.742f, 75.22629f)), owning_building_guid = 10)
@@ -535,7 +535,7 @@ object Map03 { // Cyssor
     Building15()
 
     def Building15(): Unit = { // Name: Pamba Type: amp_station GUID: 13, MapID: 15
-      LocalBuilding("Pamba", 13, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(7310f, 3078f, 62.94272f), amp_station)))
+      LocalBuilding("Pamba", 13, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(7310f, 3078f, 62.94272f), Vector3(0f, 0f, 339f), amp_station)))
       LocalObject(293, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 13)
       LocalObject(224, Door.Constructor(Vector3(7307.758f, 3071.571f, 75.84472f)), owning_building_guid = 13)
       LocalObject(225, Door.Constructor(Vector3(7312.639f, 3084.276f, 75.84472f)), owning_building_guid = 13)
@@ -663,7 +663,7 @@ object Map03 { // Cyssor
     Building59()
 
     def Building59(): Unit = { // Name: bunkerg2 Type: bunker_gauntlet GUID: 16, MapID: 59
-      LocalBuilding("bunkerg2", 16, 59, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2610f, 1338f, 64.04956f), bunker_gauntlet)))
+      LocalBuilding("bunkerg2", 16, 59, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2610f, 1338f, 64.04956f), Vector3(0f, 0f, 123f), bunker_gauntlet)))
       LocalObject(513, Door.Constructor(Vector3(2598.02f, 1359.938f, 65.57056f)), owning_building_guid = 16)
       LocalObject(514, Door.Constructor(Vector3(2625.164f, 1318.16f, 65.57056f)), owning_building_guid = 16)
     }
@@ -671,7 +671,7 @@ object Map03 { // Cyssor
     Building58()
 
     def Building58(): Unit = { // Name: bunkerg1 Type: bunker_gauntlet GUID: 17, MapID: 58
-      LocalBuilding("bunkerg1", 17, 58, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3906f, 4474f, 88.9639f), bunker_gauntlet)))
+      LocalBuilding("bunkerg1", 17, 58, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3906f, 4474f, 88.9639f), Vector3(0f, 0f, 110f), bunker_gauntlet)))
       LocalObject(574, Door.Constructor(Vector3(3899.262f, 4498.07f, 90.4849f)), owning_building_guid = 17)
       LocalObject(575, Door.Constructor(Vector3(3916.312f, 4451.257f, 90.4849f)), owning_building_guid = 17)
     }
@@ -679,7 +679,7 @@ object Map03 { // Cyssor
     Building60()
 
     def Building60(): Unit = { // Name: bunkerg3 Type: bunker_gauntlet GUID: 18, MapID: 60
-      LocalBuilding("bunkerg3", 18, 60, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4870f, 4466f, 53.91644f), bunker_gauntlet)))
+      LocalBuilding("bunkerg3", 18, 60, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4870f, 4466f, 53.91644f), Vector3(0f, 0f, 350f), bunker_gauntlet)))
       LocalObject(613, Door.Constructor(Vector3(4845.148f, 4468.44f, 55.43744f)), owning_building_guid = 18)
       LocalObject(623, Door.Constructor(Vector3(4894.214f, 4459.8f, 55.43744f)), owning_building_guid = 18)
     }
@@ -687,105 +687,105 @@ object Map03 { // Cyssor
     Building54()
 
     def Building54(): Unit = { // Name: bunker11 Type: bunker_lg GUID: 19, MapID: 54
-      LocalBuilding("bunker11", 19, 54, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(600f, 6826f, 59.91754f), bunker_lg)))
+      LocalBuilding("bunker11", 19, 54, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(600f, 6826f, 59.91754f), Vector3(0f, 0f, 354f), bunker_lg)))
       LocalObject(415, Door.Constructor(Vector3(602.859f, 6828.271f, 61.43854f)), owning_building_guid = 19)
     }
 
     Building56()
 
     def Building56(): Unit = { // Name: bunker6 Type: bunker_lg GUID: 20, MapID: 56
-      LocalBuilding("bunker6", 20, 56, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(708f, 2384f, 53.85228f), bunker_lg)))
+      LocalBuilding("bunker6", 20, 56, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(708f, 2384f, 53.85228f), Vector3(0f, 0f, 112f), bunker_lg)))
       LocalObject(447, Door.Constructor(Vector3(704.653f, 2385.458f, 55.37328f)), owning_building_guid = 20)
     }
 
     Building52()
 
     def Building52(): Unit = { // Name: bunker8 Type: bunker_lg GUID: 21, MapID: 52
-      LocalBuilding("bunker8", 21, 52, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1464f, 2568f, 45.02957f), bunker_lg)))
+      LocalBuilding("bunker8", 21, 52, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1464f, 2568f, 45.02957f), Vector3(0f, 0f, 355f), bunker_lg)))
       LocalObject(486, Door.Constructor(Vector3(1466.819f, 2570.32f, 46.55057f)), owning_building_guid = 21)
     }
 
     Building48()
 
     def Building48(): Unit = { // Name: bunker3 Type: bunker_lg GUID: 22, MapID: 48
-      LocalBuilding("bunker3", 22, 48, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5132f, 4998f, 40.94622f), bunker_lg)))
+      LocalBuilding("bunker3", 22, 48, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5132f, 4998f, 40.94622f), Vector3(0f, 0f, 107f), bunker_lg)))
       LocalObject(660, Door.Constructor(Vector3(5128.793f, 4999.745f, 42.46722f)), owning_building_guid = 22)
     }
 
     Building71()
 
     def Building71(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 23, MapID: 71
-      LocalBuilding("bunker_lg", 23, 71, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5208f, 3856f, 37.32201f), bunker_lg)))
+      LocalBuilding("bunker_lg", 23, 71, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5208f, 3856f, 37.32201f), Vector3(0f, 0f, 69f), bunker_lg)))
       LocalObject(677, Door.Constructor(Vector3(5206.547f, 3859.349f, 38.84301f)), owning_building_guid = 23)
     }
 
     Building55()
 
     def Building55(): Unit = { // Name: bunker12 Type: bunker_lg GUID: 24, MapID: 55
-      LocalBuilding("bunker12", 24, 55, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6632f, 2306f, 62.59754f), bunker_lg)))
+      LocalBuilding("bunker12", 24, 55, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6632f, 2306f, 62.59754f), Vector3(0f, 0f, 238f), bunker_lg)))
       LocalObject(740, Door.Constructor(Vector3(6632.788f, 2302.435f, 64.11855f)), owning_building_guid = 24)
     }
 
     Building51()
 
     def Building51(): Unit = { // Name: bunker7 Type: bunker_sm GUID: 25, MapID: 51
-      LocalBuilding("bunker7", 25, 51, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1700f, 2702f, 45.14794f), bunker_sm)))
+      LocalBuilding("bunker7", 25, 51, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1700f, 2702f, 45.14794f), Vector3(0f, 0f, 141f), bunker_sm)))
       LocalObject(508, Door.Constructor(Vector3(1699.083f, 2702.814f, 46.66894f)), owning_building_guid = 25)
     }
 
     Building49()
 
     def Building49(): Unit = { // Name: bunker4 Type: bunker_sm GUID: 26, MapID: 49
-      LocalBuilding("bunker4", 26, 49, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2958f, 1284f, 48.15265f), bunker_sm)))
+      LocalBuilding("bunker4", 26, 49, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2958f, 1284f, 48.15265f), Vector3(0f, 0f, 195f), bunker_sm)))
       LocalObject(549, Door.Constructor(Vector3(2956.802f, 1283.736f, 49.67365f)), owning_building_guid = 26)
     }
 
     Building53()
 
     def Building53(): Unit = { // Name: bunker10 Type: bunker_sm GUID: 27, MapID: 53
-      LocalBuilding("bunker10", 27, 53, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4238f, 7044f, 51.17726f), bunker_sm)))
+      LocalBuilding("bunker10", 27, 53, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4238f, 7044f, 51.17726f), Vector3(0f, 0f, 225f), bunker_sm)))
       LocalObject(612, Door.Constructor(Vector3(4237.095f, 7043.173f, 52.69826f)), owning_building_guid = 27)
     }
 
     Building50()
 
     def Building50(): Unit = { // Name: bunker5 Type: bunker_sm GUID: 28, MapID: 50
-      LocalBuilding("bunker5", 28, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5022f, 4280f, 53.97397f), bunker_sm)))
+      LocalBuilding("bunker5", 28, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5022f, 4280f, 53.97397f), Vector3(0f, 0f, 79f), bunker_sm)))
       LocalObject(643, Door.Constructor(Vector3(5022.288f, 4281.192f, 55.49497f)), owning_building_guid = 28)
     }
 
     Building46()
 
     def Building46(): Unit = { // Name: bunker1 Type: bunker_sm GUID: 29, MapID: 46
-      LocalBuilding("bunker1", 29, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5160f, 3442f, 48.0232f), bunker_sm)))
+      LocalBuilding("bunker1", 29, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5160f, 3442f, 48.0232f), Vector3(0f, 0f, 225f), bunker_sm)))
       LocalObject(670, Door.Constructor(Vector3(5159.095f, 3441.173f, 49.5442f)), owning_building_guid = 29)
     }
 
     Building47()
 
     def Building47(): Unit = { // Name: bunker2 Type: bunker_sm GUID: 30, MapID: 47
-      LocalBuilding("bunker2", 30, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5220f, 5806f, 56.73086f), bunker_sm)))
+      LocalBuilding("bunker2", 30, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5220f, 5806f, 56.73086f), Vector3(0f, 0f, 163f), bunker_sm)))
       LocalObject(678, Door.Constructor(Vector3(5218.845f, 5806.411f, 58.25186f)), owning_building_guid = 30)
     }
 
     Building57()
 
     def Building57(): Unit = { // Name: bunker9 Type: bunker_sm GUID: 31, MapID: 57
-      LocalBuilding("bunker9", 31, 57, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5694f, 6524f, 50.47251f), bunker_sm)))
+      LocalBuilding("bunker9", 31, 57, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5694f, 6524f, 50.47251f), Vector3(0f, 0f, 119f), bunker_sm)))
       LocalObject(710, Door.Constructor(Vector3(5693.454f, 6525.098f, 51.99351f)), owning_building_guid = 31)
     }
 
     Building70()
 
     def Building70(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 32, MapID: 70
-      LocalBuilding("bunker_sm", 32, 70, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6854f, 3344f, 36.82418f), bunker_sm)))
+      LocalBuilding("bunker_sm", 32, 70, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6854f, 3344f, 36.82418f), Vector3(0f, 0f, 274f), bunker_sm)))
       LocalObject(762, Door.Constructor(Vector3(6854.031f, 3342.774f, 38.34518f)), owning_building_guid = 32)
     }
 
     Building2()
 
     def Building2(): Unit = { // Name: Bomazi Type: comm_station GUID: 33, MapID: 2
-      LocalBuilding("Bomazi", 33, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1194f, 4574f, 57.8283f), comm_station)))
+      LocalBuilding("Bomazi", 33, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1194f, 4574f, 57.8283f), Vector3(0f, 0f, 331f), comm_station)))
       LocalObject(280, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 33)
       LocalObject(465, Door.Constructor(Vector3(1120.605f, 4564.948f, 59.5793f)), owning_building_guid = 33)
       LocalObject(466, Door.Constructor(Vector3(1123.788f, 4535.396f, 67.5433f)), owning_building_guid = 33)
@@ -904,7 +904,7 @@ object Map03 { // Cyssor
     Building11()
 
     def Building11(): Unit = { // Name: Tore Type: comm_station GUID: 36, MapID: 11
-      LocalBuilding("Tore", 36, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2958f, 2328f, 58.28852f), comm_station)))
+      LocalBuilding("Tore", 36, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2958f, 2328f, 58.28852f), Vector3(0f, 0f, 0f), comm_station)))
       LocalObject(283, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 36)
       LocalObject(542, Door.Constructor(Vector3(2898.196f, 2284.5f, 60.03952f)), owning_building_guid = 36)
       LocalObject(543, Door.Constructor(Vector3(2898.196f, 2302.693f, 68.00352f)), owning_building_guid = 36)
@@ -1023,7 +1023,7 @@ object Map03 { // Cyssor
     Building18()
 
     def Building18(): Unit = { // Name: Gunuku Type: comm_station_dsp GUID: 39, MapID: 18
-      LocalBuilding("Gunuku", 39, 18, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4936f, 4344f, 53.91644f), comm_station_dsp)))
+      LocalBuilding("Gunuku", 39, 18, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4936f, 4344f, 53.91644f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(286, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 39)
       LocalObject(357, Door.Constructor(Vector3(5004.339f, 4414.464f, 57.29444f)), owning_building_guid = 39)
       LocalObject(620, Door.Constructor(Vector3(4876.196f, 4300.501f, 55.56744f)), owning_building_guid = 39)
@@ -1164,7 +1164,7 @@ object Map03 { // Cyssor
     Building21()
 
     def Building21(): Unit = { // Name: Mukuru Type: cryo_facility GUID: 42, MapID: 21
-      LocalBuilding("Mukuru", 42, 21, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(590f, 2410f, 54.06358f), cryo_facility)))
+      LocalBuilding("Mukuru", 42, 21, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(590f, 2410f, 54.06358f), Vector3(0f, 0f, 284f), cryo_facility)))
       LocalObject(278, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 42)
       LocalObject(402, Door.Constructor(Vector3(508.4743f, 2356.694f, 55.58458f)), owning_building_guid = 42)
       LocalObject(403, Door.Constructor(Vector3(510.8202f, 2384.789f, 63.57858f)), owning_building_guid = 42)
@@ -1312,7 +1312,7 @@ object Map03 { // Cyssor
     Building19()
 
     def Building19(): Unit = { // Name: Honsi Type: cryo_facility GUID: 45, MapID: 19
-      LocalBuilding("Honsi", 45, 19, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3996f, 4526f, 88.9639f), cryo_facility)))
+      LocalBuilding("Honsi", 45, 19, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3996f, 4526f, 88.9639f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(284, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 45)
       LocalObject(576, Door.Constructor(Vector3(3937.023f, 4530.5f, 90.5149f)), owning_building_guid = 45)
       LocalObject(577, Door.Constructor(Vector3(3937.023f, 4548.693f, 98.4789f)), owning_building_guid = 45)
@@ -1460,7 +1460,7 @@ object Map03 { // Cyssor
     Building4()
 
     def Building4(): Unit = { // Name: Chuku Type: cryo_facility GUID: 48, MapID: 4
-      LocalBuilding("Chuku", 48, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4162f, 6962f, 54.02264f), cryo_facility)))
+      LocalBuilding("Chuku", 48, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4162f, 6962f, 54.02264f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(285, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 48)
       LocalObject(601, Door.Constructor(Vector3(4103.023f, 6966.5f, 55.57364f)), owning_building_guid = 48)
       LocalObject(602, Door.Constructor(Vector3(4103.023f, 6984.693f, 63.53764f)), owning_building_guid = 48)
@@ -1608,7 +1608,7 @@ object Map03 { // Cyssor
     Building8()
 
     def Building8(): Unit = { // Name: Itan Type: cryo_facility GUID: 51, MapID: 8
-      LocalBuilding("Itan", 51, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5132f, 3334f, 48.0575f), cryo_facility)))
+      LocalBuilding("Itan", 51, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5132f, 3334f, 48.0575f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(288, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 51)
       LocalObject(651, Door.Constructor(Vector3(5073.023f, 3338.5f, 49.60849f)), owning_building_guid = 51)
       LocalObject(652, Door.Constructor(Vector3(5073.023f, 3356.693f, 57.57249f)), owning_building_guid = 51)
@@ -1756,7 +1756,7 @@ object Map03 { // Cyssor
     Building16()
 
     def Building16(): Unit = { // Name: Shango Type: cryo_facility GUID: 54, MapID: 16
-      LocalBuilding("Shango", 54, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6774f, 2288f, 62.96152f), cryo_facility)))
+      LocalBuilding("Shango", 54, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6774f, 2288f, 62.96152f), Vector3(0f, 0f, 331f), cryo_facility)))
       LocalObject(291, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 54)
       LocalObject(751, Door.Constructor(Vector3(6724.599f, 2320.528f, 64.51252f)), owning_building_guid = 54)
       LocalObject(752, Door.Constructor(Vector3(6733.419f, 2336.44f, 72.47652f)), owning_building_guid = 54)
@@ -1916,7 +1916,7 @@ object Map03 { // Cyssor
     Building7()
 
     def Building7(): Unit = { // Name: Wele Type: tech_plant GUID: 66, MapID: 7
-      LocalBuilding("Wele", 66, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(532f, 6966f, 59.89929f), tech_plant)))
+      LocalBuilding("Wele", 66, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(532f, 6966f, 59.89929f), Vector3(0f, 0f, 180f), tech_plant)))
       LocalObject(277, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 66)
       LocalObject(398, Door.Constructor(Vector3(452.98f, 6962.893f, 61.44129f)), owning_building_guid = 66)
       LocalObject(399, Door.Constructor(Vector3(452.98f, 6981.086f, 69.40429f)), owning_building_guid = 66)
@@ -2042,7 +2042,7 @@ object Map03 { // Cyssor
     Building10()
 
     def Building10(): Unit = { // Name: Leza Type: tech_plant GUID: 69, MapID: 10
-      LocalBuilding("Leza", 69, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2674f, 1440f, 63.98816f), tech_plant)))
+      LocalBuilding("Leza", 69, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2674f, 1440f, 63.98816f), Vector3(0f, 0f, 121f), tech_plant)))
       LocalObject(282, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 69)
       LocalObject(515, Door.Constructor(Vector3(2625.181f, 1460.542f, 73.49316f)), owning_building_guid = 69)
       LocalObject(516, Door.Constructor(Vector3(2630.638f, 1506.133f, 65.53016f)), owning_building_guid = 69)
@@ -2168,7 +2168,7 @@ object Map03 { // Cyssor
     Building6()
 
     def Building6(): Unit = { // Name: Faro Type: tech_plant GUID: 72, MapID: 6
-      LocalBuilding("Faro", 72, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5110f, 5790f, 56.74856f), tech_plant)))
+      LocalBuilding("Faro", 72, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5110f, 5790f, 56.74856f), Vector3(0f, 0f, 267f), tech_plant)))
       LocalObject(287, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 72)
       LocalObject(639, Door.Constructor(Vector3(5012.23f, 5835.179f, 58.36956f)), owning_building_guid = 72)
       LocalObject(641, Door.Constructor(Vector3(5018.686f, 5790.174f, 58.39956f)), owning_building_guid = 72)
@@ -2294,7 +2294,7 @@ object Map03 { // Cyssor
     Building14()
 
     def Building14(): Unit = { // Name: Orisha Type: tech_plant GUID: 75, MapID: 14
-      LocalBuilding("Orisha", 75, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6976f, 1240f, 56.97867f), tech_plant)))
+      LocalBuilding("Orisha", 75, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6976f, 1240f, 56.97867f), Vector3(0f, 0f, 84f), tech_plant)))
       LocalObject(292, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 75)
       LocalObject(767, Door.Constructor(Vector3(6946.785f, 1171.217f, 66.48367f)), owning_building_guid = 75)
       LocalObject(768, Door.Constructor(Vector3(6947.472f, 1267.693f, 58.52067f)), owning_building_guid = 75)
@@ -2420,7 +2420,7 @@ object Map03 { // Cyssor
     Building22()
 
     def Building22(): Unit = { // Name: S_Wele_Tower Type: tower_a GUID: 78, MapID: 22
-      LocalBuilding("S_Wele_Tower", 78, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(618f, 6168f, 60.51881f), tower_a)))
+      LocalBuilding("S_Wele_Tower", 78, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(618f, 6168f, 60.51881f), Vector3(0f, 0f, 17f), tower_a)))
       LocalObject(3351, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 78)
       LocalObject(429, Door.Constructor(Vector3(627.1367f, 6179.159f, 62.03981f)), owning_building_guid = 78)
       LocalObject(430, Door.Constructor(Vector3(627.1367f, 6179.159f, 82.03882f)), owning_building_guid = 78)
@@ -2457,7 +2457,7 @@ object Map03 { // Cyssor
     Building61()
 
     def Building61(): Unit = { // Name: NE_Wele_Tower Type: tower_a GUID: 79, MapID: 61
-      LocalBuilding("NE_Wele_Tower", 79, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(638f, 7206f, 62.16609f), tower_a)))
+      LocalBuilding("NE_Wele_Tower", 79, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(638f, 7206f, 62.16609f), Vector3(0f, 0f, 16f), tower_a)))
       LocalObject(3352, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 79)
       LocalObject(435, Door.Constructor(Vector3(647.33f, 7216.998f, 63.68709f)), owning_building_guid = 79)
       LocalObject(436, Door.Constructor(Vector3(647.33f, 7216.998f, 83.6861f)), owning_building_guid = 79)
@@ -2494,7 +2494,7 @@ object Map03 { // Cyssor
     Building62()
 
     def Building62(): Unit = { // Name: S_Nzame_Tower Type: tower_a GUID: 80, MapID: 62
-      LocalBuilding("S_Nzame_Tower", 80, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1432f, 2500f, 42.88556f), tower_a)))
+      LocalBuilding("S_Nzame_Tower", 80, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1432f, 2500f, 42.88556f), Vector3(0f, 0f, 334f), tower_a)))
       LocalObject(3356, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 80)
       LocalObject(482, Door.Constructor(Vector3(1439.279f, 2487.549f, 44.40656f)), owning_building_guid = 80)
       LocalObject(483, Door.Constructor(Vector3(1439.279f, 2487.549f, 64.40556f)), owning_building_guid = 80)
@@ -2531,7 +2531,7 @@ object Map03 { // Cyssor
     Building27()
 
     def Building27(): Unit = { // Name: NE_Searhus_Warpgate_Tower Type: tower_a GUID: 81, MapID: 27
-      LocalBuilding("NE_Searhus_Warpgate_Tower", 81, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1534f, 1914f, 40.9772f), tower_a)))
+      LocalBuilding("NE_Searhus_Warpgate_Tower", 81, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1534f, 1914f, 40.9772f), Vector3(0f, 0f, 350f), tower_a)))
       LocalObject(3357, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 81)
       LocalObject(491, Door.Constructor(Vector3(1544.428f, 1904.038f, 42.4982f)), owning_building_guid = 81)
       LocalObject(492, Door.Constructor(Vector3(1544.428f, 1904.038f, 62.4972f)), owning_building_guid = 81)
@@ -2568,7 +2568,7 @@ object Map03 { // Cyssor
     Building26()
 
     def Building26(): Unit = { // Name: NE_Nzame_Tower Type: tower_a GUID: 82, MapID: 26
-      LocalBuilding("NE_Nzame_Tower", 82, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1950f, 3610f, 55.32143f), tower_a)))
+      LocalBuilding("NE_Nzame_Tower", 82, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1950f, 3610f, 55.32143f), Vector3(0f, 0f, 17f), tower_a)))
       LocalObject(3358, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 82)
       LocalObject(509, Door.Constructor(Vector3(1959.137f, 3621.159f, 56.84243f)), owning_building_guid = 82)
       LocalObject(510, Door.Constructor(Vector3(1959.137f, 3621.159f, 76.84143f)), owning_building_guid = 82)
@@ -2605,7 +2605,7 @@ object Map03 { // Cyssor
     Building36()
 
     def Building36(): Unit = { // Name: SE_NCSanc_Warpgate_Tower Type: tower_a GUID: 83, MapID: 36
-      LocalBuilding("SE_NCSanc_Warpgate_Tower", 83, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2838f, 6204f, 67.4752f), tower_a)))
+      LocalBuilding("SE_NCSanc_Warpgate_Tower", 83, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2838f, 6204f, 67.4752f), Vector3(0f, 0f, 8f), tower_a)))
       LocalObject(3361, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 83)
       LocalObject(538, Door.Constructor(Vector3(2848.77f, 6213.592f, 68.99621f)), owning_building_guid = 83)
       LocalObject(539, Door.Constructor(Vector3(2848.77f, 6213.592f, 88.99521f)), owning_building_guid = 83)
@@ -2642,7 +2642,7 @@ object Map03 { // Cyssor
     Building64()
 
     def Building64(): Unit = { // Name: N_Tore_Tower Type: tower_a GUID: 84, MapID: 64
-      LocalBuilding("N_Tore_Tower", 84, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3008f, 2532f, 53.84287f), tower_a)))
+      LocalBuilding("N_Tore_Tower", 84, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3008f, 2532f, 53.84287f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(3362, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 84)
       LocalObject(556, Door.Constructor(Vector3(3020f, 2524f, 55.36387f)), owning_building_guid = 84)
       LocalObject(557, Door.Constructor(Vector3(3020f, 2524f, 75.36287f)), owning_building_guid = 84)
@@ -2679,7 +2679,7 @@ object Map03 { // Cyssor
     Building35()
 
     def Building35(): Unit = { // Name: SW_Honsi_Tower Type: tower_a GUID: 85, MapID: 35
-      LocalBuilding("SW_Honsi_Tower", 85, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3430f, 4030f, 69.08597f), tower_a)))
+      LocalBuilding("SW_Honsi_Tower", 85, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3430f, 4030f, 69.08597f), Vector3(0f, 0f, 302f), tower_a)))
       LocalObject(3363, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 85)
       LocalObject(560, Door.Constructor(Vector3(3429.575f, 4015.584f, 70.60697f)), owning_building_guid = 85)
       LocalObject(561, Door.Constructor(Vector3(3429.575f, 4015.584f, 90.60597f)), owning_building_guid = 85)
@@ -2716,7 +2716,7 @@ object Map03 { // Cyssor
     Building67()
 
     def Building67(): Unit = { // Name: S_Chuku_Tower Type: tower_a GUID: 86, MapID: 67
-      LocalBuilding("S_Chuku_Tower", 86, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4008f, 5982f, 61.10294f), tower_a)))
+      LocalBuilding("S_Chuku_Tower", 86, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4008f, 5982f, 61.10294f), Vector3(0f, 0f, 0f), tower_a)))
       LocalObject(3368, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 86)
       LocalObject(594, Door.Constructor(Vector3(4020f, 5974f, 62.62394f)), owning_building_guid = 86)
       LocalObject(595, Door.Constructor(Vector3(4020f, 5974f, 82.62294f)), owning_building_guid = 86)
@@ -2753,7 +2753,7 @@ object Map03 { // Cyssor
     Building33()
 
     def Building33(): Unit = { // Name: N_Gunuku_Tower Type: tower_a GUID: 87, MapID: 33
-      LocalBuilding("N_Gunuku_Tower", 87, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4956f, 4786f, 44.49965f), tower_a)))
+      LocalBuilding("N_Gunuku_Tower", 87, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4956f, 4786f, 44.49965f), Vector3(0f, 0f, 355f), tower_a)))
       LocalObject(3370, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 87)
       LocalObject(631, Door.Constructor(Vector3(4967.257f, 4776.984f, 46.02065f)), owning_building_guid = 87)
       LocalObject(632, Door.Constructor(Vector3(4967.257f, 4776.984f, 66.01965f)), owning_building_guid = 87)
@@ -2790,7 +2790,7 @@ object Map03 { // Cyssor
     Building38()
 
     def Building38(): Unit = { // Name: W_Ekera_Tower Type: tower_a GUID: 88, MapID: 38
-      LocalBuilding("W_Ekera_Tower", 88, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5432f, 6740f, 70.09491f), tower_a)))
+      LocalBuilding("W_Ekera_Tower", 88, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5432f, 6740f, 70.09491f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(3374, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 88)
       LocalObject(689, Door.Constructor(Vector3(5444f, 6732f, 71.61591f)), owning_building_guid = 88)
       LocalObject(690, Door.Constructor(Vector3(5444f, 6732f, 91.61491f)), owning_building_guid = 88)
@@ -2827,7 +2827,7 @@ object Map03 { // Cyssor
     Building31()
 
     def Building31(): Unit = { // Name: NW_TRSanc_Warpgate_Tower Type: tower_a GUID: 89, MapID: 31
-      LocalBuilding("NW_TRSanc_Warpgate_Tower", 89, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5580f, 2080f, 59.54527f), tower_a)))
+      LocalBuilding("NW_TRSanc_Warpgate_Tower", 89, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5580f, 2080f, 59.54527f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(3375, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 89)
       LocalObject(697, Door.Constructor(Vector3(5592f, 2072f, 61.06627f)), owning_building_guid = 89)
       LocalObject(698, Door.Constructor(Vector3(5592f, 2072f, 81.06528f)), owning_building_guid = 89)
@@ -2864,7 +2864,7 @@ object Map03 { // Cyssor
     Building43()
 
     def Building43(): Unit = { // Name: S_Kaang_Tower Type: tower_a GUID: 90, MapID: 43
-      LocalBuilding("S_Kaang_Tower", 90, 43, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5878f, 3642f, 93.63689f), tower_a)))
+      LocalBuilding("S_Kaang_Tower", 90, 43, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5878f, 3642f, 93.63689f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(3377, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 90)
       LocalObject(731, Door.Constructor(Vector3(5890f, 3634f, 95.1579f)), owning_building_guid = 90)
       LocalObject(732, Door.Constructor(Vector3(5890f, 3634f, 115.1569f)), owning_building_guid = 90)
@@ -2901,7 +2901,7 @@ object Map03 { // Cyssor
     Building41()
 
     def Building41(): Unit = { // Name: NW_Pamba_Tower Type: tower_a GUID: 91, MapID: 41
-      LocalBuilding("NW_Pamba_Tower", 91, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6626f, 3680f, 47.49107f), tower_a)))
+      LocalBuilding("NW_Pamba_Tower", 91, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6626f, 3680f, 47.49107f), Vector3(0f, 0f, 18f), tower_a)))
       LocalObject(3378, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 91)
       LocalObject(741, Door.Constructor(Vector3(6634.94f, 3691.317f, 49.01207f)), owning_building_guid = 91)
       LocalObject(742, Door.Constructor(Vector3(6634.94f, 3691.317f, 69.01108f)), owning_building_guid = 91)
@@ -2938,7 +2938,7 @@ object Map03 { // Cyssor
     Building65()
 
     def Building65(): Unit = { // Name: E_Shango_Tower Type: tower_a GUID: 92, MapID: 65
-      LocalBuilding("E_Shango_Tower", 92, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6918f, 2176f, 78.13105f), tower_a)))
+      LocalBuilding("E_Shango_Tower", 92, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6918f, 2176f, 78.13105f), Vector3(0f, 0f, 317f), tower_a)))
       LocalObject(3380, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 92)
       LocalObject(763, Door.Constructor(Vector3(6921.32f, 2161.965f, 79.65205f)), owning_building_guid = 92)
       LocalObject(764, Door.Constructor(Vector3(6921.32f, 2161.965f, 99.65105f)), owning_building_guid = 92)
@@ -2975,7 +2975,7 @@ object Map03 { // Cyssor
     Building23()
 
     def Building23(): Unit = { // Name: N_Aja_Tower Type: tower_b GUID: 93, MapID: 23
-      LocalBuilding("N_Aja_Tower", 93, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(602f, 5716f, 58.60714f), tower_b)))
+      LocalBuilding("N_Aja_Tower", 93, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(602f, 5716f, 58.60714f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3350, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 93)
       LocalObject(422, Door.Constructor(Vector3(614f, 5708f, 60.12714f)), owning_building_guid = 93)
       LocalObject(423, Door.Constructor(Vector3(614f, 5708f, 70.12714f)), owning_building_guid = 93)
@@ -3012,7 +3012,7 @@ object Map03 { // Cyssor
     Building63()
 
     def Building63(): Unit = { // Name: E_Mukuru_Tower Type: tower_b GUID: 94, MapID: 63
-      LocalBuilding("E_Mukuru_Tower", 94, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(870f, 2290f, 48.92483f), tower_b)))
+      LocalBuilding("E_Mukuru_Tower", 94, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(870f, 2290f, 48.92483f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3353, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 94)
       LocalObject(455, Door.Constructor(Vector3(882f, 2282f, 50.44483f)), owning_building_guid = 94)
       LocalObject(456, Door.Constructor(Vector3(882f, 2282f, 60.44483f)), owning_building_guid = 94)
@@ -3049,7 +3049,7 @@ object Map03 { // Cyssor
     Building28()
 
     def Building28(): Unit = { // Name: S_Leza_Tower Type: tower_b GUID: 95, MapID: 28
-      LocalBuilding("S_Leza_Tower", 95, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2778f, 1254f, 64.07666f), tower_b)))
+      LocalBuilding("S_Leza_Tower", 95, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2778f, 1254f, 64.07666f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3359, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 95)
       LocalObject(528, Door.Constructor(Vector3(2790f, 1246f, 65.59666f)), owning_building_guid = 95)
       LocalObject(529, Door.Constructor(Vector3(2790f, 1246f, 75.59666f)), owning_building_guid = 95)
@@ -3086,7 +3086,7 @@ object Map03 { // Cyssor
     Building30()
 
     def Building30(): Unit = { // Name: NE_Tore_Tower Type: tower_b GUID: 96, MapID: 30
-      LocalBuilding("NE_Tore_Tower", 96, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3580f, 3226f, 46.48213f), tower_b)))
+      LocalBuilding("NE_Tore_Tower", 96, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3580f, 3226f, 46.48213f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3364, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 96)
       LocalObject(564, Door.Constructor(Vector3(3592f, 3218f, 48.00213f)), owning_building_guid = 96)
       LocalObject(565, Door.Constructor(Vector3(3592f, 3218f, 58.00213f)), owning_building_guid = 96)
@@ -3123,7 +3123,7 @@ object Map03 { // Cyssor
     Building68()
 
     def Building68(): Unit = { // Name: N_Honsi_Tower Type: tower_b GUID: 97, MapID: 68
-      LocalBuilding("N_Honsi_Tower", 97, 68, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3970f, 4816f, 91.19419f), tower_b)))
+      LocalBuilding("N_Honsi_Tower", 97, 68, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3970f, 4816f, 91.19419f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3366, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 97)
       LocalObject(581, Door.Constructor(Vector3(3982f, 4808f, 92.71419f)), owning_building_guid = 97)
       LocalObject(582, Door.Constructor(Vector3(3982f, 4808f, 102.7142f)), owning_building_guid = 97)
@@ -3160,7 +3160,7 @@ object Map03 { // Cyssor
     Building45()
 
     def Building45(): Unit = { // Name: SW_Itan_Tower Type: tower_b GUID: 98, MapID: 45
-      LocalBuilding("SW_Itan_Tower", 98, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4846f, 3116f, 59.06708f), tower_b)))
+      LocalBuilding("SW_Itan_Tower", 98, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4846f, 3116f, 59.06708f), Vector3(0f, 0f, 331f), tower_b)))
       LocalObject(3369, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 98)
       LocalObject(614, Door.Constructor(Vector3(4852.617f, 3103.185f, 60.58708f)), owning_building_guid = 98)
       LocalObject(615, Door.Constructor(Vector3(4852.617f, 3103.185f, 70.58708f)), owning_building_guid = 98)
@@ -3197,7 +3197,7 @@ object Map03 { // Cyssor
     Building32()
 
     def Building32(): Unit = { // Name: SE_Gunuku_Tower Type: tower_b GUID: 99, MapID: 32
-      LocalBuilding("SE_Gunuku_Tower", 99, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5146f, 3968f, 50.28779f), tower_b)))
+      LocalBuilding("SE_Gunuku_Tower", 99, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5146f, 3968f, 50.28779f), Vector3(0f, 0f, 349f), tower_b)))
       LocalObject(3371, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 99)
       LocalObject(667, Door.Constructor(Vector3(5156.253f, 3957.857f, 51.80779f)), owning_building_guid = 99)
       LocalObject(668, Door.Constructor(Vector3(5156.253f, 3957.857f, 61.80779f)), owning_building_guid = 99)
@@ -3234,7 +3234,7 @@ object Map03 { // Cyssor
     Building34()
 
     def Building34(): Unit = { // Name: S_Faro_Tower Type: tower_b GUID: 100, MapID: 34
-      LocalBuilding("S_Faro_Tower", 100, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5266f, 5302f, 54.97296f), tower_b)))
+      LocalBuilding("S_Faro_Tower", 100, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5266f, 5302f, 54.97296f), Vector3(0f, 0f, 286f), tower_b)))
       LocalObject(3372, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 100)
       LocalObject(679, Door.Constructor(Vector3(5261.618f, 5288.26f, 56.49296f)), owning_building_guid = 100)
       LocalObject(680, Door.Constructor(Vector3(5261.618f, 5288.26f, 66.49296f)), owning_building_guid = 100)
@@ -3271,7 +3271,7 @@ object Map03 { // Cyssor
     Building42()
 
     def Building42(): Unit = { // Name: W_Orisha_Tower Type: tower_b GUID: 101, MapID: 42
-      LocalBuilding("W_Orisha_Tower", 101, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6660f, 1302f, 51.17282f), tower_b)))
+      LocalBuilding("W_Orisha_Tower", 101, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6660f, 1302f, 51.17282f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3379, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 101)
       LocalObject(745, Door.Constructor(Vector3(6672f, 1294f, 52.69283f)), owning_building_guid = 101)
       LocalObject(746, Door.Constructor(Vector3(6672f, 1294f, 62.69283f)), owning_building_guid = 101)
@@ -3308,7 +3308,7 @@ object Map03 { // Cyssor
     Building40()
 
     def Building40(): Unit = { // Name: SW_Solsar_Warpgate_Tower Type: tower_b GUID: 102, MapID: 40
-      LocalBuilding("SW_Solsar_Warpgate_Tower", 102, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7036f, 4998f, 54.60317f), tower_b)))
+      LocalBuilding("SW_Solsar_Warpgate_Tower", 102, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7036f, 4998f, 54.60317f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3381, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 102)
       LocalObject(777, Door.Constructor(Vector3(7048f, 4990f, 56.12317f)), owning_building_guid = 102)
       LocalObject(778, Door.Constructor(Vector3(7048f, 4990f, 66.12317f)), owning_building_guid = 102)
@@ -3345,7 +3345,7 @@ object Map03 { // Cyssor
     Building66()
 
     def Building66(): Unit = { // Name: SE_Pamba_Tower Type: tower_b GUID: 103, MapID: 66
-      LocalBuilding("SE_Pamba_Tower", 103, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7524f, 2910f, 56.98198f), tower_b)))
+      LocalBuilding("SE_Pamba_Tower", 103, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7524f, 2910f, 56.98198f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(3382, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 103)
       LocalObject(803, Door.Constructor(Vector3(7536f, 2902f, 58.50198f)), owning_building_guid = 103)
       LocalObject(804, Door.Constructor(Vector3(7536f, 2902f, 68.50198f)), owning_building_guid = 103)
@@ -3382,7 +3382,7 @@ object Map03 { // Cyssor
     Building25()
 
     def Building25(): Unit = { // Name: S_Bomazi_Tower Type: tower_c GUID: 104, MapID: 25
-      LocalBuilding("S_Bomazi_Tower", 104, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1080f, 4328f, 68.30714f), tower_c)))
+      LocalBuilding("S_Bomazi_Tower", 104, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1080f, 4328f, 68.30714f), Vector3(0f, 0f, 345f), tower_c)))
       LocalObject(3354, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 104)
       LocalObject(461, Door.Constructor(Vector3(1089.521f, 4317.167f, 69.82814f)), owning_building_guid = 104)
       LocalObject(462, Door.Constructor(Vector3(1089.521f, 4317.167f, 89.82713f)), owning_building_guid = 104)
@@ -3423,7 +3423,7 @@ object Map03 { // Cyssor
     Building24()
 
     def Building24(): Unit = { // Name: NE_Aja_Tower Type: tower_c GUID: 105, MapID: 24
-      LocalBuilding("NE_Aja_Tower", 105, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1410f, 5814f, 38.33094f), tower_c)))
+      LocalBuilding("NE_Aja_Tower", 105, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1410f, 5814f, 38.33094f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(3355, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 105)
       LocalObject(478, Door.Constructor(Vector3(1422f, 5806f, 39.85194f)), owning_building_guid = 105)
       LocalObject(479, Door.Constructor(Vector3(1422f, 5806f, 59.85094f)), owning_building_guid = 105)
@@ -3464,7 +3464,7 @@ object Map03 { // Cyssor
     Building69()
 
     def Building69(): Unit = { // Name: Outpost_Tower Type: tower_c GUID: 106, MapID: 69
-      LocalBuilding("Outpost_Tower", 106, 69, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2830f, 4342f, 89.42412f), tower_c)))
+      LocalBuilding("Outpost_Tower", 106, 69, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2830f, 4342f, 89.42412f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(3360, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 106)
       LocalObject(534, Door.Constructor(Vector3(2842f, 4334f, 90.94512f)), owning_building_guid = 106)
       LocalObject(535, Door.Constructor(Vector3(2842f, 4334f, 110.9441f)), owning_building_guid = 106)
@@ -3505,7 +3505,7 @@ object Map03 { // Cyssor
     Building29()
 
     def Building29(): Unit = { // Name: SE_Tore_Tower Type: tower_c GUID: 107, MapID: 29
-      LocalBuilding("SE_Tore_Tower", 107, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3730f, 1642f, 46.48213f), tower_c)))
+      LocalBuilding("SE_Tore_Tower", 107, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3730f, 1642f, 46.48213f), Vector3(0f, 0f, 38f), tower_c)))
       LocalObject(3365, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 107)
       LocalObject(570, Door.Constructor(Vector3(3734.531f, 1655.692f, 48.00313f)), owning_building_guid = 107)
       LocalObject(571, Door.Constructor(Vector3(3734.531f, 1655.692f, 68.00214f)), owning_building_guid = 107)
@@ -3546,7 +3546,7 @@ object Map03 { // Cyssor
     Building37()
 
     def Building37(): Unit = { // Name: W_Chuku_Tower Type: tower_c GUID: 108, MapID: 37
-      LocalBuilding("W_Chuku_Tower", 108, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3978f, 7028f, 49.14362f), tower_c)))
+      LocalBuilding("W_Chuku_Tower", 108, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3978f, 7028f, 49.14362f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(3367, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 108)
       LocalObject(587, Door.Constructor(Vector3(3990f, 7020f, 50.66462f)), owning_building_guid = 108)
       LocalObject(588, Door.Constructor(Vector3(3990f, 7020f, 70.66362f)), owning_building_guid = 108)
@@ -3587,7 +3587,7 @@ object Map03 { // Cyssor
     Building39()
 
     def Building39(): Unit = { // Name: E_Faro_Tower Type: tower_c GUID: 109, MapID: 39
-      LocalBuilding("E_Faro_Tower", 109, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5340f, 5834f, 72.75002f), tower_c)))
+      LocalBuilding("E_Faro_Tower", 109, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5340f, 5834f, 72.75002f), Vector3(0f, 0f, 331f), tower_c)))
       LocalObject(3373, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 109)
       LocalObject(685, Door.Constructor(Vector3(5346.617f, 5821.186f, 74.27103f)), owning_building_guid = 109)
       LocalObject(686, Door.Constructor(Vector3(5346.617f, 5821.186f, 94.27002f)), owning_building_guid = 109)
@@ -3628,7 +3628,7 @@ object Map03 { // Cyssor
     Building44()
 
     def Building44(): Unit = { // Name: N_Kanng_Tower Type: tower_c GUID: 110, MapID: 44
-      LocalBuilding("N_Kanng_Tower", 110, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5688f, 4896f, 46.99545f), tower_c)))
+      LocalBuilding("N_Kanng_Tower", 110, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5688f, 4896f, 46.99545f), Vector3(0f, 0f, 339f), tower_c)))
       LocalObject(3376, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 110)
       LocalObject(712, Door.Constructor(Vector3(5696.336f, 4884.231f, 48.51645f)), owning_building_guid = 110)
       LocalObject(713, Door.Constructor(Vector3(5696.336f, 4884.231f, 68.51546f)), owning_building_guid = 110)

--- a/pslogin/src/main/scala/zonemaps/Map04.scala
+++ b/pslogin/src/main/scala/zonemaps/Map04.scala
@@ -23,7 +23,7 @@ object Map04 { // Ishundar
     Building8()
 
     def Building8(): Unit = { // Name: Enkidu Type: amp_station GUID: 1, MapID: 8
-      LocalBuilding("Enkidu", 1, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3318f, 3574f, 37.19054f), amp_station)))
+      LocalBuilding("Enkidu", 1, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3318f, 3574f, 37.19054f), Vector3(0f, 0f, 134f), amp_station)))
       LocalObject(222, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(180, Door.Constructor(Vector3(3312.956f, 3569.427f, 50.09254f)), owning_building_guid = 1)
       LocalObject(181, Door.Constructor(Vector3(3322.749f, 3578.879f, 50.09254f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map04 { // Ishundar
     Building51()
 
     def Building51(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 51
-      LocalBuilding("bunker_gauntlet", 4, 51, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(966f, 5404f, 72.35047f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 51, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(966f, 5404f, 72.35047f), Vector3(0f, 0f, 180f), bunker_gauntlet)))
       LocalObject(320, Door.Constructor(Vector3(941.077f, 5405.901f, 73.87148f)), owning_building_guid = 4)
       LocalObject(324, Door.Constructor(Vector3(990.898f, 5405.912f, 73.87148f)), owning_building_guid = 4)
     }
@@ -159,7 +159,7 @@ object Map04 { // Ishundar
     Building54()
 
     def Building54(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 54
-      LocalBuilding("bunker_gauntlet", 5, 54, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2830f, 4464f, 39.29373f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 54, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2830f, 4464f, 39.29373f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(402, Door.Constructor(Vector3(2828.099f, 4439.077f, 40.81473f)), owning_building_guid = 5)
       LocalObject(403, Door.Constructor(Vector3(2828.088f, 4488.898f, 40.81473f)), owning_building_guid = 5)
     }
@@ -167,7 +167,7 @@ object Map04 { // Ishundar
     Building50()
 
     def Building50(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 50
-      LocalBuilding("bunker_gauntlet", 6, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3212f, 2186f, 70.5193f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3212f, 2186f, 70.5193f), Vector3(0f, 0f, 225f), bunker_gauntlet)))
       LocalObject(427, Door.Constructor(Vector3(3193.032f, 2169.721f, 72.04031f)), owning_building_guid = 6)
       LocalObject(432, Door.Constructor(Vector3(3228.254f, 2204.958f, 72.04031f)), owning_building_guid = 6)
     }
@@ -175,7 +175,7 @@ object Map04 { // Ishundar
     Building52()
 
     def Building52(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 52
-      LocalBuilding("bunker_gauntlet", 7, 52, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4288f, 5822f, 77.53156f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 52, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4288f, 5822f, 77.53156f), Vector3(0f, 0f, 134f), bunker_gauntlet)))
       LocalObject(513, Door.Constructor(Vector3(4272.055f, 5841.249f, 79.05257f)), owning_building_guid = 7)
       LocalObject(514, Door.Constructor(Vector3(4306.671f, 5805.418f, 79.05257f)), owning_building_guid = 7)
     }
@@ -183,7 +183,7 @@ object Map04 { // Ishundar
     Building53()
 
     def Building53(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 8, MapID: 53
-      LocalBuilding("bunker_gauntlet", 8, 53, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(7108f, 5242f, 37.86362f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 8, 53, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(7108f, 5242f, 37.86362f), Vector3(0f, 0f, 225f), bunker_gauntlet)))
       LocalObject(648, Door.Constructor(Vector3(7089.033f, 5225.721f, 39.38462f)), owning_building_guid = 8)
       LocalObject(650, Door.Constructor(Vector3(7124.253f, 5260.958f, 39.38462f)), owning_building_guid = 8)
     }
@@ -191,70 +191,70 @@ object Map04 { // Ishundar
     Building42()
 
     def Building42(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 42
-      LocalBuilding("bunker_lg", 9, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1740f, 5472f, 34.41663f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1740f, 5472f, 34.41663f), Vector3(0f, 0f, 44f), bunker_lg)))
       LocalObject(355, Door.Constructor(Vector3(1740.098f, 5475.649f, 35.93763f)), owning_building_guid = 9)
     }
 
     Building43()
 
     def Building43(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 43
-      LocalBuilding("bunker_lg", 10, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2642f, 4548f, 44.8345f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2642f, 4548f, 44.8345f), Vector3(0f, 0f, 180f), bunker_lg)))
       LocalObject(380, Door.Constructor(Vector3(2639.394f, 4545.443f, 46.3555f)), owning_building_guid = 10)
     }
 
     Building45()
 
     def Building45(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 11, MapID: 45
-      LocalBuilding("bunker_lg", 11, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4034f, 2330f, 70.24219f), bunker_lg)))
+      LocalBuilding("bunker_lg", 11, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4034f, 2330f, 70.24219f), Vector3(0f, 0f, 45f), bunker_lg)))
       LocalObject(494, Door.Constructor(Vector3(4034.035f, 2333.651f, 71.76319f)), owning_building_guid = 11)
     }
 
     Building48()
 
     def Building48(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 12, MapID: 48
-      LocalBuilding("bunker_lg", 12, 48, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4740f, 2346f, 86.66288f), bunker_lg)))
+      LocalBuilding("bunker_lg", 12, 48, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4740f, 2346f, 86.66288f), Vector3(0f, 0f, 180f), bunker_lg)))
       LocalObject(557, Door.Constructor(Vector3(4737.394f, 2343.443f, 88.18388f)), owning_building_guid = 12)
     }
 
     Building64()
 
     def Building64(): Unit = { // Name: Dagon_Tower Type: bunker_sm GUID: 13, MapID: 64
-      LocalBuilding("Dagon_Tower", 13, 64, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1972f, 5528f, 39.54084f), bunker_sm)))
+      LocalBuilding("Dagon_Tower", 13, 64, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1972f, 5528f, 39.54084f), Vector3(0f, 0f, 90f), bunker_sm)))
       LocalObject(369, Door.Constructor(Vector3(1972.055f, 5529.225f, 41.06184f)), owning_building_guid = 13)
     }
 
     Building46()
 
     def Building46(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 46
-      LocalBuilding("bunker_sm", 14, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3472f, 5470f, 76.47643f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3472f, 5470f, 76.47643f), Vector3(0f, 0f, 360f), bunker_sm)))
       LocalObject(464, Door.Constructor(Vector3(3473.225f, 5469.945f, 77.99744f)), owning_building_guid = 14)
     }
 
     Building44()
 
     def Building44(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 15, MapID: 44
-      LocalBuilding("bunker_sm", 15, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3540f, 3566f, 28.99432f), bunker_sm)))
+      LocalBuilding("bunker_sm", 15, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3540f, 3566f, 28.99432f), Vector3(0f, 0f, 224f), bunker_sm)))
       LocalObject(465, Door.Constructor(Vector3(3539.081f, 3565.189f, 30.51532f)), owning_building_guid = 15)
     }
 
     Building47()
 
     def Building47(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 47
-      LocalBuilding("bunker_sm", 16, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4932f, 5166f, 78.77888f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 47, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4932f, 5166f, 78.77888f), Vector3(0f, 0f, 135f), bunker_sm)))
       LocalObject(585, Door.Constructor(Vector3(4931.173f, 5166.905f, 80.29988f)), owning_building_guid = 16)
     }
 
     Building49()
 
     def Building49(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 17, MapID: 49
-      LocalBuilding("bunker_sm", 17, 49, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6394f, 4556f, 41.16785f), bunker_sm)))
+      LocalBuilding("bunker_sm", 17, 49, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6394f, 4556f, 41.16785f), Vector3(0f, 0f, 45f), bunker_sm)))
       LocalObject(612, Door.Constructor(Vector3(6394.905f, 4556.827f, 42.68885f)), owning_building_guid = 17)
     }
 
     Building15()
 
     def Building15(): Unit = { // Name: Neti Type: comm_station GUID: 18, MapID: 15
-      LocalBuilding("Neti", 18, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3990f, 2502f, 79.94147f), comm_station)))
+      LocalBuilding("Neti", 18, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3990f, 2502f, 79.94147f), Vector3(0f, 0f, 310f), comm_station)))
       LocalObject(224, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 18)
       LocalObject(485, Door.Constructor(Vector3(3910.617f, 2491.122f, 89.65648f)), owning_building_guid = 18)
       LocalObject(486, Door.Constructor(Vector3(3918.236f, 2519.851f, 81.69247f)), owning_building_guid = 18)
@@ -373,7 +373,7 @@ object Map04 { // Ishundar
     Building11()
 
     def Building11(): Unit = { // Name: Irkalla Type: comm_station GUID: 21, MapID: 11
-      LocalBuilding("Irkalla", 21, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4826f, 5252f, 65.77693f), comm_station)))
+      LocalBuilding("Irkalla", 21, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4826f, 5252f, 65.77693f), Vector3(0f, 0f, 223f), comm_station)))
       LocalObject(227, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 21)
       LocalObject(562, Door.Constructor(Vector3(4774.679f, 5218.763f, 75.49193f)), owning_building_guid = 21)
       LocalObject(563, Door.Constructor(Vector3(4787.087f, 5205.458f, 67.52793f)), owning_building_guid = 21)
@@ -492,7 +492,7 @@ object Map04 { // Ishundar
     Building5()
 
     def Building5(): Unit = { // Name: Akkan Type: comm_station_dsp GUID: 24, MapID: 5
-      LocalBuilding("Akkan", 24, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2694f, 4324f, 39.29922f), comm_station_dsp)))
+      LocalBuilding("Akkan", 24, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2694f, 4324f, 39.29922f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(220, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 24)
       LocalObject(281, Door.Constructor(Vector3(2762.339f, 4394.464f, 42.67722f)), owning_building_guid = 24)
       LocalObject(378, Door.Constructor(Vector3(2634.196f, 4280.501f, 40.95023f)), owning_building_guid = 24)
@@ -633,7 +633,7 @@ object Map04 { // Ishundar
     Building7()
 
     def Building7(): Unit = { // Name: Dagon Type: cryo_facility GUID: 27, MapID: 7
-      LocalBuilding("Dagon", 27, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1784f, 5738f, 39.73853f), cryo_facility)))
+      LocalBuilding("Dagon", 27, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1784f, 5738f, 39.73853f), Vector3(0f, 0f, 178f), cryo_facility)))
       LocalObject(219, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 27)
       LocalObject(353, Door.Constructor(Vector3(1734.238f, 5772.257f, 41.28953f)), owning_building_guid = 27)
       LocalObject(354, Door.Constructor(Vector3(1734.873f, 5790.439f, 49.25353f)), owning_building_guid = 27)
@@ -781,7 +781,7 @@ object Map04 { // Ishundar
     Building10()
 
     def Building10(): Unit = { // Name: Hanish Type: cryo_facility GUID: 30, MapID: 10
-      LocalBuilding("Hanish", 30, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3738f, 5482f, 88.62722f), cryo_facility)))
+      LocalBuilding("Hanish", 30, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3738f, 5482f, 88.62722f), Vector3(0f, 0f, 269f), cryo_facility)))
       LocalObject(223, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 30)
       LocalObject(470, Door.Constructor(Vector3(3645.456f, 5451.61f, 90.14822f)), owning_building_guid = 30)
       LocalObject(471, Door.Constructor(Vector3(3654.676f, 5459.951f, 90.17822f)), owning_building_guid = 30)
@@ -929,7 +929,7 @@ object Map04 { // Ishundar
     Building16()
 
     def Building16(): Unit = { // Name: Zaqar Type: cryo_facility GUID: 33, MapID: 16
-      LocalBuilding("Zaqar", 33, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4740f, 2128f, 74.54427f), cryo_facility)))
+      LocalBuilding("Zaqar", 33, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4740f, 2128f, 74.54427f), Vector3(0f, 0f, 359f), cryo_facility)))
       LocalObject(226, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 33)
       LocalObject(552, Door.Constructor(Vector3(4681.11f, 2133.529f, 76.09527f)), owning_building_guid = 33)
       LocalObject(553, Door.Constructor(Vector3(4681.428f, 2151.719f, 84.05927f)), owning_building_guid = 33)
@@ -1077,7 +1077,7 @@ object Map04 { // Ishundar
     Building13()
 
     def Building13(): Unit = { // Name: Lahar Type: cryo_facility GUID: 36, MapID: 13
-      LocalBuilding("Lahar", 36, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(7044f, 5314f, 37.85578f), cryo_facility)))
+      LocalBuilding("Lahar", 36, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(7044f, 5314f, 37.85578f), Vector3(0f, 0f, 136f), cryo_facility)))
       LocalObject(229, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 36)
       LocalObject(634, Door.Constructor(Vector3(7014.26f, 5248.462f, 47.37078f)), owning_building_guid = 36)
       LocalObject(635, Door.Constructor(Vector3(7027.347f, 5235.825f, 39.40678f)), owning_building_guid = 36)
@@ -1237,7 +1237,7 @@ object Map04 { // Ishundar
     Building6()
 
     def Building6(): Unit = { // Name: Baal Type: tech_plant GUID: 42, MapID: 6
-      LocalBuilding("Baal", 42, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(942f, 5484f, 72.354f), tech_plant)))
+      LocalBuilding("Baal", 42, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(942f, 5484f, 72.354f), Vector3(0f, 0f, 225f), tech_plant)))
       LocalObject(218, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 42)
       LocalObject(312, Door.Constructor(Vector3(874.2571f, 5545.23f, 74.005f)), owning_building_guid = 42)
       LocalObject(313, Door.Constructor(Vector3(875.457f, 5438.792f, 81.85899f)), owning_building_guid = 42)
@@ -1363,7 +1363,7 @@ object Map04 { // Ishundar
     Building14()
 
     def Building14(): Unit = { // Name: Marduk Type: tech_plant GUID: 45, MapID: 14
-      LocalBuilding("Marduk", 45, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3136f, 2234f, 70.51518f), tech_plant)))
+      LocalBuilding("Marduk", 45, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3136f, 2234f, 70.51518f), Vector3(0f, 0f, 269f), tech_plant)))
       LocalObject(221, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 45)
       LocalObject(408, Door.Constructor(Vector3(3036.713f, 2275.739f, 72.13618f)), owning_building_guid = 45)
       LocalObject(409, Door.Constructor(Vector3(3044.736f, 2230.987f, 72.16618f)), owning_building_guid = 45)
@@ -1489,7 +1489,7 @@ object Map04 { // Ishundar
     Building9()
 
     def Building9(): Unit = { // Name: Girru Type: tech_plant GUID: 48, MapID: 9
-      LocalBuilding("Girru", 48, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4386f, 5932f, 77.53156f), tech_plant)))
+      LocalBuilding("Girru", 48, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4386f, 5932f, 77.53156f), Vector3(0f, 0f, 358f), tech_plant)))
       LocalObject(225, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 48)
       LocalObject(515, Door.Constructor(Vector3(4312.138f, 5864.466f, 79.07355f)), owning_building_guid = 48)
       LocalObject(516, Door.Constructor(Vector3(4312.773f, 5882.646f, 87.03655f)), owning_building_guid = 48)
@@ -1615,7 +1615,7 @@ object Map04 { // Ishundar
     Building12()
 
     def Building12(): Unit = { // Name: Kusag Type: tech_plant GUID: 51, MapID: 12
-      LocalBuilding("Kusag", 51, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6560f, 4574f, 45.59388f), tech_plant)))
+      LocalBuilding("Kusag", 51, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6560f, 4574f, 45.59388f), Vector3(0f, 0f, 141f), tech_plant)))
       LocalObject(228, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 51)
       LocalObject(617, Door.Constructor(Vector3(6496.635f, 4621.314f, 47.13588f)), owning_building_guid = 51)
       LocalObject(618, Door.Constructor(Vector3(6507.099f, 4576.606f, 55.09888f)), owning_building_guid = 51)
@@ -1741,7 +1741,7 @@ object Map04 { // Ishundar
     Building38()
 
     def Building38(): Unit = { // Name: NE_Baal_Tower Type: tower_a GUID: 54, MapID: 38
-      LocalBuilding("NE_Baal_Tower", 54, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1138f, 5212f, 91.18148f), tower_a)))
+      LocalBuilding("NE_Baal_Tower", 54, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1138f, 5212f, 91.18148f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2769, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(327, Door.Constructor(Vector3(1150f, 5204f, 92.70248f)), owning_building_guid = 54)
       LocalObject(328, Door.Constructor(Vector3(1150f, 5204f, 112.7015f)), owning_building_guid = 54)
@@ -1778,7 +1778,7 @@ object Map04 { // Ishundar
     Building37()
 
     def Building37(): Unit = { // Name: E_Dagon_Tower Type: tower_a GUID: 55, MapID: 37
-      LocalBuilding("E_Dagon_Tower", 55, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1904f, 6034f, 43.95589f), tower_a)))
+      LocalBuilding("E_Dagon_Tower", 55, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1904f, 6034f, 43.95589f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2774, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(365, Door.Constructor(Vector3(1916f, 6026f, 45.47689f)), owning_building_guid = 55)
       LocalObject(366, Door.Constructor(Vector3(1916f, 6026f, 65.47589f)), owning_building_guid = 55)
@@ -1815,7 +1815,7 @@ object Map04 { // Ishundar
     Building65()
 
     def Building65(): Unit = { // Name: W_Hanish_Tower Type: tower_a GUID: 56, MapID: 65
-      LocalBuilding("W_Hanish_Tower", 56, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2992f, 5714f, 55.85485f), tower_a)))
+      LocalBuilding("W_Hanish_Tower", 56, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2992f, 5714f, 55.85485f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2778, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(404, Door.Constructor(Vector3(3004f, 5706f, 57.37585f)), owning_building_guid = 56)
       LocalObject(405, Door.Constructor(Vector3(3004f, 5706f, 77.37485f)), owning_building_guid = 56)
@@ -1852,7 +1852,7 @@ object Map04 { // Ishundar
     Building17()
 
     def Building17(): Unit = { // Name: S_Marduk_Tower Type: tower_a GUID: 57, MapID: 17
-      LocalBuilding("S_Marduk_Tower", 57, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3212f, 1592f, 50.06226f), tower_a)))
+      LocalBuilding("S_Marduk_Tower", 57, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3212f, 1592f, 50.06226f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2780, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(428, Door.Constructor(Vector3(3224f, 1584f, 51.58326f)), owning_building_guid = 57)
       LocalObject(429, Door.Constructor(Vector3(3224f, 1584f, 71.58226f)), owning_building_guid = 57)
@@ -1889,7 +1889,7 @@ object Map04 { // Ishundar
     Building29()
 
     def Building29(): Unit = { // Name: SE_Akkan_Tower Type: tower_a GUID: 58, MapID: 29
-      LocalBuilding("SE_Akkan_Tower", 58, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3254f, 3908f, 28.96921f), tower_a)))
+      LocalBuilding("SE_Akkan_Tower", 58, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3254f, 3908f, 28.96921f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2782, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(438, Door.Constructor(Vector3(3266f, 3900f, 30.49021f)), owning_building_guid = 58)
       LocalObject(439, Door.Constructor(Vector3(3266f, 3900f, 50.48921f)), owning_building_guid = 58)
@@ -1926,7 +1926,7 @@ object Map04 { // Ishundar
     Building18()
 
     def Building18(): Unit = { // Name: W_Neti_Tower Type: tower_a GUID: 59, MapID: 18
-      LocalBuilding("W_Neti_Tower", 59, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4252f, 2648f, 108.6534f), tower_a)))
+      LocalBuilding("W_Neti_Tower", 59, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4252f, 2648f, 108.6534f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2788, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(509, Door.Constructor(Vector3(4264f, 2640f, 110.1744f)), owning_building_guid = 59)
       LocalObject(510, Door.Constructor(Vector3(4264f, 2640f, 130.1734f)), owning_building_guid = 59)
@@ -1963,7 +1963,7 @@ object Map04 { // Ishundar
     Building34()
 
     def Building34(): Unit = { // Name: SE_Hanish_Tower Type: tower_a GUID: 60, MapID: 34
-      LocalBuilding("SE_Hanish_Tower", 60, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4412f, 4858f, 85.94116f), tower_a)))
+      LocalBuilding("SE_Hanish_Tower", 60, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4412f, 4858f, 85.94116f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2789, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(525, Door.Constructor(Vector3(4424f, 4850f, 87.46217f)), owning_building_guid = 60)
       LocalObject(526, Door.Constructor(Vector3(4424f, 4850f, 107.4612f)), owning_building_guid = 60)
@@ -2000,7 +2000,7 @@ object Map04 { // Ishundar
     Building19()
 
     def Building19(): Unit = { // Name: W_Zaqar_Tower Type: tower_a GUID: 61, MapID: 19
-      LocalBuilding("W_Zaqar_Tower", 61, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4598f, 1928f, 71.5507f), tower_a)))
+      LocalBuilding("W_Zaqar_Tower", 61, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4598f, 1928f, 71.5507f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2791, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(538, Door.Constructor(Vector3(4610f, 1920f, 73.0717f)), owning_building_guid = 61)
       LocalObject(539, Door.Constructor(Vector3(4610f, 1920f, 93.07069f)), owning_building_guid = 61)
@@ -2037,7 +2037,7 @@ object Map04 { // Ishundar
     Building33()
 
     def Building33(): Unit = { // Name: E_Girru_Tower Type: tower_a GUID: 62, MapID: 33
-      LocalBuilding("E_Girru_Tower", 62, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4614f, 5918f, 55.49086f), tower_a)))
+      LocalBuilding("E_Girru_Tower", 62, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4614f, 5918f, 55.49086f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2792, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(542, Door.Constructor(Vector3(4626f, 5910f, 57.01186f)), owning_building_guid = 62)
       LocalObject(543, Door.Constructor(Vector3(4626f, 5910f, 77.01086f)), owning_building_guid = 62)
@@ -2074,7 +2074,7 @@ object Map04 { // Ishundar
     Building26()
 
     def Building26(): Unit = { // Name: SE_Irkalla_Tower Type: tower_a GUID: 63, MapID: 26
-      LocalBuilding("SE_Irkalla_Tower", 63, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5828f, 3676f, 68.67637f), tower_a)))
+      LocalBuilding("SE_Irkalla_Tower", 63, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5828f, 3676f, 68.67637f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2799, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(602, Door.Constructor(Vector3(5840f, 3668f, 70.19737f)), owning_building_guid = 63)
       LocalObject(603, Door.Constructor(Vector3(5840f, 3668f, 90.19637f)), owning_building_guid = 63)
@@ -2111,7 +2111,7 @@ object Map04 { // Ishundar
     Building23()
 
     def Building23(): Unit = { // Name: S_Kusag_Tower Type: tower_a GUID: 64, MapID: 23
-      LocalBuilding("S_Kusag_Tower", 64, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6422f, 3936f, 51.51198f), tower_a)))
+      LocalBuilding("S_Kusag_Tower", 64, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6422f, 3936f, 51.51198f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2801, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(613, Door.Constructor(Vector3(6434f, 3928f, 53.03298f)), owning_building_guid = 64)
       LocalObject(614, Door.Constructor(Vector3(6434f, 3928f, 73.03198f)), owning_building_guid = 64)
@@ -2148,7 +2148,7 @@ object Map04 { // Ishundar
     Building58()
 
     def Building58(): Unit = { // Name: Lahar_Tower Type: tower_a GUID: 65, MapID: 58
-      LocalBuilding("Lahar_Tower", 65, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6928f, 5100f, 54.45535f), tower_a)))
+      LocalBuilding("Lahar_Tower", 65, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6928f, 5100f, 54.45535f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2802, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(630, Door.Constructor(Vector3(6940f, 5092f, 55.97635f)), owning_building_guid = 65)
       LocalObject(631, Door.Constructor(Vector3(6940f, 5092f, 75.97534f)), owning_building_guid = 65)
@@ -2185,7 +2185,7 @@ object Map04 { // Ishundar
     Building32()
 
     def Building32(): Unit = { // Name: N_Searhus_Warpgate_Tower Type: tower_b GUID: 66, MapID: 32
-      LocalBuilding("N_Searhus_Warpgate_Tower", 66, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1210f, 3966f, 43.99354f), tower_b)))
+      LocalBuilding("N_Searhus_Warpgate_Tower", 66, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1210f, 3966f, 43.99354f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2770, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(331, Door.Constructor(Vector3(1222f, 3958f, 45.51354f)), owning_building_guid = 66)
       LocalObject(332, Door.Constructor(Vector3(1222f, 3958f, 55.51354f)), owning_building_guid = 66)
@@ -2222,7 +2222,7 @@ object Map04 { // Ishundar
     Building39()
 
     def Building39(): Unit = { // Name: SE_Baal_Tower Type: tower_b GUID: 67, MapID: 39
-      LocalBuilding("SE_Baal_Tower", 67, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1548f, 4666f, 89.42425f), tower_b)))
+      LocalBuilding("SE_Baal_Tower", 67, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1548f, 4666f, 89.42425f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2772, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(341, Door.Constructor(Vector3(1560f, 4658f, 90.94424f)), owning_building_guid = 67)
       LocalObject(342, Door.Constructor(Vector3(1560f, 4658f, 100.9442f)), owning_building_guid = 67)
@@ -2259,7 +2259,7 @@ object Map04 { // Ishundar
     Building31()
 
     def Building31(): Unit = { // Name: E_Searhus_Warpgate_Tower Type: tower_b GUID: 68, MapID: 31
-      LocalBuilding("E_Searhus_Warpgate_Tower", 68, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1558f, 2872f, 31.19086f), tower_b)))
+      LocalBuilding("E_Searhus_Warpgate_Tower", 68, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1558f, 2872f, 31.19086f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2773, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(347, Door.Constructor(Vector3(1570f, 2864f, 32.71085f)), owning_building_guid = 68)
       LocalObject(348, Door.Constructor(Vector3(1570f, 2864f, 42.71085f)), owning_building_guid = 68)
@@ -2296,7 +2296,7 @@ object Map04 { // Ishundar
     Building35()
 
     def Building35(): Unit = { // Name: SW_Hanish_Tower Type: tower_b GUID: 69, MapID: 35
-      LocalBuilding("SW_Hanish_Tower", 69, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3086f, 5040f, 81.67988f), tower_b)))
+      LocalBuilding("SW_Hanish_Tower", 69, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3086f, 5040f, 81.67988f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2779, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(414, Door.Constructor(Vector3(3098f, 5032f, 83.19987f)), owning_building_guid = 69)
       LocalObject(415, Door.Constructor(Vector3(3098f, 5032f, 93.19987f)), owning_building_guid = 69)
@@ -2333,7 +2333,7 @@ object Map04 { // Ishundar
     Building28()
 
     def Building28(): Unit = { // Name: NE_Enkidu_Tower Type: tower_b GUID: 70, MapID: 28
-      LocalBuilding("NE_Enkidu_Tower", 70, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3410f, 4294f, 30.17417f), tower_b)))
+      LocalBuilding("NE_Enkidu_Tower", 70, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3410f, 4294f, 30.17417f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2783, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(458, Door.Constructor(Vector3(3422f, 4286f, 31.69417f)), owning_building_guid = 70)
       LocalObject(459, Door.Constructor(Vector3(3422f, 4286f, 41.69417f)), owning_building_guid = 70)
@@ -2370,7 +2370,7 @@ object Map04 { // Ishundar
     Building21()
 
     def Building21(): Unit = { // Name: NE_Neti_Tower Type: tower_b GUID: 71, MapID: 21
-      LocalBuilding("NE_Neti_Tower", 71, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4162f, 3218f, 95.02856f), tower_b)))
+      LocalBuilding("NE_Neti_Tower", 71, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4162f, 3218f, 95.02856f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2787, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(503, Door.Constructor(Vector3(4174f, 3210f, 96.54855f)), owning_building_guid = 71)
       LocalObject(504, Door.Constructor(Vector3(4174f, 3210f, 106.5486f)), owning_building_guid = 71)
@@ -2407,7 +2407,7 @@ object Map04 { // Ishundar
     Building27()
 
     def Building27(): Unit = { // Name: S_Irkalla_Tower Type: tower_b GUID: 72, MapID: 27
-      LocalBuilding("S_Irkalla_Tower", 72, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4414f, 4176f, 63.80005f), tower_b)))
+      LocalBuilding("S_Irkalla_Tower", 72, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4414f, 4176f, 63.80005f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2790, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(529, Door.Constructor(Vector3(4426f, 4168f, 65.32005f)), owning_building_guid = 72)
       LocalObject(530, Door.Constructor(Vector3(4426f, 4168f, 75.32005f)), owning_building_guid = 72)
@@ -2444,7 +2444,7 @@ object Map04 { // Ishundar
     Building59()
 
     def Building59(): Unit = { // Name: VSSanc_Warpgate_Tower Type: tower_b GUID: 73, MapID: 59
-      LocalBuilding("VSSanc_Warpgate_Tower", 73, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4658f, 6628f, 42.60658f), tower_b)))
+      LocalBuilding("VSSanc_Warpgate_Tower", 73, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4658f, 6628f, 42.60658f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2793, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(546, Door.Constructor(Vector3(4670f, 6620f, 44.12658f)), owning_building_guid = 73)
       LocalObject(547, Door.Constructor(Vector3(4670f, 6620f, 54.12658f)), owning_building_guid = 73)
@@ -2481,7 +2481,7 @@ object Map04 { // Ishundar
     Building25()
 
     def Building25(): Unit = { // Name: N_Ceryshen_Warpgate_Tower Type: tower_b GUID: 74, MapID: 25
-      LocalBuilding("N_Ceryshen_Warpgate_Tower", 74, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5394f, 4228f, 38.99171f), tower_b)))
+      LocalBuilding("N_Ceryshen_Warpgate_Tower", 74, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5394f, 4228f, 38.99171f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2797, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 74)
       LocalObject(590, Door.Constructor(Vector3(5406f, 4220f, 40.51171f)), owning_building_guid = 74)
       LocalObject(591, Door.Constructor(Vector3(5406f, 4220f, 50.51171f)), owning_building_guid = 74)
@@ -2518,7 +2518,7 @@ object Map04 { // Ishundar
     Building22()
 
     def Building22(): Unit = { // Name: SE_Ceryshen_Warpgate_Tower Type: tower_b GUID: 75, MapID: 22
-      LocalBuilding("SE_Ceryshen_Warpgate_Tower", 75, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5814f, 2996f, 41.7468f), tower_b)))
+      LocalBuilding("SE_Ceryshen_Warpgate_Tower", 75, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5814f, 2996f, 41.7468f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2798, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 75)
       LocalObject(596, Door.Constructor(Vector3(5826f, 2988f, 43.2668f)), owning_building_guid = 75)
       LocalObject(597, Door.Constructor(Vector3(5826f, 2988f, 53.2668f)), owning_building_guid = 75)
@@ -2555,7 +2555,7 @@ object Map04 { // Ishundar
     Building24()
 
     def Building24(): Unit = { // Name: NW_Kusag_Tower Type: tower_b GUID: 76, MapID: 24
-      LocalBuilding("NW_Kusag_Tower", 76, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6348f, 4802f, 38.76578f), tower_b)))
+      LocalBuilding("NW_Kusag_Tower", 76, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6348f, 4802f, 38.76578f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2800, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 76)
       LocalObject(606, Door.Constructor(Vector3(6360f, 4794f, 40.28578f)), owning_building_guid = 76)
       LocalObject(607, Door.Constructor(Vector3(6360f, 4794f, 50.28578f)), owning_building_guid = 76)
@@ -2592,7 +2592,7 @@ object Map04 { // Ishundar
     Building63()
 
     def Building63(): Unit = { // Name: NW_Dagon_Tower Type: tower_c GUID: 77, MapID: 63
-      LocalBuilding("NW_Dagon_Tower", 77, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1302f, 6050f, 44.72154f), tower_c)))
+      LocalBuilding("NW_Dagon_Tower", 77, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1302f, 6050f, 44.72154f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2771, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 77)
       LocalObject(337, Door.Constructor(Vector3(1314f, 6042f, 46.24254f)), owning_building_guid = 77)
       LocalObject(338, Door.Constructor(Vector3(1314f, 6042f, 66.24154f)), owning_building_guid = 77)
@@ -2633,7 +2633,7 @@ object Map04 { // Ishundar
     Building40()
 
     def Building40(): Unit = { // Name: S_Dagon_Tower Type: tower_c GUID: 78, MapID: 40
-      LocalBuilding("S_Dagon_Tower", 78, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2228f, 5158f, 46.85532f), tower_c)))
+      LocalBuilding("S_Dagon_Tower", 78, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2228f, 5158f, 46.85532f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2775, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 78)
       LocalObject(370, Door.Constructor(Vector3(2240f, 5150f, 48.37632f)), owning_building_guid = 78)
       LocalObject(371, Door.Constructor(Vector3(2240f, 5150f, 68.37532f)), owning_building_guid = 78)
@@ -2674,7 +2674,7 @@ object Map04 { // Ishundar
     Building60()
 
     def Building60(): Unit = { // Name: Akkan_Tower Type: tower_c GUID: 79, MapID: 60
-      LocalBuilding("Akkan_Tower", 79, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2474f, 4454f, 51.89481f), tower_c)))
+      LocalBuilding("Akkan_Tower", 79, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2474f, 4454f, 51.89481f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2776, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 79)
       LocalObject(374, Door.Constructor(Vector3(2486f, 4446f, 53.41581f)), owning_building_guid = 79)
       LocalObject(375, Door.Constructor(Vector3(2486f, 4446f, 73.41481f)), owning_building_guid = 79)
@@ -2715,7 +2715,7 @@ object Map04 { // Ishundar
     Building30()
 
     def Building30(): Unit = { // Name: SW_Enkidu_Tower Type: tower_c GUID: 80, MapID: 30
-      LocalBuilding("SW_Enkidu_Tower", 80, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2726f, 3276f, 56.60795f), tower_c)))
+      LocalBuilding("SW_Enkidu_Tower", 80, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2726f, 3276f, 56.60795f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2777, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 80)
       LocalObject(389, Door.Constructor(Vector3(2738f, 3268f, 58.12895f)), owning_building_guid = 80)
       LocalObject(390, Door.Constructor(Vector3(2738f, 3268f, 78.12795f)), owning_building_guid = 80)
@@ -2756,7 +2756,7 @@ object Map04 { // Ishundar
     Building62()
 
     def Building62(): Unit = { // Name: Marduk_Tower Type: tower_c GUID: 81, MapID: 62
-      LocalBuilding("Marduk_Tower", 81, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3218f, 2478f, 75.78687f), tower_c)))
+      LocalBuilding("Marduk_Tower", 81, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3218f, 2478f, 75.78687f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2781, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 81)
       LocalObject(433, Door.Constructor(Vector3(3230f, 2470f, 77.30788f)), owning_building_guid = 81)
       LocalObject(434, Door.Constructor(Vector3(3230f, 2470f, 97.30687f)), owning_building_guid = 81)
@@ -2797,7 +2797,7 @@ object Map04 { // Ishundar
     Building56()
 
     def Building56(): Unit = { // Name: Hanish_Tower Type: tower_c GUID: 82, MapID: 56
-      LocalBuilding("Hanish_Tower", 82, 56, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3580f, 5294f, 69.18471f), tower_c)))
+      LocalBuilding("Hanish_Tower", 82, 56, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3580f, 5294f, 69.18471f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2784, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 82)
       LocalObject(466, Door.Constructor(Vector3(3592f, 5286f, 70.70571f)), owning_building_guid = 82)
       LocalObject(467, Door.Constructor(Vector3(3592f, 5286f, 90.70471f)), owning_building_guid = 82)
@@ -2838,7 +2838,7 @@ object Map04 { // Ishundar
     Building36()
 
     def Building36(): Unit = { // Name: W_Girru_Tower Type: tower_c GUID: 83, MapID: 36
-      LocalBuilding("W_Girru_Tower", 83, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3738f, 6048f, 55.94899f), tower_c)))
+      LocalBuilding("W_Girru_Tower", 83, 36, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3738f, 6048f, 55.94899f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2785, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 83)
       LocalObject(477, Door.Constructor(Vector3(3750f, 6040f, 57.46999f)), owning_building_guid = 83)
       LocalObject(478, Door.Constructor(Vector3(3750f, 6040f, 77.46899f)), owning_building_guid = 83)
@@ -2879,7 +2879,7 @@ object Map04 { // Ishundar
     Building61()
 
     def Building61(): Unit = { // Name: TRSanc_Warpgate_Tower Type: tower_c GUID: 84, MapID: 61
-      LocalBuilding("TRSanc_Warpgate_Tower", 84, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4098f, 988f, 52.18349f), tower_c)))
+      LocalBuilding("TRSanc_Warpgate_Tower", 84, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4098f, 988f, 52.18349f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2786, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 84)
       LocalObject(499, Door.Constructor(Vector3(4110f, 980f, 53.70449f)), owning_building_guid = 84)
       LocalObject(500, Door.Constructor(Vector3(4110f, 980f, 73.70349f)), owning_building_guid = 84)
@@ -2920,7 +2920,7 @@ object Map04 { // Ishundar
     Building41()
 
     def Building41(): Unit = { // Name: W_Ceryshen_Warpgate_Tower Type: tower_c GUID: 85, MapID: 41
-      LocalBuilding("W_Ceryshen_Warpgate_Tower", 85, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4810f, 3474f, 38.48336f), tower_c)))
+      LocalBuilding("W_Ceryshen_Warpgate_Tower", 85, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4810f, 3474f, 38.48336f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2794, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 85)
       LocalObject(568, Door.Constructor(Vector3(4822f, 3466f, 40.00436f)), owning_building_guid = 85)
       LocalObject(569, Door.Constructor(Vector3(4822f, 3466f, 60.00336f)), owning_building_guid = 85)
@@ -2961,7 +2961,7 @@ object Map04 { // Ishundar
     Building55()
 
     def Building55(): Unit = { // Name: Irkalla_Tower Type: tower_c GUID: 86, MapID: 55
-      LocalBuilding("Irkalla_Tower", 86, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4884f, 4940f, 67.48396f), tower_c)))
+      LocalBuilding("Irkalla_Tower", 86, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4884f, 4940f, 67.48396f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2795, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 86)
       LocalObject(581, Door.Constructor(Vector3(4896f, 4932f, 69.00496f)), owning_building_guid = 86)
       LocalObject(582, Door.Constructor(Vector3(4896f, 4932f, 89.00395f)), owning_building_guid = 86)
@@ -3002,7 +3002,7 @@ object Map04 { // Ishundar
     Building20()
 
     def Building20(): Unit = { // Name: E_Zaqar_Tower Type: tower_c GUID: 87, MapID: 20
-      LocalBuilding("E_Zaqar_Tower", 87, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5312f, 2240f, 31.13437f), tower_c)))
+      LocalBuilding("E_Zaqar_Tower", 87, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5312f, 2240f, 31.13437f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2796, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 87)
       LocalObject(586, Door.Constructor(Vector3(5324f, 2232f, 32.65537f)), owning_building_guid = 87)
       LocalObject(587, Door.Constructor(Vector3(5324f, 2232f, 52.65437f)), owning_building_guid = 87)
@@ -3043,7 +3043,7 @@ object Map04 { // Ishundar
     Building57()
 
     def Building57(): Unit = { // Name: E_Ceryshen_Warpgate_Tower Type: tower_c GUID: 88, MapID: 57
-      LocalBuilding("E_Ceryshen_Warpgate_Tower", 88, 57, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7020f, 3444f, 28.58011f), tower_c)))
+      LocalBuilding("E_Ceryshen_Warpgate_Tower", 88, 57, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7020f, 3444f, 28.58011f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2803, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 88)
       LocalObject(637, Door.Constructor(Vector3(7032f, 3436f, 30.10111f)), owning_building_guid = 88)
       LocalObject(638, Door.Constructor(Vector3(7032f, 3436f, 50.10011f)), owning_building_guid = 88)

--- a/pslogin/src/main/scala/zonemaps/Map05.scala
+++ b/pslogin/src/main/scala/zonemaps/Map05.scala
@@ -23,7 +23,7 @@ object Map05 { // Forseral
     Building13()
 
     def Building13(): Unit = { // Name: Eadon Type: amp_station GUID: 1, MapID: 13
-      LocalBuilding("Eadon", 1, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2716f, 2956f, 53.31126f), amp_station)))
+      LocalBuilding("Eadon", 1, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2716f, 2956f, 53.31126f), Vector3(0f, 0f, 228f), amp_station)))
       LocalObject(156, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(122, Door.Constructor(Vector3(2710.802f, 2960.397f, 66.21326f)), owning_building_guid = 1)
       LocalObject(123, Door.Constructor(Vector3(2720.914f, 2951.288f, 66.21326f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map05 { // Forseral
     Building10()
 
     def Building10(): Unit = { // Name: Pwyll Type: amp_station GUID: 4, MapID: 10
-      LocalBuilding("Pwyll", 4, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4738f, 4852f, 103.9842f), amp_station)))
+      LocalBuilding("Pwyll", 4, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4738f, 4852f, 103.9842f), Vector3(0f, 0f, 191f), amp_station)))
       LocalObject(162, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(124, Door.Constructor(Vector3(4736.495f, 4858.64f, 116.8862f)), owning_building_guid = 4)
       LocalObject(125, Door.Constructor(Vector3(4739.088f, 4845.279f, 116.8862f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map05 { // Forseral
     Building33()
 
     def Building33(): Unit = { // Name: bunkerg1 Type: bunker_gauntlet GUID: 7, MapID: 33
-      LocalBuilding("bunkerg1", 7, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2700f, 2850f, 53.31126f), bunker_gauntlet)))
+      LocalBuilding("bunkerg1", 7, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2700f, 2850f, 53.31126f), Vector3(0f, 0f, 138f), bunker_gauntlet)))
       LocalObject(244, Door.Constructor(Vector3(2682.751f, 2868.089f, 54.83226f)), owning_building_guid = 7)
       LocalObject(248, Door.Constructor(Vector3(2719.782f, 2834.761f, 54.83226f)), owning_building_guid = 7)
     }
@@ -287,7 +287,7 @@ object Map05 { // Forseral
     Building34()
 
     def Building34(): Unit = { // Name: bunkerg2 Type: bunker_gauntlet GUID: 8, MapID: 34
-      LocalBuilding("bunkerg2", 8, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4314f, 4146f, 75.96667f), bunker_gauntlet)))
+      LocalBuilding("bunkerg2", 8, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4314f, 4146f, 75.96667f), Vector3(0f, 0f, 132f), bunker_gauntlet)))
       LocalObject(335, Door.Constructor(Vector3(4298.736f, 4165.793f, 77.48768f)), owning_building_guid = 8)
       LocalObject(339, Door.Constructor(Vector3(4332.081f, 4128.776f, 77.48768f)), owning_building_guid = 8)
     }
@@ -295,7 +295,7 @@ object Map05 { // Forseral
     Building35()
 
     def Building35(): Unit = { // Name: bunkerg3 Type: bunker_gauntlet GUID: 9, MapID: 35
-      LocalBuilding("bunkerg3", 9, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5806f, 4440f, 54.7853f), bunker_gauntlet)))
+      LocalBuilding("bunkerg3", 9, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5806f, 4440f, 54.7853f), Vector3(0f, 0f, 91f), bunker_gauntlet)))
       LocalObject(415, Door.Constructor(Vector3(5807.466f, 4464.952f, 56.3063f)), owning_building_guid = 9)
       LocalObject(416, Door.Constructor(Vector3(5808.346f, 4415.139f, 56.3063f)), owning_building_guid = 9)
     }
@@ -303,56 +303,56 @@ object Map05 { // Forseral
     Building29()
 
     def Building29(): Unit = { // Name: bunker2 Type: bunker_lg GUID: 10, MapID: 29
-      LocalBuilding("bunker2", 10, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4302f, 4344f, 75.92862f), bunker_lg)))
+      LocalBuilding("bunker2", 10, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4302f, 4344f, 75.92862f), Vector3(0f, 0f, 262f), bunker_lg)))
       LocalObject(337, Door.Constructor(Vector3(4304.169f, 4341.063f, 77.44962f)), owning_building_guid = 10)
     }
 
     Building30()
 
     def Building30(): Unit = { // Name: bunker3 Type: bunker_lg GUID: 11, MapID: 30
-      LocalBuilding("bunker3", 11, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5616f, 3768f, 60.98056f), bunker_lg)))
+      LocalBuilding("bunker3", 11, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5616f, 3768f, 60.98056f), Vector3(0f, 0f, 104f), bunker_lg)))
       LocalObject(414, Door.Constructor(Vector3(5612.889f, 3769.91f, 62.50156f)), owning_building_guid = 11)
     }
 
     Building31()
 
     def Building31(): Unit = { // Name: bunker4 Type: bunker_sm GUID: 12, MapID: 31
-      LocalBuilding("bunker4", 12, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3206f, 2552f, 56.18124f), bunker_sm)))
+      LocalBuilding("bunker4", 12, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3206f, 2552f, 56.18124f), Vector3(0f, 0f, 316f), bunker_sm)))
       LocalObject(259, Door.Constructor(Vector3(3206.843f, 2551.109f, 57.70224f)), owning_building_guid = 12)
     }
 
     Building32()
 
     def Building32(): Unit = { // Name: bunker5 Type: bunker_sm GUID: 13, MapID: 32
-      LocalBuilding("bunker5", 13, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3250f, 2604f, 56.18457f), bunker_sm)))
+      LocalBuilding("bunker5", 13, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3250f, 2604f, 56.18457f), Vector3(0f, 0f, 322f), bunker_sm)))
       LocalObject(260, Door.Constructor(Vector3(3250.931f, 2603.202f, 57.70557f)), owning_building_guid = 13)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 40
-      LocalBuilding("bunker_sm", 14, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3650f, 5340f, 50.30309f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3650f, 5340f, 50.30309f), Vector3(0f, 0f, 308f), bunker_sm)))
       LocalObject(309, Door.Constructor(Vector3(3650.711f, 5339.001f, 51.82409f)), owning_building_guid = 14)
     }
 
     Building28()
 
     def Building28(): Unit = { // Name: bunker1 Type: bunker_sm GUID: 15, MapID: 28
-      LocalBuilding("bunker1", 15, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3712f, 4644f, 58.56919f), bunker_sm)))
+      LocalBuilding("bunker1", 15, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3712f, 4644f, 58.56919f), Vector3(0f, 0f, 137f), bunker_sm)))
       LocalObject(324, Door.Constructor(Vector3(3711.142f, 4644.875f, 60.09019f)), owning_building_guid = 15)
     }
 
     Building41()
 
     def Building41(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 41
-      LocalBuilding("bunker_sm", 16, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4888f, 2866f, 61.5153f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4888f, 2866f, 61.5153f), Vector3(0f, 0f, 222f), bunker_sm)))
       LocalObject(396, Door.Constructor(Vector3(4887.053f, 2865.221f, 63.0363f)), owning_building_guid = 16)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: Caer Type: comm_station GUID: 17, MapID: 36
-      LocalBuilding("Caer", 17, 36, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4658f, 2644f, 55.99231f), comm_station)))
+      LocalBuilding("Caer", 17, 36, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4658f, 2644f, 55.99231f), Vector3(0f, 0f, 255f), comm_station)))
       LocalObject(161, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 17)
       LocalObject(356, Door.Constructor(Vector3(4598.849f, 2685.214f, 57.74331f)), owning_building_guid = 17)
       LocalObject(357, Door.Constructor(Vector3(4603.557f, 2702.787f, 65.70731f)), owning_building_guid = 17)
@@ -471,7 +471,7 @@ object Map05 { // Forseral
     Building9()
 
     def Building9(): Unit = { // Name: Dagda Type: comm_station GUID: 20, MapID: 9
-      LocalBuilding("Dagda", 20, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5912f, 4436f, 54.7319f), comm_station)))
+      LocalBuilding("Dagda", 20, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5912f, 4436f, 54.7319f), Vector3(0f, 0f, 219f), comm_station)))
       LocalObject(164, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 20)
       LocalObject(417, Door.Constructor(Vector3(5858.486f, 4406.424f, 64.4469f)), owning_building_guid = 20)
       LocalObject(418, Door.Constructor(Vector3(5869.935f, 4392.286f, 56.48289f)), owning_building_guid = 20)
@@ -590,7 +590,7 @@ object Map05 { // Forseral
     Building12()
 
     def Building12(): Unit = { // Name: Bel Type: comm_station_dsp GUID: 23, MapID: 12
-      LocalBuilding("Bel", 23, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3612f, 4694f, 57.91497f), comm_station_dsp)))
+      LocalBuilding("Bel", 23, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3612f, 4694f, 57.91497f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(159, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 23)
       LocalObject(205, Door.Constructor(Vector3(3680.339f, 4764.464f, 61.29297f)), owning_building_guid = 23)
       LocalObject(280, Door.Constructor(Vector3(3552.196f, 4650.501f, 59.56598f)), owning_building_guid = 23)
@@ -731,7 +731,7 @@ object Map05 { // Forseral
     Building5()
 
     def Building5(): Unit = { // Name: Ogma Type: cryo_facility GUID: 26, MapID: 5
-      LocalBuilding("Ogma", 26, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3538f, 3288f, 113.9927f), cryo_facility)))
+      LocalBuilding("Ogma", 26, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3538f, 3288f, 113.9927f), Vector3(0f, 0f, 260f), cryo_facility)))
       LocalObject(158, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 26)
       LocalObject(274, Door.Constructor(Vector3(3441.841f, 3272.462f, 115.5137f)), owning_building_guid = 26)
       LocalObject(275, Door.Constructor(Vector3(3452.252f, 3279.257f, 115.5437f)), owning_building_guid = 26)
@@ -879,7 +879,7 @@ object Map05 { // Forseral
     Building6()
 
     def Building6(): Unit = { // Name: Neit Type: cryo_facility GUID: 29, MapID: 6
-      LocalBuilding("Neit", 29, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4350f, 4238f, 75.96667f), cryo_facility)))
+      LocalBuilding("Neit", 29, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4350f, 4238f, 75.96667f), Vector3(0f, 0f, 42f), cryo_facility)))
       LocalObject(160, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 29)
       LocalObject(332, Door.Constructor(Vector3(4273.177f, 4260.066f, 77.51768f)), owning_building_guid = 29)
       LocalObject(333, Door.Constructor(Vector3(4286.697f, 4272.239f, 85.48167f)), owning_building_guid = 29)
@@ -1027,7 +1027,7 @@ object Map05 { // Forseral
     Building7()
 
     def Building7(): Unit = { // Name: Lugh Type: cryo_facility GUID: 32, MapID: 7
-      LocalBuilding("Lugh", 32, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6148f, 5118f, 71.64068f), cryo_facility)))
+      LocalBuilding("Lugh", 32, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6148f, 5118f, 71.64068f), Vector3(0f, 0f, 165f), cryo_facility)))
       LocalObject(165, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 32)
       LocalObject(444, Door.Constructor(Vector3(6107.22f, 5162.573f, 73.19168f)), owning_building_guid = 32)
       LocalObject(445, Door.Constructor(Vector3(6111.929f, 5180.146f, 81.15568f)), owning_building_guid = 32)
@@ -1187,7 +1187,7 @@ object Map05 { // Forseral
     Building11()
 
     def Building11(): Unit = { // Name: Anu Type: tech_plant GUID: 39, MapID: 11
-      LocalBuilding("Anu", 39, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3360f, 2538f, 56.18457f), tech_plant)))
+      LocalBuilding("Anu", 39, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3360f, 2538f, 56.18457f), Vector3(0f, 0f, 47f), tech_plant)))
       LocalObject(157, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 39)
       LocalObject(261, Door.Constructor(Vector3(3295.273f, 2500.649f, 65.68958f)), owning_building_guid = 39)
       LocalObject(262, Door.Constructor(Vector3(3308.578f, 2488.242f, 57.72657f)), owning_building_guid = 39)
@@ -1313,7 +1313,7 @@ object Map05 { // Forseral
     Building8()
 
     def Building8(): Unit = { // Name: Gwydion Type: tech_plant GUID: 42, MapID: 8
-      LocalBuilding("Gwydion", 42, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5548f, 3858f, 60.98056f), tech_plant)))
+      LocalBuilding("Gwydion", 42, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5548f, 3858f, 60.98056f), Vector3(0f, 0f, 316f), tech_plant)))
       LocalObject(163, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 42)
       LocalObject(401, Door.Constructor(Vector3(5447.92f, 3857.235f, 62.52256f)), owning_building_guid = 42)
       LocalObject(402, Door.Constructor(Vector3(5449.761f, 3813.852f, 62.60156f)), owning_building_guid = 42)
@@ -1439,7 +1439,7 @@ object Map05 { // Forseral
     Building14()
 
     def Building14(): Unit = { // Name: S_Solsar_Warpgate_Tower Type: tower_a GUID: 45, MapID: 14
-      LocalBuilding("S_Solsar_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1598f, 3414f, 49.07939f), tower_a)))
+      LocalBuilding("S_Solsar_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1598f, 3414f, 49.07939f), Vector3(0f, 0f, 335f), tower_a)))
       LocalObject(1894, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 45)
       LocalObject(230, Door.Constructor(Vector3(1605.495f, 3401.678f, 50.60039f)), owning_building_guid = 45)
       LocalObject(231, Door.Constructor(Vector3(1605.495f, 3401.678f, 70.5994f)), owning_building_guid = 45)
@@ -1476,7 +1476,7 @@ object Map05 { // Forseral
     Building17()
 
     def Building17(): Unit = { // Name: NE_TRSanc_Warpgate_Tower Type: tower_a GUID: 46, MapID: 17
-      LocalBuilding("NE_TRSanc_Warpgate_Tower", 46, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3612f, 1746f, 51.49541f), tower_a)))
+      LocalBuilding("NE_TRSanc_Warpgate_Tower", 46, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3612f, 1746f, 51.49541f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1898, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 46)
       LocalObject(305, Door.Constructor(Vector3(3624f, 1738f, 53.01641f)), owning_building_guid = 46)
       LocalObject(306, Door.Constructor(Vector3(3624f, 1738f, 73.01541f)), owning_building_guid = 46)
@@ -1513,7 +1513,7 @@ object Map05 { // Forseral
     Building37()
 
     def Building37(): Unit = { // Name: N_Ogma_Tower Type: tower_a GUID: 47, MapID: 37
-      LocalBuilding("N_Ogma_Tower", 47, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3662f, 3532f, 101.2391f), tower_a)))
+      LocalBuilding("N_Ogma_Tower", 47, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3662f, 3532f, 101.2391f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1899, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 47)
       LocalObject(313, Door.Constructor(Vector3(3674f, 3524f, 102.7601f)), owning_building_guid = 47)
       LocalObject(314, Door.Constructor(Vector3(3674f, 3524f, 122.759f)), owning_building_guid = 47)
@@ -1550,7 +1550,7 @@ object Map05 { // Forseral
     Building27()
 
     def Building27(): Unit = { // Name: S_Bel_Tower Type: tower_a GUID: 48, MapID: 27
-      LocalBuilding("S_Bel_Tower", 48, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3694f, 4482f, 48.92117f), tower_a)))
+      LocalBuilding("S_Bel_Tower", 48, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3694f, 4482f, 48.92117f), Vector3(0f, 0f, 304f), tower_a)))
       LocalObject(1900, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 48)
       LocalObject(319, Door.Constructor(Vector3(3694.078f, 4467.578f, 50.44217f)), owning_building_guid = 48)
       LocalObject(320, Door.Constructor(Vector3(3694.078f, 4467.578f, 70.44117f)), owning_building_guid = 48)
@@ -1587,7 +1587,7 @@ object Map05 { // Forseral
     Building25()
 
     def Building25(): Unit = { // Name: SE_Ceryshen_Warpgate_Tower Type: tower_a GUID: 49, MapID: 25
-      LocalBuilding("SE_Ceryshen_Warpgate_Tower", 49, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3832f, 6326f, 50.13886f), tower_a)))
+      LocalBuilding("SE_Ceryshen_Warpgate_Tower", 49, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3832f, 6326f, 50.13886f), Vector3(0f, 0f, 314f), tower_a)))
       LocalObject(1901, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 49)
       LocalObject(328, Door.Constructor(Vector3(3834.581f, 6311.811f, 51.65986f)), owning_building_guid = 49)
       LocalObject(329, Door.Constructor(Vector3(3834.581f, 6311.811f, 71.65886f)), owning_building_guid = 49)
@@ -1624,7 +1624,7 @@ object Map05 { // Forseral
     Building39()
 
     def Building39(): Unit = { // Name: W_Pwyll_Tower Type: tower_a GUID: 50, MapID: 39
-      LocalBuilding("W_Pwyll_Tower", 50, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4486f, 4862f, 90.87802f), tower_a)))
+      LocalBuilding("W_Pwyll_Tower", 50, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4486f, 4862f, 90.87802f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1903, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 50)
       LocalObject(352, Door.Constructor(Vector3(4498f, 4854f, 92.39902f)), owning_building_guid = 50)
       LocalObject(353, Door.Constructor(Vector3(4498f, 4854f, 112.398f)), owning_building_guid = 50)
@@ -1661,7 +1661,7 @@ object Map05 { // Forseral
     Building20()
 
     def Building20(): Unit = { // Name: NW_Gwydion_Tower Type: tower_a GUID: 51, MapID: 20
-      LocalBuilding("NW_Gwydion_Tower", 51, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5410f, 4044f, 59.84832f), tower_a)))
+      LocalBuilding("NW_Gwydion_Tower", 51, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5410f, 4044f, 59.84832f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1906, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 51)
       LocalObject(397, Door.Constructor(Vector3(5422f, 4036f, 61.36932f)), owning_building_guid = 51)
       LocalObject(398, Door.Constructor(Vector3(5422f, 4036f, 81.36832f)), owning_building_guid = 51)
@@ -1698,7 +1698,7 @@ object Map05 { // Forseral
     Building22()
 
     def Building22(): Unit = { // Name: NW_Lugh_Tower Type: tower_a GUID: 52, MapID: 22
-      LocalBuilding("NW_Lugh_Tower", 52, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5940f, 5298f, 87.00064f), tower_a)))
+      LocalBuilding("NW_Lugh_Tower", 52, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5940f, 5298f, 87.00064f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1908, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(435, Door.Constructor(Vector3(5952f, 5290f, 88.52164f)), owning_building_guid = 52)
       LocalObject(436, Door.Constructor(Vector3(5952f, 5290f, 108.5206f)), owning_building_guid = 52)
@@ -1735,7 +1735,7 @@ object Map05 { // Forseral
     Building15()
 
     def Building15(): Unit = { // Name: NW_Eadon_Tower Type: tower_b GUID: 53, MapID: 15
-      LocalBuilding("NW_Eadon_Tower", 53, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2588f, 3168f, 49.78637f), tower_b)))
+      LocalBuilding("NW_Eadon_Tower", 53, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2588f, 3168f, 49.78637f), Vector3(0f, 0f, 318f), tower_b)))
       LocalObject(1895, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(234, Door.Constructor(Vector3(2591.565f, 3154.025f, 51.30637f)), owning_building_guid = 53)
       LocalObject(235, Door.Constructor(Vector3(2591.565f, 3154.025f, 61.30637f)), owning_building_guid = 53)
@@ -1772,7 +1772,7 @@ object Map05 { // Forseral
     Building26()
 
     def Building26(): Unit = { // Name: N_Bel_Tower Type: tower_b GUID: 54, MapID: 26
-      LocalBuilding("N_Bel_Tower", 54, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3568f, 5310f, 53.99487f), tower_b)))
+      LocalBuilding("N_Bel_Tower", 54, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3568f, 5310f, 53.99487f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1897, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(288, Door.Constructor(Vector3(3580f, 5302f, 55.51487f)), owning_building_guid = 54)
       LocalObject(289, Door.Constructor(Vector3(3580f, 5302f, 65.51488f)), owning_building_guid = 54)
@@ -1809,7 +1809,7 @@ object Map05 { // Forseral
     Building38()
 
     def Building38(): Unit = { // Name: S_Neit_Tower Type: tower_b GUID: 55, MapID: 38
-      LocalBuilding("S_Neit_Tower", 55, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4440f, 3986f, 67.92352f), tower_b)))
+      LocalBuilding("S_Neit_Tower", 55, 38, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4440f, 3986f, 67.92352f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1902, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(346, Door.Constructor(Vector3(4452f, 3978f, 69.44352f)), owning_building_guid = 55)
       LocalObject(347, Door.Constructor(Vector3(4452f, 3978f, 79.44353f)), owning_building_guid = 55)
@@ -1846,7 +1846,7 @@ object Map05 { // Forseral
     Building18()
 
     def Building18(): Unit = { // Name: E_TRSanc_Warpgate_Tower Type: tower_b GUID: 56, MapID: 18
-      LocalBuilding("E_TRSanc_Warpgate_Tower", 56, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4822f, 2820f, 67.8167f), tower_b)))
+      LocalBuilding("E_TRSanc_Warpgate_Tower", 56, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4822f, 2820f, 67.8167f), Vector3(0f, 0f, 34f), tower_b)))
       LocalObject(1905, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(389, Door.Constructor(Vector3(4827.475f, 2833.343f, 69.3367f)), owning_building_guid = 56)
       LocalObject(390, Door.Constructor(Vector3(4827.475f, 2833.343f, 79.3367f)), owning_building_guid = 56)
@@ -1883,7 +1883,7 @@ object Map05 { // Forseral
     Building21()
 
     def Building21(): Unit = { // Name: N_Dagda_Tower Type: tower_b GUID: 57, MapID: 21
-      LocalBuilding("N_Dagda_Tower", 57, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5896f, 4678f, 50.33113f), tower_b)))
+      LocalBuilding("N_Dagda_Tower", 57, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5896f, 4678f, 50.33113f), Vector3(0f, 0f, 14f), tower_b)))
       LocalObject(1907, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(421, Door.Constructor(Vector3(5905.708f, 4688.666f, 51.85113f)), owning_building_guid = 57)
       LocalObject(422, Door.Constructor(Vector3(5905.708f, 4688.666f, 61.85113f)), owning_building_guid = 57)
@@ -1920,7 +1920,7 @@ object Map05 { // Forseral
     Building16()
 
     def Building16(): Unit = { // Name: NE_Anu_Tower Type: tower_c GUID: 58, MapID: 16
-      LocalBuilding("NE_Anu_Tower", 58, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3572f, 2702f, 43.39885f), tower_c)))
+      LocalBuilding("NE_Anu_Tower", 58, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3572f, 2702f, 43.39885f), Vector3(0f, 0f, 42f), tower_c)))
       LocalObject(1896, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(286, Door.Constructor(Vector3(3575.565f, 2715.975f, 44.91985f)), owning_building_guid = 58)
       LocalObject(287, Door.Constructor(Vector3(3575.565f, 2715.975f, 64.91885f)), owning_building_guid = 58)
@@ -1961,7 +1961,7 @@ object Map05 { // Forseral
     Building24()
 
     def Building24(): Unit = { // Name: N_Pwyll_Tower Type: tower_c GUID: 59, MapID: 24
-      LocalBuilding("N_Pwyll_Tower", 59, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4728f, 5584f, 48.18415f), tower_c)))
+      LocalBuilding("N_Pwyll_Tower", 59, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4728f, 5584f, 48.18415f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1904, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(377, Door.Constructor(Vector3(4740f, 5576f, 49.70515f)), owning_building_guid = 59)
       LocalObject(378, Door.Constructor(Vector3(4740f, 5576f, 69.70415f)), owning_building_guid = 59)
@@ -2002,7 +2002,7 @@ object Map05 { // Forseral
     Building19()
 
     def Building19(): Unit = { // Name: S_Gwydion_Tower Type: tower_c GUID: 60, MapID: 19
-      LocalBuilding("S_Gwydion_Tower", 60, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6018f, 2726f, 46.91305f), tower_c)))
+      LocalBuilding("S_Gwydion_Tower", 60, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6018f, 2726f, 46.91305f), Vector3(0f, 0f, 308f), tower_c)))
       LocalObject(1909, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(440, Door.Constructor(Vector3(6019.084f, 2711.619f, 48.43405f)), owning_building_guid = 60)
       LocalObject(441, Door.Constructor(Vector3(6019.084f, 2711.619f, 68.43305f)), owning_building_guid = 60)
@@ -2043,7 +2043,7 @@ object Map05 { // Forseral
     Building23()
 
     def Building23(): Unit = { // Name: W_Oshur_Warpgate_Tower Type: tower_c GUID: 61, MapID: 23
-      LocalBuilding("W_Oshur_Warpgate_Tower", 61, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7008f, 3838f, 49.3027f), tower_c)))
+      LocalBuilding("W_Oshur_Warpgate_Tower", 61, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7008f, 3838f, 49.3027f), Vector3(0f, 0f, 106f), tower_c)))
       LocalObject(1910, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(455, Door.Constructor(Vector3(6997.002f, 3847.33f, 50.8237f)), owning_building_guid = 61)
       LocalObject(456, Door.Constructor(Vector3(6997.002f, 3847.33f, 70.8227f)), owning_building_guid = 61)

--- a/pslogin/src/main/scala/zonemaps/Map06.scala
+++ b/pslogin/src/main/scala/zonemaps/Map06.scala
@@ -23,7 +23,7 @@ object Map06 { // Ceryshen
     Building1()
 
     def Building1(): Unit = { // Name: Akna Type: amp_station GUID: 1, MapID: 1
-      LocalBuilding("Akna", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4406f, 3738f, 218.9079f), amp_station)))
+      LocalBuilding("Akna", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4406f, 3738f, 218.9079f), Vector3(0f, 0f, 312f), amp_station)))
       LocalObject(181, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(146, Door.Constructor(Vector3(4401.084f, 3733.29f, 231.8099f)), owning_building_guid = 1)
       LocalObject(147, Door.Constructor(Vector3(4411.2f, 3742.394f, 231.8099f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map06 { // Ceryshen
     Building43()
 
     def Building43(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 43
-      LocalBuilding("bunker_gauntlet", 4, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3072f, 2262f, 237.2147f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3072f, 2262f, 237.2147f), Vector3(0f, 0f, 315f), bunker_gauntlet)))
       LocalObject(287, Door.Constructor(Vector3(3053.042f, 2278.254f, 238.7357f)), owning_building_guid = 4)
       LocalObject(289, Door.Constructor(Vector3(3088.279f, 2243.032f, 238.7357f)), owning_building_guid = 4)
     }
@@ -159,7 +159,7 @@ object Map06 { // Ceryshen
     Building44()
 
     def Building44(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 44
-      LocalBuilding("bunker_gauntlet", 5, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4084f, 5194f, 232.2395f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4084f, 5194f, 232.2395f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(405, Door.Constructor(Vector3(4082.099f, 5169.077f, 233.7605f)), owning_building_guid = 5)
       LocalObject(406, Door.Constructor(Vector3(4082.088f, 5218.898f, 233.7605f)), owning_building_guid = 5)
     }
@@ -167,7 +167,7 @@ object Map06 { // Ceryshen
     Building42()
 
     def Building42(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 42
-      LocalBuilding("bunker_gauntlet", 6, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4086f, 4288f, 266.4175f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4086f, 4288f, 266.4175f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(407, Door.Constructor(Vector3(4084.099f, 4263.077f, 267.9385f)), owning_building_guid = 6)
       LocalObject(408, Door.Constructor(Vector3(4084.088f, 4312.898f, 267.9385f)), owning_building_guid = 6)
     }
@@ -175,7 +175,7 @@ object Map06 { // Ceryshen
     Building41()
 
     def Building41(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 41
-      LocalBuilding("bunker_gauntlet", 7, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5866f, 3550f, 96.40965f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5866f, 3550f, 96.40965f), Vector3(0f, 0f, 360f), bunker_gauntlet)))
       LocalObject(496, Door.Constructor(Vector3(5841.102f, 3548.088f, 97.93066f)), owning_building_guid = 7)
       LocalObject(501, Door.Constructor(Vector3(5890.923f, 3548.099f, 97.93066f)), owning_building_guid = 7)
     }
@@ -183,70 +183,70 @@ object Map06 { // Ceryshen
     Building33()
 
     def Building33(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 8, MapID: 33
-      LocalBuilding("bunker_lg", 8, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2958f, 2048f, 238.7697f), bunker_lg)))
+      LocalBuilding("bunker_lg", 8, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2958f, 2048f, 238.7697f), Vector3(0f, 0f, 45f), bunker_lg)))
       LocalObject(281, Door.Constructor(Vector3(2958.035f, 2051.651f, 240.2907f)), owning_building_guid = 8)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 40
-      LocalBuilding("bunker_lg", 9, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3566f, 5902f, 219.7465f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3566f, 5902f, 219.7465f), Vector3(0f, 0f, 180f), bunker_lg)))
       LocalObject(326, Door.Constructor(Vector3(3563.394f, 5899.443f, 221.2675f)), owning_building_guid = 9)
     }
 
     Building35()
 
     def Building35(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 35
-      LocalBuilding("bunker_lg", 10, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3608f, 3584f, 222.4627f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3608f, 3584f, 222.4627f), Vector3(0f, 0f, 0f), bunker_lg)))
       LocalObject(333, Door.Constructor(Vector3(3610.606f, 3586.557f, 223.9837f)), owning_building_guid = 10)
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 11, MapID: 38
-      LocalBuilding("bunker_lg", 11, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3800f, 4326f, 268.4381f), bunker_lg)))
+      LocalBuilding("bunker_lg", 11, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3800f, 4326f, 268.4381f), Vector3(0f, 0f, 225f), bunker_lg)))
       LocalObject(362, Door.Constructor(Vector3(3799.965f, 4322.349f, 269.9591f)), owning_building_guid = 11)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 12, MapID: 36
-      LocalBuilding("bunker_lg", 12, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5122f, 3188f, 217.751f), bunker_lg)))
+      LocalBuilding("bunker_lg", 12, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5122f, 3188f, 217.751f), Vector3(0f, 0f, 90f), bunker_lg)))
       LocalObject(470, Door.Constructor(Vector3(5119.443f, 3190.606f, 219.272f)), owning_building_guid = 12)
     }
 
     Building45()
 
     def Building45(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 13, MapID: 45
-      LocalBuilding("bunker_sm", 13, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3198f, 5836f, 234.3076f), bunker_sm)))
+      LocalBuilding("bunker_sm", 13, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3198f, 5836f, 234.3076f), Vector3(0f, 0f, 360f), bunker_sm)))
       LocalObject(290, Door.Constructor(Vector3(3199.225f, 5835.945f, 235.8286f)), owning_building_guid = 13)
     }
 
     Building39()
 
     def Building39(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 39
-      LocalBuilding("bunker_sm", 14, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3858f, 5178f, 233.2084f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3858f, 5178f, 233.2084f), Vector3(0f, 0f, 45f), bunker_sm)))
       LocalObject(363, Door.Constructor(Vector3(3858.905f, 5178.827f, 234.7294f)), owning_building_guid = 14)
     }
 
     Building34()
 
     def Building34(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 15, MapID: 34
-      LocalBuilding("bunker_sm", 15, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3922f, 1994f, 260.3741f), bunker_sm)))
+      LocalBuilding("bunker_sm", 15, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3922f, 1994f, 260.3741f), Vector3(0f, 0f, 225f), bunker_sm)))
       LocalObject(374, Door.Constructor(Vector3(3921.095f, 1993.173f, 261.8951f)), owning_building_guid = 15)
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 37
-      LocalBuilding("bunker_sm", 16, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4394f, 3876f, 218.9932f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4394f, 3876f, 218.9932f), Vector3(0f, 0f, 224f), bunker_sm)))
       LocalObject(438, Door.Constructor(Vector3(4393.081f, 3875.189f, 220.5142f)), owning_building_guid = 16)
     }
 
     Building4()
 
     def Building4(): Unit = { // Name: Keelut Type: comm_station GUID: 17, MapID: 4
-      LocalBuilding("Keelut", 17, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3700f, 1956f, 265.1138f), comm_station)))
+      LocalBuilding("Keelut", 17, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3700f, 1956f, 265.1138f), Vector3(0f, 0f, 269f), comm_station)))
       LocalObject(178, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 17)
       LocalObject(336, Door.Constructor(Vector3(3632.635f, 1981.68f, 266.8648f)), owning_building_guid = 17)
       LocalObject(337, Door.Constructor(Vector3(3632.952f, 1999.87f, 274.8288f)), owning_building_guid = 17)
@@ -365,7 +365,7 @@ object Map06 { // Ceryshen
     Building2()
 
     def Building2(): Unit = { // Name: Anguta Type: comm_station_dsp GUID: 20, MapID: 2
-      LocalBuilding("Anguta", 20, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3944f, 4240f, 266.4438f), comm_station_dsp)))
+      LocalBuilding("Anguta", 20, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3944f, 4240f, 266.4438f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(180, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 20)
       LocalObject(222, Door.Constructor(Vector3(4012.339f, 4310.464f, 269.8218f)), owning_building_guid = 20)
       LocalObject(370, Door.Constructor(Vector3(3884.196f, 4196.501f, 268.0948f)), owning_building_guid = 20)
@@ -506,7 +506,7 @@ object Map06 { // Ceryshen
     Building8()
 
     def Building8(): Unit = { // Name: Tarqaq Type: cryo_facility GUID: 23, MapID: 8
-      LocalBuilding("Tarqaq", 23, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2980f, 2228f, 237.2173f), cryo_facility)))
+      LocalBuilding("Tarqaq", 23, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2980f, 2228f, 237.2173f), Vector3(0f, 0f, 218f), cryo_facility)))
       LocalObject(175, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 23)
       LocalObject(272, Door.Constructor(Vector3(2898.143f, 2280.796f, 238.7383f)), owning_building_guid = 23)
       LocalObject(273, Door.Constructor(Vector3(2908.659f, 2236.593f, 246.7323f)), owning_building_guid = 23)
@@ -654,7 +654,7 @@ object Map06 { // Ceryshen
     Building7()
 
     def Building7(): Unit = { // Name: Sedna Type: cryo_facility GUID: 26, MapID: 7
-      LocalBuilding("Sedna", 26, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3982f, 5224f, 232.2285f), cryo_facility)))
+      LocalBuilding("Sedna", 26, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3982f, 5224f, 232.2285f), Vector3(0f, 0f, 179f), cryo_facility)))
       LocalObject(179, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 26)
       LocalObject(381, Door.Constructor(Vector3(3931.648f, 5257.384f, 233.7795f)), owning_building_guid = 26)
       LocalObject(382, Door.Constructor(Vector3(3931.966f, 5275.574f, 241.7435f)), owning_building_guid = 26)
@@ -802,7 +802,7 @@ object Map06 { // Ceryshen
     Building9()
 
     def Building9(): Unit = { // Name: Tootega Type: cryo_facility GUID: 29, MapID: 9
-      LocalBuilding("Tootega", 29, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5106f, 3298f, 217.0609f), cryo_facility)))
+      LocalBuilding("Tootega", 29, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5106f, 3298f, 217.0609f), Vector3(0f, 0f, 271f), cryo_facility)))
       LocalObject(182, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 29)
       LocalObject(459, Door.Constructor(Vector3(5014.572f, 3264.399f, 218.5819f)), owning_building_guid = 29)
       LocalObject(460, Door.Constructor(Vector3(5023.178f, 3291.247f, 226.5759f)), owning_building_guid = 29)
@@ -962,7 +962,7 @@ object Map06 { // Ceryshen
     Building3()
 
     def Building3(): Unit = { // Name: Igaluk Type: tech_plant GUID: 36, MapID: 3
-      LocalBuilding("Igaluk", 36, 3, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3320f, 5756f, 234.4307f), tech_plant)))
+      LocalBuilding("Igaluk", 36, 3, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3320f, 5756f, 234.4307f), Vector3(0f, 0f, 269f), tech_plant)))
       LocalObject(176, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 36)
       LocalObject(299, Door.Constructor(Vector3(3220.713f, 5797.739f, 236.0517f)), owning_building_guid = 36)
       LocalObject(300, Door.Constructor(Vector3(3228.736f, 5752.987f, 236.0817f)), owning_building_guid = 36)
@@ -1088,7 +1088,7 @@ object Map06 { // Ceryshen
     Building5()
 
     def Building5(): Unit = { // Name: Nerrivik Type: tech_plant GUID: 39, MapID: 5
-      LocalBuilding("Nerrivik", 39, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3642f, 3710f, 222.4253f), tech_plant)))
+      LocalBuilding("Nerrivik", 39, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3642f, 3710f, 222.4253f), Vector3(0f, 0f, 223f), tech_plant)))
       LocalObject(177, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 39)
       LocalObject(327, Door.Constructor(Vector3(3573.92f, 3667.142f, 231.9303f)), owning_building_guid = 39)
       LocalObject(328, Door.Constructor(Vector3(3576.435f, 3773.557f, 224.0763f)), owning_building_guid = 39)
@@ -1214,7 +1214,7 @@ object Map06 { // Ceryshen
     Building6()
 
     def Building6(): Unit = { // Name: Pinga Type: tech_plant GUID: 42, MapID: 6
-      LocalBuilding("Pinga", 42, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5860f, 3444f, 96.40965f), tech_plant)))
+      LocalBuilding("Pinga", 42, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5860f, 3444f, 96.40965f), Vector3(0f, 0f, 90f), tech_plant)))
       LocalObject(183, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 42)
       LocalObject(493, Door.Constructor(Vector3(5828.734f, 3468.559f, 97.95165f)), owning_building_guid = 42)
       LocalObject(494, Door.Constructor(Vector3(5828.734f, 3486.752f, 105.9146f)), owning_building_guid = 42)
@@ -1340,7 +1340,7 @@ object Map06 { // Ceryshen
     Building14()
 
     def Building14(): Unit = { // Name: W_Amerish_Warpgate_Tower Type: tower_a GUID: 45, MapID: 14
-      LocalBuilding("W_Amerish_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1822f, 2648f, 186.5722f), tower_a)))
+      LocalBuilding("W_Amerish_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1822f, 2648f, 186.5722f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2183, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 45)
       LocalObject(246, Door.Constructor(Vector3(1834f, 2640f, 188.0932f)), owning_building_guid = 45)
       LocalObject(247, Door.Constructor(Vector3(1834f, 2640f, 208.0922f)), owning_building_guid = 45)
@@ -1377,7 +1377,7 @@ object Map06 { // Ceryshen
     Building25()
 
     def Building25(): Unit = { // Name: N_Amerish_Warpgate_Tower Type: tower_a GUID: 46, MapID: 25
-      LocalBuilding("N_Amerish_Warpgate_Tower", 46, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2616f, 4086f, 21.97363f), tower_a)))
+      LocalBuilding("N_Amerish_Warpgate_Tower", 46, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2616f, 4086f, 21.97363f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2186, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 46)
       LocalObject(260, Door.Constructor(Vector3(2628f, 4078f, 23.49463f)), owning_building_guid = 46)
       LocalObject(261, Door.Constructor(Vector3(2628f, 4078f, 43.49363f)), owning_building_guid = 46)
@@ -1414,7 +1414,7 @@ object Map06 { // Ceryshen
     Building32()
 
     def Building32(): Unit = { // Name: S_Tarqaq_Tower Type: tower_a GUID: 47, MapID: 32
-      LocalBuilding("S_Tarqaq_Tower", 47, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2914f, 1496f, 51.68828f), tower_a)))
+      LocalBuilding("S_Tarqaq_Tower", 47, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2914f, 1496f, 51.68828f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2189, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 47)
       LocalObject(277, Door.Constructor(Vector3(2926f, 1488f, 53.20928f)), owning_building_guid = 47)
       LocalObject(278, Door.Constructor(Vector3(2926f, 1488f, 73.20828f)), owning_building_guid = 47)
@@ -1451,7 +1451,7 @@ object Map06 { // Ceryshen
     Building23()
 
     def Building23(): Unit = { // Name: NW_Anguta_Tower Type: tower_a GUID: 48, MapID: 23
-      LocalBuilding("NW_Anguta_Tower", 48, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3206f, 4790f, 68.82293f), tower_a)))
+      LocalBuilding("NW_Anguta_Tower", 48, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3206f, 4790f, 68.82293f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2191, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 48)
       LocalObject(295, Door.Constructor(Vector3(3218f, 4782f, 70.34393f)), owning_building_guid = 48)
       LocalObject(296, Door.Constructor(Vector3(3218f, 4782f, 90.34293f)), owning_building_guid = 48)
@@ -1488,7 +1488,7 @@ object Map06 { // Ceryshen
     Building46()
 
     def Building46(): Unit = { // Name: Igaluk_Tower Type: tower_a GUID: 49, MapID: 46
-      LocalBuilding("Igaluk_Tower", 49, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3386f, 5984f, 215.4855f), tower_a)))
+      LocalBuilding("Igaluk_Tower", 49, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3386f, 5984f, 215.4855f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2193, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 49)
       LocalObject(318, Door.Constructor(Vector3(3398f, 5976f, 217.0065f)), owning_building_guid = 49)
       LocalObject(319, Door.Constructor(Vector3(3398f, 5976f, 237.0056f)), owning_building_guid = 49)
@@ -1525,7 +1525,7 @@ object Map06 { // Ceryshen
     Building53()
 
     def Building53(): Unit = { // Name: Keelut_Tower Type: tower_a GUID: 50, MapID: 53
-      LocalBuilding("Keelut_Tower", 50, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3636f, 1720f, 250.5918f), tower_a)))
+      LocalBuilding("Keelut_Tower", 50, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3636f, 1720f, 250.5918f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2195, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 50)
       LocalObject(340, Door.Constructor(Vector3(3648f, 1712f, 252.1127f)), owning_building_guid = 50)
       LocalObject(341, Door.Constructor(Vector3(3648f, 1712f, 272.1118f)), owning_building_guid = 50)
@@ -1562,7 +1562,7 @@ object Map06 { // Ceryshen
     Building50()
 
     def Building50(): Unit = { // Name: Nerrivik_Tower Type: tower_a GUID: 51, MapID: 50
-      LocalBuilding("Nerrivik_Tower", 51, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3724f, 3498f, 224.6254f), tower_a)))
+      LocalBuilding("Nerrivik_Tower", 51, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3724f, 3498f, 224.6254f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2196, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 51)
       LocalObject(355, Door.Constructor(Vector3(3736f, 3490f, 226.1464f)), owning_building_guid = 51)
       LocalObject(356, Door.Constructor(Vector3(3736f, 3490f, 246.1454f)), owning_building_guid = 51)
@@ -1599,7 +1599,7 @@ object Map06 { // Ceryshen
     Building28()
 
     def Building28(): Unit = { // Name: N_Keelut_Tower Type: tower_a GUID: 52, MapID: 28
-      LocalBuilding("N_Keelut_Tower", 52, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3914f, 2464f, 243.5026f), tower_a)))
+      LocalBuilding("N_Keelut_Tower", 52, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3914f, 2464f, 243.5026f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2198, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(377, Door.Constructor(Vector3(3926f, 2456f, 245.0236f)), owning_building_guid = 52)
       LocalObject(378, Door.Constructor(Vector3(3926f, 2456f, 265.0226f)), owning_building_guid = 52)
@@ -1636,7 +1636,7 @@ object Map06 { // Ceryshen
     Building47()
 
     def Building47(): Unit = { // Name: Sedna_Tower Type: tower_a GUID: 53, MapID: 47
-      LocalBuilding("Sedna_Tower", 53, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4174f, 5364f, 226.9693f), tower_a)))
+      LocalBuilding("Sedna_Tower", 53, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4174f, 5364f, 226.9693f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2200, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(415, Door.Constructor(Vector3(4186f, 5356f, 228.4903f)), owning_building_guid = 53)
       LocalObject(416, Door.Constructor(Vector3(4186f, 5356f, 248.4893f)), owning_building_guid = 53)
@@ -1673,7 +1673,7 @@ object Map06 { // Ceryshen
     Building27()
 
     def Building27(): Unit = { // Name: S_Akna_Tower Type: tower_a GUID: 54, MapID: 27
-      LocalBuilding("S_Akna_Tower", 54, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4254f, 3096f, 218.2696f), tower_a)))
+      LocalBuilding("S_Akna_Tower", 54, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4254f, 3096f, 218.2696f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2201, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(419, Door.Constructor(Vector3(4266f, 3088f, 219.7906f)), owning_building_guid = 54)
       LocalObject(420, Door.Constructor(Vector3(4266f, 3088f, 239.7896f)), owning_building_guid = 54)
@@ -1710,7 +1710,7 @@ object Map06 { // Ceryshen
     Building22()
 
     def Building22(): Unit = { // Name: N_Hossin_Warpgate_Tower Type: tower_a GUID: 55, MapID: 22
-      LocalBuilding("N_Hossin_Warpgate_Tower", 55, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4836f, 5218f, 22.86996f), tower_a)))
+      LocalBuilding("N_Hossin_Warpgate_Tower", 55, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4836f, 5218f, 22.86996f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2204, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(449, Door.Constructor(Vector3(4848f, 5210f, 24.39096f)), owning_building_guid = 55)
       LocalObject(450, Door.Constructor(Vector3(4848f, 5210f, 44.38996f)), owning_building_guid = 55)
@@ -1747,7 +1747,7 @@ object Map06 { // Ceryshen
     Building52()
 
     def Building52(): Unit = { // Name: Tootega_Tower Type: tower_a GUID: 56, MapID: 52
-      LocalBuilding("Tootega_Tower", 56, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5030f, 3086f, 231.7553f), tower_a)))
+      LocalBuilding("Tootega_Tower", 56, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5030f, 3086f, 231.7553f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2206, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(462, Door.Constructor(Vector3(5042f, 3078f, 233.2763f)), owning_building_guid = 56)
       LocalObject(463, Door.Constructor(Vector3(5042f, 3078f, 253.2753f)), owning_building_guid = 56)
@@ -1784,7 +1784,7 @@ object Map06 { // Ceryshen
     Building15()
 
     def Building15(): Unit = { // Name: SW_Amerish_Warpgate_Tower Type: tower_b GUID: 57, MapID: 15
-      LocalBuilding("SW_Amerish_Warpgate_Tower", 57, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2040f, 1690f, 219.3832f), tower_b)))
+      LocalBuilding("SW_Amerish_Warpgate_Tower", 57, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2040f, 1690f, 219.3832f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2184, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(250, Door.Constructor(Vector3(2052f, 1682f, 220.9032f)), owning_building_guid = 57)
       LocalObject(251, Door.Constructor(Vector3(2052f, 1682f, 230.9032f)), owning_building_guid = 57)
@@ -1821,7 +1821,7 @@ object Map06 { // Ceryshen
     Building26()
 
     def Building26(): Unit = { // Name: SW_Nerrivik_Tower Type: tower_b GUID: 58, MapID: 26
-      LocalBuilding("SW_Nerrivik_Tower", 58, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3282f, 2966f, 243.6248f), tower_b)))
+      LocalBuilding("SW_Nerrivik_Tower", 58, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3282f, 2966f, 243.6248f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2192, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(305, Door.Constructor(Vector3(3294f, 2958f, 245.1448f)), owning_building_guid = 58)
       LocalObject(306, Door.Constructor(Vector3(3294f, 2958f, 255.1448f)), owning_building_guid = 58)
@@ -1858,7 +1858,7 @@ object Map06 { // Ceryshen
     Building48()
 
     def Building48(): Unit = { // Name: Anguta_Tower Type: tower_b GUID: 59, MapID: 48
-      LocalBuilding("Anguta_Tower", 59, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3860f, 4518f, 268.7284f), tower_b)))
+      LocalBuilding("Anguta_Tower", 59, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3860f, 4518f, 268.7284f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2197, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(364, Door.Constructor(Vector3(3872f, 4510f, 270.2484f)), owning_building_guid = 59)
       LocalObject(365, Door.Constructor(Vector3(3872f, 4510f, 280.2484f)), owning_building_guid = 59)
@@ -1895,7 +1895,7 @@ object Map06 { // Ceryshen
     Building31()
 
     def Building31(): Unit = { // Name: N_Sedna_Tower Type: tower_b GUID: 60, MapID: 31
-      LocalBuilding("N_Sedna_Tower", 60, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4088f, 5718f, 141.2804f), tower_b)))
+      LocalBuilding("N_Sedna_Tower", 60, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4088f, 5718f, 141.2804f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2199, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(409, Door.Constructor(Vector3(4100f, 5710f, 142.8004f)), owning_building_guid = 60)
       LocalObject(410, Door.Constructor(Vector3(4100f, 5710f, 152.8004f)), owning_building_guid = 60)
@@ -1932,7 +1932,7 @@ object Map06 { // Ceryshen
     Building18()
 
     def Building18(): Unit = { // Name: N_Ishundar_Warpgate_Tower Type: tower_b GUID: 61, MapID: 18
-      LocalBuilding("N_Ishundar_Warpgate_Tower", 61, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4870f, 2432f, 20.75137f), tower_b)))
+      LocalBuilding("N_Ishundar_Warpgate_Tower", 61, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4870f, 2432f, 20.75137f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2205, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(453, Door.Constructor(Vector3(4882f, 2424f, 22.27137f)), owning_building_guid = 61)
       LocalObject(454, Door.Constructor(Vector3(4882f, 2424f, 32.27137f)), owning_building_guid = 61)
@@ -1969,7 +1969,7 @@ object Map06 { // Ceryshen
     Building20()
 
     def Building20(): Unit = { // Name: N_Tootega_Tower Type: tower_b GUID: 62, MapID: 20
-      LocalBuilding("N_Tootega_Tower", 62, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5120f, 3880f, 234.6615f), tower_b)))
+      LocalBuilding("N_Tootega_Tower", 62, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5120f, 3880f, 234.6615f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2207, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(473, Door.Constructor(Vector3(5132f, 3872f, 236.1815f)), owning_building_guid = 62)
       LocalObject(474, Door.Constructor(Vector3(5132f, 3872f, 246.1815f)), owning_building_guid = 62)
@@ -2006,7 +2006,7 @@ object Map06 { // Ceryshen
     Building29()
 
     def Building29(): Unit = { // Name: E_Forseral_Warpgate_Tower Type: tower_c GUID: 63, MapID: 29
-      LocalBuilding("E_Forseral_Warpgate_Tower", 63, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2372f, 5710f, 33.28257f), tower_c)))
+      LocalBuilding("E_Forseral_Warpgate_Tower", 63, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2372f, 5710f, 33.28257f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2185, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(256, Door.Constructor(Vector3(2384f, 5702f, 34.80357f)), owning_building_guid = 63)
       LocalObject(257, Door.Constructor(Vector3(2384f, 5702f, 54.80257f)), owning_building_guid = 63)
@@ -2047,7 +2047,7 @@ object Map06 { // Ceryshen
     Building54()
 
     def Building54(): Unit = { // Name: Amerish_Warpgate_Tower Type: tower_c GUID: 64, MapID: 54
-      LocalBuilding("Amerish_Warpgate_Tower", 64, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2630f, 2730f, 182.7152f), tower_c)))
+      LocalBuilding("Amerish_Warpgate_Tower", 64, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2630f, 2730f, 182.7152f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2187, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(264, Door.Constructor(Vector3(2642f, 2722f, 184.2362f)), owning_building_guid = 64)
       LocalObject(265, Door.Constructor(Vector3(2642f, 2722f, 204.2352f)), owning_building_guid = 64)
@@ -2088,7 +2088,7 @@ object Map06 { // Ceryshen
     Building16()
 
     def Building16(): Unit = { // Name: SW_Tarqaq_Tower Type: tower_c GUID: 65, MapID: 16
-      LocalBuilding("SW_Tarqaq_Tower", 65, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2820f, 2072f, 237.9481f), tower_c)))
+      LocalBuilding("SW_Tarqaq_Tower", 65, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2820f, 2072f, 237.9481f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2188, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(268, Door.Constructor(Vector3(2832f, 2064f, 239.4691f)), owning_building_guid = 65)
       LocalObject(269, Door.Constructor(Vector3(2832f, 2064f, 259.4681f)), owning_building_guid = 65)
@@ -2129,7 +2129,7 @@ object Map06 { // Ceryshen
     Building24()
 
     def Building24(): Unit = { // Name: NW_Nerrivik_Tower Type: tower_c GUID: 66, MapID: 24
-      LocalBuilding("NW_Nerrivik_Tower", 66, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3188f, 3972f, 187.1799f), tower_c)))
+      LocalBuilding("NW_Nerrivik_Tower", 66, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3188f, 3972f, 187.1799f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2190, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(291, Door.Constructor(Vector3(3200f, 3964f, 188.7009f)), owning_building_guid = 66)
       LocalObject(292, Door.Constructor(Vector3(3200f, 3964f, 208.6999f)), owning_building_guid = 66)
@@ -2170,7 +2170,7 @@ object Map06 { // Ceryshen
     Building30()
 
     def Building30(): Unit = { // Name: S_Igaluk_Tower Type: tower_c GUID: 67, MapID: 30
-      LocalBuilding("S_Igaluk_Tower", 67, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3474f, 5228f, 240.8136f), tower_c)))
+      LocalBuilding("S_Igaluk_Tower", 67, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3474f, 5228f, 240.8136f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2194, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(322, Door.Constructor(Vector3(3486f, 5220f, 242.3346f)), owning_building_guid = 67)
       LocalObject(323, Door.Constructor(Vector3(3486f, 5220f, 262.3336f)), owning_building_guid = 67)
@@ -2211,7 +2211,7 @@ object Map06 { // Ceryshen
     Building17()
 
     def Building17(): Unit = { // Name: E_Keelut_Tower Type: tower_c GUID: 68, MapID: 17
-      LocalBuilding("E_Keelut_Tower", 68, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4352f, 1834f, 152.6882f), tower_c)))
+      LocalBuilding("E_Keelut_Tower", 68, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4352f, 1834f, 152.6882f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2202, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(426, Door.Constructor(Vector3(4364f, 1826f, 154.2092f)), owning_building_guid = 68)
       LocalObject(427, Door.Constructor(Vector3(4364f, 1826f, 174.2082f)), owning_building_guid = 68)
@@ -2252,7 +2252,7 @@ object Map06 { // Ceryshen
     Building49()
 
     def Building49(): Unit = { // Name: Akna_Tower Type: tower_c GUID: 69, MapID: 49
-      LocalBuilding("Akna_Tower", 69, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4354f, 3990f, 237.69f), tower_c)))
+      LocalBuilding("Akna_Tower", 69, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4354f, 3990f, 237.69f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2203, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(430, Door.Constructor(Vector3(4366f, 3982f, 239.211f)), owning_building_guid = 69)
       LocalObject(431, Door.Constructor(Vector3(4366f, 3982f, 259.2101f)), owning_building_guid = 69)
@@ -2293,7 +2293,7 @@ object Map06 { // Ceryshen
     Building51()
 
     def Building51(): Unit = { // Name: Hossin_Warpgate_Tower Type: tower_c GUID: 70, MapID: 51
-      LocalBuilding("Hossin_Warpgate_Tower", 70, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5342f, 4332f, 28.19361f), tower_c)))
+      LocalBuilding("Hossin_Warpgate_Tower", 70, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5342f, 4332f, 28.19361f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2208, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(481, Door.Constructor(Vector3(5354f, 4324f, 29.71461f)), owning_building_guid = 70)
       LocalObject(482, Door.Constructor(Vector3(5354f, 4324f, 49.71361f)), owning_building_guid = 70)
@@ -2334,7 +2334,7 @@ object Map06 { // Ceryshen
     Building19()
 
     def Building19(): Unit = { // Name: NE_Ishundar_Warpgate_Tower Type: tower_c GUID: 71, MapID: 19
-      LocalBuilding("NE_Ishundar_Warpgate_Tower", 71, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5694f, 2434f, 20.01801f), tower_c)))
+      LocalBuilding("NE_Ishundar_Warpgate_Tower", 71, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5694f, 2434f, 20.01801f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2209, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(485, Door.Constructor(Vector3(5706f, 2426f, 21.53901f)), owning_building_guid = 71)
       LocalObject(486, Door.Constructor(Vector3(5706f, 2426f, 41.53801f)), owning_building_guid = 71)
@@ -2375,7 +2375,7 @@ object Map06 { // Ceryshen
     Building55()
 
     def Building55(): Unit = { // Name: Pinga_Tower Type: tower_c GUID: 72, MapID: 55
-      LocalBuilding("Pinga_Tower", 72, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5768f, 3202f, 97.4664f), tower_c)))
+      LocalBuilding("Pinga_Tower", 72, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5768f, 3202f, 97.4664f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2210, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(489, Door.Constructor(Vector3(5780f, 3194f, 98.9874f)), owning_building_guid = 72)
       LocalObject(490, Door.Constructor(Vector3(5780f, 3194f, 118.9864f)), owning_building_guid = 72)
@@ -2416,7 +2416,7 @@ object Map06 { // Ceryshen
     Building21()
 
     def Building21(): Unit = { // Name: NE_Pinga_Tower Type: tower_c GUID: 73, MapID: 21
-      LocalBuilding("NE_Pinga_Tower", 73, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6320f, 3992f, 37.5779f), tower_c)))
+      LocalBuilding("NE_Pinga_Tower", 73, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6320f, 3992f, 37.5779f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2211, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(508, Door.Constructor(Vector3(6332f, 3984f, 39.0989f)), owning_building_guid = 73)
       LocalObject(509, Door.Constructor(Vector3(6332f, 3984f, 59.0979f)), owning_building_guid = 73)

--- a/pslogin/src/main/scala/zonemaps/Map07.scala
+++ b/pslogin/src/main/scala/zonemaps/Map07.scala
@@ -23,7 +23,7 @@ object Map07 { // Esamir
     Building8()
 
     def Building8(): Unit = { // Name: Freyr Type: amp_station GUID: 1, MapID: 8
-      LocalBuilding("Freyr", 1, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2908f, 3746f, 55.58336f), amp_station)))
+      LocalBuilding("Freyr", 1, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2908f, 3746f, 55.58336f), Vector3(0f, 0f, 72f), amp_station)))
       LocalObject(213, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(164, Door.Constructor(Vector3(2901.594f, 3748.306f, 68.48537f)), owning_building_guid = 1)
       LocalObject(165, Door.Constructor(Vector3(2914.537f, 3744.098f, 68.48537f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map07 { // Esamir
     Building11()
 
     def Building11(): Unit = { // Name: Kvasir Type: amp_station GUID: 4, MapID: 11
-      LocalBuilding("Kvasir", 4, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4016f, 1636f, 68.37366f), amp_station)))
+      LocalBuilding("Kvasir", 4, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4016f, 1636f, 68.37366f), Vector3(0f, 0f, 278f), amp_station)))
       LocalObject(218, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(166, Door.Constructor(Vector3(4009.291f, 1634.844f, 81.27567f)), owning_building_guid = 4)
       LocalObject(167, Door.Constructor(Vector3(4022.769f, 1636.735f, 81.27567f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map07 { // Esamir
     Building13()
 
     def Building13(): Unit = { // Name: Nott Type: amp_station GUID: 7, MapID: 13
-      LocalBuilding("Nott", 7, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6822f, 4234f, 46.3271f), amp_station)))
+      LocalBuilding("Nott", 7, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6822f, 4234f, 46.3271f), Vector3(0f, 0f, 62f), amp_station)))
       LocalObject(221, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 7)
       LocalObject(168, Door.Constructor(Vector3(6816.092f, 4237.384f, 59.2291f)), owning_building_guid = 7)
       LocalObject(169, Door.Constructor(Vector3(6828.107f, 4230.992f, 59.2291f)), owning_building_guid = 7)
@@ -407,7 +407,7 @@ object Map07 { // Esamir
     Building45()
 
     def Building45(): Unit = { // Name: bunkerg4 Type: bunker_gauntlet GUID: 10, MapID: 45
-      LocalBuilding("bunkerg4", 10, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2332f, 2086f, 85.39127f), bunker_gauntlet)))
+      LocalBuilding("bunkerg4", 10, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2332f, 2086f, 85.39127f), Vector3(0f, 0f, 337f), bunker_gauntlet)))
       LocalObject(363, Door.Constructor(Vector3(2308.334f, 2093.969f, 86.91228f)), owning_building_guid = 10)
       LocalObject(373, Door.Constructor(Vector3(2354.199f, 2074.512f, 86.91228f)), owning_building_guid = 10)
     }
@@ -415,7 +415,7 @@ object Map07 { // Esamir
     Building44()
 
     def Building44(): Unit = { // Name: bunkerg3 Type: bunker_gauntlet GUID: 11, MapID: 44
-      LocalBuilding("bunkerg3", 11, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3242f, 7204f, 77.57013f), bunker_gauntlet)))
+      LocalBuilding("bunkerg3", 11, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3242f, 7204f, 77.57013f), Vector3(0f, 0f, 227f), bunker_gauntlet)))
       LocalObject(409, Door.Constructor(Vector3(3223.612f, 7187.069f, 79.09113f)), owning_building_guid = 11)
       LocalObject(418, Door.Constructor(Vector3(3257.582f, 7223.513f, 79.09113f)), owning_building_guid = 11)
     }
@@ -423,7 +423,7 @@ object Map07 { // Esamir
     Building42()
 
     def Building42(): Unit = { // Name: bunkerg1 Type: bunker_gauntlet GUID: 12, MapID: 42
-      LocalBuilding("bunkerg1", 12, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3468f, 4516f, 75.12246f), bunker_gauntlet)))
+      LocalBuilding("bunkerg1", 12, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3468f, 4516f, 75.12246f), Vector3(0f, 0f, 227f), bunker_gauntlet)))
       LocalObject(447, Door.Constructor(Vector3(3449.612f, 4499.069f, 76.64346f)), owning_building_guid = 12)
       LocalObject(454, Door.Constructor(Vector3(3483.582f, 4535.513f, 76.64346f)), owning_building_guid = 12)
     }
@@ -431,7 +431,7 @@ object Map07 { // Esamir
     Building43()
 
     def Building43(): Unit = { // Name: bunkerg2 Type: bunker_gauntlet GUID: 13, MapID: 43
-      LocalBuilding("bunkerg2", 13, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3816f, 6076f, 59.98318f), bunker_gauntlet)))
+      LocalBuilding("bunkerg2", 13, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3816f, 6076f, 59.98318f), Vector3(0f, 0f, 74f), bunker_gauntlet)))
       LocalObject(473, Door.Constructor(Vector3(3810.975f, 6051.54f, 61.50418f)), owning_building_guid = 13)
       LocalObject(474, Door.Constructor(Vector3(3824.697f, 6099.434f, 61.50418f)), owning_building_guid = 13)
     }
@@ -439,63 +439,63 @@ object Map07 { // Esamir
     Building34()
 
     def Building34(): Unit = { // Name: bunker2 Type: bunker_lg GUID: 14, MapID: 34
-      LocalBuilding("bunker2", 14, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(946f, 2856f, 74.08158f), bunker_lg)))
+      LocalBuilding("bunker2", 14, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(946f, 2856f, 74.08158f), Vector3(0f, 0f, 223f), bunker_lg)))
       LocalObject(306, Door.Constructor(Vector3(945.838f, 2852.353f, 75.60258f)), owning_building_guid = 14)
     }
 
     Building35()
 
     def Building35(): Unit = { // Name: bunker3 Type: bunker_lg GUID: 15, MapID: 35
-      LocalBuilding("bunker3", 15, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3026f, 3702f, 55.36764f), bunker_lg)))
+      LocalBuilding("bunker3", 15, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3026f, 3702f, 55.36764f), Vector3(0f, 0f, 141f), bunker_lg)))
       LocalObject(396, Door.Constructor(Vector3(3022.365f, 3701.653f, 56.88864f)), owning_building_guid = 15)
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: bunker5 Type: bunker_lg GUID: 16, MapID: 37
-      LocalBuilding("bunker5", 16, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3138f, 7404f, 77.53236f), bunker_lg)))
+      LocalBuilding("bunker5", 16, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3138f, 7404f, 77.53236f), Vector3(0f, 0f, 263f), bunker_lg)))
       LocalObject(400, Door.Constructor(Vector3(3140.22f, 7401.102f, 79.05337f)), owning_building_guid = 16)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunker8 Type: bunker_lg GUID: 17, MapID: 40
-      LocalBuilding("bunker8", 17, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3632f, 3158f, 66.75056f), bunker_lg)))
+      LocalBuilding("bunker8", 17, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3632f, 3158f, 66.75056f), Vector3(0f, 0f, 270f), bunker_lg)))
       LocalObject(455, Door.Constructor(Vector3(3634.557f, 3155.394f, 68.27157f)), owning_building_guid = 17)
     }
 
     Building33()
 
     def Building33(): Unit = { // Name: bunker1 Type: bunker_sm GUID: 18, MapID: 33
-      LocalBuilding("bunker1", 18, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1066f, 2700f, 73.6301f), bunker_sm)))
+      LocalBuilding("bunker1", 18, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1066f, 2700f, 73.6301f), Vector3(0f, 0f, 174f), bunker_sm)))
       LocalObject(318, Door.Constructor(Vector3(1064.787f, 2700.183f, 75.1511f)), owning_building_guid = 18)
     }
 
     Building39()
 
     def Building39(): Unit = { // Name: bunker7 Type: bunker_sm GUID: 19, MapID: 39
-      LocalBuilding("bunker7", 19, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2024f, 5436f, 68.63918f), bunker_sm)))
+      LocalBuilding("bunker7", 19, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2024f, 5436f, 68.63918f), Vector3(0f, 0f, 41f), bunker_sm)))
       LocalObject(348, Door.Constructor(Vector3(2024.961f, 5436.762f, 70.16019f)), owning_building_guid = 19)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: bunker4 Type: bunker_sm GUID: 20, MapID: 36
-      LocalBuilding("bunker4", 20, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3416f, 4742f, 75.41428f), bunker_sm)))
+      LocalBuilding("bunker4", 20, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3416f, 4742f, 75.41428f), Vector3(0f, 0f, 231f), bunker_sm)))
       LocalObject(444, Door.Constructor(Vector3(3415.186f, 4741.083f, 76.93529f)), owning_building_guid = 20)
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: bunker6 Type: bunker_sm GUID: 21, MapID: 38
-      LocalBuilding("bunker6", 21, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5560f, 2582f, 53.30706f), bunker_sm)))
+      LocalBuilding("bunker6", 21, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5560f, 2582f, 53.30706f), Vector3(0f, 0f, 138f), bunker_sm)))
       LocalObject(557, Door.Constructor(Vector3(5559.126f, 2582.861f, 54.82806f)), owning_building_guid = 21)
     }
 
     Building16()
 
     def Building16(): Unit = { // Name: Jarl Type: comm_station GUID: 22, MapID: 16
-      LocalBuilding("Jarl", 22, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2012f, 5530f, 68.28211f), comm_station)))
+      LocalBuilding("Jarl", 22, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2012f, 5530f, 68.28211f), Vector3(0f, 0f, 289f), comm_station)))
       LocalObject(211, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 22)
       LocalObject(340, Door.Constructor(Vector3(1933.992f, 5548.292f, 77.99712f)), owning_building_guid = 22)
       LocalObject(341, Door.Constructor(Vector3(1939.915f, 5531.091f, 70.03311f)), owning_building_guid = 22)
@@ -614,7 +614,7 @@ object Map07 { // Esamir
     Building14()
 
     def Building14(): Unit = { // Name: Vidar Type: comm_station GUID: 25, MapID: 14
-      LocalBuilding("Vidar", 25, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3720f, 3102f, 66.58833f), comm_station)))
+      LocalBuilding("Vidar", 25, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3720f, 3102f, 66.58833f), Vector3(0f, 0f, 360f), comm_station)))
       LocalObject(216, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 25)
       LocalObject(460, Door.Constructor(Vector3(3660.196f, 3058.5f, 68.33933f)), owning_building_guid = 25)
       LocalObject(461, Door.Constructor(Vector3(3660.196f, 3076.693f, 76.30333f)), owning_building_guid = 25)
@@ -733,7 +733,7 @@ object Map07 { // Esamir
     Building5()
 
     def Building5(): Unit = { // Name: Andvari Type: comm_station_dsp GUID: 28, MapID: 5
-      LocalBuilding("Andvari", 28, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3172f, 7272f, 77.53838f), comm_station_dsp)))
+      LocalBuilding("Andvari", 28, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3172f, 7272f, 77.53838f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(214, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 28)
       LocalObject(261, Door.Constructor(Vector3(3240.339f, 7342.464f, 80.91637f)), owning_building_guid = 28)
       LocalObject(397, Door.Constructor(Vector3(3112.196f, 7228.501f, 79.18938f)), owning_building_guid = 28)
@@ -874,7 +874,7 @@ object Map07 { // Esamir
     Building15()
 
     def Building15(): Unit = { // Name: ymir Type: cryo_facility GUID: 31, MapID: 15
-      LocalBuilding("ymir", 31, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1860f, 3946f, 69.04202f), cryo_facility)))
+      LocalBuilding("ymir", 31, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1860f, 3946f, 69.04202f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(210, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 31)
       LocalObject(325, Door.Constructor(Vector3(1801.023f, 3950.5f, 70.59303f)), owning_building_guid = 31)
       LocalObject(326, Door.Constructor(Vector3(1801.023f, 3968.693f, 78.55702f)), owning_building_guid = 31)
@@ -1022,7 +1022,7 @@ object Map07 { // Esamir
     Building17()
 
     def Building17(): Unit = { // Name: Ran Type: cryo_facility GUID: 34, MapID: 17
-      LocalBuilding("Ran", 34, 17, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2342f, 1992f, 85.51286f), cryo_facility)))
+      LocalBuilding("Ran", 34, 17, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2342f, 1992f, 85.51286f), Vector3(0f, 0f, 246f), cryo_facility)))
       LocalObject(212, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 34)
       LocalObject(358, Door.Constructor(Vector3(2244.938f, 2000.186f, 87.03387f)), owning_building_guid = 34)
       LocalObject(359, Door.Constructor(Vector3(2256.684f, 2004.261f, 87.06387f)), owning_building_guid = 34)
@@ -1170,7 +1170,7 @@ object Map07 { // Esamir
     Building12()
 
     def Building12(): Unit = { // Name: Mani Type: cryo_facility GUID: 37, MapID: 12
-      LocalBuilding("Mani", 37, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5008f, 4926f, 57.77154f), cryo_facility)))
+      LocalBuilding("Mani", 37, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5008f, 4926f, 57.77154f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(219, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 37)
       LocalObject(525, Door.Constructor(Vector3(4949.023f, 4930.5f, 59.32254f)), owning_building_guid = 37)
       LocalObject(526, Door.Constructor(Vector3(4949.023f, 4948.693f, 67.28654f)), owning_building_guid = 37)
@@ -1330,7 +1330,7 @@ object Map07 { // Esamir
     Building9()
 
     def Building9(): Unit = { // Name: Gjallar Type: tech_plant GUID: 44, MapID: 9
-      LocalBuilding("Gjallar", 44, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(958f, 2734f, 74.05927f), tech_plant)))
+      LocalBuilding("Gjallar", 44, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(958f, 2734f, 74.05927f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(209, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 44)
       LocalObject(300, Door.Constructor(Vector3(886.54f, 2663.929f, 75.60126f)), owning_building_guid = 44)
       LocalObject(301, Door.Constructor(Vector3(886.54f, 2682.121f, 83.56426f)), owning_building_guid = 44)
@@ -1456,7 +1456,7 @@ object Map07 { // Esamir
     Building7()
 
     def Building7(): Unit = { // Name: Eisa Type: tech_plant GUID: 47, MapID: 7
-      LocalBuilding("Eisa", 47, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3394f, 4622f, 75.30442f), tech_plant)))
+      LocalBuilding("Eisa", 47, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3394f, 4622f, 75.30442f), Vector3(0f, 0f, 337f), tech_plant)))
       LocalObject(215, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 47)
       LocalObject(431, Door.Constructor(Vector3(3300.842f, 4585.421f, 76.84642f)), owning_building_guid = 47)
       LocalObject(432, Door.Constructor(Vector3(3307.95f, 4602.167f, 84.80942f)), owning_building_guid = 47)
@@ -1582,7 +1582,7 @@ object Map07 { // Esamir
     Building6()
 
     def Building6(): Unit = { // Name: Dagur Type: tech_plant GUID: 50, MapID: 6
-      LocalBuilding("Dagur", 50, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3936f, 6108f, 60.06042f), tech_plant)))
+      LocalBuilding("Dagur", 50, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3936f, 6108f, 60.06042f), Vector3(0f, 0f, 79f), tech_plant)))
       LocalObject(217, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 50)
       LocalObject(475, Door.Constructor(Vector3(3900.902f, 6042.025f, 69.56542f)), owning_building_guid = 50)
       LocalObject(476, Door.Constructor(Vector3(3909.995f, 6138.074f, 61.60242f)), owning_building_guid = 50)
@@ -1708,7 +1708,7 @@ object Map07 { // Esamir
     Building10()
 
     def Building10(): Unit = { // Name: Helhiem Type: tech_plant GUID: 53, MapID: 10
-      LocalBuilding("Helhiem", 53, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5448f, 2608f, 53.3311f), tech_plant)))
+      LocalBuilding("Helhiem", 53, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5448f, 2608f, 53.3311f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(220, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 53)
       LocalObject(544, Door.Constructor(Vector3(5376.54f, 2537.929f, 54.8731f)), owning_building_guid = 53)
       LocalObject(545, Door.Constructor(Vector3(5376.54f, 2556.121f, 62.8361f)), owning_building_guid = 53)
@@ -1834,7 +1834,7 @@ object Map07 { // Esamir
     Building53()
 
     def Building53(): Unit = { // Name: N_Gjallar_Tower Type: tower_a GUID: 56, MapID: 53
-      LocalBuilding("N_Gjallar_Tower", 56, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(986f, 3016f, 82.00085f), tower_a)))
+      LocalBuilding("N_Gjallar_Tower", 56, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(986f, 3016f, 82.00085f), Vector3(0f, 0f, 347f), tower_a)))
       LocalObject(2525, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(311, Door.Constructor(Vector3(995.8928f, 3005.506f, 83.52186f)), owning_building_guid = 56)
       LocalObject(312, Door.Constructor(Vector3(995.8928f, 3005.506f, 103.5209f)), owning_building_guid = 56)
@@ -1871,7 +1871,7 @@ object Map07 { // Esamir
     Building31()
 
     def Building31(): Unit = { // Name: N_Ymir_Tower Type: tower_a GUID: 57, MapID: 31
-      LocalBuilding("N_Ymir_Tower", 57, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1810f, 4194f, 79.81811f), tower_a)))
+      LocalBuilding("N_Ymir_Tower", 57, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1810f, 4194f, 79.81811f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2527, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(328, Door.Constructor(Vector3(1822f, 4186f, 81.33911f)), owning_building_guid = 57)
       LocalObject(329, Door.Constructor(Vector3(1822f, 4186f, 101.3381f)), owning_building_guid = 57)
@@ -1908,7 +1908,7 @@ object Map07 { // Esamir
     Building52()
 
     def Building52(): Unit = { // Name: E_Jarl_Tower Type: tower_a GUID: 58, MapID: 52
-      LocalBuilding("E_Jarl_Tower", 58, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2222f, 5656f, 67.37571f), tower_a)))
+      LocalBuilding("E_Jarl_Tower", 58, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2222f, 5656f, 67.37571f), Vector3(0f, 0f, 46f), tower_a)))
       LocalObject(2528, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(354, Door.Constructor(Vector3(2224.581f, 5670.189f, 68.89671f)), owning_building_guid = 58)
       LocalObject(355, Door.Constructor(Vector3(2224.581f, 5670.189f, 88.89571f)), owning_building_guid = 58)
@@ -1945,7 +1945,7 @@ object Map07 { // Esamir
     Building49()
 
     def Building49(): Unit = { // Name: N_Ran_Tower Type: tower_a GUID: 59, MapID: 49
-      LocalBuilding("N_Ran_Tower", 59, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2298f, 2210f, 85.70513f), tower_a)))
+      LocalBuilding("N_Ran_Tower", 59, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2298f, 2210f, 85.70513f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2529, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(364, Door.Constructor(Vector3(2310f, 2202f, 87.22614f)), owning_building_guid = 59)
       LocalObject(365, Door.Constructor(Vector3(2310f, 2202f, 107.2251f)), owning_building_guid = 59)
@@ -1982,7 +1982,7 @@ object Map07 { // Esamir
     Building21()
 
     def Building21(): Unit = { // Name: W_Searhus_Warpgate_Tower Type: tower_a GUID: 60, MapID: 21
-      LocalBuilding("W_Searhus_Warpgate_Tower", 60, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2300f, 3034f, 88.18629f), tower_a)))
+      LocalBuilding("W_Searhus_Warpgate_Tower", 60, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2300f, 3034f, 88.18629f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2530, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(368, Door.Constructor(Vector3(2312f, 3026f, 89.70729f)), owning_building_guid = 60)
       LocalObject(369, Door.Constructor(Vector3(2312f, 3026f, 109.7063f)), owning_building_guid = 60)
@@ -2019,7 +2019,7 @@ object Map07 { // Esamir
     Building48()
 
     def Building48(): Unit = { // Name: E_Freyr_Tower Type: tower_a GUID: 61, MapID: 48
-      LocalBuilding("E_Freyr_Tower", 61, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3276f, 3710f, 53.76141f), tower_a)))
+      LocalBuilding("E_Freyr_Tower", 61, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3276f, 3710f, 53.76141f), Vector3(0f, 0f, 0f), tower_a)))
       LocalObject(2533, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(426, Door.Constructor(Vector3(3288f, 3702f, 55.28241f)), owning_building_guid = 61)
       LocalObject(427, Door.Constructor(Vector3(3288f, 3702f, 75.2814f)), owning_building_guid = 61)
@@ -2056,7 +2056,7 @@ object Map07 { // Esamir
     Building22()
 
     def Building22(): Unit = { // Name: S_Andvari_Tower Type: tower_a GUID: 62, MapID: 22
-      LocalBuilding("S_Andvari_Tower", 62, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3320f, 6550f, 91.44566f), tower_a)))
+      LocalBuilding("S_Andvari_Tower", 62, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3320f, 6550f, 91.44566f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2534, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(435, Door.Constructor(Vector3(3332f, 6542f, 92.96667f)), owning_building_guid = 62)
       LocalObject(436, Door.Constructor(Vector3(3332f, 6542f, 112.9657f)), owning_building_guid = 62)
@@ -2093,7 +2093,7 @@ object Map07 { // Esamir
     Building18()
 
     def Building18(): Unit = { // Name: SE_Eisa_Tower Type: tower_a GUID: 63, MapID: 18
-      LocalBuilding("SE_Eisa_Tower", 63, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3644f, 4338f, 103.9521f), tower_a)))
+      LocalBuilding("SE_Eisa_Tower", 63, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3644f, 4338f, 103.9521f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2536, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(456, Door.Constructor(Vector3(3656f, 4330f, 105.4732f)), owning_building_guid = 63)
       LocalObject(457, Door.Constructor(Vector3(3656f, 4330f, 125.4722f)), owning_building_guid = 63)
@@ -2130,7 +2130,7 @@ object Map07 { // Esamir
     Building32()
 
     def Building32(): Unit = { // Name: S_Kvasir_Tower Type: tower_a GUID: 64, MapID: 32
-      LocalBuilding("S_Kvasir_Tower", 64, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4126f, 1362f, 62.56905f), tower_a)))
+      LocalBuilding("S_Kvasir_Tower", 64, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4126f, 1362f, 62.56905f), Vector3(0f, 0f, 318f), tower_a)))
       LocalObject(2537, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(505, Door.Constructor(Vector3(4129.564f, 1348.025f, 64.09005f)), owning_building_guid = 64)
       LocalObject(506, Door.Constructor(Vector3(4129.564f, 1348.025f, 84.08905f)), owning_building_guid = 64)
@@ -2167,7 +2167,7 @@ object Map07 { // Esamir
     Building46()
 
     def Building46(): Unit = { // Name: N_Mani_Tower Type: tower_a GUID: 65, MapID: 46
-      LocalBuilding("N_Mani_Tower", 65, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4968f, 5154f, 47.77367f), tower_a)))
+      LocalBuilding("N_Mani_Tower", 65, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4968f, 5154f, 47.77367f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2541, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(528, Door.Constructor(Vector3(4980f, 5146f, 49.29467f)), owning_building_guid = 65)
       LocalObject(529, Door.Constructor(Vector3(4980f, 5146f, 69.29367f)), owning_building_guid = 65)
@@ -2204,7 +2204,7 @@ object Map07 { // Esamir
     Building50()
 
     def Building50(): Unit = { // Name: E_Helhiem_Tower Type: tower_a GUID: 66, MapID: 50
-      LocalBuilding("E_Helhiem_Tower", 66, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5672f, 2702f, 52.44301f), tower_a)))
+      LocalBuilding("E_Helhiem_Tower", 66, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5672f, 2702f, 52.44301f), Vector3(0f, 0f, 327f), tower_a)))
       LocalObject(2543, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(558, Door.Constructor(Vector3(5677.707f, 2688.755f, 53.96401f)), owning_building_guid = 66)
       LocalObject(559, Door.Constructor(Vector3(5677.707f, 2688.755f, 73.96301f)), owning_building_guid = 66)
@@ -2241,7 +2241,7 @@ object Map07 { // Esamir
     Building19()
 
     def Building19(): Unit = { // Name: E_Oshur_Warpgate_Tower Type: tower_a GUID: 67, MapID: 19
-      LocalBuilding("E_Oshur_Warpgate_Tower", 67, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5916f, 3990f, 56.33412f), tower_a)))
+      LocalBuilding("E_Oshur_Warpgate_Tower", 67, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5916f, 3990f, 56.33412f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2545, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(568, Door.Constructor(Vector3(5928f, 3982f, 57.85512f)), owning_building_guid = 67)
       LocalObject(569, Door.Constructor(Vector3(5928f, 3982f, 77.85412f)), owning_building_guid = 67)
@@ -2278,7 +2278,7 @@ object Map07 { // Esamir
     Building23()
 
     def Building23(): Unit = { // Name: Outpost_Tower Type: tower_a GUID: 68, MapID: 23
-      LocalBuilding("Outpost_Tower", 68, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6334f, 5258f, 58.87936f), tower_a)))
+      LocalBuilding("Outpost_Tower", 68, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6334f, 5258f, 58.87936f), Vector3(0f, 0f, 346f), tower_a)))
       LocalObject(2546, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(572, Door.Constructor(Vector3(6343.708f, 5247.334f, 60.40036f)), owning_building_guid = 68)
       LocalObject(573, Door.Constructor(Vector3(6343.708f, 5247.334f, 80.39936f)), owning_building_guid = 68)
@@ -2315,7 +2315,7 @@ object Map07 { // Esamir
     Building20()
 
     def Building20(): Unit = { // Name: NE_VSSanc_Warpgate_Tower Type: tower_a GUID: 69, MapID: 20
-      LocalBuilding("NE_VSSanc_Warpgate_Tower", 69, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6928f, 1758f, 78.24335f), tower_a)))
+      LocalBuilding("NE_VSSanc_Warpgate_Tower", 69, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6928f, 1758f, 78.24335f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2547, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(593, Door.Constructor(Vector3(6940f, 1750f, 79.76436f)), owning_building_guid = 69)
       LocalObject(594, Door.Constructor(Vector3(6940f, 1750f, 99.76335f)), owning_building_guid = 69)
@@ -2352,7 +2352,7 @@ object Map07 { // Esamir
     Building47()
 
     def Building47(): Unit = { // Name: SE_Nott_Tower Type: tower_a GUID: 70, MapID: 47
-      LocalBuilding("SE_Nott_Tower", 70, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7018f, 4124f, 47.17856f), tower_a)))
+      LocalBuilding("SE_Nott_Tower", 70, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7018f, 4124f, 47.17856f), Vector3(0f, 0f, 338f), tower_a)))
       LocalObject(2548, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(597, Door.Constructor(Vector3(7026.129f, 4112.087f, 48.69956f)), owning_building_guid = 70)
       LocalObject(598, Door.Constructor(Vector3(7026.129f, 4112.087f, 68.69856f)), owning_building_guid = 70)
@@ -2389,7 +2389,7 @@ object Map07 { // Esamir
     Building41()
 
     def Building41(): Unit = { // Name: N_NCSanc_Warpgate_Tower Type: tower_b GUID: 71, MapID: 41
-      LocalBuilding("N_NCSanc_Warpgate_Tower", 71, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(754f, 6932f, 44.69741f), tower_b)))
+      LocalBuilding("N_NCSanc_Warpgate_Tower", 71, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(754f, 6932f, 44.69741f), Vector3(0f, 0f, 30f), tower_b)))
       LocalObject(2524, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(294, Door.Constructor(Vector3(760.3923f, 6944.928f, 46.21741f)), owning_building_guid = 71)
       LocalObject(295, Door.Constructor(Vector3(760.3923f, 6944.928f, 56.21741f)), owning_building_guid = 71)
@@ -2426,7 +2426,7 @@ object Map07 { // Esamir
     Building54()
 
     def Building54(): Unit = { // Name: S_NCSanc_Tower Type: tower_b GUID: 72, MapID: 54
-      LocalBuilding("S_NCSanc_Tower", 72, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1456f, 6060f, 120.4505f), tower_b)))
+      LocalBuilding("S_NCSanc_Tower", 72, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1456f, 6060f, 120.4505f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2526, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(319, Door.Constructor(Vector3(1468f, 6052f, 121.9705f)), owning_building_guid = 72)
       LocalObject(320, Door.Constructor(Vector3(1468f, 6052f, 131.9705f)), owning_building_guid = 72)
@@ -2463,7 +2463,7 @@ object Map07 { // Esamir
     Building25()
 
     def Building25(): Unit = { // Name: SE_Dagur_Tower Type: tower_b GUID: 73, MapID: 25
-      LocalBuilding("SE_Dagur_Tower", 73, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4248f, 5802f, 48.16736f), tower_b)))
+      LocalBuilding("SE_Dagur_Tower", 73, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4248f, 5802f, 48.16736f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2538, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(509, Door.Constructor(Vector3(4260f, 5794f, 49.68736f)), owning_building_guid = 73)
       LocalObject(510, Door.Constructor(Vector3(4260f, 5794f, 59.68736f)), owning_building_guid = 73)
@@ -2500,7 +2500,7 @@ object Map07 { // Esamir
     Building28()
 
     def Building28(): Unit = { // Name: SW_Mani_Tower Type: tower_b GUID: 74, MapID: 28
-      LocalBuilding("SW_Mani_Tower", 74, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4476f, 4308f, 70.25056f), tower_b)))
+      LocalBuilding("SW_Mani_Tower", 74, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4476f, 4308f, 70.25056f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2539, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 74)
       LocalObject(515, Door.Constructor(Vector3(4488f, 4300f, 71.77055f)), owning_building_guid = 74)
       LocalObject(516, Door.Constructor(Vector3(4488f, 4300f, 81.77055f)), owning_building_guid = 74)
@@ -2537,7 +2537,7 @@ object Map07 { // Esamir
     Building30()
 
     def Building30(): Unit = { // Name: NW_VSSanc_Warpgate_Tower Type: tower_b GUID: 75, MapID: 30
-      LocalBuilding("NW_VSSanc_Warpgate_Tower", 75, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5736f, 1382f, 84.58815f), tower_b)))
+      LocalBuilding("NW_VSSanc_Warpgate_Tower", 75, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5736f, 1382f, 84.58815f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2544, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 75)
       LocalObject(562, Door.Constructor(Vector3(5748f, 1374f, 86.10815f)), owning_building_guid = 75)
       LocalObject(563, Door.Constructor(Vector3(5748f, 1374f, 96.10815f)), owning_building_guid = 75)
@@ -2574,7 +2574,7 @@ object Map07 { // Esamir
     Building29()
 
     def Building29(): Unit = { // Name: SE_Searhus_Warpgate_Tower Type: tower_c GUID: 76, MapID: 29
-      LocalBuilding("SE_Searhus_Warpgate_Tower", 76, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3222f, 2488f, 89.08353f), tower_c)))
+      LocalBuilding("SE_Searhus_Warpgate_Tower", 76, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3222f, 2488f, 89.08353f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2531, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 76)
       LocalObject(412, Door.Constructor(Vector3(3234f, 2480f, 90.60453f)), owning_building_guid = 76)
       LocalObject(413, Door.Constructor(Vector3(3234f, 2480f, 110.6035f)), owning_building_guid = 76)
@@ -2615,7 +2615,7 @@ object Map07 { // Esamir
     Building26()
 
     def Building26(): Unit = { // Name: W_Vidar_Tower Type: tower_c GUID: 77, MapID: 26
-      LocalBuilding("W_Vidar_Tower", 77, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3270f, 3168f, 85.63189f), tower_c)))
+      LocalBuilding("W_Vidar_Tower", 77, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3270f, 3168f, 85.63189f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2532, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 77)
       LocalObject(422, Door.Constructor(Vector3(3282f, 3160f, 87.15289f)), owning_building_guid = 77)
       LocalObject(423, Door.Constructor(Vector3(3282f, 3160f, 107.1519f)), owning_building_guid = 77)
@@ -2656,7 +2656,7 @@ object Map07 { // Esamir
     Building51()
 
     def Building51(): Unit = { // Name: NE_Andvari_Tower Type: tower_c GUID: 78, MapID: 51
-      LocalBuilding("NE_Andvari_Tower", 78, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3446f, 7598f, 50.04425f), tower_c)))
+      LocalBuilding("NE_Andvari_Tower", 78, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3446f, 7598f, 50.04425f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2535, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 78)
       LocalObject(448, Door.Constructor(Vector3(3458f, 7590f, 51.56525f)), owning_building_guid = 78)
       LocalObject(449, Door.Constructor(Vector3(3458f, 7590f, 71.56425f)), owning_building_guid = 78)
@@ -2697,7 +2697,7 @@ object Map07 { // Esamir
     Building27()
 
     def Building27(): Unit = { // Name: SW_Oshur_Warpgate_Tower Type: tower_c GUID: 79, MapID: 27
-      LocalBuilding("SW_Oshur_Warpgate_Tower", 79, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4872f, 3408f, 58.76949f), tower_c)))
+      LocalBuilding("SW_Oshur_Warpgate_Tower", 79, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4872f, 3408f, 58.76949f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2540, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 79)
       LocalObject(521, Door.Constructor(Vector3(4884f, 3400f, 60.29049f)), owning_building_guid = 79)
       LocalObject(522, Door.Constructor(Vector3(4884f, 3400f, 80.28949f)), owning_building_guid = 79)
@@ -2738,7 +2738,7 @@ object Map07 { // Esamir
     Building24()
 
     def Building24(): Unit = { // Name: E_Dagur_Tower Type: tower_c GUID: 80, MapID: 24
-      LocalBuilding("E_Dagur_Tower", 80, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4994f, 5868f, 50.79501f), tower_c)))
+      LocalBuilding("E_Dagur_Tower", 80, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4994f, 5868f, 50.79501f), Vector3(0f, 0f, 41f), tower_c)))
       LocalObject(2542, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 80)
       LocalObject(534, Door.Constructor(Vector3(4997.808f, 5881.91f, 52.31601f)), owning_building_guid = 80)
       LocalObject(535, Door.Constructor(Vector3(4997.808f, 5881.91f, 72.315f)), owning_building_guid = 80)

--- a/pslogin/src/main/scala/zonemaps/Map08.scala
+++ b/pslogin/src/main/scala/zonemaps/Map08.scala
@@ -23,7 +23,7 @@ object Map08 { // Oshur Prime
     Building10()
 
     def Building10(): Unit = { // Name: Mithra Type: amp_station GUID: 1, MapID: 10
-      LocalBuilding("Mithra", 1, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2556f, 4528f, 43.54625f), amp_station)))
+      LocalBuilding("Mithra", 1, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2556f, 4528f, 43.54625f), Vector3(0f, 0f, 179f), amp_station)))
       LocalObject(158, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(128, Door.Constructor(Vector3(2555.667f, 4521.2f, 56.44825f)), owning_building_guid = 1)
       LocalObject(129, Door.Constructor(Vector3(2555.908f, 4534.808f, 56.44825f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map08 { // Oshur Prime
     Building36()
 
     def Building36(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 36
-      LocalBuilding("bunker_gauntlet", 4, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2512f, 4400f, 43.54625f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2512f, 4400f, 43.54625f), Vector3(0f, 0f, 180f), bunker_gauntlet)))
       LocalObject(246, Door.Constructor(Vector3(2487.077f, 4401.901f, 45.06725f)), owning_building_guid = 4)
       LocalObject(250, Door.Constructor(Vector3(2536.898f, 4401.912f, 45.06725f)), owning_building_guid = 4)
     }
@@ -159,7 +159,7 @@ object Map08 { // Oshur Prime
     Building35()
 
     def Building35(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 35
-      LocalBuilding("bunker_gauntlet", 5, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3690f, 2828f, 47.2434f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3690f, 2828f, 47.2434f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(324, Door.Constructor(Vector3(3688.099f, 2803.077f, 48.7644f)), owning_building_guid = 5)
       LocalObject(325, Door.Constructor(Vector3(3688.088f, 2852.898f, 48.7644f)), owning_building_guid = 5)
     }
@@ -167,7 +167,7 @@ object Map08 { // Oshur Prime
     Building37()
 
     def Building37(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 37
-      LocalBuilding("bunker_gauntlet", 6, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3920f, 4790f, 48.64008f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3920f, 4790f, 48.64008f), Vector3(0f, 0f, 360f), bunker_gauntlet)))
       LocalObject(339, Door.Constructor(Vector3(3895.102f, 4788.088f, 50.16108f)), owning_building_guid = 6)
       LocalObject(349, Door.Constructor(Vector3(3944.923f, 4788.099f, 50.16108f)), owning_building_guid = 6)
     }
@@ -175,7 +175,7 @@ object Map08 { // Oshur Prime
     Building38()
 
     def Building38(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 38
-      LocalBuilding("bunker_gauntlet", 7, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5646f, 3830f, 50.48064f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5646f, 3830f, 50.48064f), Vector3(0f, 0f, 225f), bunker_gauntlet)))
       LocalObject(449, Door.Constructor(Vector3(5627.033f, 3813.721f, 52.00164f)), owning_building_guid = 7)
       LocalObject(450, Door.Constructor(Vector3(5662.253f, 3848.958f, 52.00164f)), owning_building_guid = 7)
     }
@@ -183,63 +183,63 @@ object Map08 { // Oshur Prime
     Building31()
 
     def Building31(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 8, MapID: 31
-      LocalBuilding("bunker_lg", 8, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2634f, 4650f, 43.54879f), bunker_lg)))
+      LocalBuilding("bunker_lg", 8, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2634f, 4650f, 43.54879f), Vector3(0f, 0f, 225f), bunker_lg)))
       LocalObject(265, Door.Constructor(Vector3(2633.965f, 4646.349f, 45.06979f)), owning_building_guid = 8)
     }
 
     Building30()
 
     def Building30(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 30
-      LocalBuilding("bunker_lg", 9, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4150f, 2192f, 50.98085f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4150f, 2192f, 50.98085f), Vector3(0f, 0f, 90f), bunker_lg)))
       LocalObject(367, Door.Constructor(Vector3(4147.443f, 2194.606f, 52.50185f)), owning_building_guid = 9)
     }
 
     Building32()
 
     def Building32(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 32
-      LocalBuilding("bunker_lg", 10, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4828f, 4020f, 60.46708f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4828f, 4020f, 60.46708f), Vector3(0f, 0f, 270f), bunker_lg)))
       LocalObject(408, Door.Constructor(Vector3(4830.557f, 4017.394f, 61.98808f)), owning_building_guid = 10)
     }
 
     Building28()
 
     def Building28(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 11, MapID: 28
-      LocalBuilding("bunker_sm", 11, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2466f, 3306f, 32.02363f), bunker_sm)))
+      LocalBuilding("bunker_sm", 11, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2466f, 3306f, 32.02363f), Vector3(0f, 0f, 180f), bunker_sm)))
       LocalObject(245, Door.Constructor(Vector3(2464.775f, 3306.055f, 33.54463f)), owning_building_guid = 11)
     }
 
     Building34()
 
     def Building34(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 12, MapID: 34
-      LocalBuilding("bunker_sm", 12, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3274f, 4058f, 29.62605f), bunker_sm)))
+      LocalBuilding("bunker_sm", 12, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3274f, 4058f, 29.62605f), Vector3(0f, 0f, 135f), bunker_sm)))
       LocalObject(295, Door.Constructor(Vector3(3273.173f, 4058.905f, 31.14705f)), owning_building_guid = 12)
     }
 
     Building29()
 
     def Building29(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 13, MapID: 29
-      LocalBuilding("bunker_sm", 13, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3436f, 3066f, 49.3685f), bunker_sm)))
+      LocalBuilding("bunker_sm", 13, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3436f, 3066f, 49.3685f), Vector3(0f, 0f, 270f), bunker_sm)))
       LocalObject(296, Door.Constructor(Vector3(3435.945f, 3064.775f, 50.8895f)), owning_building_guid = 13)
     }
 
     Building46()
 
     def Building46(): Unit = { // Name: Hvar_Tower Type: bunker_sm GUID: 14, MapID: 46
-      LocalBuilding("Hvar_Tower", 14, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3882f, 4388f, 37.29616f), bunker_sm)))
+      LocalBuilding("Hvar_Tower", 14, 46, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3882f, 4388f, 37.29616f), Vector3(0f, 0f, 90f), bunker_sm)))
       LocalObject(336, Door.Constructor(Vector3(3882.055f, 4389.225f, 38.81716f)), owning_building_guid = 14)
     }
 
     Building33()
 
     def Building33(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 15, MapID: 33
-      LocalBuilding("bunker_sm", 15, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4920f, 5414f, 53.96307f), bunker_sm)))
+      LocalBuilding("bunker_sm", 15, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4920f, 5414f, 53.96307f), Vector3(0f, 0f, 135f), bunker_sm)))
       LocalObject(413, Door.Constructor(Vector3(4919.173f, 5414.905f, 55.48407f)), owning_building_guid = 15)
     }
 
     Building7()
 
     def Building7(): Unit = { // Name: Hvar Type: comm_station GUID: 16, MapID: 7
-      LocalBuilding("Hvar", 16, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3908f, 4688f, 48.62961f), comm_station)))
+      LocalBuilding("Hvar", 16, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3908f, 4688f, 48.62961f), Vector3(0f, 0f, 179f), comm_station)))
       LocalObject(161, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 16)
       LocalObject(332, Door.Constructor(Vector3(3847.677f, 4681.552f, 50.38061f)), owning_building_guid = 16)
       LocalObject(333, Door.Constructor(Vector3(3847.995f, 4699.742f, 58.34461f)), owning_building_guid = 16)
@@ -358,7 +358,7 @@ object Map08 { // Oshur Prime
     Building5()
 
     def Building5(): Unit = { // Name: Atar Type: comm_station_dsp GUID: 19, MapID: 5
-      LocalBuilding("Atar", 19, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3550f, 2798f, 47.04011f), comm_station_dsp)))
+      LocalBuilding("Atar", 19, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3550f, 2798f, 47.04011f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(160, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 19)
       LocalObject(204, Door.Constructor(Vector3(3618.339f, 2868.464f, 50.41811f)), owning_building_guid = 19)
       LocalObject(297, Door.Constructor(Vector3(3490.196f, 2754.501f, 48.69111f)), owning_building_guid = 19)
@@ -499,7 +499,7 @@ object Map08 { // Oshur Prime
     Building11()
 
     def Building11(): Unit = { // Name: Rashnu Type: cryo_facility GUID: 22, MapID: 11
-      LocalBuilding("Rashnu", 22, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3050f, 3898f, 59.5276f), cryo_facility)))
+      LocalBuilding("Rashnu", 22, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3050f, 3898f, 59.5276f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(159, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 22)
       LocalObject(280, Door.Constructor(Vector3(2991.023f, 3902.5f, 61.07859f)), owning_building_guid = 22)
       LocalObject(281, Door.Constructor(Vector3(2991.023f, 3920.693f, 69.04259f)), owning_building_guid = 22)
@@ -647,7 +647,7 @@ object Map08 { // Oshur Prime
     Building13()
 
     def Building13(): Unit = { // Name: Zal Type: cryo_facility GUID: 25, MapID: 13
-      LocalBuilding("Zal", 25, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3970f, 2242f, 61.23898f), cryo_facility)))
+      LocalBuilding("Zal", 25, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3970f, 2242f, 61.23898f), Vector3(0f, 0f, 227f), cryo_facility)))
       LocalObject(162, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 25)
       LocalObject(335, Door.Constructor(Vector3(3880.892f, 2281.341f, 62.75998f)), owning_building_guid = 25)
       LocalObject(338, Door.Constructor(Vector3(3893.324f, 2281.369f, 62.78997f)), owning_building_guid = 25)
@@ -795,7 +795,7 @@ object Map08 { // Oshur Prime
     Building12()
 
     def Building12(): Unit = { // Name: Yazata Type: cryo_facility GUID: 28, MapID: 12
-      LocalBuilding("Yazata", 28, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4680f, 3934f, 61.7468f), cryo_facility)))
+      LocalBuilding("Yazata", 28, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4680f, 3934f, 61.7468f), Vector3(0f, 0f, 90f), cryo_facility)))
       LocalObject(163, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 28)
       LocalObject(380, Door.Constructor(Vector3(4612.197f, 3891.674f, 63.2978f)), owning_building_guid = 28)
       LocalObject(381, Door.Constructor(Vector3(4612.197f, 3909.867f, 71.2618f)), owning_building_guid = 28)
@@ -955,7 +955,7 @@ object Map08 { // Oshur Prime
     Building9()
 
     def Building9(): Unit = { // Name: Jamshid Type: tech_plant GUID: 34, MapID: 9
-      LocalBuilding("Jamshid", 34, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2274f, 3448f, 52.4434f), tech_plant)))
+      LocalBuilding("Jamshid", 34, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2274f, 3448f, 52.4434f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(157, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 34)
       LocalObject(228, Door.Constructor(Vector3(2202.54f, 3377.929f, 53.9854f)), owning_building_guid = 34)
       LocalObject(229, Door.Constructor(Vector3(2202.54f, 3396.121f, 61.9484f)), owning_building_guid = 34)
@@ -1081,7 +1081,7 @@ object Map08 { // Oshur Prime
     Building6()
 
     def Building6(): Unit = { // Name: Dahaka Type: tech_plant GUID: 37, MapID: 6
-      LocalBuilding("Dahaka", 37, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4758f, 5388f, 53.64695f), tech_plant)))
+      LocalBuilding("Dahaka", 37, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4758f, 5388f, 53.64695f), Vector3(0f, 0f, 222f), tech_plant)))
       LocalObject(164, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 37)
       LocalObject(390, Door.Constructor(Vector3(4689.182f, 5346.336f, 63.15195f)), owning_building_guid = 37)
       LocalObject(391, Door.Constructor(Vector3(4693.555f, 5452.692f, 55.29795f)), owning_building_guid = 37)
@@ -1207,7 +1207,7 @@ object Map08 { // Oshur Prime
     Building8()
 
     def Building8(): Unit = { // Name: Izha Type: tech_plant GUID: 40, MapID: 8
-      LocalBuilding("Izha", 40, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5518f, 3878f, 50.5227f), tech_plant)))
+      LocalBuilding("Izha", 40, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5518f, 3878f, 50.5227f), Vector3(0f, 0f, 230f), tech_plant)))
       LocalObject(165, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 40)
       LocalObject(430, Door.Constructor(Vector3(5445.178f, 3933.093f, 52.1737f)), owning_building_guid = 40)
       LocalObject(431, Door.Constructor(Vector3(5455.65f, 3827.164f, 60.0277f)), owning_building_guid = 40)
@@ -1333,7 +1333,7 @@ object Map08 { // Oshur Prime
     Building16()
 
     def Building16(): Unit = { // Name: N_Jamshid_Tower Type: tower_a GUID: 43, MapID: 16
-      LocalBuilding("N_Jamshid_Tower", 43, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2312f, 3692f, 40.78366f), tower_a)))
+      LocalBuilding("N_Jamshid_Tower", 43, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2312f, 3692f, 40.78366f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1924, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 43)
       LocalObject(239, Door.Constructor(Vector3(2324f, 3684f, 42.30466f)), owning_building_guid = 43)
       LocalObject(240, Door.Constructor(Vector3(2324f, 3684f, 62.30367f)), owning_building_guid = 43)
@@ -1370,7 +1370,7 @@ object Map08 { // Oshur Prime
     Building40()
 
     def Building40(): Unit = { // Name: Rashnu_Tower Type: tower_a GUID: 44, MapID: 40
-      LocalBuilding("Rashnu_Tower", 44, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3244f, 3758f, 49.76207f), tower_a)))
+      LocalBuilding("Rashnu_Tower", 44, 40, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3244f, 3758f, 49.76207f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1928, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 44)
       LocalObject(291, Door.Constructor(Vector3(3256f, 3750f, 51.28307f)), owning_building_guid = 44)
       LocalObject(292, Door.Constructor(Vector3(3256f, 3750f, 71.28207f)), owning_building_guid = 44)
@@ -1407,7 +1407,7 @@ object Map08 { // Oshur Prime
     Building14()
 
     def Building14(): Unit = { // Name: S_Forseral_Warpgate_Tower Type: tower_a GUID: 45, MapID: 14
-      LocalBuilding("S_Forseral_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3520f, 5578f, 53.28131f), tower_a)))
+      LocalBuilding("S_Forseral_Warpgate_Tower", 45, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3520f, 5578f, 53.28131f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1929, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 45)
       LocalObject(303, Door.Constructor(Vector3(3532f, 5570f, 54.80231f)), owning_building_guid = 45)
       LocalObject(304, Door.Constructor(Vector3(3532f, 5570f, 74.80132f)), owning_building_guid = 45)
@@ -1444,7 +1444,7 @@ object Map08 { // Oshur Prime
     Building21()
 
     def Building21(): Unit = { // Name: W_Yazata_Tower Type: tower_a GUID: 46, MapID: 21
-      LocalBuilding("W_Yazata_Tower", 46, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4074f, 3888f, 36.98511f), tower_a)))
+      LocalBuilding("W_Yazata_Tower", 46, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4074f, 3888f, 36.98511f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1932, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 46)
       LocalObject(359, Door.Constructor(Vector3(4086f, 3880f, 38.50611f)), owning_building_guid = 46)
       LocalObject(360, Door.Constructor(Vector3(4086f, 3880f, 58.50511f)), owning_building_guid = 46)
@@ -1481,7 +1481,7 @@ object Map08 { // Oshur Prime
     Building42()
 
     def Building42(): Unit = { // Name: Zal_Tower Type: tower_a GUID: 47, MapID: 42
-      LocalBuilding("Zal_Tower", 47, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4132f, 2062f, 44.47557f), tower_a)))
+      LocalBuilding("Zal_Tower", 47, 42, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4132f, 2062f, 44.47557f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1933, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 47)
       LocalObject(363, Door.Constructor(Vector3(4144f, 2054f, 45.99657f)), owning_building_guid = 47)
       LocalObject(364, Door.Constructor(Vector3(4144f, 2054f, 65.99557f)), owning_building_guid = 47)
@@ -1518,7 +1518,7 @@ object Map08 { // Oshur Prime
     Building27()
 
     def Building27(): Unit = { // Name: SW_Esamir_Warpgate_Tower Type: tower_a GUID: 48, MapID: 27
-      LocalBuilding("SW_Esamir_Warpgate_Tower", 48, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5040f, 2300f, 57.00369f), tower_a)))
+      LocalBuilding("SW_Esamir_Warpgate_Tower", 48, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5040f, 2300f, 57.00369f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1938, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 48)
       LocalObject(414, Door.Constructor(Vector3(5052f, 2292f, 58.52469f)), owning_building_guid = 48)
       LocalObject(415, Door.Constructor(Vector3(5052f, 2292f, 78.5237f)), owning_building_guid = 48)
@@ -1555,7 +1555,7 @@ object Map08 { // Oshur Prime
     Building22()
 
     def Building22(): Unit = { // Name: S_Hossin_Warpgate_Tower Type: tower_a GUID: 49, MapID: 22
-      LocalBuilding("S_Hossin_Warpgate_Tower", 49, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5080f, 4766f, 75.09348f), tower_a)))
+      LocalBuilding("S_Hossin_Warpgate_Tower", 49, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5080f, 4766f, 75.09348f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1939, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 49)
       LocalObject(418, Door.Constructor(Vector3(5092f, 4758f, 76.61448f)), owning_building_guid = 49)
       LocalObject(419, Door.Constructor(Vector3(5092f, 4758f, 96.61348f)), owning_building_guid = 49)
@@ -1592,7 +1592,7 @@ object Map08 { // Oshur Prime
     Building44()
 
     def Building44(): Unit = { // Name: Izha_Tower Type: tower_a GUID: 50, MapID: 44
-      LocalBuilding("Izha_Tower", 50, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5240f, 3934f, 49.1933f), tower_a)))
+      LocalBuilding("Izha_Tower", 50, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5240f, 3934f, 49.1933f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1940, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 50)
       LocalObject(422, Door.Constructor(Vector3(5252f, 3926f, 50.7143f)), owning_building_guid = 50)
       LocalObject(423, Door.Constructor(Vector3(5252f, 3926f, 70.7133f)), owning_building_guid = 50)
@@ -1629,7 +1629,7 @@ object Map08 { // Oshur Prime
     Building18()
 
     def Building18(): Unit = { // Name: NE_Amerish_Warpgate_Tower Type: tower_b GUID: 51, MapID: 18
-      LocalBuilding("NE_Amerish_Warpgate_Tower", 51, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2888f, 2148f, 37.99061f), tower_b)))
+      LocalBuilding("NE_Amerish_Warpgate_Tower", 51, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2888f, 2148f, 37.99061f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1926, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 51)
       LocalObject(270, Door.Constructor(Vector3(2900f, 2140f, 39.51061f)), owning_building_guid = 51)
       LocalObject(271, Door.Constructor(Vector3(2900f, 2140f, 49.51061f)), owning_building_guid = 51)
@@ -1666,7 +1666,7 @@ object Map08 { // Oshur Prime
     Building15()
 
     def Building15(): Unit = { // Name: W_Hvar_Tower Type: tower_b GUID: 52, MapID: 15
-      LocalBuilding("W_Hvar_Tower", 52, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3700f, 4456f, 53.26608f), tower_b)))
+      LocalBuilding("W_Hvar_Tower", 52, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3700f, 4456f, 53.26608f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1931, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(326, Door.Constructor(Vector3(3712f, 4448f, 54.78608f)), owning_building_guid = 52)
       LocalObject(327, Door.Constructor(Vector3(3712f, 4448f, 64.78608f)), owning_building_guid = 52)
@@ -1703,7 +1703,7 @@ object Map08 { // Oshur Prime
     Building23()
 
     def Building23(): Unit = { // Name: NE_Zal_Tower Type: tower_b GUID: 53, MapID: 23
-      LocalBuilding("NE_Zal_Tower", 53, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4290f, 2990f, 42.18527f), tower_b)))
+      LocalBuilding("NE_Zal_Tower", 53, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4290f, 2990f, 42.18527f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1934, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(368, Door.Constructor(Vector3(4302f, 2982f, 43.70527f)), owning_building_guid = 53)
       LocalObject(369, Door.Constructor(Vector3(4302f, 2982f, 53.70527f)), owning_building_guid = 53)
@@ -1740,7 +1740,7 @@ object Map08 { // Oshur Prime
     Building20()
 
     def Building20(): Unit = { // Name: S_Dahaka_Tower Type: tower_b GUID: 54, MapID: 20
-      LocalBuilding("S_Dahaka_Tower", 54, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4514f, 4768f, 74.48821f), tower_b)))
+      LocalBuilding("S_Dahaka_Tower", 54, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4514f, 4768f, 74.48821f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1935, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(374, Door.Constructor(Vector3(4526f, 4760f, 76.00821f)), owning_building_guid = 54)
       LocalObject(375, Door.Constructor(Vector3(4526f, 4760f, 86.00821f)), owning_building_guid = 54)
@@ -1777,7 +1777,7 @@ object Map08 { // Oshur Prime
     Building45()
 
     def Building45(): Unit = { // Name: Hossin_Warpgate_Tower Type: tower_b GUID: 55, MapID: 45
-      LocalBuilding("Hossin_Warpgate_Tower", 55, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5520f, 5532f, 37.21363f), tower_b)))
+      LocalBuilding("Hossin_Warpgate_Tower", 55, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5520f, 5532f, 37.21363f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1942, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(441, Door.Constructor(Vector3(5532f, 5524f, 38.73363f)), owning_building_guid = 55)
       LocalObject(442, Door.Constructor(Vector3(5532f, 5524f, 48.73363f)), owning_building_guid = 55)
@@ -1814,7 +1814,7 @@ object Map08 { // Oshur Prime
     Building26()
 
     def Building26(): Unit = { // Name: E_Esamir_Warpgate_Tower Type: tower_b GUID: 56, MapID: 26
-      LocalBuilding("E_Esamir_Warpgate_Tower", 56, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5844f, 2602f, 36.16751f), tower_b)))
+      LocalBuilding("E_Esamir_Warpgate_Tower", 56, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5844f, 2602f, 36.16751f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1943, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(451, Door.Constructor(Vector3(5856f, 2594f, 37.68751f)), owning_building_guid = 56)
       LocalObject(452, Door.Constructor(Vector3(5856f, 2594f, 47.68751f)), owning_building_guid = 56)
@@ -1851,7 +1851,7 @@ object Map08 { // Oshur Prime
     Building39()
 
     def Building39(): Unit = { // Name: Mithra_Tower Type: tower_c GUID: 57, MapID: 39
-      LocalBuilding("Mithra_Tower", 57, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2830f, 4502f, 55.56146f), tower_c)))
+      LocalBuilding("Mithra_Tower", 57, 39, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2830f, 4502f, 55.56146f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1925, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(266, Door.Constructor(Vector3(2842f, 4494f, 57.08246f)), owning_building_guid = 57)
       LocalObject(267, Door.Constructor(Vector3(2842f, 4494f, 77.08146f)), owning_building_guid = 57)
@@ -1892,7 +1892,7 @@ object Map08 { // Oshur Prime
     Building17()
 
     def Building17(): Unit = { // Name: S_Rashnu_Tower Type: tower_c GUID: 58, MapID: 17
-      LocalBuilding("S_Rashnu_Tower", 58, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2972f, 2932f, 59.87292f), tower_c)))
+      LocalBuilding("S_Rashnu_Tower", 58, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2972f, 2932f, 59.87292f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1927, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(276, Door.Constructor(Vector3(2984f, 2924f, 61.39392f)), owning_building_guid = 58)
       LocalObject(277, Door.Constructor(Vector3(2984f, 2924f, 81.39292f)), owning_building_guid = 58)
@@ -1933,7 +1933,7 @@ object Map08 { // Oshur Prime
     Building41()
 
     def Building41(): Unit = { // Name: Atar_Tower Type: tower_c GUID: 59, MapID: 41
-      LocalBuilding("Atar_Tower", 59, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3562f, 3134f, 39.94067f), tower_c)))
+      LocalBuilding("Atar_Tower", 59, 41, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3562f, 3134f, 39.94067f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1930, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(311, Door.Constructor(Vector3(3574f, 3126f, 41.46167f)), owning_building_guid = 59)
       LocalObject(312, Door.Constructor(Vector3(3574f, 3126f, 61.46067f)), owning_building_guid = 59)
@@ -1974,7 +1974,7 @@ object Map08 { // Oshur Prime
     Building43()
 
     def Building43(): Unit = { // Name: Yazata_Tower Type: tower_c GUID: 60, MapID: 43
-      LocalBuilding("Yazata_Tower", 60, 43, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4640f, 3674f, 71.13654f), tower_c)))
+      LocalBuilding("Yazata_Tower", 60, 43, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4640f, 3674f, 71.13654f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1936, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(382, Door.Constructor(Vector3(4652f, 3666f, 72.65755f)), owning_building_guid = 60)
       LocalObject(383, Door.Constructor(Vector3(4652f, 3666f, 92.65654f)), owning_building_guid = 60)
@@ -2015,7 +2015,7 @@ object Map08 { // Oshur Prime
     Building19()
 
     def Building19(): Unit = { // Name: NE_Dahaka_Tower Type: tower_c GUID: 61, MapID: 19
-      LocalBuilding("NE_Dahaka_Tower", 61, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4882f, 5580f, 74.37141f), tower_c)))
+      LocalBuilding("NE_Dahaka_Tower", 61, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4882f, 5580f, 74.37141f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1937, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(409, Door.Constructor(Vector3(4894f, 5572f, 75.89241f)), owning_building_guid = 61)
       LocalObject(410, Door.Constructor(Vector3(4894f, 5572f, 95.8914f)), owning_building_guid = 61)
@@ -2056,7 +2056,7 @@ object Map08 { // Oshur Prime
     Building25()
 
     def Building25(): Unit = { // Name: S_Izha_Tower Type: tower_c GUID: 62, MapID: 25
-      LocalBuilding("S_Izha_Tower", 62, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5296f, 3324f, 36.35033f), tower_c)))
+      LocalBuilding("S_Izha_Tower", 62, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5296f, 3324f, 36.35033f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1941, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(426, Door.Constructor(Vector3(5308f, 3316f, 37.87133f)), owning_building_guid = 62)
       LocalObject(427, Door.Constructor(Vector3(5308f, 3316f, 57.87033f)), owning_building_guid = 62)
@@ -2097,7 +2097,7 @@ object Map08 { // Oshur Prime
     Building24()
 
     def Building24(): Unit = { // Name: SE_Izha_Tower Type: tower_c GUID: 63, MapID: 24
-      LocalBuilding("SE_Izha_Tower", 63, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6248f, 3502f, 60.33504f), tower_c)))
+      LocalBuilding("SE_Izha_Tower", 63, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6248f, 3502f, 60.33504f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1944, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(457, Door.Constructor(Vector3(6260f, 3494f, 61.85604f)), owning_building_guid = 63)
       LocalObject(458, Door.Constructor(Vector3(6260f, 3494f, 81.85504f)), owning_building_guid = 63)

--- a/pslogin/src/main/scala/zonemaps/Map09.scala
+++ b/pslogin/src/main/scala/zonemaps/Map09.scala
@@ -23,7 +23,7 @@ object Map09 { // Searhus
     Building14()
 
     def Building14(): Unit = { // Name: Rehua Type: amp_station GUID: 1, MapID: 14
-      LocalBuilding("Rehua", 1, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3736f, 2160f, 59.77203f), amp_station)))
+      LocalBuilding("Rehua", 1, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3736f, 2160f, 59.77203f), Vector3(0f, 0f, 333f), amp_station)))
       LocalObject(213, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(163, Door.Constructor(Vector3(3733.099f, 2153.841f, 72.67403f)), owning_building_guid = 1)
       LocalObject(164, Door.Constructor(Vector3(3739.28f, 2165.966f, 72.67403f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map09 { // Searhus
     Building13()
 
     def Building13(): Unit = { // Name: Pele Type: amp_station GUID: 4, MapID: 13
-      LocalBuilding("Pele", 4, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4440f, 3688f, 208.002f), amp_station)))
+      LocalBuilding("Pele", 4, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4440f, 3688f, 208.002f), Vector3(0f, 0f, 327f), amp_station)))
       LocalObject(217, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(165, Door.Constructor(Vector3(4436.471f, 3682.178f, 220.904f)), owning_building_guid = 4)
       LocalObject(166, Door.Constructor(Vector3(4443.886f, 3693.591f, 220.904f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map09 { // Searhus
     Building10()
 
     def Building10(): Unit = { // Name: Matagi Type: amp_station GUID: 7, MapID: 10
-      LocalBuilding("Matagi", 7, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5268f, 5004f, 239.1049f), amp_station)))
+      LocalBuilding("Matagi", 7, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5268f, 5004f, 239.1049f), Vector3(0f, 0f, 21f), amp_station)))
       LocalObject(222, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 7)
       LocalObject(167, Door.Constructor(Vector3(5265.761f, 5010.43f, 252.0069f)), owning_building_guid = 7)
       LocalObject(168, Door.Constructor(Vector3(5270.636f, 4997.723f, 252.0069f)), owning_building_guid = 7)
@@ -407,7 +407,7 @@ object Map09 { // Searhus
     Building42()
 
     def Building42(): Unit = { // Name: bunkerg6 Type: bunker_gauntlet GUID: 10, MapID: 42
-      LocalBuilding("bunkerg6", 10, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1068f, 4234f, 59.97345f), bunker_gauntlet)))
+      LocalBuilding("bunkerg6", 10, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1068f, 4234f, 59.97345f), Vector3(0f, 0f, 61f), bunker_gauntlet)))
       LocalObject(311, Door.Constructor(Vector3(1057.601f, 4211.297f, 61.49445f)), owning_building_guid = 10)
       LocalObject(312, Door.Constructor(Vector3(1081.746f, 4254.876f, 61.49445f)), owning_building_guid = 10)
     }
@@ -415,7 +415,7 @@ object Map09 { // Searhus
     Building43()
 
     def Building43(): Unit = { // Name: bunkerg7 Type: bunker_gauntlet GUID: 11, MapID: 43
-      LocalBuilding("bunkerg7", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3642f, 2072f, 59.77203f), bunker_gauntlet)))
+      LocalBuilding("bunkerg7", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3642f, 2072f, 59.77203f), Vector3(0f, 0f, 137f), bunker_gauntlet)))
       LocalObject(388, Door.Constructor(Vector3(3625.069f, 2090.388f, 61.29303f)), owning_building_guid = 11)
       LocalObject(392, Door.Constructor(Vector3(3661.513f, 2056.418f, 61.29303f)), owning_building_guid = 11)
     }
@@ -423,7 +423,7 @@ object Map09 { // Searhus
     Building41()
 
     def Building41(): Unit = { // Name: bunkerg5 Type: bunker_gauntlet GUID: 12, MapID: 41
-      LocalBuilding("bunkerg5", 12, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4532f, 6648f, 48.86586f), bunker_gauntlet)))
+      LocalBuilding("bunkerg5", 12, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4532f, 6648f, 48.86586f), Vector3(0f, 0f, 175f), bunker_gauntlet)))
       LocalObject(476, Door.Constructor(Vector3(4507.337f, 6652.066f, 50.38686f)), owning_building_guid = 12)
       LocalObject(482, Door.Constructor(Vector3(4556.97f, 6647.735f, 50.38686f)), owning_building_guid = 12)
     }
@@ -431,7 +431,7 @@ object Map09 { // Searhus
     Building38()
 
     def Building38(): Unit = { // Name: bungerg2 Type: bunker_gauntlet GUID: 13, MapID: 38
-      LocalBuilding("bungerg2", 13, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5936f, 2184f, 90.95889f), bunker_gauntlet)))
+      LocalBuilding("bungerg2", 13, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5936f, 2184f, 90.95889f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(591, Door.Constructor(Vector3(5934.099f, 2159.077f, 92.4799f)), owning_building_guid = 13)
       LocalObject(592, Door.Constructor(Vector3(5934.088f, 2208.898f, 92.4799f)), owning_building_guid = 13)
     }
@@ -439,7 +439,7 @@ object Map09 { // Searhus
     Building39()
 
     def Building39(): Unit = { // Name: bunkerg3 Type: bunker_gauntlet GUID: 14, MapID: 39
-      LocalBuilding("bunkerg3", 14, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6376f, 5224f, 55.30717f), bunker_gauntlet)))
+      LocalBuilding("bunkerg3", 14, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6376f, 5224f, 55.30717f), Vector3(0f, 0f, 19f), bunker_gauntlet)))
       LocalObject(597, Door.Constructor(Vector3(6353.081f, 5214.086f, 56.82817f)), owning_building_guid = 14)
       LocalObject(600, Door.Constructor(Vector3(6400.184f, 5230.317f, 56.82817f)), owning_building_guid = 14)
     }
@@ -447,63 +447,63 @@ object Map09 { // Searhus
     Building34()
 
     def Building34(): Unit = { // Name: bunker6 Type: bunker_lg GUID: 15, MapID: 34
-      LocalBuilding("bunker6", 15, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1192f, 4018f, 59.95798f), bunker_lg)))
+      LocalBuilding("bunker6", 15, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1192f, 4018f, 59.95798f), Vector3(0f, 0f, 56f), bunker_lg)))
       LocalObject(324, Door.Constructor(Vector3(1191.337f, 4021.59f, 61.47898f)), owning_building_guid = 15)
     }
 
     Building30()
 
     def Building30(): Unit = { // Name: bunker1 Type: bunker_lg GUID: 16, MapID: 30
-      LocalBuilding("bunker1", 16, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3838f, 2626f, 151.0666f), bunker_lg)))
+      LocalBuilding("bunker1", 16, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3838f, 2626f, 151.0666f), Vector3(0f, 0f, 69f), bunker_lg)))
       LocalObject(432, Door.Constructor(Vector3(3836.547f, 2629.349f, 152.5876f)), owning_building_guid = 16)
     }
 
     Building35()
 
     def Building35(): Unit = { // Name: bunker7 Type: bunker_lg GUID: 17, MapID: 35
-      LocalBuilding("bunker7", 17, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4780f, 6576f, 39.89838f), bunker_lg)))
+      LocalBuilding("bunker7", 17, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4780f, 6576f, 39.89838f), Vector3(0f, 0f, 89f), bunker_lg)))
       LocalObject(510, Door.Constructor(Vector3(4777.489f, 6578.65f, 41.41938f)), owning_building_guid = 17)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunkerg4 Type: bunker_lg GUID: 18, MapID: 40
-      LocalBuilding("bunkerg4", 18, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6486f, 5064f, 55.30717f), bunker_lg)))
+      LocalBuilding("bunkerg4", 18, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6486f, 5064f, 55.30717f), Vector3(0f, 0f, 70f), bunker_lg)))
       LocalObject(610, Door.Constructor(Vector3(6484.488f, 5067.323f, 56.82817f)), owning_building_guid = 18)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: bunker8 Type: bunker_sm GUID: 19, MapID: 36
-      LocalBuilding("bunker8", 19, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3670f, 5682f, 236.1003f), bunker_sm)))
+      LocalBuilding("bunker8", 19, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3670f, 5682f, 236.1003f), Vector3(0f, 0f, 303f), bunker_sm)))
       LocalObject(395, Door.Constructor(Vector3(3670.621f, 5680.943f, 237.6213f)), owning_building_guid = 19)
     }
 
     Building33()
 
     def Building33(): Unit = { // Name: bunker5 Type: bunker_sm GUID: 20, MapID: 33
-      LocalBuilding("bunker5", 20, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4142f, 4096f, 204.7803f), bunker_sm)))
+      LocalBuilding("bunker5", 20, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4142f, 4096f, 204.7803f), Vector3(0f, 0f, 132f), bunker_sm)))
       LocalObject(448, Door.Constructor(Vector3(4141.221f, 4096.947f, 206.3013f)), owning_building_guid = 20)
     }
 
     Building32()
 
     def Building32(): Unit = { // Name: bunker4 Type: bunker_sm GUID: 21, MapID: 32
-      LocalBuilding("bunker4", 21, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5238f, 3866f, 346.1104f), bunker_sm)))
+      LocalBuilding("bunker4", 21, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5238f, 3866f, 346.1104f), Vector3(0f, 0f, 47f), bunker_sm)))
       LocalObject(545, Door.Constructor(Vector3(5238.875f, 3866.858f, 347.6314f)), owning_building_guid = 21)
     }
 
     Building31()
 
     def Building31(): Unit = { // Name: bunker2 Type: bunker_sm GUID: 22, MapID: 31
-      LocalBuilding("bunker2", 22, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5726f, 2268f, 90.95889f), bunker_sm)))
+      LocalBuilding("bunker2", 22, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(5726f, 2268f, 90.95889f), Vector3(0f, 0f, 24f), bunker_sm)))
       LocalObject(571, Door.Constructor(Vector3(5727.142f, 2268.448f, 92.4799f)), owning_building_guid = 22)
     }
 
     Building17()
 
     def Building17(): Unit = { // Name: Wakea Type: comm_station GUID: 23, MapID: 17
-      LocalBuilding("Wakea", 23, 17, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1738f, 5314f, 62.99478f), comm_station)))
+      LocalBuilding("Wakea", 23, 17, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1738f, 5314f, 62.99478f), Vector3(0f, 0f, 360f), comm_station)))
       LocalObject(212, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 23)
       LocalObject(337, Door.Constructor(Vector3(1678.196f, 5270.5f, 64.74578f)), owning_building_guid = 23)
       LocalObject(338, Door.Constructor(Vector3(1678.196f, 5288.693f, 72.70978f)), owning_building_guid = 23)
@@ -622,7 +622,7 @@ object Map09 { // Searhus
     Building9()
 
     def Building9(): Unit = { // Name: Laka Type: comm_station GUID: 26, MapID: 9
-      LocalBuilding("Laka", 26, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4632f, 6704f, 48.95818f), comm_station)))
+      LocalBuilding("Laka", 26, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4632f, 6704f, 48.95818f), Vector3(0f, 0f, 66f), comm_station)))
       LocalObject(219, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 26)
       LocalObject(483, Door.Constructor(Vector3(4570.104f, 6732.105f, 50.70918f)), owning_building_guid = 26)
       LocalObject(486, Door.Constructor(Vector3(4575.586f, 6764.146f, 50.67918f)), owning_building_guid = 26)
@@ -741,7 +741,7 @@ object Map09 { // Searhus
     Building12()
 
     def Building12(): Unit = { // Name: Oro Type: comm_station GUID: 29, MapID: 12
-      LocalBuilding("Oro", 29, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4896f, 4538f, 208.002f), comm_station)))
+      LocalBuilding("Oro", 29, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4896f, 4538f, 208.002f), Vector3(0f, 0f, 295f), comm_station)))
       LocalObject(220, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 29)
       LocalObject(511, Door.Constructor(Vector3(4816.507f, 4548.038f, 217.7169f)), owning_building_guid = 29)
       LocalObject(512, Door.Constructor(Vector3(4824.195f, 4531.55f, 209.753f)), owning_building_guid = 29)
@@ -860,7 +860,7 @@ object Map09 { // Searhus
     Building15()
 
     def Building15(): Unit = { // Name: Sina Type: comm_station_dsp GUID: 32, MapID: 15
-      LocalBuilding("Sina", 32, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5838f, 2198f, 90.95889f), comm_station_dsp)))
+      LocalBuilding("Sina", 32, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5838f, 2198f, 90.95889f), Vector3(0f, 0f, 39f), comm_station_dsp)))
       LocalObject(223, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 32)
       LocalObject(277, Door.Constructor(Vector3(5846.765f, 2295.768f, 94.33689f)), owning_building_guid = 32)
       LocalObject(572, Door.Constructor(Vector3(5756.884f, 2286.67f, 92.60989f)), owning_building_guid = 32)
@@ -1001,7 +1001,7 @@ object Map09 { // Searhus
     Building5()
 
     def Building5(): Unit = { // Name: Drakulu Type: cryo_facility GUID: 35, MapID: 5
-      LocalBuilding("Drakulu", 35, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3746f, 2702f, 151.0666f), cryo_facility)))
+      LocalBuilding("Drakulu", 35, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3746f, 2702f, 151.0666f), Vector3(0f, 0f, 266f), cryo_facility)))
       LocalObject(215, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 35)
       LocalObject(390, Door.Constructor(Vector3(3651.992f, 2676.496f, 152.5876f)), owning_building_guid = 35)
       LocalObject(393, Door.Constructor(Vector3(3661.636f, 2684.342f, 152.6176f)), owning_building_guid = 35)
@@ -1149,7 +1149,7 @@ object Map09 { // Searhus
     Building6()
 
     def Building6(): Unit = { // Name: Hiro Type: cryo_facility GUID: 38, MapID: 6
-      LocalBuilding("Hiro", 38, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4570f, 5696f, 190.0754f), cryo_facility)))
+      LocalBuilding("Hiro", 38, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4570f, 5696f, 190.0754f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(218, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 38)
       LocalObject(477, Door.Constructor(Vector3(4511.023f, 5700.5f, 191.6264f)), owning_building_guid = 38)
       LocalObject(478, Door.Constructor(Vector3(4511.023f, 5718.693f, 199.5904f)), owning_building_guid = 38)
@@ -1297,7 +1297,7 @@ object Map09 { // Searhus
     Building4()
 
     def Building4(): Unit = { // Name: Akua Type: cryo_facility GUID: 41, MapID: 4
-      LocalBuilding("Akua", 41, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5274f, 3958f, 346.1272f), cryo_facility)))
+      LocalBuilding("Akua", 41, 4, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5274f, 3958f, 346.1272f), Vector3(0f, 0f, 50f), cryo_facility)))
       LocalObject(221, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 41)
       LocalObject(537, Door.Constructor(Vector3(5194.853f, 3969.159f, 347.6782f)), owning_building_guid = 41)
       LocalObject(538, Door.Constructor(Vector3(5206.547f, 3983.096f, 355.6422f)), owning_building_guid = 41)
@@ -1445,7 +1445,7 @@ object Map09 { // Searhus
     Building7()
 
     def Building7(): Unit = { // Name: Iva Type: cryo_facility GUID: 44, MapID: 7
-      LocalBuilding("Iva", 44, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6452f, 5150f, 55.30717f), cryo_facility)))
+      LocalBuilding("Iva", 44, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6452f, 5150f, 55.30717f), Vector3(0f, 0f, 91f), cryo_facility)))
       LocalObject(224, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 44)
       LocalObject(598, Door.Constructor(Vector3(6384.628f, 5124.688f, 64.82217f)), owning_building_guid = 44)
       LocalObject(599, Door.Constructor(Vector3(6384.946f, 5106.497f, 56.85817f)), owning_building_guid = 44)
@@ -1605,7 +1605,7 @@ object Map09 { // Searhus
     Building16()
 
     def Building16(): Unit = { // Name: Tara Type: tech_plant GUID: 50, MapID: 16
-      LocalBuilding("Tara", 50, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1172f, 4140f, 59.97345f), tech_plant)))
+      LocalBuilding("Tara", 50, 16, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1172f, 4140f, 59.97345f), Vector3(0f, 0f, 175f), tech_plant)))
       LocalObject(211, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 50)
       LocalObject(313, Door.Constructor(Vector3(1093.01f, 4143.792f, 61.51545f)), owning_building_guid = 50)
       LocalObject(314, Door.Constructor(Vector3(1094.596f, 4161.916f, 69.47845f)), owning_building_guid = 50)
@@ -1731,7 +1731,7 @@ object Map09 { // Searhus
     Building8()
 
     def Building8(): Unit = { // Name: Karihi Type: tech_plant GUID: 53, MapID: 8
-      LocalBuilding("Karihi", 53, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3756f, 5592f, 236.1003f), tech_plant)))
+      LocalBuilding("Karihi", 53, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3756f, 5592f, 236.1003f), Vector3(0f, 0f, 31f), tech_plant)))
       LocalObject(214, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 53)
       LocalObject(396, Door.Constructor(Vector3(3683.486f, 5573.938f, 245.6053f)), owning_building_guid = 53)
       LocalObject(398, Door.Constructor(Vector3(3692.855f, 5558.344f, 237.6423f)), owning_building_guid = 53)
@@ -1857,7 +1857,7 @@ object Map09 { // Searhus
     Building11()
 
     def Building11(): Unit = { // Name: Ngaru Type: tech_plant GUID: 56, MapID: 11
-      LocalBuilding("Ngaru", 56, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4100f, 4200f, 204.9974f), tech_plant)))
+      LocalBuilding("Ngaru", 56, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4100f, 4200f, 204.9974f), Vector3(0f, 0f, 309f), tech_plant)))
       LocalObject(216, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 56)
       LocalObject(433, Door.Constructor(Vector3(3997.113f, 4168.154f, 206.6184f)), owning_building_guid = 56)
       LocalObject(434, Door.Constructor(Vector3(4000.573f, 4211.438f, 206.5394f)), owning_building_guid = 56)
@@ -1983,7 +1983,7 @@ object Map09 { // Searhus
     Building47()
 
     def Building47(): Unit = { // Name: N_Tara_Tower Type: tower_a GUID: 59, MapID: 47
-      LocalBuilding("N_Tara_Tower", 59, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1134f, 4500f, 60.84628f), tower_a)))
+      LocalBuilding("N_Tara_Tower", 59, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1134f, 4500f, 60.84628f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2619, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(317, Door.Constructor(Vector3(1146f, 4492f, 62.36728f)), owning_building_guid = 59)
       LocalObject(318, Door.Constructor(Vector3(1146f, 4492f, 82.36628f)), owning_building_guid = 59)
@@ -2020,7 +2020,7 @@ object Map09 { // Searhus
     Building20()
 
     def Building20(): Unit = { // Name: SE_Wakea_Tower Type: tower_a GUID: 60, MapID: 20
-      LocalBuilding("SE_Wakea_Tower", 60, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1934f, 5188f, 54.91245f), tower_a)))
+      LocalBuilding("SE_Wakea_Tower", 60, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1934f, 5188f, 54.91245f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2622, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(354, Door.Constructor(Vector3(1946f, 5180f, 56.43345f)), owning_building_guid = 60)
       LocalObject(355, Door.Constructor(Vector3(1946f, 5180f, 76.43245f)), owning_building_guid = 60)
@@ -2057,7 +2057,7 @@ object Map09 { // Searhus
     Building18()
 
     def Building18(): Unit = { // Name: E_Esamir_Warpgate_Tower Type: tower_a GUID: 61, MapID: 18
-      LocalBuilding("E_Esamir_Warpgate_Tower", 61, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2544f, 1462f, 53.86364f), tower_a)))
+      LocalBuilding("E_Esamir_Warpgate_Tower", 61, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2544f, 1462f, 53.86364f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2624, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(364, Door.Constructor(Vector3(2556f, 1454f, 55.38464f)), owning_building_guid = 61)
       LocalObject(365, Door.Constructor(Vector3(2556f, 1454f, 75.38364f)), owning_building_guid = 61)
@@ -2094,7 +2094,7 @@ object Map09 { // Searhus
     Building26()
 
     def Building26(): Unit = { // Name: W_Ngaru_Tower Type: tower_a GUID: 62, MapID: 26
-      LocalBuilding("W_Ngaru_Tower", 62, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3398f, 4100f, 357.944f), tower_a)))
+      LocalBuilding("W_Ngaru_Tower", 62, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3398f, 4100f, 357.944f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2627, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(380, Door.Constructor(Vector3(3410f, 4092f, 359.465f)), owning_building_guid = 62)
       LocalObject(381, Door.Constructor(Vector3(3410f, 4092f, 379.464f)), owning_building_guid = 62)
@@ -2131,7 +2131,7 @@ object Map09 { // Searhus
     Building46()
 
     def Building46(): Unit = { // Name: NW_Karihi_Tower Type: tower_a GUID: 63, MapID: 46
-      LocalBuilding("NW_Karihi_Tower", 63, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3578f, 5818f, 215.015f), tower_a)))
+      LocalBuilding("NW_Karihi_Tower", 63, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3578f, 5818f, 215.015f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2628, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(384, Door.Constructor(Vector3(3590f, 5810f, 216.536f)), owning_building_guid = 63)
       LocalObject(385, Door.Constructor(Vector3(3590f, 5810f, 236.535f)), owning_building_guid = 63)
@@ -2168,7 +2168,7 @@ object Map09 { // Searhus
     Building48()
 
     def Building48(): Unit = { // Name: E_Drakulu_Tower Type: tower_a GUID: 64, MapID: 48
-      LocalBuilding("E_Drakulu_Tower", 64, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3992f, 2634f, 157.9653f), tower_a)))
+      LocalBuilding("E_Drakulu_Tower", 64, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3992f, 2634f, 157.9653f), Vector3(0f, 0f, 16f), tower_a)))
       LocalObject(2629, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(435, Door.Constructor(Vector3(4001.33f, 2644.998f, 159.4863f)), owning_building_guid = 64)
       LocalObject(436, Door.Constructor(Vector3(4001.33f, 2644.998f, 179.4853f)), owning_building_guid = 64)
@@ -2205,7 +2205,7 @@ object Map09 { // Searhus
     Building51()
 
     def Building51(): Unit = { // Name: N_Ngaru_Tower Type: tower_a GUID: 65, MapID: 51
-      LocalBuilding("N_Ngaru_Tower", 65, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4212f, 4846f, 220.0201f), tower_a)))
+      LocalBuilding("N_Ngaru_Tower", 65, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4212f, 4846f, 220.0201f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2630, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(451, Door.Constructor(Vector3(4224f, 4838f, 221.5411f)), owning_building_guid = 65)
       LocalObject(452, Door.Constructor(Vector3(4224f, 4838f, 241.5401f)), owning_building_guid = 65)
@@ -2242,7 +2242,7 @@ object Map09 { // Searhus
     Building44()
 
     def Building44(): Unit = { // Name: S_Laka_Tower Type: tower_a GUID: 66, MapID: 44
-      LocalBuilding("S_Laka_Tower", 66, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4362f, 6216f, 53.49857f), tower_a)))
+      LocalBuilding("S_Laka_Tower", 66, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4362f, 6216f, 53.49857f), Vector3(0f, 0f, 306f), tower_a)))
       LocalObject(2631, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(456, Door.Constructor(Vector3(4362.581f, 6201.589f, 55.01957f)), owning_building_guid = 66)
       LocalObject(457, Door.Constructor(Vector3(4362.581f, 6201.589f, 75.01857f)), owning_building_guid = 66)
@@ -2279,7 +2279,7 @@ object Map09 { // Searhus
     Building52()
 
     def Building52(): Unit = { // Name: NW_Oro_Tower Type: tower_a GUID: 67, MapID: 52
-      LocalBuilding("NW_Oro_Tower", 67, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4744f, 4694f, 211.0904f), tower_a)))
+      LocalBuilding("NW_Oro_Tower", 67, 52, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4744f, 4694f, 211.0904f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2633, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(506, Door.Constructor(Vector3(4756f, 4686f, 212.6114f)), owning_building_guid = 67)
       LocalObject(507, Door.Constructor(Vector3(4756f, 4686f, 232.6104f)), owning_building_guid = 67)
@@ -2316,7 +2316,7 @@ object Map09 { // Searhus
     Building45()
 
     def Building45(): Unit = { // Name: E_Hiro_Tower Type: tower_a GUID: 68, MapID: 45
-      LocalBuilding("E_Hiro_Tower", 68, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4852f, 5700f, 177.862f), tower_a)))
+      LocalBuilding("E_Hiro_Tower", 68, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4852f, 5700f, 177.862f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2635, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(521, Door.Constructor(Vector3(4864f, 5692f, 179.383f)), owning_building_guid = 68)
       LocalObject(522, Door.Constructor(Vector3(4864f, 5692f, 199.382f)), owning_building_guid = 68)
@@ -2353,7 +2353,7 @@ object Map09 { // Searhus
     Building19()
 
     def Building19(): Unit = { // Name: NE_Iva_Tower Type: tower_a GUID: 69, MapID: 19
-      LocalBuilding("NE_Iva_Tower", 69, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7004f, 5834f, 43.82611f), tower_a)))
+      LocalBuilding("NE_Iva_Tower", 69, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(7004f, 5834f, 43.82611f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2641, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(619, Door.Constructor(Vector3(7016f, 5826f, 45.34711f)), owning_building_guid = 69)
       LocalObject(620, Door.Constructor(Vector3(7016f, 5826f, 65.34611f)), owning_building_guid = 69)
@@ -2390,7 +2390,7 @@ object Map09 { // Searhus
     Building53()
 
     def Building53(): Unit = { // Name: S_Ishundar_Warpgate_Tower Type: tower_b GUID: 70, MapID: 53
-      LocalBuilding("S_Ishundar_Warpgate_Tower", 70, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1258f, 6332f, 41.90735f), tower_b)))
+      LocalBuilding("S_Ishundar_Warpgate_Tower", 70, 53, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1258f, 6332f, 41.90735f), Vector3(0f, 0f, 5f), tower_b)))
       LocalObject(2620, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(331, Door.Constructor(Vector3(1269.257f, 6341.016f, 43.42735f)), owning_building_guid = 70)
       LocalObject(332, Door.Constructor(Vector3(1269.257f, 6341.016f, 53.42735f)), owning_building_guid = 70)
@@ -2427,7 +2427,7 @@ object Map09 { // Searhus
     Building28()
 
     def Building28(): Unit = { // Name: NE_Esamir_Warpgate_Tower Type: tower_b GUID: 71, MapID: 28
-      LocalBuilding("NE_Esamir_Warpgate_Tower", 71, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2312f, 2572f, 47.95525f), tower_b)))
+      LocalBuilding("NE_Esamir_Warpgate_Tower", 71, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2312f, 2572f, 47.95525f), Vector3(0f, 0f, 334f), tower_b)))
       LocalObject(2623, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(358, Door.Constructor(Vector3(2319.279f, 2559.549f, 49.47525f)), owning_building_guid = 71)
       LocalObject(359, Door.Constructor(Vector3(2319.279f, 2559.549f, 59.47525f)), owning_building_guid = 71)
@@ -2464,7 +2464,7 @@ object Map09 { // Searhus
     Building24()
 
     def Building24(): Unit = { // Name: E_Ishundar_Warpgate_Tower Type: tower_b GUID: 72, MapID: 24
-      LocalBuilding("E_Ishundar_Warpgate_Tower", 72, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2552f, 6916f, 52.0414f), tower_b)))
+      LocalBuilding("E_Ishundar_Warpgate_Tower", 72, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2552f, 6916f, 52.0414f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2625, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(368, Door.Constructor(Vector3(2564f, 6908f, 53.56141f)), owning_building_guid = 72)
       LocalObject(369, Door.Constructor(Vector3(2564f, 6908f, 63.56141f)), owning_building_guid = 72)
@@ -2501,7 +2501,7 @@ object Map09 { // Searhus
     Building49()
 
     def Building49(): Unit = { // Name: W_Rehua_Tower Type: tower_b GUID: 73, MapID: 49
-      LocalBuilding("W_Rehua_Tower", 73, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3354f, 1956f, 54.89647f), tower_b)))
+      LocalBuilding("W_Rehua_Tower", 73, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3354f, 1956f, 54.89647f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2626, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(374, Door.Constructor(Vector3(3366f, 1948f, 56.41647f)), owning_building_guid = 73)
       LocalObject(375, Door.Constructor(Vector3(3366f, 1948f, 66.41647f)), owning_building_guid = 73)
@@ -2538,7 +2538,7 @@ object Map09 { // Searhus
     Building22()
 
     def Building22(): Unit = { // Name: W_Sina_Tower Type: tower_b GUID: 74, MapID: 22
-      LocalBuilding("W_Sina_Tower", 74, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4834f, 1886f, 56.61641f), tower_b)))
+      LocalBuilding("W_Sina_Tower", 74, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4834f, 1886f, 56.61641f), Vector3(0f, 0f, 16f), tower_b)))
       LocalObject(2634, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 74)
       LocalObject(514, Door.Constructor(Vector3(4843.33f, 1896.998f, 58.13641f)), owning_building_guid = 74)
       LocalObject(515, Door.Constructor(Vector3(4843.33f, 1896.998f, 68.13641f)), owning_building_guid = 74)
@@ -2575,7 +2575,7 @@ object Map09 { // Searhus
     Building23()
 
     def Building23(): Unit = { // Name: SE_Tara_Tower Type: tower_c GUID: 75, MapID: 23
-      LocalBuilding("SE_Tara_Tower", 75, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1772f, 3744f, 43.52397f), tower_c)))
+      LocalBuilding("SE_Tara_Tower", 75, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1772f, 3744f, 43.52397f), Vector3(0f, 0f, 55f), tower_c)))
       LocalObject(2621, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 75)
       LocalObject(348, Door.Constructor(Vector3(1772.33f, 3758.418f, 45.04497f)), owning_building_guid = 75)
       LocalObject(349, Door.Constructor(Vector3(1772.33f, 3758.418f, 65.04398f)), owning_building_guid = 75)
@@ -2616,7 +2616,7 @@ object Map09 { // Searhus
     Building21()
 
     def Building21(): Unit = { // Name: NE_Pele_Tower Type: tower_c GUID: 76, MapID: 21
-      LocalBuilding("NE_Pele_Tower", 76, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4686f, 3958f, 193.4062f), tower_c)))
+      LocalBuilding("NE_Pele_Tower", 76, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4686f, 3958f, 193.4062f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2632, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 76)
       LocalObject(502, Door.Constructor(Vector3(4698f, 3950f, 194.9272f)), owning_building_guid = 76)
       LocalObject(503, Door.Constructor(Vector3(4698f, 3950f, 214.9262f)), owning_building_guid = 76)
@@ -2657,7 +2657,7 @@ object Map09 { // Searhus
     Building25()
 
     def Building25(): Unit = { // Name: SE_Laka_Tower Type: tower_c GUID: 77, MapID: 25
-      LocalBuilding("SE_Laka_Tower", 77, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5268f, 6372f, 48.24061f), tower_c)))
+      LocalBuilding("SE_Laka_Tower", 77, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5268f, 6372f, 48.24061f), Vector3(0f, 0f, 11f), tower_c)))
       LocalObject(2636, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 77)
       LocalObject(552, Door.Constructor(Vector3(5278.253f, 6382.143f, 49.76161f)), owning_building_guid = 77)
       LocalObject(553, Door.Constructor(Vector3(5278.253f, 6382.143f, 69.7606f)), owning_building_guid = 77)
@@ -2698,7 +2698,7 @@ object Map09 { // Searhus
     Building29()
 
     def Building29(): Unit = { // Name: NE_Matagi_Tower Type: tower_c GUID: 78, MapID: 29
-      LocalBuilding("NE_Matagi_Tower", 78, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5380f, 5216f, 236.7046f), tower_c)))
+      LocalBuilding("NE_Matagi_Tower", 78, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5380f, 5216f, 236.7046f), Vector3(0f, 0f, 33f), tower_c)))
       LocalObject(2637, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 78)
       LocalObject(567, Door.Constructor(Vector3(5385.707f, 5229.245f, 238.2256f)), owning_building_guid = 78)
       LocalObject(568, Door.Constructor(Vector3(5385.707f, 5229.245f, 258.2246f)), owning_building_guid = 78)
@@ -2739,7 +2739,7 @@ object Map09 { // Searhus
     Building37()
 
     def Building37(): Unit = { // Name: NE_Sina_Tower Type: tower_c GUID: 79, MapID: 37
-      LocalBuilding("NE_Sina_Tower", 79, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6202f, 2442f, 49.96948f), tower_c)))
+      LocalBuilding("NE_Sina_Tower", 79, 37, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6202f, 2442f, 49.96948f), Vector3(0f, 0f, 296f), tower_c)))
       LocalObject(2638, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 79)
       LocalObject(593, Door.Constructor(Vector3(6200.07f, 2427.708f, 51.49048f)), owning_building_guid = 79)
       LocalObject(594, Door.Constructor(Vector3(6200.07f, 2427.708f, 71.48949f)), owning_building_guid = 79)
@@ -2780,7 +2780,7 @@ object Map09 { // Searhus
     Building27()
 
     def Building27(): Unit = { // Name: S_Iva_Tower Type: tower_c GUID: 80, MapID: 27
-      LocalBuilding("S_Iva_Tower", 80, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6438f, 4958f, 63.71655f), tower_c)))
+      LocalBuilding("S_Iva_Tower", 80, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6438f, 4958f, 63.71655f), Vector3(0f, 0f, 324f), tower_c)))
       LocalObject(2639, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 80)
       LocalObject(603, Door.Constructor(Vector3(6443.006f, 4944.475f, 65.23755f)), owning_building_guid = 80)
       LocalObject(604, Door.Constructor(Vector3(6443.006f, 4944.475f, 85.23654f)), owning_building_guid = 80)
@@ -2821,7 +2821,7 @@ object Map09 { // Searhus
     Building50()
 
     def Building50(): Unit = { // Name: W_Cyssor_Warpgate_Tower Type: tower_c GUID: 81, MapID: 50
-      LocalBuilding("W_Cyssor_Warpgate_Tower", 81, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6630f, 3188f, 51.50481f), tower_c)))
+      LocalBuilding("W_Cyssor_Warpgate_Tower", 81, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6630f, 3188f, 51.50481f), Vector3(0f, 0f, 15f), tower_c)))
       LocalObject(2640, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 81)
       LocalObject(615, Door.Constructor(Vector3(6639.521f, 3198.833f, 53.02581f)), owning_building_guid = 81)
       LocalObject(616, Door.Constructor(Vector3(6639.521f, 3198.833f, 73.02481f)), owning_building_guid = 81)

--- a/pslogin/src/main/scala/zonemaps/Map10.scala
+++ b/pslogin/src/main/scala/zonemaps/Map10.scala
@@ -23,7 +23,7 @@ object Map10 { // Amerish
     Building13()
 
     def Building13(): Unit = { // Name: Sungrey Type: amp_station GUID: 1, MapID: 13
-      LocalBuilding("Sungrey", 1, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4686f, 5546f, 72.05738f), amp_station)))
+      LocalBuilding("Sungrey", 1, 13, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4686f, 5546f, 72.05738f), Vector3(0f, 0f, 89f), amp_station)))
       LocalObject(197, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(151, Door.Constructor(Vector3(4679.2f, 5546.333f, 84.95938f)), owning_building_guid = 1)
       LocalObject(152, Door.Constructor(Vector3(4692.808f, 5546.092f, 84.95938f)), owning_building_guid = 1)
@@ -151,7 +151,7 @@ object Map10 { // Amerish
     Building49()
 
     def Building49(): Unit = { // Name: Verica Type: amp_station GUID: 4, MapID: 49
-      LocalBuilding("Verica", 4, 49, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4902f, 3534f, 47.26933f), amp_station)))
+      LocalBuilding("Verica", 4, 49, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4902f, 3534f, 47.26933f), Vector3(0f, 0f, 270f), amp_station)))
       LocalObject(198, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(153, Door.Constructor(Vector3(4895.195f, 3533.789f, 60.17133f)), owning_building_guid = 4)
       LocalObject(154, Door.Constructor(Vector3(4908.805f, 3533.786f, 60.17133f)), owning_building_guid = 4)
@@ -279,7 +279,7 @@ object Map10 { // Amerish
     Building44()
 
     def Building44(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 44
-      LocalBuilding("bunker_gauntlet", 7, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4418f, 2340f, 47.18137f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 44, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4418f, 2340f, 47.18137f), Vector3(0f, 0f, 270f), bunker_gauntlet)))
       LocalObject(393, Door.Constructor(Vector3(4416.099f, 2315.077f, 48.70237f)), owning_building_guid = 7)
       LocalObject(394, Door.Constructor(Vector3(4416.088f, 2364.898f, 48.70237f)), owning_building_guid = 7)
     }
@@ -287,77 +287,77 @@ object Map10 { // Amerish
     Building41()
 
     def Building41(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 8, MapID: 41
-      LocalBuilding("bunker_lg", 8, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3754f, 5092f, 57.63699f), bunker_lg)))
+      LocalBuilding("bunker_lg", 8, 41, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3754f, 5092f, 57.63699f), Vector3(0f, 0f, 360f), bunker_lg)))
       LocalObject(356, Door.Constructor(Vector3(3756.606f, 5094.557f, 59.15799f)), owning_building_guid = 8)
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 37
-      LocalBuilding("bunker_lg", 9, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4288f, 2540f, 47.49414f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4288f, 2540f, 47.49414f), Vector3(0f, 0f, 225f), bunker_lg)))
       LocalObject(385, Door.Constructor(Vector3(4287.965f, 2536.349f, 49.01514f)), owning_building_guid = 9)
     }
 
     Building42()
 
     def Building42(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 42
-      LocalBuilding("bunker_lg", 10, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4570f, 5668f, 69.13481f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 42, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4570f, 5668f, 69.13481f), Vector3(0f, 0f, 225f), bunker_lg)))
       LocalObject(401, Door.Constructor(Vector3(4569.965f, 5664.349f, 70.65582f)), owning_building_guid = 10)
     }
 
     Building43()
 
     def Building43(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 11, MapID: 43
-      LocalBuilding("bunker_lg", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4734f, 6182f, 69.42805f), bunker_lg)))
+      LocalBuilding("bunker_lg", 11, 43, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4734f, 6182f, 69.42805f), Vector3(0f, 0f, 45f), bunker_lg)))
       LocalObject(434, Door.Constructor(Vector3(4734.035f, 6185.651f, 70.94905f)), owning_building_guid = 11)
     }
 
     Building40()
 
     def Building40(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 12, MapID: 40
-      LocalBuilding("bunker_lg", 12, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6116f, 5328f, 61.81373f), bunker_lg)))
+      LocalBuilding("bunker_lg", 12, 40, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6116f, 5328f, 61.81373f), Vector3(0f, 0f, 270f), bunker_lg)))
       LocalObject(512, Door.Constructor(Vector3(6118.557f, 5325.394f, 63.33473f)), owning_building_guid = 12)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 13, MapID: 36
-      LocalBuilding("bunker_sm", 13, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3390f, 2748f, 69.11893f), bunker_sm)))
+      LocalBuilding("bunker_sm", 13, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(3390f, 2748f, 69.11893f), Vector3(0f, 0f, 270f), bunker_sm)))
       LocalObject(326, Door.Constructor(Vector3(3389.945f, 2746.775f, 70.63993f)), owning_building_guid = 13)
     }
 
     Building45()
 
     def Building45(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 45
-      LocalBuilding("bunker_sm", 14, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4006f, 5186f, 46.02675f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 45, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(4006f, 5186f, 46.02675f), Vector3(0f, 0f, 180f), bunker_sm)))
       LocalObject(374, Door.Constructor(Vector3(4004.775f, 5186.055f, 47.54775f)), owning_building_guid = 14)
     }
 
     Building50()
 
     def Building50(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 15, MapID: 50
-      LocalBuilding("bunker_sm", 15, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6156f, 2592f, 41.59035f), bunker_sm)))
+      LocalBuilding("bunker_sm", 15, 50, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6156f, 2592f, 41.59035f), Vector3(0f, 0f, 90f), bunker_sm)))
       LocalObject(517, Door.Constructor(Vector3(6156.055f, 2593.225f, 43.11135f)), owning_building_guid = 15)
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 38
-      LocalBuilding("bunker_sm", 16, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6168f, 3532f, 37.92495f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6168f, 3532f, 37.92495f), Vector3(0f, 0f, 224f), bunker_sm)))
       LocalObject(518, Door.Constructor(Vector3(6167.081f, 3531.189f, 39.44595f)), owning_building_guid = 16)
     }
 
     Building39()
 
     def Building39(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 17, MapID: 39
-      LocalBuilding("bunker_sm", 17, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6550f, 4324f, 56.2203f), bunker_sm)))
+      LocalBuilding("bunker_sm", 17, 39, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(6550f, 4324f, 56.2203f), Vector3(0f, 0f, 90f), bunker_sm)))
       LocalObject(550, Door.Constructor(Vector3(6550.055f, 4325.225f, 57.7413f)), owning_building_guid = 17)
     }
 
     Building6()
 
     def Building6(): Unit = { // Name: Cetan Type: comm_station GUID: 18, MapID: 6
-      LocalBuilding("Cetan", 18, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3500f, 2544f, 47.96331f), comm_station)))
+      LocalBuilding("Cetan", 18, 6, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3500f, 2544f, 47.96331f), Vector3(0f, 0f, 38f), comm_station)))
       LocalObject(193, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 18)
       LocalObject(329, Door.Constructor(Vector3(3458.543f, 2597.875f, 49.71431f)), owning_building_guid = 18)
       LocalObject(334, Door.Constructor(Vector3(3468.454f, 2487.239f, 57.67831f)), owning_building_guid = 18)
@@ -476,7 +476,7 @@ object Map10 { // Amerish
     Building12()
 
     def Building12(): Unit = { // Name: Qumu Type: comm_station GUID: 21, MapID: 12
-      LocalBuilding("Qumu", 21, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3904f, 5172f, 46.34075f), comm_station)))
+      LocalBuilding("Qumu", 21, 12, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3904f, 5172f, 46.34075f), Vector3(0f, 0f, 44f), comm_station)))
       LocalObject(194, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 21)
       LocalObject(357, Door.Constructor(Vector3(3857.139f, 5221.246f, 48.09175f)), owning_building_guid = 21)
       LocalObject(358, Door.Constructor(Vector3(3870.225f, 5233.883f, 56.05475f)), owning_building_guid = 21)
@@ -595,7 +595,7 @@ object Map10 { // Amerish
     Building5()
 
     def Building5(): Unit = { // Name: Azeban Type: comm_station_dsp GUID: 24, MapID: 5
-      LocalBuilding("Azeban", 24, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6260f, 5234f, 61.88216f), comm_station_dsp)))
+      LocalBuilding("Azeban", 24, 5, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6260f, 5234f, 61.88216f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(201, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 24)
       LocalObject(254, Door.Constructor(Vector3(6328.339f, 5304.464f, 65.26015f)), owning_building_guid = 24)
       LocalObject(523, Door.Constructor(Vector3(6200.196f, 5190.501f, 63.53316f)), owning_building_guid = 24)
@@ -736,7 +736,7 @@ object Map10 { // Amerish
     Building8()
 
     def Building8(): Unit = { // Name: Ikanam Type: cryo_facility GUID: 27, MapID: 8
-      LocalBuilding("Ikanam", 27, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2694f, 2352f, 57.10244f), cryo_facility)))
+      LocalBuilding("Ikanam", 27, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2694f, 2352f, 57.10244f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(191, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 27)
       LocalObject(294, Door.Constructor(Vector3(2635.023f, 2356.5f, 58.65344f)), owning_building_guid = 27)
       LocalObject(295, Door.Constructor(Vector3(2635.023f, 2374.693f, 66.61744f)), owning_building_guid = 27)
@@ -884,7 +884,7 @@ object Map10 { // Amerish
     Building11()
 
     def Building11(): Unit = { // Name: Onatha Type: cryo_facility GUID: 30, MapID: 11
-      LocalBuilding("Onatha", 30, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3350f, 5732f, 47.90467f), cryo_facility)))
+      LocalBuilding("Onatha", 30, 11, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(3350f, 5732f, 47.90467f), Vector3(0f, 0f, 360f), cryo_facility)))
       LocalObject(192, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 30)
       LocalObject(309, Door.Constructor(Vector3(3291.023f, 5736.5f, 49.45567f)), owning_building_guid = 30)
       LocalObject(310, Door.Constructor(Vector3(3291.023f, 5754.693f, 57.41967f)), owning_building_guid = 30)
@@ -1032,7 +1032,7 @@ object Map10 { // Amerish
     Building9()
 
     def Building9(): Unit = { // Name: Kyoi Type: cryo_facility GUID: 33, MapID: 9
-      LocalBuilding("Kyoi", 33, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5556f, 2232f, 62.32201f), cryo_facility)))
+      LocalBuilding("Kyoi", 33, 9, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5556f, 2232f, 62.32201f), Vector3(0f, 0f, 88f), cryo_facility)))
       LocalObject(199, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 33)
       LocalObject(484, Door.Constructor(Vector3(5486.761f, 2192.066f, 63.873f)), owning_building_guid = 33)
       LocalObject(485, Door.Constructor(Vector3(5487.396f, 2210.248f, 71.83701f)), owning_building_guid = 33)
@@ -1180,7 +1180,7 @@ object Map10 { // Amerish
     Building15()
 
     def Building15(): Unit = { // Name: Xelas Type: cryo_facility GUID: 36, MapID: 15
-      LocalBuilding("Xelas", 36, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6644f, 4402f, 56.31071f), cryo_facility)))
+      LocalBuilding("Xelas", 36, 15, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(6644f, 4402f, 56.31071f), Vector3(0f, 0f, 62f), cryo_facility)))
       LocalObject(202, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 36)
       LocalObject(551, Door.Constructor(Vector3(6564.263f, 4396.46f, 57.86171f)), owning_building_guid = 36)
       LocalObject(552, Door.Constructor(Vector3(6572.804f, 4412.523f, 65.82571f)), owning_building_guid = 36)
@@ -1340,7 +1340,7 @@ object Map10 { // Amerish
     Building7()
 
     def Building7(): Unit = { // Name: Heyoka Type: tech_plant GUID: 43, MapID: 7
-      LocalBuilding("Heyoka", 43, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4298f, 2404f, 47.49414f), tech_plant)))
+      LocalBuilding("Heyoka", 43, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4298f, 2404f, 47.49414f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(195, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 43)
       LocalObject(379, Door.Constructor(Vector3(4226.54f, 2333.929f, 49.03614f)), owning_building_guid = 43)
       LocalObject(380, Door.Constructor(Vector3(4226.54f, 2352.121f, 56.99914f)), owning_building_guid = 43)
@@ -1466,7 +1466,7 @@ object Map10 { // Amerish
     Building14()
 
     def Building14(): Unit = { // Name: Tumas Type: tech_plant GUID: 46, MapID: 14
-      LocalBuilding("Tumas", 46, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4610f, 6292f, 69.42805f), tech_plant)))
+      LocalBuilding("Tumas", 46, 14, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(4610f, 6292f, 69.42805f), Vector3(0f, 0f, 89f), tech_plant)))
       LocalObject(196, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 46)
       LocalObject(402, Door.Constructor(Vector3(4579.167f, 6317.101f, 70.97005f)), owning_building_guid = 46)
       LocalObject(403, Door.Constructor(Vector3(4579.485f, 6335.291f, 78.93304f)), owning_building_guid = 46)
@@ -1592,7 +1592,7 @@ object Map10 { // Amerish
     Building10()
 
     def Building10(): Unit = { // Name: Mekala Type: tech_plant GUID: 49, MapID: 10
-      LocalBuilding("Mekala", 49, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5986f, 3002f, 58.83252f), tech_plant)))
+      LocalBuilding("Mekala", 49, 10, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(5986f, 3002f, 58.83252f), Vector3(0f, 0f, 360f), tech_plant)))
       LocalObject(200, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 49)
       LocalObject(499, Door.Constructor(Vector3(5914.54f, 2931.929f, 60.37452f)), owning_building_guid = 49)
       LocalObject(500, Door.Constructor(Vector3(5914.54f, 2950.121f, 68.33752f)), owning_building_guid = 49)
@@ -1718,7 +1718,7 @@ object Map10 { // Amerish
     Building19()
 
     def Building19(): Unit = { // Name: E_Ikanam_Tower Type: tower_a GUID: 52, MapID: 19
-      LocalBuilding("E_Ikanam_Tower", 52, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2994f, 2306f, 52.08814f), tower_a)))
+      LocalBuilding("E_Ikanam_Tower", 52, 19, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2994f, 2306f, 52.08814f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2389, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(305, Door.Constructor(Vector3(3006f, 2298f, 53.60914f)), owning_building_guid = 52)
       LocalObject(306, Door.Constructor(Vector3(3006f, 2298f, 73.60814f)), owning_building_guid = 52)
@@ -1755,7 +1755,7 @@ object Map10 { // Amerish
     Building34()
 
     def Building34(): Unit = { // Name: W_Qumu_Tower Type: tower_a GUID: 53, MapID: 34
-      LocalBuilding("W_Qumu_Tower", 53, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3448f, 5518f, 54.41446f), tower_a)))
+      LocalBuilding("W_Qumu_Tower", 53, 34, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3448f, 5518f, 54.41446f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2392, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(330, Door.Constructor(Vector3(3460f, 5510f, 55.93546f)), owning_building_guid = 53)
       LocalObject(331, Door.Constructor(Vector3(3460f, 5510f, 75.93446f)), owning_building_guid = 53)
@@ -1792,7 +1792,7 @@ object Map10 { // Amerish
     Building20()
 
     def Building20(): Unit = { // Name: NE_Cetan_Tower Type: tower_a GUID: 54, MapID: 20
-      LocalBuilding("NE_Cetan_Tower", 54, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3912f, 3212f, 43.86781f), tower_a)))
+      LocalBuilding("NE_Cetan_Tower", 54, 20, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3912f, 3212f, 43.86781f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2395, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(367, Door.Constructor(Vector3(3924f, 3204f, 45.38881f)), owning_building_guid = 54)
       LocalObject(368, Door.Constructor(Vector3(3924f, 3204f, 65.38782f)), owning_building_guid = 54)
@@ -1829,7 +1829,7 @@ object Map10 { // Amerish
     Building32()
 
     def Building32(): Unit = { // Name: NW_Sungrey_Tower Type: tower_a GUID: 55, MapID: 32
-      LocalBuilding("NW_Sungrey_Tower", 55, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4826f, 5260f, 88.36119f), tower_a)))
+      LocalBuilding("NW_Sungrey_Tower", 55, 32, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4826f, 5260f, 88.36119f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2399, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(441, Door.Constructor(Vector3(4838f, 5252f, 89.88219f)), owning_building_guid = 55)
       LocalObject(442, Door.Constructor(Vector3(4838f, 5252f, 109.8812f)), owning_building_guid = 55)
@@ -1866,7 +1866,7 @@ object Map10 { // Amerish
     Building23()
 
     def Building23(): Unit = { // Name: E_Kyoi_Tower Type: tower_a GUID: 56, MapID: 23
-      LocalBuilding("E_Kyoi_Tower", 56, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5458f, 2004f, 81.14763f), tower_a)))
+      LocalBuilding("E_Kyoi_Tower", 56, 23, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5458f, 2004f, 81.14763f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2404, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(480, Door.Constructor(Vector3(5470f, 1996f, 82.66863f)), owning_building_guid = 56)
       LocalObject(481, Door.Constructor(Vector3(5470f, 1996f, 102.6676f)), owning_building_guid = 56)
@@ -1903,7 +1903,7 @@ object Map10 { // Amerish
     Building28()
 
     def Building28(): Unit = { // Name: W_Azeban_Tower Type: tower_a GUID: 57, MapID: 28
-      LocalBuilding("W_Azeban_Tower", 57, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5554f, 5326f, 43.06631f), tower_a)))
+      LocalBuilding("W_Azeban_Tower", 57, 28, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5554f, 5326f, 43.06631f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2405, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(490, Door.Constructor(Vector3(5566f, 5318f, 44.58731f)), owning_building_guid = 57)
       LocalObject(491, Door.Constructor(Vector3(5566f, 5318f, 64.5863f)), owning_building_guid = 57)
@@ -1940,7 +1940,7 @@ object Map10 { // Amerish
     Building48()
 
     def Building48(): Unit = { // Name: Azeban_Tower Type: tower_a GUID: 58, MapID: 48
-      LocalBuilding("Azeban_Tower", 58, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6176f, 5550f, 49.46858f), tower_a)))
+      LocalBuilding("Azeban_Tower", 58, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6176f, 5550f, 49.46858f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2407, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(519, Door.Constructor(Vector3(6188f, 5542f, 50.98958f)), owning_building_guid = 58)
       LocalObject(520, Door.Constructor(Vector3(6188f, 5542f, 70.98859f)), owning_building_guid = 58)
@@ -1977,7 +1977,7 @@ object Map10 { // Amerish
     Building30()
 
     def Building30(): Unit = { // Name: S_Ceryshen_Warpgate_Tower Type: tower_a GUID: 59, MapID: 30
-      LocalBuilding("S_Ceryshen_Warpgate_Tower", 59, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6302f, 6398f, 106.5124f), tower_a)))
+      LocalBuilding("S_Ceryshen_Warpgate_Tower", 59, 30, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6302f, 6398f, 106.5124f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(2408, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(535, Door.Constructor(Vector3(6314f, 6390f, 108.0334f)), owning_building_guid = 59)
       LocalObject(536, Door.Constructor(Vector3(6314f, 6390f, 128.0324f)), owning_building_guid = 59)
@@ -2014,7 +2014,7 @@ object Map10 { // Amerish
     Building16()
 
     def Building16(): Unit = { // Name: NE_Solsar_Warpgate_Tower Type: tower_b GUID: 60, MapID: 16
-      LocalBuilding("NE_Solsar_Warpgate_Tower", 60, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1910f, 1664f, 43.16405f), tower_b)))
+      LocalBuilding("NE_Solsar_Warpgate_Tower", 60, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1910f, 1664f, 43.16405f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2387, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(284, Door.Constructor(Vector3(1922f, 1656f, 44.68405f)), owning_building_guid = 60)
       LocalObject(285, Door.Constructor(Vector3(1922f, 1656f, 54.68405f)), owning_building_guid = 60)
@@ -2051,7 +2051,7 @@ object Map10 { // Amerish
     Building26()
 
     def Building26(): Unit = { // Name: NE_NCSanc_Warpgate_Tower Type: tower_b GUID: 61, MapID: 26
-      LocalBuilding("NE_NCSanc_Warpgate_Tower", 61, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3488f, 4702f, 60.32801f), tower_b)))
+      LocalBuilding("NE_NCSanc_Warpgate_Tower", 61, 26, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3488f, 4702f, 60.32801f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2393, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(341, Door.Constructor(Vector3(3500f, 4694f, 61.84801f)), owning_building_guid = 61)
       LocalObject(342, Door.Constructor(Vector3(3500f, 4694f, 71.84801f)), owning_building_guid = 61)
@@ -2088,7 +2088,7 @@ object Map10 { // Amerish
     Building21()
 
     def Building21(): Unit = { // Name: SE_Heyoka_Tower Type: tower_b GUID: 62, MapID: 21
-      LocalBuilding("SE_Heyoka_Tower", 62, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4456f, 2654f, 69.41827f), tower_b)))
+      LocalBuilding("SE_Heyoka_Tower", 62, 21, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4456f, 2654f, 69.41827f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2397, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 62)
       LocalObject(395, Door.Constructor(Vector3(4468f, 2646f, 70.93827f)), owning_building_guid = 62)
       LocalObject(396, Door.Constructor(Vector3(4468f, 2646f, 80.93828f)), owning_building_guid = 62)
@@ -2125,7 +2125,7 @@ object Map10 { // Amerish
     Building24()
 
     def Building24(): Unit = { // Name: NE_Heyoka_Tower Type: tower_b GUID: 63, MapID: 24
-      LocalBuilding("NE_Heyoka_Tower", 63, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4702f, 3278f, 55.6656f), tower_b)))
+      LocalBuilding("NE_Heyoka_Tower", 63, 24, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4702f, 3278f, 55.6656f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2398, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 63)
       LocalObject(423, Door.Constructor(Vector3(4714f, 3270f, 57.1856f)), owning_building_guid = 63)
       LocalObject(424, Door.Constructor(Vector3(4714f, 3270f, 67.18559f)), owning_building_guid = 63)
@@ -2162,7 +2162,7 @@ object Map10 { // Amerish
     Building31()
 
     def Building31(): Unit = { // Name: SE_Tumas_Tower Type: tower_b GUID: 64, MapID: 31
-      LocalBuilding("SE_Tumas_Tower", 64, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4988f, 6190f, 41.46329f), tower_b)))
+      LocalBuilding("SE_Tumas_Tower", 64, 31, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4988f, 6190f, 41.46329f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2401, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 64)
       LocalObject(464, Door.Constructor(Vector3(5000f, 6182f, 42.98329f)), owning_building_guid = 64)
       LocalObject(465, Door.Constructor(Vector3(5000f, 6182f, 52.98329f)), owning_building_guid = 64)
@@ -2199,7 +2199,7 @@ object Map10 { // Amerish
     Building25()
 
     def Building25(): Unit = { // Name: S_Oshur_Warpgate_Tower Type: tower_b GUID: 65, MapID: 25
-      LocalBuilding("S_Oshur_Warpgate_Tower", 65, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5122f, 4320f, 59.33499f), tower_b)))
+      LocalBuilding("S_Oshur_Warpgate_Tower", 65, 25, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5122f, 4320f, 59.33499f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(2402, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 65)
       LocalObject(470, Door.Constructor(Vector3(5134f, 4312f, 60.85499f)), owning_building_guid = 65)
       LocalObject(471, Door.Constructor(Vector3(5134f, 4312f, 70.855f)), owning_building_guid = 65)
@@ -2236,7 +2236,7 @@ object Map10 { // Amerish
     Building17()
 
     def Building17(): Unit = { // Name: NW_Ikanam_Tower Type: tower_c GUID: 66, MapID: 17
-      LocalBuilding("NW_Ikanam_Tower", 66, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2224f, 2782f, 52.59641f), tower_c)))
+      LocalBuilding("NW_Ikanam_Tower", 66, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2224f, 2782f, 52.59641f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2388, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 66)
       LocalObject(290, Door.Constructor(Vector3(2236f, 2774f, 54.11741f)), owning_building_guid = 66)
       LocalObject(291, Door.Constructor(Vector3(2236f, 2774f, 74.11641f)), owning_building_guid = 66)
@@ -2277,7 +2277,7 @@ object Map10 { // Amerish
     Building35()
 
     def Building35(): Unit = { // Name: N_Onatha_Tower Type: tower_c GUID: 67, MapID: 35
-      LocalBuilding("N_Onatha_Tower", 67, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3352f, 6674f, 57.33703f), tower_c)))
+      LocalBuilding("N_Onatha_Tower", 67, 35, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3352f, 6674f, 57.33703f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2390, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 67)
       LocalObject(316, Door.Constructor(Vector3(3364f, 6666f, 58.85803f)), owning_building_guid = 67)
       LocalObject(317, Door.Constructor(Vector3(3364f, 6666f, 78.85703f)), owning_building_guid = 67)
@@ -2318,7 +2318,7 @@ object Map10 { // Amerish
     Building18()
 
     def Building18(): Unit = { // Name: NW_Cetan_Tower Type: tower_c GUID: 68, MapID: 18
-      LocalBuilding("NW_Cetan_Tower", 68, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3368f, 3472f, 49.55655f), tower_c)))
+      LocalBuilding("NW_Cetan_Tower", 68, 18, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3368f, 3472f, 49.55655f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2391, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 68)
       LocalObject(321, Door.Constructor(Vector3(3380f, 3464f, 51.07755f)), owning_building_guid = 68)
       LocalObject(322, Door.Constructor(Vector3(3380f, 3464f, 71.07655f)), owning_building_guid = 68)
@@ -2359,7 +2359,7 @@ object Map10 { // Amerish
     Building47()
 
     def Building47(): Unit = { // Name: Cetan_Tower Type: tower_c GUID: 69, MapID: 47
-      LocalBuilding("Cetan_Tower", 69, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3686f, 2664f, 68.50925f), tower_c)))
+      LocalBuilding("Cetan_Tower", 69, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3686f, 2664f, 68.50925f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2394, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 69)
       LocalObject(352, Door.Constructor(Vector3(3698f, 2656f, 70.03025f)), owning_building_guid = 69)
       LocalObject(353, Door.Constructor(Vector3(3698f, 2656f, 90.02925f)), owning_building_guid = 69)
@@ -2400,7 +2400,7 @@ object Map10 { // Amerish
     Building33()
 
     def Building33(): Unit = { // Name: NW_Oshur_Warpgate_Tower Type: tower_c GUID: 70, MapID: 33
-      LocalBuilding("NW_Oshur_Warpgate_Tower", 70, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4000f, 5430f, 66.66187f), tower_c)))
+      LocalBuilding("NW_Oshur_Warpgate_Tower", 70, 33, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4000f, 5430f, 66.66187f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2396, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 70)
       LocalObject(375, Door.Constructor(Vector3(4012f, 5422f, 68.18288f)), owning_building_guid = 70)
       LocalObject(376, Door.Constructor(Vector3(4012f, 5422f, 88.18187f)), owning_building_guid = 70)
@@ -2441,7 +2441,7 @@ object Map10 { // Amerish
     Building22()
 
     def Building22(): Unit = { // Name: NW_Kyoi_Tower Type: tower_c GUID: 71, MapID: 22
-      LocalBuilding("NW_Kyoi_Tower", 71, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4978f, 2646f, 62.90847f), tower_c)))
+      LocalBuilding("NW_Kyoi_Tower", 71, 22, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4978f, 2646f, 62.90847f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2400, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 71)
       LocalObject(458, Door.Constructor(Vector3(4990f, 2638f, 64.42947f)), owning_building_guid = 71)
       LocalObject(459, Door.Constructor(Vector3(4990f, 2638f, 84.42847f)), owning_building_guid = 71)
@@ -2482,7 +2482,7 @@ object Map10 { // Amerish
     Building29()
 
     def Building29(): Unit = { // Name: W_Ceryshen_Warpgate_Tower Type: tower_c GUID: 72, MapID: 29
-      LocalBuilding("W_Ceryshen_Warpgate_Tower", 72, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5424f, 7052f, 61.30546f), tower_c)))
+      LocalBuilding("W_Ceryshen_Warpgate_Tower", 72, 29, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5424f, 7052f, 61.30546f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2403, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 72)
       LocalObject(476, Door.Constructor(Vector3(5436f, 7044f, 62.82646f)), owning_building_guid = 72)
       LocalObject(477, Door.Constructor(Vector3(5436f, 7044f, 82.82546f)), owning_building_guid = 72)
@@ -2523,7 +2523,7 @@ object Map10 { // Amerish
     Building46()
 
     def Building46(): Unit = { // Name: Mekala_Tower Type: tower_c GUID: 73, MapID: 46
-      LocalBuilding("Mekala_Tower", 73, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6134f, 3198f, 54.44196f), tower_c)))
+      LocalBuilding("Mekala_Tower", 73, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6134f, 3198f, 54.44196f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2406, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 73)
       LocalObject(513, Door.Constructor(Vector3(6146f, 3190f, 55.96296f)), owning_building_guid = 73)
       LocalObject(514, Door.Constructor(Vector3(6146f, 3190f, 75.96196f)), owning_building_guid = 73)
@@ -2564,7 +2564,7 @@ object Map10 { // Amerish
     Building27()
 
     def Building27(): Unit = { // Name: NW_Xelas_Tower Type: tower_c GUID: 74, MapID: 27
-      LocalBuilding("NW_Xelas_Tower", 74, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6444f, 4606f, 49.63475f), tower_c)))
+      LocalBuilding("NW_Xelas_Tower", 74, 27, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6444f, 4606f, 49.63475f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(2409, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 74)
       LocalObject(546, Door.Constructor(Vector3(6456f, 4598f, 51.15575f)), owning_building_guid = 74)
       LocalObject(547, Door.Constructor(Vector3(6456f, 4598f, 71.15475f)), owning_building_guid = 74)

--- a/pslogin/src/main/scala/zonemaps/Map11.scala
+++ b/pslogin/src/main/scala/zonemaps/Map11.scala
@@ -21,7 +21,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building37()
 
     def Building37(): Unit = { // Name: Cyssor_HART Type: orbital_building_nc GUID: 1, MapID: 37
-      LocalBuilding("Cyssor_HART", 1, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2258f, 5538f, 65.20142f), orbital_building_nc)))
+      LocalBuilding("Cyssor_HART", 1, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2258f, 5538f, 65.20142f), Vector3(0f, 0f, 89f), orbital_building_nc)))
       LocalObject(371, Door.Constructor(Vector3(2177.802f, 5527.388f, 69.30743f)), owning_building_guid = 1)
       LocalObject(372, Door.Constructor(Vector3(2178.221f, 5551.384f, 69.30743f)), owning_building_guid = 1)
       LocalObject(374, Door.Constructor(Vector3(2337.779f, 5524.616f, 69.30743f)), owning_building_guid = 1)
@@ -127,7 +127,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building23()
 
     def Building23(): Unit = { // Name: Amerish_HART Type: orbital_building_nc GUID: 2, MapID: 23
-      LocalBuilding("Amerish_HART", 2, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4152f, 6070f, 43.87661f), orbital_building_nc)))
+      LocalBuilding("Amerish_HART", 2, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4152f, 6070f, 43.87661f), Vector3(0f, 0f, 89f), orbital_building_nc)))
       LocalObject(382, Door.Constructor(Vector3(4071.802f, 6059.388f, 47.98261f)), owning_building_guid = 2)
       LocalObject(383, Door.Constructor(Vector3(4072.221f, 6083.384f, 47.98261f)), owning_building_guid = 2)
       LocalObject(386, Door.Constructor(Vector3(4231.778f, 6056.616f, 47.98261f)), owning_building_guid = 2)
@@ -233,7 +233,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building4()
 
     def Building4(): Unit = { // Name: Esamir_HART Type: orbital_building_nc GUID: 3, MapID: 4
-      LocalBuilding("Esamir_HART", 3, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4816f, 3506f, 68.73806f), orbital_building_nc)))
+      LocalBuilding("Esamir_HART", 3, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4816f, 3506f, 68.73806f), Vector3(0f, 0f, 315f), orbital_building_nc)))
       LocalObject(394, Door.Constructor(Vector3(4750.953f, 3457.91f, 72.84406f)), owning_building_guid = 3)
       LocalObject(395, Door.Constructor(Vector3(4767.924f, 3440.939f, 72.84406f)), owning_building_guid = 3)
       LocalObject(396, Door.Constructor(Vector3(4864.076f, 3571.061f, 72.84406f)), owning_building_guid = 3)
@@ -339,7 +339,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building50()
 
     def Building50(): Unit = { // Name: nc_SW_Cyssor_Warpgate_Tower Type: tower_a GUID: 28, MapID: 50
-      LocalBuilding("nc_SW_Cyssor_Warpgate_Tower", 28, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1980f, 5718f, 55.22141f), tower_a)))
+      LocalBuilding("nc_SW_Cyssor_Warpgate_Tower", 28, 50, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1980f, 5718f, 55.22141f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1094, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 28)
       LocalObject(316, Door.Constructor(Vector3(1992f, 5710f, 56.74241f)), owning_building_guid = 28)
       LocalObject(317, Door.Constructor(Vector3(1992f, 5710f, 76.74141f)), owning_building_guid = 28)
@@ -376,7 +376,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building54()
 
     def Building54(): Unit = { // Name: nc_Far_Cyssor_Tower Type: tower_a GUID: 29, MapID: 54
-      LocalBuilding("nc_Far_Cyssor_Tower", 29, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2940f, 5192f, 47.96524f), tower_a)))
+      LocalBuilding("nc_Far_Cyssor_Tower", 29, 54, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2940f, 5192f, 47.96524f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1096, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 29)
       LocalObject(326, Door.Constructor(Vector3(2952f, 5184f, 49.48624f)), owning_building_guid = 29)
       LocalObject(327, Door.Constructor(Vector3(2952f, 5184f, 69.48524f)), owning_building_guid = 29)
@@ -413,7 +413,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building55()
 
     def Building55(): Unit = { // Name: nc_Far_Amerish_Tower Type: tower_a GUID: 30, MapID: 55
-      LocalBuilding("nc_Far_Amerish_Tower", 30, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4206f, 5296f, 67.51106f), tower_a)))
+      LocalBuilding("nc_Far_Amerish_Tower", 30, 55, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4206f, 5296f, 67.51106f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1100, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 30)
       LocalObject(344, Door.Constructor(Vector3(4218f, 5288f, 69.03207f)), owning_building_guid = 30)
       LocalObject(345, Door.Constructor(Vector3(4218f, 5288f, 89.03107f)), owning_building_guid = 30)
@@ -450,7 +450,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building44()
 
     def Building44(): Unit = { // Name: nc_Far_Esamir_Tower Type: tower_a GUID: 31, MapID: 44
-      LocalBuilding("nc_Far_Esamir_Tower", 31, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4228f, 3982f, 63.52824f), tower_a)))
+      LocalBuilding("nc_Far_Esamir_Tower", 31, 44, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4228f, 3982f, 63.52824f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1101, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 31)
       LocalObject(348, Door.Constructor(Vector3(4240f, 3974f, 65.04925f)), owning_building_guid = 31)
       LocalObject(349, Door.Constructor(Vector3(4240f, 3974f, 85.04825f)), owning_building_guid = 31)
@@ -487,7 +487,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building48()
 
     def Building48(): Unit = { // Name: nc_SE_Amerish_Warpgate_Tower Type: tower_a GUID: 32, MapID: 48
-      LocalBuilding("nc_SE_Amerish_Warpgate_Tower", 32, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4458f, 6256f, 43.92254f), tower_a)))
+      LocalBuilding("nc_SE_Amerish_Warpgate_Tower", 32, 48, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4458f, 6256f, 43.92254f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1102, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 32)
       LocalObject(352, Door.Constructor(Vector3(4470f, 6248f, 45.44354f)), owning_building_guid = 32)
       LocalObject(353, Door.Constructor(Vector3(4470f, 6248f, 65.44254f)), owning_building_guid = 32)
@@ -524,7 +524,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building46()
 
     def Building46(): Unit = { // Name: nc_W_Esamir_Warpgate_Tower Type: tower_a GUID: 33, MapID: 46
-      LocalBuilding("nc_W_Esamir_Warpgate_Tower", 33, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4886f, 3164f, 48.7764f), tower_a)))
+      LocalBuilding("nc_W_Esamir_Warpgate_Tower", 33, 46, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4886f, 3164f, 48.7764f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1103, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 33)
       LocalObject(356, Door.Constructor(Vector3(4898f, 3156f, 50.2974f)), owning_building_guid = 33)
       LocalObject(357, Door.Constructor(Vector3(4898f, 3156f, 70.2964f)), owning_building_guid = 33)
@@ -561,7 +561,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building49()
 
     def Building49(): Unit = { // Name: nc_SE_Cyssor_Warpgate_Tower Type: tower_b GUID: 34, MapID: 49
-      LocalBuilding("nc_SE_Cyssor_Warpgate_Tower", 34, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2506f, 5776f, 63.62667f), tower_b)))
+      LocalBuilding("nc_SE_Cyssor_Warpgate_Tower", 34, 49, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2506f, 5776f, 63.62667f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1095, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 34)
       LocalObject(320, Door.Constructor(Vector3(2518f, 5768f, 65.14667f)), owning_building_guid = 34)
       LocalObject(321, Door.Constructor(Vector3(2518f, 5768f, 75.14667f)), owning_building_guid = 34)
@@ -598,7 +598,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building47()
 
     def Building47(): Unit = { // Name: nc_SW_Amerish_Warpgate_Tower Type: tower_b GUID: 35, MapID: 47
-      LocalBuilding("nc_SW_Amerish_Warpgate_Tower", 35, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3844f, 5888f, 44.39456f), tower_b)))
+      LocalBuilding("nc_SW_Amerish_Warpgate_Tower", 35, 47, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3844f, 5888f, 44.39456f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1098, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 35)
       LocalObject(334, Door.Constructor(Vector3(3856f, 5880f, 45.91456f)), owning_building_guid = 35)
       LocalObject(335, Door.Constructor(Vector3(3856f, 5880f, 55.91456f)), owning_building_guid = 35)
@@ -635,7 +635,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building45()
 
     def Building45(): Unit = { // Name: nc_N_Esamir_Warpgate_Tower Type: tower_b GUID: 36, MapID: 45
-      LocalBuilding("nc_N_Esamir_Warpgate_Tower", 36, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5020f, 3810f, 65.63448f), tower_b)))
+      LocalBuilding("nc_N_Esamir_Warpgate_Tower", 36, 45, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5020f, 3810f, 65.63448f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1104, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 36)
       LocalObject(360, Door.Constructor(Vector3(5032f, 3802f, 67.15448f)), owning_building_guid = 36)
       LocalObject(361, Door.Constructor(Vector3(5032f, 3802f, 77.15448f)), owning_building_guid = 36)
@@ -672,7 +672,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building58()
 
     def Building58(): Unit = { // Name: nc_Cyssor_Outpost_Tower Type: tower_c GUID: 37, MapID: 58
-      LocalBuilding("nc_Cyssor_Outpost_Tower", 37, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1978f, 4802f, 62.46139f), tower_c)))
+      LocalBuilding("nc_Cyssor_Outpost_Tower", 37, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1978f, 4802f, 62.46139f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1093, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 37)
       LocalObject(312, Door.Constructor(Vector3(1990f, 4794f, 63.98239f)), owning_building_guid = 37)
       LocalObject(313, Door.Constructor(Vector3(1990f, 4794f, 83.98139f)), owning_building_guid = 37)
@@ -713,7 +713,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building51()
 
     def Building51(): Unit = { // Name: nc_Central_Tower Type: tower_c GUID: 38, MapID: 51
-      LocalBuilding("nc_Central_Tower", 38, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3340f, 4668f, 61.79601f), tower_c)))
+      LocalBuilding("nc_Central_Tower", 38, 51, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3340f, 4668f, 61.79601f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1097, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 38)
       LocalObject(330, Door.Constructor(Vector3(3352f, 4660f, 63.31701f)), owning_building_guid = 38)
       LocalObject(331, Door.Constructor(Vector3(3352f, 4660f, 83.31601f)), owning_building_guid = 38)
@@ -754,7 +754,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building56()
 
     def Building56(): Unit = { // Name: nc_Esamir_Outpost_Tower Type: tower_c GUID: 39, MapID: 56
-      LocalBuilding("nc_Esamir_Outpost_Tower", 39, 56, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4140f, 2924f, 39.29424f), tower_c)))
+      LocalBuilding("nc_Esamir_Outpost_Tower", 39, 56, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4140f, 2924f, 39.29424f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1099, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 39)
       LocalObject(340, Door.Constructor(Vector3(4152f, 2916f, 40.81524f)), owning_building_guid = 39)
       LocalObject(341, Door.Constructor(Vector3(4152f, 2916f, 60.81424f)), owning_building_guid = 39)
@@ -795,7 +795,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building57()
 
     def Building57(): Unit = { // Name: nc_Amerish_Outpost_Tower Type: tower_c GUID: 40, MapID: 57
-      LocalBuilding("nc_Amerish_Outpost_Tower", 40, 57, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5290f, 6160f, 39.10642f), tower_c)))
+      LocalBuilding("nc_Amerish_Outpost_Tower", 40, 57, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5290f, 6160f, 39.10642f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1105, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 40)
       LocalObject(366, Door.Constructor(Vector3(5302f, 6152f, 40.62742f)), owning_building_guid = 40)
       LocalObject(367, Door.Constructor(Vector3(5302f, 6152f, 60.62642f)), owning_building_guid = 40)
@@ -836,7 +836,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building30()
 
     def Building30(): Unit = { // Name: Cyssor_Spawn1 Type: VT_building_nc GUID: 41, MapID: 30
-      LocalBuilding("Cyssor_Spawn1", 41, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2168f, 5392f, 65.21291f), VT_building_nc)))
+      LocalBuilding("Cyssor_Spawn1", 41, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2168f, 5392f, 65.21291f), Vector3(0f, 0f, 44f), VT_building_nc)))
       LocalObject(234, Door.Constructor(Vector3(2162.214f, 5444.023f, 67.2889f)), owning_building_guid = 41)
       LocalObject(235, Door.Constructor(Vector3(2162.343f, 5450.527f, 67.2889f)), owning_building_guid = 41)
       LocalObject(236, Door.Constructor(Vector3(2168.919f, 5443.906f, 67.2889f)), owning_building_guid = 41)
@@ -868,7 +868,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building35()
 
     def Building35(): Unit = { // Name: Cyssor_Spawn2 Type: VT_building_nc GUID: 42, MapID: 35
-      LocalBuilding("Cyssor_Spawn2", 42, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2400f, 5402f, 64.68082f), VT_building_nc)))
+      LocalBuilding("Cyssor_Spawn2", 42, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2400f, 5402f, 64.68082f), Vector3(0f, 0f, 89f), VT_building_nc)))
       LocalObject(240, Door.Constructor(Vector3(2354.615f, 5439.385f, 66.75681f)), owning_building_guid = 42)
       LocalObject(241, Door.Constructor(Vector3(2359.122f, 5434.694f, 66.75681f)), owning_building_guid = 42)
       LocalObject(242, Door.Constructor(Vector3(2359.439f, 5444.042f, 66.75681f)), owning_building_guid = 42)
@@ -900,7 +900,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building36()
 
     def Building36(): Unit = { // Name: Cyssor_Spawn3 Type: VT_building_nc GUID: 43, MapID: 36
-      LocalBuilding("Cyssor_Spawn3", 43, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2452f, 5542f, 65.20798f), VT_building_nc)))
+      LocalBuilding("Cyssor_Spawn3", 43, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2452f, 5542f, 65.20798f), Vector3(0f, 0f, 136f), VT_building_nc)))
       LocalObject(246, Door.Constructor(Vector3(2393.473f, 5547.714f, 67.28398f)), owning_building_guid = 43)
       LocalObject(247, Door.Constructor(Vector3(2393.59f, 5541.009f, 67.28398f)), owning_building_guid = 43)
       LocalObject(248, Door.Constructor(Vector3(2393.706f, 5534.304f, 67.28398f)), owning_building_guid = 43)
@@ -932,7 +932,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building53()
 
     def Building53(): Unit = { // Name: amerish_spawn1 Type: VT_building_nc GUID: 44, MapID: 53
-      LocalBuilding("amerish_spawn1", 44, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3996f, 5924f, 43.87661f), VT_building_nc)))
+      LocalBuilding("amerish_spawn1", 44, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3996f, 5924f, 43.87661f), Vector3(0f, 0f, 44f), VT_building_nc)))
       LocalObject(252, Door.Constructor(Vector3(3990.214f, 5976.023f, 45.95261f)), owning_building_guid = 44)
       LocalObject(253, Door.Constructor(Vector3(3990.343f, 5982.527f, 45.95261f)), owning_building_guid = 44)
       LocalObject(254, Door.Constructor(Vector3(3996.919f, 5975.906f, 45.95261f)), owning_building_guid = 44)
@@ -964,7 +964,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building18()
 
     def Building18(): Unit = { // Name: amerish_spawn2 Type: VT_building_nc GUID: 45, MapID: 18
-      LocalBuilding("amerish_spawn2", 45, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4148f, 5892f, 43.87661f), VT_building_nc)))
+      LocalBuilding("amerish_spawn2", 45, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4148f, 5892f, 43.87661f), Vector3(0f, 0f, 44f), VT_building_nc)))
       LocalObject(258, Door.Constructor(Vector3(4142.213f, 5944.023f, 45.95261f)), owning_building_guid = 45)
       LocalObject(259, Door.Constructor(Vector3(4142.343f, 5950.527f, 45.95261f)), owning_building_guid = 45)
       LocalObject(260, Door.Constructor(Vector3(4148.919f, 5943.906f, 45.95261f)), owning_building_guid = 45)
@@ -996,7 +996,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building52()
 
     def Building52(): Unit = { // Name: amerish_spawn3 Type: VT_building_nc GUID: 46, MapID: 52
-      LocalBuilding("amerish_spawn3", 46, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4302f, 5918f, 43.87661f), VT_building_nc)))
+      LocalBuilding("amerish_spawn3", 46, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4302f, 5918f, 43.87661f), Vector3(0f, 0f, 44f), VT_building_nc)))
       LocalObject(264, Door.Constructor(Vector3(4296.213f, 5970.023f, 45.95261f)), owning_building_guid = 46)
       LocalObject(265, Door.Constructor(Vector3(4296.343f, 5976.527f, 45.95261f)), owning_building_guid = 46)
       LocalObject(266, Door.Constructor(Vector3(4302.919f, 5969.906f, 45.95261f)), owning_building_guid = 46)
@@ -1028,7 +1028,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building5()
 
     def Building5(): Unit = { // Name: Esamir_Spawn1 Type: VT_building_nc GUID: 47, MapID: 5
-      LocalBuilding("Esamir_Spawn1", 47, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4662f, 3362f, 68.73806f), VT_building_nc)))
+      LocalBuilding("Esamir_Spawn1", 47, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4662f, 3362f, 68.73806f), Vector3(0f, 0f, 358f), VT_building_nc)))
       LocalObject(270, Door.Constructor(Vector3(4695.403f, 3402.301f, 70.81406f)), owning_building_guid = 47)
       LocalObject(271, Door.Constructor(Vector3(4699.977f, 3397.396f, 70.81406f)), owning_building_guid = 47)
       LocalObject(272, Door.Constructor(Vector3(4700.171f, 3406.725f, 70.81406f)), owning_building_guid = 47)
@@ -1060,7 +1060,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building7()
 
     def Building7(): Unit = { // Name: Esamir_Spawn2 Type: VT_building_nc GUID: 48, MapID: 7
-      LocalBuilding("Esamir_Spawn2", 48, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4692f, 3636f, 68.73806f), VT_building_nc)))
+      LocalBuilding("Esamir_Spawn2", 48, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4692f, 3636f, 68.73806f), Vector3(0f, 0f, 270f), VT_building_nc)))
       LocalObject(276, Door.Constructor(Vector3(4723.958f, 3594.54f, 70.81406f)), owning_building_guid = 48)
       LocalObject(277, Door.Constructor(Vector3(4728.546f, 3589.93f, 70.81406f)), owning_building_guid = 48)
       LocalObject(278, Door.Constructor(Vector3(4728.7f, 3599.282f, 70.81406f)), owning_building_guid = 48)
@@ -1092,7 +1092,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building6()
 
     def Building6(): Unit = { // Name: Esamir_Spawn3 Type: VT_building_nc GUID: 49, MapID: 6
-      LocalBuilding("Esamir_Spawn3", 49, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4966f, 3658f, 68.73806f), VT_building_nc)))
+      LocalBuilding("Esamir_Spawn3", 49, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4966f, 3658f, 68.73806f), Vector3(0f, 0f, 179f), VT_building_nc)))
       LocalObject(282, Door.Constructor(Vector3(4919.299f, 3622.264f, 70.81406f)), owning_building_guid = 49)
       LocalObject(283, Door.Constructor(Vector3(4923.958f, 3617.439f, 70.81406f)), owning_building_guid = 49)
       LocalObject(284, Door.Constructor(Vector3(4923.989f, 3626.771f, 70.81406f)), owning_building_guid = 49)
@@ -1124,7 +1124,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building34()
 
     def Building34(): Unit = { // Name: Cyssor_Air2 Type: vt_dropship GUID: 50, MapID: 34
-      LocalBuilding("Cyssor_Air2", 50, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5496f, 65.20686f), vt_dropship)))
+      LocalBuilding("Cyssor_Air2", 50, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5496f, 65.20686f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(300, Terminal.Constructor(Vector3(2101.469f, 5495.71f, 68.07486f), dropship_vehicle_terminal), owning_building_guid = 50)
       LocalObject(288, VehicleSpawnPad.Constructor(Vector3(2081.589f, 5495.958f, 61.22186f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 50, terminal_guid = 300)
     }
@@ -1132,7 +1132,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building38()
 
     def Building38(): Unit = { // Name: Cyssor_Air1 Type: vt_dropship GUID: 51, MapID: 38
-      LocalBuilding("Cyssor_Air1", 51, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5572f, 65.20757f), vt_dropship)))
+      LocalBuilding("Cyssor_Air1", 51, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5572f, 65.20757f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(301, Terminal.Constructor(Vector3(2101.469f, 5571.71f, 68.07558f), dropship_vehicle_terminal), owning_building_guid = 51)
       LocalObject(289, VehicleSpawnPad.Constructor(Vector3(2081.589f, 5571.958f, 61.22257f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 51, terminal_guid = 301)
     }
@@ -1140,7 +1140,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building39()
 
     def Building39(): Unit = { // Name: Cyssor_Air4 Type: vt_dropship GUID: 52, MapID: 39
-      LocalBuilding("Cyssor_Air4", 52, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2290f, 5386f, 65.21352f), vt_dropship)))
+      LocalBuilding("Cyssor_Air4", 52, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2290f, 5386f, 65.21352f), Vector3(0f, 0f, 269f), vt_dropship)))
       LocalObject(302, Terminal.Constructor(Vector3(2290.29f, 5409.469f, 68.08153f), dropship_vehicle_terminal), owning_building_guid = 52)
       LocalObject(290, VehicleSpawnPad.Constructor(Vector3(2290.043f, 5389.589f, 61.22852f), dropship_pad_doors, Vector3(0, 0, 91)), owning_building_guid = 52, terminal_guid = 302)
     }
@@ -1148,7 +1148,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building33()
 
     def Building33(): Unit = { // Name: Cyssor_Air3 Type: vt_dropship GUID: 53, MapID: 33
-      LocalBuilding("Cyssor_Air3", 53, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2464f, 5640f, 65.20798f), vt_dropship)))
+      LocalBuilding("Cyssor_Air3", 53, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2464f, 5640f, 65.20798f), Vector3(0f, 0f, 42f), vt_dropship)))
       LocalObject(303, Terminal.Constructor(Vector3(2446.639f, 5624.207f, 68.07599f), dropship_vehicle_terminal), owning_building_guid = 53)
       LocalObject(291, VehicleSpawnPad.Constructor(Vector3(2461.346f, 5637.583f, 61.22298f), dropship_pad_doors, Vector3(0, 0, -42)), owning_building_guid = 53, terminal_guid = 303)
     }
@@ -1156,7 +1156,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building22()
 
     def Building22(): Unit = { // Name: amerish_air3 Type: vt_dropship GUID: 54, MapID: 22
-      LocalBuilding("amerish_air3", 54, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3926f, 6060f, 43.87661f), vt_dropship)))
+      LocalBuilding("amerish_air3", 54, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3926f, 6060f, 43.87661f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(304, Terminal.Constructor(Vector3(3949.469f, 6059.71f, 46.74461f), dropship_vehicle_terminal), owning_building_guid = 54)
       LocalObject(292, VehicleSpawnPad.Constructor(Vector3(3929.589f, 6059.958f, 39.89161f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 54, terminal_guid = 304)
     }
@@ -1164,7 +1164,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building25()
 
     def Building25(): Unit = { // Name: amerish_air4 Type: vt_dropship GUID: 55, MapID: 25
-      LocalBuilding("amerish_air4", 55, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3986f, 6176f, 43.87661f), vt_dropship)))
+      LocalBuilding("amerish_air4", 55, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3986f, 6176f, 43.87661f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(305, Terminal.Constructor(Vector3(4009.469f, 6175.71f, 46.74461f), dropship_vehicle_terminal), owning_building_guid = 55)
       LocalObject(293, VehicleSpawnPad.Constructor(Vector3(3989.589f, 6175.958f, 39.89161f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 55, terminal_guid = 305)
     }
@@ -1172,7 +1172,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building24()
 
     def Building24(): Unit = { // Name: amerish_air2 Type: vt_dropship GUID: 56, MapID: 24
-      LocalBuilding("amerish_air2", 56, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4320f, 6168f, 43.87661f), vt_dropship)))
+      LocalBuilding("amerish_air2", 56, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4320f, 6168f, 43.87661f), Vector3(0f, 0f, 359f), vt_dropship)))
       LocalObject(306, Terminal.Constructor(Vector3(4296.531f, 6168.29f, 46.74461f), dropship_vehicle_terminal), owning_building_guid = 56)
       LocalObject(294, VehicleSpawnPad.Constructor(Vector3(4316.411f, 6168.042f, 39.89161f), dropship_pad_doors, Vector3(0, 0, 1)), owning_building_guid = 56, terminal_guid = 306)
     }
@@ -1180,7 +1180,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building21()
 
     def Building21(): Unit = { // Name: amerish_air1 Type: vt_dropship GUID: 57, MapID: 21
-      LocalBuilding("amerish_air1", 57, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4376f, 6058f, 43.87661f), vt_dropship)))
+      LocalBuilding("amerish_air1", 57, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4376f, 6058f, 43.87661f), Vector3(0f, 0f, 359f), vt_dropship)))
       LocalObject(307, Terminal.Constructor(Vector3(4352.531f, 6058.29f, 46.74461f), dropship_vehicle_terminal), owning_building_guid = 57)
       LocalObject(295, VehicleSpawnPad.Constructor(Vector3(4372.411f, 6058.042f, 39.89161f), dropship_pad_doors, Vector3(0, 0, 1)), owning_building_guid = 57, terminal_guid = 307)
     }
@@ -1188,7 +1188,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building14()
 
     def Building14(): Unit = { // Name: Esamir_Air2 Type: vt_dropship GUID: 58, MapID: 14
-      LocalBuilding("Esamir_Air2", 58, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4620f, 3466f, 68.73806f), vt_dropship)))
+      LocalBuilding("Esamir_Air2", 58, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4620f, 3466f, 68.73806f), Vector3(0f, 0f, 225f), vt_dropship)))
       LocalObject(308, Terminal.Constructor(Vector3(4636.511f, 3482.681f, 71.60606f), dropship_vehicle_terminal), owning_building_guid = 58)
       LocalObject(296, VehicleSpawnPad.Constructor(Vector3(4622.523f, 3468.552f, 64.75306f), dropship_pad_doors, Vector3(0, 0, 135)), owning_building_guid = 58, terminal_guid = 308)
     }
@@ -1196,7 +1196,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building17()
 
     def Building17(): Unit = { // Name: Esamir_Air1 Type: vt_dropship GUID: 59, MapID: 17
-      LocalBuilding("Esamir_Air1", 59, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4768f, 3318f, 68.73806f), vt_dropship)))
+      LocalBuilding("Esamir_Air1", 59, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4768f, 3318f, 68.73806f), Vector3(0f, 0f, 225f), vt_dropship)))
       LocalObject(309, Terminal.Constructor(Vector3(4784.511f, 3334.681f, 71.60606f), dropship_vehicle_terminal), owning_building_guid = 59)
       LocalObject(297, VehicleSpawnPad.Constructor(Vector3(4770.523f, 3320.552f, 64.75306f), dropship_pad_doors, Vector3(0, 0, 135)), owning_building_guid = 59, terminal_guid = 309)
     }
@@ -1204,7 +1204,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building15()
 
     def Building15(): Unit = { // Name: Esamir_Air4 Type: vt_dropship GUID: 60, MapID: 15
-      LocalBuilding("Esamir_Air4", 60, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4868f, 3696f, 68.73806f), vt_dropship)))
+      LocalBuilding("Esamir_Air4", 60, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4868f, 3696f, 68.73806f), Vector3(0f, 0f, 45f), vt_dropship)))
       LocalObject(310, Terminal.Constructor(Vector3(4851.489f, 3679.319f, 71.60606f), dropship_vehicle_terminal), owning_building_guid = 60)
       LocalObject(298, VehicleSpawnPad.Constructor(Vector3(4865.477f, 3693.448f, 64.75306f), dropship_pad_doors, Vector3(0, 0, -45)), owning_building_guid = 60, terminal_guid = 310)
     }
@@ -1212,7 +1212,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building16()
 
     def Building16(): Unit = { // Name: Esamir_Air3 Type: vt_dropship GUID: 61, MapID: 16
-      LocalBuilding("Esamir_Air3", 61, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5010f, 3556f, 68.73806f), vt_dropship)))
+      LocalBuilding("Esamir_Air3", 61, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5010f, 3556f, 68.73806f), Vector3(0f, 0f, 45f), vt_dropship)))
       LocalObject(311, Terminal.Constructor(Vector3(4993.489f, 3539.319f, 71.60606f), dropship_vehicle_terminal), owning_building_guid = 61)
       LocalObject(299, VehicleSpawnPad.Constructor(Vector3(5007.477f, 3553.448f, 64.75306f), dropship_pad_doors, Vector3(0, 0, -45)), owning_building_guid = 61, terminal_guid = 311)
     }
@@ -1220,79 +1220,79 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building67()
 
     def Building67(): Unit = { // Name: NC_NW_Tport_04 Type: vt_spawn GUID: 62, MapID: 67
-      LocalBuilding("NC_NW_Tport_04", 62, 67, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2132f, 5532f, 65.20512f), vt_spawn)))
+      LocalBuilding("NC_NW_Tport_04", 62, 67, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2132f, 5532f, 65.20512f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building69()
 
     def Building69(): Unit = { // Name: NC_NW_Tport_02 Type: vt_spawn GUID: 63, MapID: 69
-      LocalBuilding("NC_NW_Tport_02", 63, 69, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2242f, 5432f, 65.2088f), vt_spawn)))
+      LocalBuilding("NC_NW_Tport_02", 63, 69, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2242f, 5432f, 65.2088f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building70()
 
     def Building70(): Unit = { // Name: NC_NW_Tport_01 Type: vt_spawn GUID: 64, MapID: 70
-      LocalBuilding("NC_NW_Tport_01", 64, 70, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2258f, 5642f, 65.20429f), vt_spawn)))
+      LocalBuilding("NC_NW_Tport_01", 64, 70, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2258f, 5642f, 65.20429f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building68()
 
     def Building68(): Unit = { // Name: NC_NW_Tport_03 Type: vt_spawn GUID: 65, MapID: 68
-      LocalBuilding("NC_NW_Tport_03", 65, 68, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2388f, 5618f, 65.20798f), vt_spawn)))
+      LocalBuilding("NC_NW_Tport_03", 65, 68, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2388f, 5618f, 65.20798f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building66()
 
     def Building66(): Unit = { // Name: NC_NE_Tport_02 Type: vt_spawn GUID: 66, MapID: 66
-      LocalBuilding("NC_NE_Tport_02", 66, 66, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4060f, 5986f, 43.87661f), vt_spawn)))
+      LocalBuilding("NC_NE_Tport_02", 66, 66, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4060f, 5986f, 43.87661f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building65()
 
     def Building65(): Unit = { // Name: NC_NE_Tport_03 Type: vt_spawn GUID: 67, MapID: 65
-      LocalBuilding("NC_NE_Tport_03", 67, 65, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4156f, 6160f, 43.87661f), vt_spawn)))
+      LocalBuilding("NC_NE_Tport_03", 67, 65, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4156f, 6160f, 43.87661f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building63()
 
     def Building63(): Unit = { // Name: NC_NE_Tport_01 Type: vt_spawn GUID: 68, MapID: 63
-      LocalBuilding("NC_NE_Tport_01", 68, 63, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4212f, 5954f, 43.87661f), vt_spawn)))
+      LocalBuilding("NC_NE_Tport_01", 68, 63, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4212f, 5954f, 43.87661f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building64()
 
     def Building64(): Unit = { // Name: NC_NE_Tport_04 Type: vt_spawn GUID: 69, MapID: 64
-      LocalBuilding("NC_NE_Tport_04", 69, 64, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4258f, 6148f, 43.87661f), vt_spawn)))
+      LocalBuilding("NC_NE_Tport_04", 69, 64, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4258f, 6148f, 43.87661f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building59()
 
     def Building59(): Unit = { // Name: NC_SE_Tport_04 Type: vt_spawn GUID: 70, MapID: 59
-      LocalBuilding("NC_SE_Tport_04", 70, 59, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4698f, 3506f, 68.73806f), vt_spawn)))
+      LocalBuilding("NC_SE_Tport_04", 70, 59, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4698f, 3506f, 68.73806f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building60()
 
     def Building60(): Unit = { // Name: NC_SE_Tport_03 Type: vt_spawn GUID: 71, MapID: 60
-      LocalBuilding("NC_SE_Tport_03", 71, 60, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4818f, 3622f, 68.73806f), vt_spawn)))
+      LocalBuilding("NC_SE_Tport_03", 71, 60, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4818f, 3622f, 68.73806f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building61()
 
     def Building61(): Unit = { // Name: NC_SE_Tport_02 Type: vt_spawn GUID: 72, MapID: 61
-      LocalBuilding("NC_SE_Tport_02", 72, 61, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4826f, 3398f, 68.73806f), vt_spawn)))
+      LocalBuilding("NC_SE_Tport_02", 72, 61, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4826f, 3398f, 68.73806f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building62()
 
     def Building62(): Unit = { // Name: NC_SE_Tport_01 Type: vt_spawn GUID: 73, MapID: 62
-      LocalBuilding("NC_SE_Tport_01", 73, 62, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4922f, 3500f, 68.73806f), vt_spawn)))
+      LocalBuilding("NC_SE_Tport_01", 73, 62, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4922f, 3500f, 68.73806f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building42()
 
     def Building42(): Unit = { // Name: Cyssor_Vehicle6 Type: vt_vehicle GUID: 74, MapID: 42
-      LocalBuilding("Cyssor_Vehicle6", 74, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5642f, 65.20348f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle6", 74, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2078f, 5642f, 65.20348f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1144, Terminal.Constructor(Vector3(2078.008f, 5627.508f, 67.89047f), ground_vehicle_terminal), owning_building_guid = 74)
       LocalObject(756, VehicleSpawnPad.Constructor(Vector3(2077.973f, 5642.147f, 63.73248f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 74, terminal_guid = 1144)
     }
@@ -1300,7 +1300,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building32()
 
     def Building32(): Unit = { // Name: Cyssor_Vehicle1 Type: vt_vehicle GUID: 75, MapID: 32
-      LocalBuilding("Cyssor_Vehicle1", 75, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2082f, 5418f, 65.21249f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle1", 75, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2082f, 5418f, 65.21249f), Vector3(0f, 0f, 180f), vt_vehicle)))
       LocalObject(1145, Terminal.Constructor(Vector3(2096.492f, 5418.008f, 67.89949f), ground_vehicle_terminal), owning_building_guid = 75)
       LocalObject(757, VehicleSpawnPad.Constructor(Vector3(2081.853f, 5417.973f, 63.74149f), mb_pad_creation, Vector3(0, 0, -90)), owning_building_guid = 75, terminal_guid = 1145)
     }
@@ -1308,7 +1308,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building41()
 
     def Building41(): Unit = { // Name: Cyssor_Vehicle5 Type: vt_vehicle GUID: 76, MapID: 41
-      LocalBuilding("Cyssor_Vehicle5", 76, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2186f, 5662f, 65.20142f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle5", 76, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2186f, 5662f, 65.20142f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1146, Terminal.Constructor(Vector3(2186.008f, 5647.508f, 67.88842f), ground_vehicle_terminal), owning_building_guid = 76)
       LocalObject(758, VehicleSpawnPad.Constructor(Vector3(2185.973f, 5662.147f, 63.73042f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 76, terminal_guid = 1146)
     }
@@ -1316,7 +1316,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building43()
 
     def Building43(): Unit = { // Name: Cyssor_Vehicle4 Type: vt_vehicle GUID: 77, MapID: 43
-      LocalBuilding("Cyssor_Vehicle4", 77, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2328f, 5662f, 65.20798f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle4", 77, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2328f, 5662f, 65.20798f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1147, Terminal.Constructor(Vector3(2327.755f, 5647.51f, 67.89498f), ground_vehicle_terminal), owning_building_guid = 77)
       LocalObject(759, VehicleSpawnPad.Constructor(Vector3(2327.976f, 5662.147f, 63.73698f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 77, terminal_guid = 1147)
     }
@@ -1324,7 +1324,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building40()
 
     def Building40(): Unit = { // Name: Cyssor_Vehicle3 Type: vt_vehicle GUID: 78, MapID: 40
-      LocalBuilding("Cyssor_Vehicle3", 78, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2410f, 5694f, 65.20798f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle3", 78, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2410f, 5694f, 65.20798f), Vector3(0f, 0f, 133f), vt_vehicle)))
       LocalObject(1148, Terminal.Constructor(Vector3(2419.889f, 5683.407f, 67.89498f), ground_vehicle_terminal), owning_building_guid = 78)
       LocalObject(760, VehicleSpawnPad.Constructor(Vector3(2409.88f, 5694.089f, 63.73698f), mb_pad_creation, Vector3(0, 0, -43)), owning_building_guid = 78, terminal_guid = 1148)
     }
@@ -1332,7 +1332,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building31()
 
     def Building31(): Unit = { // Name: Cyssor_Vehicle2 Type: vt_vehicle GUID: 79, MapID: 31
-      LocalBuilding("Cyssor_Vehicle2", 79, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2468f, 5458f, 65.2127f), vt_vehicle)))
+      LocalBuilding("Cyssor_Vehicle2", 79, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2468f, 5458f, 65.2127f), Vector3(0f, 0f, 1f), vt_vehicle)))
       LocalObject(1149, Terminal.Constructor(Vector3(2453.51f, 5457.739f, 67.8997f), ground_vehicle_terminal), owning_building_guid = 79)
       LocalObject(761, VehicleSpawnPad.Constructor(Vector3(2468.146f, 5458.03f, 63.7417f), mb_pad_creation, Vector3(0, 0, 89)), owning_building_guid = 79, terminal_guid = 1149)
     }
@@ -1340,7 +1340,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building19()
 
     def Building19(): Unit = { // Name: amerish_vehicle1 Type: vt_vehicle GUID: 80, MapID: 19
-      LocalBuilding("amerish_vehicle1", 80, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3990f, 6094f, 43.87661f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle1", 80, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3990f, 6094f, 43.87661f), Vector3(0f, 0f, 133f), vt_vehicle)))
       LocalObject(1151, Terminal.Constructor(Vector3(3999.889f, 6083.407f, 46.56361f), ground_vehicle_terminal), owning_building_guid = 80)
       LocalObject(762, VehicleSpawnPad.Constructor(Vector3(3989.88f, 6094.089f, 42.40561f), mb_pad_creation, Vector3(0, 0, -43)), owning_building_guid = 80, terminal_guid = 1151)
     }
@@ -1348,7 +1348,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building29()
 
     def Building29(): Unit = { // Name: amerish_vehicle2 Type: vt_vehicle GUID: 81, MapID: 29
-      LocalBuilding("amerish_vehicle2", 81, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4000f, 6248f, 43.87661f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle2", 81, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4000f, 6248f, 43.87661f), Vector3(0f, 0f, 88f), vt_vehicle)))
       LocalObject(1150, Terminal.Constructor(Vector3(3999.502f, 6233.517f, 46.56361f), ground_vehicle_terminal), owning_building_guid = 81)
       LocalObject(763, VehicleSpawnPad.Constructor(Vector3(3999.978f, 6248.148f, 42.40561f), mb_pad_creation, Vector3(0, 0, 2)), owning_building_guid = 81, terminal_guid = 1150)
     }
@@ -1356,7 +1356,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building28()
 
     def Building28(): Unit = { // Name: amerish_vehicle3 Type: vt_vehicle GUID: 82, MapID: 28
-      LocalBuilding("amerish_vehicle3", 82, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4104f, 6194f, 43.87661f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle3", 82, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4104f, 6194f, 43.87661f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1152, Terminal.Constructor(Vector3(4103.755f, 6179.51f, 46.56361f), ground_vehicle_terminal), owning_building_guid = 82)
       LocalObject(764, VehicleSpawnPad.Constructor(Vector3(4103.976f, 6194.147f, 42.40561f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 82, terminal_guid = 1152)
     }
@@ -1364,7 +1364,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building27()
 
     def Building27(): Unit = { // Name: amerish_vehicle4 Type: vt_vehicle GUID: 83, MapID: 27
-      LocalBuilding("amerish_vehicle4", 83, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4200f, 6196f, 43.87661f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle4", 83, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4200f, 6196f, 43.87661f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1153, Terminal.Constructor(Vector3(4199.755f, 6181.51f, 46.56361f), ground_vehicle_terminal), owning_building_guid = 83)
       LocalObject(765, VehicleSpawnPad.Constructor(Vector3(4199.976f, 6196.147f, 42.40561f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 83, terminal_guid = 1153)
     }
@@ -1372,7 +1372,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building26()
 
     def Building26(): Unit = { // Name: amerish_vehicle5 Type: vt_vehicle GUID: 84, MapID: 26
-      LocalBuilding("amerish_vehicle5", 84, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4304f, 6244f, 43.92173f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle5", 84, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4304f, 6244f, 43.92173f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1154, Terminal.Constructor(Vector3(4303.755f, 6229.51f, 46.60873f), ground_vehicle_terminal), owning_building_guid = 84)
       LocalObject(766, VehicleSpawnPad.Constructor(Vector3(4303.976f, 6244.147f, 42.45073f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 84, terminal_guid = 1154)
     }
@@ -1380,7 +1380,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building20()
 
     def Building20(): Unit = { // Name: amerish_vehicle6 Type: vt_vehicle GUID: 85, MapID: 20
-      LocalBuilding("amerish_vehicle6", 85, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4316f, 6094f, 43.87661f), vt_vehicle)))
+      LocalBuilding("amerish_vehicle6", 85, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4316f, 6094f, 43.87661f), Vector3(0f, 0f, 46f), vt_vehicle)))
       LocalObject(1155, Terminal.Constructor(Vector3(4305.939f, 6083.57f, 46.56361f), ground_vehicle_terminal), owning_building_guid = 85)
       LocalObject(767, VehicleSpawnPad.Constructor(Vector3(4316.083f, 6094.125f, 42.40561f), mb_pad_creation, Vector3(0, 0, 44)), owning_building_guid = 85, terminal_guid = 1155)
     }
@@ -1388,7 +1388,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building12()
 
     def Building12(): Unit = { // Name: Esamir_Vehicle1 Type: vt_vehicle GUID: 86, MapID: 12
-      LocalBuilding("Esamir_Vehicle1", 86, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4644f, 3540f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle1", 86, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4644f, 3540f, 68.73806f), Vector3(0f, 0f, 226f), vt_vehicle)))
       LocalObject(1156, Terminal.Constructor(Vector3(4654.061f, 3550.43f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 86)
       LocalObject(768, VehicleSpawnPad.Constructor(Vector3(4643.917f, 3539.875f, 67.26706f), mb_pad_creation, Vector3(0, 0, 224)), owning_building_guid = 86, terminal_guid = 1156)
     }
@@ -1396,7 +1396,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building13()
 
     def Building13(): Unit = { // Name: Esamir_Vehicle2 Type: vt_vehicle GUID: 87, MapID: 13
-      LocalBuilding("Esamir_Vehicle2", 87, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4782f, 3680f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle2", 87, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4782f, 3680f, 68.73806f), Vector3(0f, 0f, 45f), vt_vehicle)))
       LocalObject(1157, Terminal.Constructor(Vector3(4771.758f, 3669.747f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 87)
       LocalObject(769, VehicleSpawnPad.Constructor(Vector3(4782.085f, 3680.123f, 67.26706f), mb_pad_creation, Vector3(0, 0, 45)), owning_building_guid = 87, terminal_guid = 1157)
     }
@@ -1404,7 +1404,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building8()
 
     def Building8(): Unit = { // Name: Esamir_Vehicle6 Type: vt_vehicle GUID: 88, MapID: 8
-      LocalBuilding("Esamir_Vehicle6", 88, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4834f, 3276f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle6", 88, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4834f, 3276f, 68.73806f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1158, Terminal.Constructor(Vector3(4823.747f, 3286.242f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 88)
       LocalObject(770, VehicleSpawnPad.Constructor(Vector3(4834.123f, 3275.915f, 67.26706f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 88, terminal_guid = 1158)
     }
@@ -1412,7 +1412,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building9()
 
     def Building9(): Unit = { // Name: Esamir_Vehicle5 Type: vt_vehicle GUID: 89, MapID: 9
-      LocalBuilding("Esamir_Vehicle5", 89, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4878f, 3378f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle5", 89, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4878f, 3378f, 68.73806f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1159, Terminal.Constructor(Vector3(4867.747f, 3388.242f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 89)
       LocalObject(771, VehicleSpawnPad.Constructor(Vector3(4878.123f, 3377.915f, 67.26706f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 89, terminal_guid = 1159)
     }
@@ -1420,7 +1420,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building10()
 
     def Building10(): Unit = { // Name: Esamir_Vehicle4 Type: vt_vehicle GUID: 90, MapID: 10
-      LocalBuilding("Esamir_Vehicle4", 90, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4948f, 3446f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle4", 90, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(4948f, 3446f, 68.73806f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1160, Terminal.Constructor(Vector3(4937.747f, 3456.242f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 90)
       LocalObject(772, VehicleSpawnPad.Constructor(Vector3(4948.123f, 3445.915f, 67.26706f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 90, terminal_guid = 1160)
     }
@@ -1428,7 +1428,7 @@ object Map11 { // HOME1 (NEW CONGLOMORATE SANCTUARY)
     Building11()
 
     def Building11(): Unit = { // Name: Esamir_Vehicle3 Type: vt_vehicle GUID: 91, MapID: 11
-      LocalBuilding("Esamir_Vehicle3", 91, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5048f, 3492f, 68.73806f), vt_vehicle)))
+      LocalBuilding("Esamir_Vehicle3", 91, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5048f, 3492f, 68.73806f), Vector3(0f, 0f, 314f), vt_vehicle)))
       LocalObject(1161, Terminal.Constructor(Vector3(5037.927f, 3502.419f, 71.42506f), ground_vehicle_terminal), owning_building_guid = 91)
       LocalObject(773, VehicleSpawnPad.Constructor(Vector3(5048.122f, 3491.913f, 67.26706f), mb_pad_creation, Vector3(0, 0, 136)), owning_building_guid = 91, terminal_guid = 1161)
     }

--- a/pslogin/src/main/scala/zonemaps/Map12.scala
+++ b/pslogin/src/main/scala/zonemaps/Map12.scala
@@ -21,7 +21,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building4()
 
     def Building4(): Unit = { // Name: Hart_Ishundar Type: orbital_building_tr GUID: 1, MapID: 4
-      LocalBuilding("Hart_Ishundar", 1, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2922f, 5230f, 35.99899f), orbital_building_tr)))
+      LocalBuilding("Hart_Ishundar", 1, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2922f, 5230f, 35.99899f), Vector3(0f, 0f, 90f), orbital_building_tr)))
       LocalObject(382, Door.Constructor(Vector3(2842f, 5217.99f, 40.10499f)), owning_building_guid = 1)
       LocalObject(383, Door.Constructor(Vector3(2842f, 5241.99f, 40.10499f)), owning_building_guid = 1)
       LocalObject(390, Door.Constructor(Vector3(3002f, 5218.01f, 40.10499f)), owning_building_guid = 1)
@@ -127,7 +127,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building40()
 
     def Building40(): Unit = { // Name: Hart_Cyssor Type: orbital_building_tr GUID: 2, MapID: 40
-      LocalBuilding("Hart_Cyssor", 2, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3006f, 2984f, 34.91934f), orbital_building_tr)))
+      LocalBuilding("Hart_Cyssor", 2, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3006f, 2984f, 34.91934f), Vector3(0f, 0f, 90f), orbital_building_tr)))
       LocalObject(387, Door.Constructor(Vector3(2926f, 2971.99f, 39.02534f)), owning_building_guid = 2)
       LocalObject(388, Door.Constructor(Vector3(2926f, 2995.99f, 39.02534f)), owning_building_guid = 2)
       LocalObject(394, Door.Constructor(Vector3(3086f, 2972.01f, 39.02534f)), owning_building_guid = 2)
@@ -233,7 +233,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building22()
 
     def Building22(): Unit = { // Name: Hart_Forseral Type: orbital_building_tr GUID: 3, MapID: 22
-      LocalBuilding("Hart_Forseral", 3, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5232f, 3908f, 35.9291f), orbital_building_tr)))
+      LocalBuilding("Hart_Forseral", 3, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5232f, 3908f, 35.9291f), Vector3(0f, 0f, 90f), orbital_building_tr)))
       LocalObject(402, Door.Constructor(Vector3(5152f, 3895.99f, 40.0351f)), owning_building_guid = 3)
       LocalObject(403, Door.Constructor(Vector3(5152f, 3919.99f, 40.0351f)), owning_building_guid = 3)
       LocalObject(406, Door.Constructor(Vector3(5312f, 3896.01f, 40.0351f)), owning_building_guid = 3)
@@ -339,7 +339,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building58()
 
     def Building58(): Unit = { // Name: NW_Ishundar_WG_tower Type: tower_a GUID: 52, MapID: 58
-      LocalBuilding("NW_Ishundar_WG_tower", 52, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2620f, 5418f, 35.99397f), tower_a)))
+      LocalBuilding("NW_Ishundar_WG_tower", 52, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2620f, 5418f, 35.99397f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1037, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 52)
       LocalObject(336, Door.Constructor(Vector3(2632f, 5410f, 37.51497f)), owning_building_guid = 52)
       LocalObject(337, Door.Constructor(Vector3(2632f, 5410f, 57.51397f)), owning_building_guid = 52)
@@ -376,7 +376,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building66()
 
     def Building66(): Unit = { // Name: W_Cyssor_WG_tower Type: tower_a GUID: 53, MapID: 66
-      LocalBuilding("W_Cyssor_WG_tower", 53, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2806f, 3292f, 32.44872f), tower_a)))
+      LocalBuilding("W_Cyssor_WG_tower", 53, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2806f, 3292f, 32.44872f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1039, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 53)
       LocalObject(346, Door.Constructor(Vector3(2818f, 3284f, 33.96972f)), owning_building_guid = 53)
       LocalObject(347, Door.Constructor(Vector3(2818f, 3284f, 53.96872f)), owning_building_guid = 53)
@@ -413,7 +413,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building60()
 
     def Building60(): Unit = { // Name: W_Forseral_WG_tower Type: tower_a GUID: 54, MapID: 60
-      LocalBuilding("W_Forseral_WG_tower", 54, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4564f, 4572f, 54.12079f), tower_a)))
+      LocalBuilding("W_Forseral_WG_tower", 54, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4564f, 4572f, 54.12079f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1044, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 54)
       LocalObject(368, Door.Constructor(Vector3(4576f, 4564f, 55.64179f)), owning_building_guid = 54)
       LocalObject(369, Door.Constructor(Vector3(4576f, 4564f, 75.64079f)), owning_building_guid = 54)
@@ -450,7 +450,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building63()
 
     def Building63(): Unit = { // Name: SW_Forseral_WG_tower Type: tower_a GUID: 55, MapID: 63
-      LocalBuilding("SW_Forseral_WG_tower", 55, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4972f, 3678f, 35.9291f), tower_a)))
+      LocalBuilding("SW_Forseral_WG_tower", 55, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4972f, 3678f, 35.9291f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1045, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 55)
       LocalObject(372, Door.Constructor(Vector3(4984f, 3670f, 37.4501f)), owning_building_guid = 55)
       LocalObject(373, Door.Constructor(Vector3(4984f, 3670f, 57.4491f)), owning_building_guid = 55)
@@ -487,7 +487,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building65()
 
     def Building65(): Unit = { // Name: SW_Ishundar_WG_tower Type: tower_b GUID: 56, MapID: 65
-      LocalBuilding("SW_Ishundar_WG_tower", 56, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2794f, 4210f, 36.31348f), tower_b)))
+      LocalBuilding("SW_Ishundar_WG_tower", 56, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2794f, 4210f, 36.31348f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1038, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 56)
       LocalObject(340, Door.Constructor(Vector3(2806f, 4202f, 37.83348f)), owning_building_guid = 56)
       LocalObject(341, Door.Constructor(Vector3(2806f, 4202f, 47.83348f)), owning_building_guid = 56)
@@ -524,7 +524,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building64()
 
     def Building64(): Unit = { // Name: E_Cyssor_WG_tower Type: tower_b GUID: 57, MapID: 64
-      LocalBuilding("E_Cyssor_WG_tower", 57, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4484f, 3080f, 50.39579f), tower_b)))
+      LocalBuilding("E_Cyssor_WG_tower", 57, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4484f, 3080f, 50.39579f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1043, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 57)
       LocalObject(362, Door.Constructor(Vector3(4496f, 3072f, 51.91579f)), owning_building_guid = 57)
       LocalObject(363, Door.Constructor(Vector3(4496f, 3072f, 61.91579f)), owning_building_guid = 57)
@@ -561,7 +561,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building59()
 
     def Building59(): Unit = { // Name: N_Ishundar_WG_tower Type: tower_c GUID: 58, MapID: 59
-      LocalBuilding("N_Ishundar_WG_tower", 58, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3236f, 5040f, 37.58544f), tower_c)))
+      LocalBuilding("N_Ishundar_WG_tower", 58, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3236f, 5040f, 37.58544f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1040, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 58)
       LocalObject(350, Door.Constructor(Vector3(3248f, 5032f, 39.10644f)), owning_building_guid = 58)
       LocalObject(351, Door.Constructor(Vector3(3248f, 5032f, 59.10544f)), owning_building_guid = 58)
@@ -602,7 +602,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building67()
 
     def Building67(): Unit = { // Name: SW_Cyssor_WG_tower Type: tower_c GUID: 59, MapID: 67
-      LocalBuilding("SW_Cyssor_WG_tower", 59, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3260f, 2758f, 34.92906f), tower_c)))
+      LocalBuilding("SW_Cyssor_WG_tower", 59, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3260f, 2758f, 34.92906f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1041, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 59)
       LocalObject(354, Door.Constructor(Vector3(3272f, 2750f, 36.45006f)), owning_building_guid = 59)
       LocalObject(355, Door.Constructor(Vector3(3272f, 2750f, 56.44906f)), owning_building_guid = 59)
@@ -643,7 +643,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building61()
 
     def Building61(): Unit = { // Name: N_Cyssor_WG_tower Type: tower_c GUID: 60, MapID: 61
-      LocalBuilding("N_Cyssor_WG_tower", 60, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3906f, 3832f, 46.40522f), tower_c)))
+      LocalBuilding("N_Cyssor_WG_tower", 60, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3906f, 3832f, 46.40522f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1042, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 60)
       LocalObject(358, Door.Constructor(Vector3(3918f, 3824f, 47.92622f)), owning_building_guid = 60)
       LocalObject(359, Door.Constructor(Vector3(3918f, 3824f, 67.92522f)), owning_building_guid = 60)
@@ -684,7 +684,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building62()
 
     def Building62(): Unit = { // Name: SE_Forseral_WG_tower Type: tower_c GUID: 61, MapID: 62
-      LocalBuilding("SE_Forseral_WG_tower", 61, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5488f, 4168f, 35.9291f), tower_c)))
+      LocalBuilding("SE_Forseral_WG_tower", 61, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5488f, 4168f, 35.9291f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1046, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 61)
       LocalObject(376, Door.Constructor(Vector3(5500f, 4160f, 37.4501f)), owning_building_guid = 61)
       LocalObject(377, Door.Constructor(Vector3(5500f, 4160f, 57.4491f)), owning_building_guid = 61)
@@ -725,7 +725,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building14()
 
     def Building14(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 62, MapID: 14
-      LocalBuilding("VT_building_tr", 62, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2728f, 5288f, 35.99899f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 62, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2728f, 5288f, 35.99899f), Vector3(0f, 0f, 270f), VT_building_tr)))
       LocalObject(258, Door.Constructor(Vector3(2759.958f, 5246.54f, 38.07499f)), owning_building_guid = 62)
       LocalObject(259, Door.Constructor(Vector3(2764.546f, 5241.93f, 38.07499f)), owning_building_guid = 62)
       LocalObject(260, Door.Constructor(Vector3(2764.7f, 5251.282f, 38.07499f)), owning_building_guid = 62)
@@ -757,7 +757,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building43()
 
     def Building43(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 63, MapID: 43
-      LocalBuilding("VT_building_tr", 63, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2798f, 3038f, 34.92469f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 63, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2798f, 3038f, 34.92469f), Vector3(0f, 0f, 315f), VT_building_tr)))
       LocalObject(264, Door.Constructor(Vector3(2849.914f, 3031.281f, 37.00069f)), owning_building_guid = 63)
       LocalObject(265, Door.Constructor(Vector3(2849.914f, 3037.987f, 37.00069f)), owning_building_guid = 63)
       LocalObject(266, Door.Constructor(Vector3(2849.914f, 3044.693f, 37.00069f)), owning_building_guid = 63)
@@ -789,7 +789,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building13()
 
     def Building13(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 64, MapID: 13
-      LocalBuilding("VT_building_tr", 64, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2920f, 5052f, 35.99899f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 64, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2920f, 5052f, 35.99899f), Vector3(0f, 0f, 45f), VT_building_tr)))
       LocalObject(270, Door.Constructor(Vector3(2913.307f, 5103.915f, 38.07499f)), owning_building_guid = 64)
       LocalObject(271, Door.Constructor(Vector3(2913.323f, 5110.419f, 38.07499f)), owning_building_guid = 64)
       LocalObject(272, Door.Constructor(Vector3(2920.013f, 5103.915f, 38.07499f)), owning_building_guid = 64)
@@ -821,7 +821,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building15()
 
     def Building15(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 65, MapID: 15
-      LocalBuilding("VT_building_tr", 65, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3112f, 5286f, 35.99899f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 65, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3112f, 5286f, 35.99899f), Vector3(0f, 0f, 180f), VT_building_tr)))
       LocalObject(276, Door.Constructor(Vector3(3065.93f, 5249.454f, 38.07499f)), owning_building_guid = 65)
       LocalObject(277, Door.Constructor(Vector3(3070.54f, 5254.042f, 38.07499f)), owning_building_guid = 65)
       LocalObject(278, Door.Constructor(Vector3(3070.672f, 5244.712f, 38.07499f)), owning_building_guid = 65)
@@ -853,7 +853,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building42()
 
     def Building42(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 66, MapID: 42
-      LocalBuilding("VT_building_tr", 66, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3164f, 3102f, 34.9224f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 66, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3164f, 3102f, 34.9224f), Vector3(0f, 0f, 225f), VT_building_tr)))
       LocalObject(288, Door.Constructor(Vector3(3157.266f, 3043.582f, 36.9984f)), owning_building_guid = 66)
       LocalObject(289, Door.Constructor(Vector3(3157.281f, 3050.086f, 36.9984f)), owning_building_guid = 66)
       LocalObject(290, Door.Constructor(Vector3(3163.972f, 3043.582f, 36.9984f)), owning_building_guid = 66)
@@ -885,7 +885,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building41()
 
     def Building41(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 67, MapID: 41
-      LocalBuilding("VT_building_tr", 67, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3196f, 2882f, 34.92251f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 67, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3196f, 2882f, 34.92251f), Vector3(0f, 0f, 135f), VT_building_tr)))
       LocalObject(282, Door.Constructor(Vector3(3137.581f, 2875.323f, 36.99851f)), owning_building_guid = 67)
       LocalObject(283, Door.Constructor(Vector3(3137.582f, 2882.028f, 36.99851f)), owning_building_guid = 67)
       LocalObject(284, Door.Constructor(Vector3(3137.582f, 2888.734f, 36.99851f)), owning_building_guid = 67)
@@ -917,7 +917,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building25()
 
     def Building25(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 68, MapID: 25
-      LocalBuilding("VT_building_tr", 68, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5026f, 3908f, 35.9291f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 68, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5026f, 3908f, 35.9291f), Vector3(0f, 0f, 315f), VT_building_tr)))
       LocalObject(294, Door.Constructor(Vector3(5077.915f, 3901.281f, 38.0051f)), owning_building_guid = 68)
       LocalObject(295, Door.Constructor(Vector3(5077.915f, 3907.987f, 38.0051f)), owning_building_guid = 68)
       LocalObject(296, Door.Constructor(Vector3(5077.915f, 3914.693f, 38.0051f)), owning_building_guid = 68)
@@ -949,7 +949,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building23()
 
     def Building23(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 69, MapID: 23
-      LocalBuilding("VT_building_tr", 69, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5230f, 3732f, 35.9291f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 69, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5230f, 3732f, 35.9291f), Vector3(0f, 0f, 45f), VT_building_tr)))
       LocalObject(300, Door.Constructor(Vector3(5223.307f, 3783.914f, 38.0051f)), owning_building_guid = 69)
       LocalObject(301, Door.Constructor(Vector3(5223.323f, 3790.419f, 38.0051f)), owning_building_guid = 69)
       LocalObject(302, Door.Constructor(Vector3(5230.013f, 3783.914f, 38.0051f)), owning_building_guid = 69)
@@ -981,7 +981,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building24()
 
     def Building24(): Unit = { // Name: VT_building_tr Type: VT_building_tr GUID: 70, MapID: 24
-      LocalBuilding("VT_building_tr", 70, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5440f, 3906f, 35.9291f), VT_building_tr)))
+      LocalBuilding("VT_building_tr", 70, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5440f, 3906f, 35.9291f), Vector3(0f, 0f, 135f), VT_building_tr)))
       LocalObject(306, Door.Constructor(Vector3(5381.581f, 3899.323f, 38.0051f)), owning_building_guid = 70)
       LocalObject(307, Door.Constructor(Vector3(5381.582f, 3906.028f, 38.0051f)), owning_building_guid = 70)
       LocalObject(308, Door.Constructor(Vector3(5381.582f, 3912.734f, 38.0051f)), owning_building_guid = 70)
@@ -1013,7 +1013,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building8()
 
     def Building8(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 71, MapID: 8
-      LocalBuilding("vt_dropship", 71, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2754f, 5088f, 35.99899f), vt_dropship)))
+      LocalBuilding("vt_dropship", 71, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2754f, 5088f, 35.99899f), Vector3(0f, 0f, 224f), vt_dropship)))
       LocalObject(324, Terminal.Constructor(Vector3(2770.8f, 5104.39f, 38.86699f), dropship_vehicle_terminal), owning_building_guid = 71)
       LocalObject(312, VehicleSpawnPad.Constructor(Vector3(2756.568f, 5090.507f, 32.01399f), dropship_pad_doors, Vector3(0, 0, 136)), owning_building_guid = 71, terminal_guid = 324)
     }
@@ -1021,7 +1021,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building5()
 
     def Building5(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 72, MapID: 5
-      LocalBuilding("vt_dropship", 72, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2780f, 5414f, 35.99899f), vt_dropship)))
+      LocalBuilding("vt_dropship", 72, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2780f, 5414f, 35.99899f), Vector3(0f, 0f, 134f), vt_dropship)))
       LocalObject(325, Terminal.Constructor(Vector3(2796.39f, 5397.201f, 38.86699f), dropship_vehicle_terminal), owning_building_guid = 72)
       LocalObject(313, VehicleSpawnPad.Constructor(Vector3(2782.508f, 5411.432f, 32.01399f), dropship_pad_doors, Vector3(0, 0, 226)), owning_building_guid = 72, terminal_guid = 325)
     }
@@ -1029,7 +1029,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building44()
 
     def Building44(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 73, MapID: 44
-      LocalBuilding("vt_dropship", 73, 44, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2818f, 2864f, 34.92273f), vt_dropship)))
+      LocalBuilding("vt_dropship", 73, 44, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2818f, 2864f, 34.92273f), Vector3(0f, 0f, 180f), vt_dropship)))
       LocalObject(326, Terminal.Constructor(Vector3(2841.47f, 2864.12f, 37.79073f), dropship_vehicle_terminal), owning_building_guid = 73)
       LocalObject(314, VehicleSpawnPad.Constructor(Vector3(2821.589f, 2864.02f, 30.93773f), dropship_pad_doors, Vector3(0, 0, 180)), owning_building_guid = 73, terminal_guid = 326)
     }
@@ -1037,7 +1037,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building48()
 
     def Building48(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 74, MapID: 48
-      LocalBuilding("vt_dropship", 74, 48, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 3148f, 34.92273f), vt_dropship)))
+      LocalBuilding("vt_dropship", 74, 48, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 3148f, 34.92273f), Vector3(0f, 0f, 90f), vt_dropship)))
       LocalObject(327, Terminal.Constructor(Vector3(2848.12f, 3124.53f, 37.79073f), dropship_vehicle_terminal), owning_building_guid = 74)
       LocalObject(315, VehicleSpawnPad.Constructor(Vector3(2848.02f, 3144.411f, 30.93773f), dropship_pad_doors, Vector3(0, 0, -90)), owning_building_guid = 74, terminal_guid = 327)
     }
@@ -1045,7 +1045,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building49()
 
     def Building49(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 75, MapID: 49
-      LocalBuilding("vt_dropship", 75, 49, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3050f, 3186f, 34.91574f), vt_dropship)))
+      LocalBuilding("vt_dropship", 75, 49, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3050f, 3186f, 34.91574f), Vector3(0f, 0f, 90f), vt_dropship)))
       LocalObject(329, Terminal.Constructor(Vector3(3050.12f, 3162.53f, 37.78374f), dropship_vehicle_terminal), owning_building_guid = 75)
       LocalObject(316, VehicleSpawnPad.Constructor(Vector3(3050.02f, 3182.411f, 30.93074f), dropship_pad_doors, Vector3(0, 0, -90)), owning_building_guid = 75, terminal_guid = 329)
     }
@@ -1053,7 +1053,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building6()
 
     def Building6(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 76, MapID: 6
-      LocalBuilding("vt_dropship", 76, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3062f, 5416f, 35.99899f), vt_dropship)))
+      LocalBuilding("vt_dropship", 76, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3062f, 5416f, 35.99899f), Vector3(0f, 0f, 44f), vt_dropship)))
       LocalObject(328, Terminal.Constructor(Vector3(3045.2f, 5399.61f, 38.86699f), dropship_vehicle_terminal), owning_building_guid = 76)
       LocalObject(317, VehicleSpawnPad.Constructor(Vector3(3059.432f, 5413.493f, 32.01399f), dropship_pad_doors, Vector3(0, 0, -44)), owning_building_guid = 76, terminal_guid = 328)
     }
@@ -1061,7 +1061,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building46()
 
     def Building46(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 77, MapID: 46
-      LocalBuilding("vt_dropship", 77, 46, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3088f, 2784f, 34.92098f), vt_dropship)))
+      LocalBuilding("vt_dropship", 77, 46, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3088f, 2784f, 34.92098f), Vector3(0f, 0f, 270f), vt_dropship)))
       LocalObject(331, Terminal.Constructor(Vector3(3087.88f, 2807.47f, 37.78898f), dropship_vehicle_terminal), owning_building_guid = 77)
       LocalObject(319, VehicleSpawnPad.Constructor(Vector3(3087.98f, 2787.589f, 30.93598f), dropship_pad_doors, Vector3(0, 0, 90)), owning_building_guid = 77, terminal_guid = 331)
     }
@@ -1069,7 +1069,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building7()
 
     def Building7(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 78, MapID: 7
-      LocalBuilding("vt_dropship", 78, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3090f, 5088f, 35.99899f), vt_dropship)))
+      LocalBuilding("vt_dropship", 78, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3090f, 5088f, 35.99899f), Vector3(0f, 0f, 314f), vt_dropship)))
       LocalObject(330, Terminal.Constructor(Vector3(3073.61f, 5104.799f, 38.86699f), dropship_vehicle_terminal), owning_building_guid = 78)
       LocalObject(318, VehicleSpawnPad.Constructor(Vector3(3087.492f, 5090.568f, 32.01399f), dropship_pad_doors, Vector3(0, 0, 46)), owning_building_guid = 78, terminal_guid = 330)
     }
@@ -1077,7 +1077,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building26()
 
     def Building26(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 79, MapID: 26
-      LocalBuilding("vt_dropship", 79, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5050f, 3804f, 35.9291f), vt_dropship)))
+      LocalBuilding("vt_dropship", 79, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5050f, 3804f, 35.9291f), Vector3(0f, 0f, 180f), vt_dropship)))
       LocalObject(333, Terminal.Constructor(Vector3(5073.47f, 3804.12f, 38.7971f), dropship_vehicle_terminal), owning_building_guid = 79)
       LocalObject(321, VehicleSpawnPad.Constructor(Vector3(5053.589f, 3804.02f, 31.9441f), dropship_pad_doors, Vector3(0, 0, 180)), owning_building_guid = 79, terminal_guid = 333)
     }
@@ -1085,7 +1085,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building30()
 
     def Building30(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 80, MapID: 30
-      LocalBuilding("vt_dropship", 80, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5050f, 4014f, 35.9291f), vt_dropship)))
+      LocalBuilding("vt_dropship", 80, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5050f, 4014f, 35.9291f), Vector3(0f, 0f, 90f), vt_dropship)))
       LocalObject(332, Terminal.Constructor(Vector3(5050.12f, 3990.53f, 38.7971f), dropship_vehicle_terminal), owning_building_guid = 80)
       LocalObject(320, VehicleSpawnPad.Constructor(Vector3(5050.02f, 4010.411f, 31.9441f), dropship_pad_doors, Vector3(0, 0, -90)), owning_building_guid = 80, terminal_guid = 332)
     }
@@ -1093,7 +1093,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building31()
 
     def Building31(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 81, MapID: 31
-      LocalBuilding("vt_dropship", 81, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5414f, 4010f, 35.9291f), vt_dropship)))
+      LocalBuilding("vt_dropship", 81, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5414f, 4010f, 35.9291f), Vector3(0f, 0f, 90f), vt_dropship)))
       LocalObject(335, Terminal.Constructor(Vector3(5414.12f, 3986.53f, 38.7971f), dropship_vehicle_terminal), owning_building_guid = 81)
       LocalObject(323, VehicleSpawnPad.Constructor(Vector3(5414.02f, 4006.411f, 31.9441f), dropship_pad_doors, Vector3(0, 0, -90)), owning_building_guid = 81, terminal_guid = 335)
     }
@@ -1101,7 +1101,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building28()
 
     def Building28(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 82, MapID: 28
-      LocalBuilding("vt_dropship", 82, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5416f, 3812f, 35.9291f), vt_dropship)))
+      LocalBuilding("vt_dropship", 82, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5416f, 3812f, 35.9291f), Vector3(0f, 0f, 0f), vt_dropship)))
       LocalObject(334, Terminal.Constructor(Vector3(5392.53f, 3811.88f, 38.7971f), dropship_vehicle_terminal), owning_building_guid = 82)
       LocalObject(322, VehicleSpawnPad.Constructor(Vector3(5412.411f, 3811.98f, 31.9441f), dropship_pad_doors, Vector3(0, 0, 0)), owning_building_guid = 82, terminal_guid = 334)
     }
@@ -1109,79 +1109,79 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building17()
 
     def Building17(): Unit = { // Name: TR_NW_Tport_03 Type: vt_spawn GUID: 83, MapID: 17
-      LocalBuilding("TR_NW_Tport_03", 83, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2842f, 5166f, 35.99899f), vt_spawn)))
+      LocalBuilding("TR_NW_Tport_03", 83, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2842f, 5166f, 35.99899f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building19()
 
     def Building19(): Unit = { // Name: TR_NW_Tport_01 Type: vt_spawn GUID: 84, MapID: 19
-      LocalBuilding("TR_NW_Tport_01", 84, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2852f, 5312f, 35.99899f), vt_spawn)))
+      LocalBuilding("TR_NW_Tport_01", 84, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2852f, 5312f, 35.99899f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building54()
 
     def Building54(): Unit = { // Name: TR_SW_Tport_03 Type: vt_spawn GUID: 85, MapID: 54
-      LocalBuilding("TR_SW_Tport_03", 85, 54, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2928f, 2910f, 34.92174f), vt_spawn)))
+      LocalBuilding("TR_SW_Tport_03", 85, 54, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2928f, 2910f, 34.92174f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building56()
 
     def Building56(): Unit = { // Name: TR_SW_Tport_01 Type: vt_spawn GUID: 86, MapID: 56
-      LocalBuilding("TR_SW_Tport_01", 86, 56, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2938f, 3056f, 34.91694f), vt_spawn)))
+      LocalBuilding("TR_SW_Tport_01", 86, 56, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2938f, 3056f, 34.91694f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building16()
 
     def Building16(): Unit = { // Name: TR_NW_Tport_02 Type: vt_spawn GUID: 87, MapID: 16
-      LocalBuilding("TR_NW_Tport_02", 87, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2990f, 5312f, 35.99899f), vt_spawn)))
+      LocalBuilding("TR_NW_Tport_02", 87, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2990f, 5312f, 35.99899f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building18()
 
     def Building18(): Unit = { // Name: TR_NW_Tport_04 Type: vt_spawn GUID: 88, MapID: 18
-      LocalBuilding("TR_NW_Tport_04", 88, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2998f, 5166f, 35.99899f), vt_spawn)))
+      LocalBuilding("TR_NW_Tport_04", 88, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2998f, 5166f, 35.99899f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building57()
 
     def Building57(): Unit = { // Name: TR_SW_Tport_02 Type: vt_spawn GUID: 89, MapID: 57
-      LocalBuilding("TR_SW_Tport_02", 89, 57, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3076f, 3056f, 34.91595f), vt_spawn)))
+      LocalBuilding("TR_SW_Tport_02", 89, 57, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3076f, 3056f, 34.91595f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building55()
 
     def Building55(): Unit = { // Name: TR_SW_Tport_04 Type: vt_spawn GUID: 90, MapID: 55
-      LocalBuilding("TR_SW_Tport_04", 90, 55, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3084f, 2910f, 34.91639f), vt_spawn)))
+      LocalBuilding("TR_SW_Tport_04", 90, 55, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3084f, 2910f, 34.91639f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: TR_E_Tport_03 Type: vt_spawn GUID: 91, MapID: 36
-      LocalBuilding("TR_E_Tport_03", 91, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5154f, 3834f, 35.9291f), vt_spawn)))
+      LocalBuilding("TR_E_Tport_03", 91, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5154f, 3834f, 35.9291f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: TR_E_Tport_01 Type: vt_spawn GUID: 92, MapID: 38
-      LocalBuilding("TR_E_Tport_01", 92, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5164f, 3982f, 35.9291f), vt_spawn)))
+      LocalBuilding("TR_E_Tport_01", 92, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5164f, 3982f, 35.9291f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building39()
 
     def Building39(): Unit = { // Name: TR_E_Tport_02 Type: vt_spawn GUID: 93, MapID: 39
-      LocalBuilding("TR_E_Tport_02", 93, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5302f, 3982f, 35.9291f), vt_spawn)))
+      LocalBuilding("TR_E_Tport_02", 93, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5302f, 3982f, 35.9291f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: TR_E_Tport_04 Type: vt_spawn GUID: 94, MapID: 37
-      LocalBuilding("TR_E_Tport_04", 94, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5310f, 3834f, 35.9291f), vt_spawn)))
+      LocalBuilding("TR_E_Tport_04", 94, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5310f, 3834f, 35.9291f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building11()
 
     def Building11(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 95, MapID: 11
-      LocalBuilding("vt_vehicle", 95, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2780f, 5160f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 95, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2780f, 5160f, 35.99899f), Vector3(0f, 0f, 225f), vt_vehicle)))
       LocalObject(1079, Terminal.Constructor(Vector3(2790.242f, 5170.253f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 95)
       LocalObject(724, VehicleSpawnPad.Constructor(Vector3(2779.915f, 5159.877f, 34.52799f), mb_pad_creation, Vector3(0, 0, 225)), owning_building_guid = 95, terminal_guid = 1079)
     }
@@ -1189,7 +1189,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building12()
 
     def Building12(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 96, MapID: 12
-      LocalBuilding("vt_vehicle", 96, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2826f, 5114f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 96, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2826f, 5114f, 35.99899f), Vector3(0f, 0f, 225f), vt_vehicle)))
       LocalObject(1080, Terminal.Constructor(Vector3(2836.242f, 5124.253f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 96)
       LocalObject(725, VehicleSpawnPad.Constructor(Vector3(2825.915f, 5113.877f, 34.52799f), mb_pad_creation, Vector3(0, 0, 225)), owning_building_guid = 96, terminal_guid = 1080)
     }
@@ -1197,7 +1197,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building47()
 
     def Building47(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 97, MapID: 47
-      LocalBuilding("vt_vehicle", 97, 47, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 2946f, 34.92273f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 97, 47, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 2946f, 34.92273f), Vector3(0f, 0f, 180f), vt_vehicle)))
       LocalObject(1081, Terminal.Constructor(Vector3(2862.492f, 2946.008f, 37.60973f), ground_vehicle_terminal), owning_building_guid = 97)
       LocalObject(726, VehicleSpawnPad.Constructor(Vector3(2847.853f, 2945.973f, 33.45173f), mb_pad_creation, Vector3(0, 0, -90)), owning_building_guid = 97, terminal_guid = 1081)
     }
@@ -1205,7 +1205,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building20()
 
     def Building20(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 98, MapID: 20
-      LocalBuilding("vt_vehicle", 98, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2874f, 5402f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 98, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2874f, 5402f, 35.99899f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1082, Terminal.Constructor(Vector3(2874.008f, 5387.508f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 98)
       LocalObject(727, VehicleSpawnPad.Constructor(Vector3(2873.973f, 5402.147f, 34.52799f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 98, terminal_guid = 1082)
     }
@@ -1213,7 +1213,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building52()
 
     def Building52(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 99, MapID: 52
-      LocalBuilding("vt_vehicle", 99, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2908f, 2814f, 34.91781f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 99, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2908f, 2814f, 34.91781f), Vector3(0f, 0f, 270f), vt_vehicle)))
       LocalObject(1083, Terminal.Constructor(Vector3(2907.992f, 2828.492f, 37.60481f), ground_vehicle_terminal), owning_building_guid = 99)
       LocalObject(728, VehicleSpawnPad.Constructor(Vector3(2908.027f, 2813.853f, 33.44681f), mb_pad_creation, Vector3(0, 0, 180)), owning_building_guid = 99, terminal_guid = 1083)
     }
@@ -1221,7 +1221,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building53()
 
     def Building53(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 100, MapID: 53
-      LocalBuilding("vt_vehicle", 100, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2934f, 3140f, 34.91683f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 100, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2934f, 3140f, 34.91683f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1084, Terminal.Constructor(Vector3(2934.008f, 3125.508f, 37.60383f), ground_vehicle_terminal), owning_building_guid = 100)
       LocalObject(729, VehicleSpawnPad.Constructor(Vector3(2933.973f, 3140.147f, 33.44583f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 100, terminal_guid = 1084)
     }
@@ -1229,7 +1229,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building21()
 
     def Building21(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 101, MapID: 21
-      LocalBuilding("vt_vehicle", 101, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2962f, 5402f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 101, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2962f, 5402f, 35.99899f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1085, Terminal.Constructor(Vector3(2962.008f, 5387.508f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 101)
       LocalObject(730, VehicleSpawnPad.Constructor(Vector3(2961.973f, 5402.147f, 34.52799f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 101, terminal_guid = 1085)
     }
@@ -1237,7 +1237,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building45()
 
     def Building45(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 102, MapID: 45
-      LocalBuilding("vt_vehicle", 102, 45, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3012f, 2816f, 34.91574f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 102, 45, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3012f, 2816f, 34.91574f), Vector3(0f, 0f, 270f), vt_vehicle)))
       LocalObject(1087, Terminal.Constructor(Vector3(3011.992f, 2830.492f, 37.60274f), ground_vehicle_terminal), owning_building_guid = 102)
       LocalObject(731, VehicleSpawnPad.Constructor(Vector3(3012.027f, 2815.853f, 33.44474f), mb_pad_creation, Vector3(0, 0, 180)), owning_building_guid = 102, terminal_guid = 1087)
     }
@@ -1245,7 +1245,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building10()
 
     def Building10(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 103, MapID: 10
-      LocalBuilding("vt_vehicle", 103, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3018f, 5116f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 103, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3018f, 5116f, 35.99899f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1086, Terminal.Constructor(Vector3(3007.747f, 5126.242f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 103)
       LocalObject(732, VehicleSpawnPad.Constructor(Vector3(3018.123f, 5115.915f, 34.52799f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 103, terminal_guid = 1086)
     }
@@ -1253,7 +1253,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building9()
 
     def Building9(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 104, MapID: 9
-      LocalBuilding("vt_vehicle", 104, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3064f, 5162f, 35.99899f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 104, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3064f, 5162f, 35.99899f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1088, Terminal.Constructor(Vector3(3053.747f, 5172.242f, 38.68599f), ground_vehicle_terminal), owning_building_guid = 104)
       LocalObject(733, VehicleSpawnPad.Constructor(Vector3(3064.123f, 5161.915f, 34.52799f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 104, terminal_guid = 1088)
     }
@@ -1261,7 +1261,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building51()
 
     def Building51(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 105, MapID: 51
-      LocalBuilding("vt_vehicle", 105, 51, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3136f, 3182f, 34.92273f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 105, 51, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3136f, 3182f, 34.92273f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1089, Terminal.Constructor(Vector3(3136.008f, 3167.508f, 37.60973f), ground_vehicle_terminal), owning_building_guid = 105)
       LocalObject(734, VehicleSpawnPad.Constructor(Vector3(3135.973f, 3182.147f, 33.45173f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 105, terminal_guid = 1089)
     }
@@ -1269,7 +1269,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building50()
 
     def Building50(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 106, MapID: 50
-      LocalBuilding("vt_vehicle", 106, 50, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3222f, 2984f, 34.92273f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 106, 50, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3222f, 2984f, 34.92273f), Vector3(0f, 0f, 0f), vt_vehicle)))
       LocalObject(1090, Terminal.Constructor(Vector3(3207.508f, 2983.992f, 37.60973f), ground_vehicle_terminal), owning_building_guid = 106)
       LocalObject(735, VehicleSpawnPad.Constructor(Vector3(3222.147f, 2984.027f, 33.45173f), mb_pad_creation, Vector3(0, 0, 90)), owning_building_guid = 106, terminal_guid = 1090)
     }
@@ -1277,7 +1277,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building32()
 
     def Building32(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 107, MapID: 32
-      LocalBuilding("vt_vehicle", 107, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5118f, 4012f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 107, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5118f, 4012f, 35.9291f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1091, Terminal.Constructor(Vector3(5118.008f, 3997.508f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 107)
       LocalObject(736, VehicleSpawnPad.Constructor(Vector3(5117.973f, 4012.147f, 34.4581f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 107, terminal_guid = 1091)
     }
@@ -1285,7 +1285,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building27()
 
     def Building27(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 108, MapID: 27
-      LocalBuilding("vt_vehicle", 108, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5126f, 3740f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 108, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5126f, 3740f, 35.9291f), Vector3(0f, 0f, 270f), vt_vehicle)))
       LocalObject(1092, Terminal.Constructor(Vector3(5125.992f, 3754.492f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 108)
       LocalObject(737, VehicleSpawnPad.Constructor(Vector3(5126.027f, 3739.853f, 34.4581f), mb_pad_creation, Vector3(0, 0, 180)), owning_building_guid = 108, terminal_guid = 1092)
     }
@@ -1293,7 +1293,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building34()
 
     def Building34(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 109, MapID: 34
-      LocalBuilding("vt_vehicle", 109, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5202f, 4038f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 109, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5202f, 4038f, 35.9291f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1093, Terminal.Constructor(Vector3(5202.008f, 4023.508f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 109)
       LocalObject(738, VehicleSpawnPad.Constructor(Vector3(5201.973f, 4038.147f, 34.4581f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 109, terminal_guid = 1093)
     }
@@ -1301,7 +1301,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building35()
 
     def Building35(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 110, MapID: 35
-      LocalBuilding("vt_vehicle", 110, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5258f, 4038f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 110, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5258f, 4038f, 35.9291f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1094, Terminal.Constructor(Vector3(5258.008f, 4023.508f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 110)
       LocalObject(739, VehicleSpawnPad.Constructor(Vector3(5257.973f, 4038.147f, 34.4581f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 110, terminal_guid = 1094)
     }
@@ -1309,7 +1309,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building29()
 
     def Building29(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 111, MapID: 29
-      LocalBuilding("vt_vehicle", 111, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5338f, 3740f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 111, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5338f, 3740f, 35.9291f), Vector3(0f, 0f, 270f), vt_vehicle)))
       LocalObject(1095, Terminal.Constructor(Vector3(5337.992f, 3754.492f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 111)
       LocalObject(740, VehicleSpawnPad.Constructor(Vector3(5338.027f, 3739.853f, 34.4581f), mb_pad_creation, Vector3(0, 0, 180)), owning_building_guid = 111, terminal_guid = 1095)
     }
@@ -1317,7 +1317,7 @@ object Map12 { // HOME2 (TERRAN REPUBLIC SANCTUARY)
     Building33()
 
     def Building33(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 112, MapID: 33
-      LocalBuilding("vt_vehicle", 112, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5342f, 4014f, 35.9291f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 112, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5342f, 4014f, 35.9291f), Vector3(0f, 0f, 90f), vt_vehicle)))
       LocalObject(1096, Terminal.Constructor(Vector3(5342.008f, 3999.508f, 38.6161f), ground_vehicle_terminal), owning_building_guid = 112)
       LocalObject(741, VehicleSpawnPad.Constructor(Vector3(5341.973f, 4014.147f, 34.4581f), mb_pad_creation, Vector3(0, 0, 0)), owning_building_guid = 112, terminal_guid = 1096)
     }

--- a/pslogin/src/main/scala/zonemaps/Map13.scala
+++ b/pslogin/src/main/scala/zonemaps/Map13.scala
@@ -21,7 +21,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building22()
 
     def Building22(): Unit = { // Name: Hart_Ishundar Type: orbital_building_vs GUID: 1, MapID: 22
-      LocalBuilding("Hart_Ishundar", 1, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2978f, 4834f, 56.08539f), orbital_building_vs)))
+      LocalBuilding("Hart_Ishundar", 1, 22, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2978f, 4834f, 56.08539f), Vector3(0f, 0f, 270f), orbital_building_vs)))
       LocalObject(360, Door.Constructor(Vector3(2898f, 4821.99f, 60.19139f)), owning_building_guid = 1)
       LocalObject(361, Door.Constructor(Vector3(2898f, 4845.99f, 60.19139f)), owning_building_guid = 1)
       LocalObject(362, Door.Constructor(Vector3(3058f, 4822.01f, 60.19139f)), owning_building_guid = 1)
@@ -127,7 +127,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building4()
 
     def Building4(): Unit = { // Name: Hart_Esamir Type: orbital_building_vs GUID: 2, MapID: 4
-      LocalBuilding("Hart_Esamir", 2, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3688f, 2808f, 90.85312f), orbital_building_vs)))
+      LocalBuilding("Hart_Esamir", 2, 4, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3688f, 2808f, 90.85312f), Vector3(0f, 0f, 270f), orbital_building_vs)))
       LocalObject(370, Door.Constructor(Vector3(3608f, 2795.99f, 94.95912f)), owning_building_guid = 2)
       LocalObject(371, Door.Constructor(Vector3(3608f, 2819.99f, 94.95912f)), owning_building_guid = 2)
       LocalObject(374, Door.Constructor(Vector3(3768f, 2796.01f, 94.95912f)), owning_building_guid = 2)
@@ -233,7 +233,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building40()
 
     def Building40(): Unit = { // Name: Hart_Hossin Type: orbital_building_vs GUID: 3, MapID: 40
-      LocalBuilding("Hart_Hossin", 3, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5610f, 4238f, 103.2289f), orbital_building_vs)))
+      LocalBuilding("Hart_Hossin", 3, 40, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5610f, 4238f, 103.2289f), Vector3(0f, 0f, 270f), orbital_building_vs)))
       LocalObject(382, Door.Constructor(Vector3(5530f, 4225.99f, 107.3349f)), owning_building_guid = 3)
       LocalObject(383, Door.Constructor(Vector3(5530f, 4249.99f, 107.3349f)), owning_building_guid = 3)
       LocalObject(384, Door.Constructor(Vector3(5690f, 4226.01f, 107.3349f)), owning_building_guid = 3)
@@ -339,7 +339,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building58()
 
     def Building58(): Unit = { // Name: S_Ishundar_WG_tower Type: tower_a GUID: 28, MapID: 58
-      LocalBuilding("S_Ishundar_WG_tower", 28, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2708f, 5084f, 56.14882f), tower_a)))
+      LocalBuilding("S_Ishundar_WG_tower", 28, 58, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2708f, 5084f, 56.14882f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1015, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 28)
       LocalObject(312, Door.Constructor(Vector3(2720f, 5076f, 57.66982f)), owning_building_guid = 28)
       LocalObject(313, Door.Constructor(Vector3(2720f, 5076f, 77.66882f)), owning_building_guid = 28)
@@ -376,7 +376,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building63()
 
     def Building63(): Unit = { // Name: Esamir_WG_tower Type: tower_a GUID: 29, MapID: 63
-      LocalBuilding("Esamir_WG_tower", 29, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3968f, 2600f, 90.86123f), tower_a)))
+      LocalBuilding("Esamir_WG_tower", 29, 63, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3968f, 2600f, 90.86123f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1019, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 29)
       LocalObject(330, Door.Constructor(Vector3(3980f, 2592f, 92.38223f)), owning_building_guid = 29)
       LocalObject(331, Door.Constructor(Vector3(3980f, 2592f, 112.3812f)), owning_building_guid = 29)
@@ -413,7 +413,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building66()
 
     def Building66(): Unit = { // Name: SE_Hossin_WG_tower Type: tower_a GUID: 30, MapID: 66
-      LocalBuilding("SE_Hossin_WG_tower", 30, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6006f, 4414f, 97.87095f), tower_a)))
+      LocalBuilding("SE_Hossin_WG_tower", 30, 66, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(6006f, 4414f, 97.87095f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(1024, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 30)
       LocalObject(354, Door.Constructor(Vector3(6018f, 4406f, 99.39195f)), owning_building_guid = 30)
       LocalObject(355, Door.Constructor(Vector3(6018f, 4406f, 119.3909f)), owning_building_guid = 30)
@@ -450,7 +450,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building60()
 
     def Building60(): Unit = { // Name: NW_Esamir_WG_tower Type: tower_b GUID: 31, MapID: 60
-      LocalBuilding("NW_Esamir_WG_tower", 31, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3208f, 3524f, 92.25745f), tower_b)))
+      LocalBuilding("NW_Esamir_WG_tower", 31, 60, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3208f, 3524f, 92.25745f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1016, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 31)
       LocalObject(316, Door.Constructor(Vector3(3220f, 3516f, 93.77745f)), owning_building_guid = 31)
       LocalObject(317, Door.Constructor(Vector3(3220f, 3516f, 103.7775f)), owning_building_guid = 31)
@@ -487,7 +487,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building64()
 
     def Building64(): Unit = { // Name: W_Hossin_WG_tower Type: tower_b GUID: 32, MapID: 64
-      LocalBuilding("W_Hossin_WG_tower", 32, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3988f, 4380f, 87.9162f), tower_b)))
+      LocalBuilding("W_Hossin_WG_tower", 32, 64, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3988f, 4380f, 87.9162f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1020, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 32)
       LocalObject(334, Door.Constructor(Vector3(4000f, 4372f, 89.4362f)), owning_building_guid = 32)
       LocalObject(335, Door.Constructor(Vector3(4000f, 4372f, 99.4362f)), owning_building_guid = 32)
@@ -524,7 +524,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building67()
 
     def Building67(): Unit = { // Name: NE_Esamir_WG_tower Type: tower_b GUID: 33, MapID: 67
-      LocalBuilding("NE_Esamir_WG_tower", 33, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5098f, 2978f, 97.9873f), tower_b)))
+      LocalBuilding("NE_Esamir_WG_tower", 33, 67, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5098f, 2978f, 97.9873f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(1022, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 33)
       LocalObject(344, Door.Constructor(Vector3(5110f, 2970f, 99.5073f)), owning_building_guid = 33)
       LocalObject(345, Door.Constructor(Vector3(5110f, 2970f, 109.5073f)), owning_building_guid = 33)
@@ -561,7 +561,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building59()
 
     def Building59(): Unit = { // Name: SE_Ishundar_WG_tower Type: tower_c GUID: 34, MapID: 59
-      LocalBuilding("SE_Ishundar_WG_tower", 34, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3224f, 4594f, 56.08539f), tower_c)))
+      LocalBuilding("SE_Ishundar_WG_tower", 34, 59, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3224f, 4594f, 56.08539f), Vector3(0f, 0f, 0f), tower_c)))
       LocalObject(1017, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 34)
       LocalObject(322, Door.Constructor(Vector3(3236f, 4586f, 57.60639f)), owning_building_guid = 34)
       LocalObject(323, Door.Constructor(Vector3(3236f, 4586f, 77.60539f)), owning_building_guid = 34)
@@ -602,7 +602,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building62()
 
     def Building62(): Unit = { // Name: N_Esamir_WG_tower Type: tower_c GUID: 35, MapID: 62
-      LocalBuilding("N_Esamir_WG_tower", 35, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3670f, 3180f, 89.51079f), tower_c)))
+      LocalBuilding("N_Esamir_WG_tower", 35, 62, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(3670f, 3180f, 89.51079f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1018, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 35)
       LocalObject(326, Door.Constructor(Vector3(3682f, 3172f, 91.03179f)), owning_building_guid = 35)
       LocalObject(327, Door.Constructor(Vector3(3682f, 3172f, 111.0308f)), owning_building_guid = 35)
@@ -643,7 +643,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building61()
 
     def Building61(): Unit = { // Name: Continent_Central_tower Type: tower_c GUID: 36, MapID: 61
-      LocalBuilding("Continent_Central_tower", 36, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4410f, 3728f, 83.92174f), tower_c)))
+      LocalBuilding("Continent_Central_tower", 36, 61, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(4410f, 3728f, 83.92174f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1021, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 36)
       LocalObject(340, Door.Constructor(Vector3(4422f, 3720f, 85.44274f)), owning_building_guid = 36)
       LocalObject(341, Door.Constructor(Vector3(4422f, 3720f, 105.4417f)), owning_building_guid = 36)
@@ -684,7 +684,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building65()
 
     def Building65(): Unit = { // Name: SW_Hossin_WG_tower Type: tower_c GUID: 37, MapID: 65
-      LocalBuilding("SW_Hossin_WG_tower", 37, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5160f, 4266f, 93.25694f), tower_c)))
+      LocalBuilding("SW_Hossin_WG_tower", 37, 65, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(5160f, 4266f, 93.25694f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(1023, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 37)
       LocalObject(350, Door.Constructor(Vector3(5172f, 4258f, 94.77794f)), owning_building_guid = 37)
       LocalObject(351, Door.Constructor(Vector3(5172f, 4258f, 114.7769f)), owning_building_guid = 37)
@@ -725,7 +725,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building33()
 
     def Building33(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 38, MapID: 33
-      LocalBuilding("VT_building_vs", 38, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 4948f, 56.08539f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 38, 33, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2848f, 4948f, 56.08539f), Vector3(0f, 0f, 180f), VT_building_vs)))
       LocalObject(234, Door.Constructor(Vector3(2801.93f, 4911.454f, 58.16139f)), owning_building_guid = 38)
       LocalObject(235, Door.Constructor(Vector3(2806.54f, 4916.042f, 58.16139f)), owning_building_guid = 38)
       LocalObject(236, Door.Constructor(Vector3(2806.672f, 4906.712f, 58.16139f)), owning_building_guid = 38)
@@ -757,7 +757,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building35()
 
     def Building35(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 39, MapID: 35
-      LocalBuilding("VT_building_vs", 39, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3122f, 4690f, 56.08539f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 39, 35, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3122f, 4690f, 56.08539f), Vector3(0f, 0f, 90f), VT_building_vs)))
       LocalObject(240, Door.Constructor(Vector3(3075.97f, 4726.587f, 58.16139f)), owning_building_guid = 39)
       LocalObject(241, Door.Constructor(Vector3(3080.558f, 4721.976f, 58.16139f)), owning_building_guid = 39)
       LocalObject(242, Door.Constructor(Vector3(3080.712f, 4731.328f, 58.16139f)), owning_building_guid = 39)
@@ -789,7 +789,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building34()
 
     def Building34(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 40, MapID: 34
-      LocalBuilding("VT_building_vs", 40, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3144f, 4930f, 56.08539f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 40, 34, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3144f, 4930f, 56.08539f), Vector3(0f, 0f, 225f), VT_building_vs)))
       LocalObject(246, Door.Constructor(Vector3(3137.266f, 4871.582f, 58.16139f)), owning_building_guid = 40)
       LocalObject(247, Door.Constructor(Vector3(3137.281f, 4878.085f, 58.16139f)), owning_building_guid = 40)
       LocalObject(248, Door.Constructor(Vector3(3143.972f, 4871.582f, 58.16139f)), owning_building_guid = 40)
@@ -821,7 +821,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building7()
 
     def Building7(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 41, MapID: 7
-      LocalBuilding("VT_building_vs", 41, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3592f, 2966f, 90.8536f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 41, 7, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3592f, 2966f, 90.8536f), Vector3(0f, 0f, 224f), VT_building_vs)))
       LocalObject(252, Door.Constructor(Vector3(3584.247f, 2907.708f, 92.9296f)), owning_building_guid = 41)
       LocalObject(253, Door.Constructor(Vector3(3584.376f, 2914.211f, 92.9296f)), owning_building_guid = 41)
       LocalObject(254, Door.Constructor(Vector3(3590.952f, 2907.591f, 92.9296f)), owning_building_guid = 41)
@@ -853,7 +853,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building12()
 
     def Building12(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 42, MapID: 12
-      LocalBuilding("VT_building_vs", 42, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3690f, 2656f, 90.84919f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 42, 12, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3690f, 2656f, 90.84919f), Vector3(0f, 0f, 44f), VT_building_vs)))
       LocalObject(258, Door.Constructor(Vector3(3684.214f, 2708.023f, 92.92519f)), owning_building_guid = 42)
       LocalObject(259, Door.Constructor(Vector3(3684.343f, 2714.527f, 92.92519f)), owning_building_guid = 42)
       LocalObject(260, Door.Constructor(Vector3(3690.919f, 2707.906f, 92.92519f)), owning_building_guid = 42)
@@ -885,7 +885,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building13()
 
     def Building13(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 43, MapID: 13
-      LocalBuilding("VT_building_vs", 43, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3788f, 2968f, 90.8505f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 43, 13, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3788f, 2968f, 90.8505f), Vector3(0f, 0f, 224f), VT_building_vs)))
       LocalObject(264, Door.Constructor(Vector3(3780.247f, 2909.708f, 92.9265f)), owning_building_guid = 43)
       LocalObject(265, Door.Constructor(Vector3(3780.376f, 2916.211f, 92.9265f)), owning_building_guid = 43)
       LocalObject(266, Door.Constructor(Vector3(3786.952f, 2909.591f, 92.9265f)), owning_building_guid = 43)
@@ -917,7 +917,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building50()
 
     def Building50(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 44, MapID: 50
-      LocalBuilding("VT_building_vs", 44, 50, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5470f, 4094f, 103.2367f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 44, 50, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5470f, 4094f, 103.2367f), Vector3(0f, 0f, 0f), VT_building_vs)))
       LocalObject(276, Door.Constructor(Vector3(5501.976f, 4135.442f, 105.3127f)), owning_building_guid = 44)
       LocalObject(277, Door.Constructor(Vector3(5506.587f, 4140.03f, 105.3127f)), owning_building_guid = 44)
       LocalObject(278, Door.Constructor(Vector3(5506.718f, 4130.7f, 105.3127f)), owning_building_guid = 44)
@@ -949,7 +949,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building49()
 
     def Building49(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 45, MapID: 49
-      LocalBuilding("VT_building_vs", 45, 49, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5494f, 4394f, 103.232f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 45, 49, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5494f, 4394f, 103.232f), Vector3(0f, 0f, 225f), VT_building_vs)))
       LocalObject(270, Door.Constructor(Vector3(5487.266f, 4335.582f, 105.308f)), owning_building_guid = 45)
       LocalObject(271, Door.Constructor(Vector3(5487.281f, 4342.085f, 105.308f)), owning_building_guid = 45)
       LocalObject(272, Door.Constructor(Vector3(5493.972f, 4335.582f, 105.308f)), owning_building_guid = 45)
@@ -981,7 +981,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building48()
 
     def Building48(): Unit = { // Name: VT_building_vs Type: VT_building_vs GUID: 46, MapID: 48
-      LocalBuilding("VT_building_vs", 46, 48, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5796f, 4330f, 103.2358f), VT_building_vs)))
+      LocalBuilding("VT_building_vs", 46, 48, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5796f, 4330f, 103.2358f), Vector3(0f, 0f, 180f), VT_building_vs)))
       LocalObject(282, Door.Constructor(Vector3(5749.93f, 4293.454f, 105.3118f)), owning_building_guid = 46)
       LocalObject(283, Door.Constructor(Vector3(5754.54f, 4298.042f, 105.3118f)), owning_building_guid = 46)
       LocalObject(284, Door.Constructor(Vector3(5754.672f, 4288.712f, 105.3118f)), owning_building_guid = 46)
@@ -1013,7 +1013,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building37()
 
     def Building37(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 47, MapID: 37
-      LocalBuilding("vt_dropship", 47, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2764f, 4842f, 56.08539f), vt_dropship)))
+      LocalBuilding("vt_dropship", 47, 37, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2764f, 4842f, 56.08539f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(300, Terminal.Constructor(Vector3(2787.469f, 4841.71f, 58.95339f), dropship_vehicle_terminal), owning_building_guid = 47)
       LocalObject(288, VehicleSpawnPad.Constructor(Vector3(2767.589f, 4841.958f, 52.10039f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 47, terminal_guid = 300)
     }
@@ -1021,7 +1021,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building24()
 
     def Building24(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 48, MapID: 24
-      LocalBuilding("vt_dropship", 48, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2928f, 5050f, 56.08539f), vt_dropship)))
+      LocalBuilding("vt_dropship", 48, 24, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2928f, 5050f, 56.08539f), Vector3(0f, 0f, 89f), vt_dropship)))
       LocalObject(301, Terminal.Constructor(Vector3(2927.71f, 5026.531f, 58.95339f), dropship_vehicle_terminal), owning_building_guid = 48)
       LocalObject(289, VehicleSpawnPad.Constructor(Vector3(2927.957f, 5046.411f, 52.10039f), dropship_pad_doors, Vector3(0, 0, -89)), owning_building_guid = 48, terminal_guid = 301)
     }
@@ -1029,7 +1029,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building36()
 
     def Building36(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 49, MapID: 36
-      LocalBuilding("vt_dropship", 49, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3018f, 4618f, 56.08539f), vt_dropship)))
+      LocalBuilding("vt_dropship", 49, 36, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3018f, 4618f, 56.08539f), Vector3(0f, 0f, 269f), vt_dropship)))
       LocalObject(302, Terminal.Constructor(Vector3(3018.29f, 4641.469f, 58.95339f), dropship_vehicle_terminal), owning_building_guid = 49)
       LocalObject(290, VehicleSpawnPad.Constructor(Vector3(3018.043f, 4621.589f, 52.10039f), dropship_pad_doors, Vector3(0, 0, 91)), owning_building_guid = 49, terminal_guid = 302)
     }
@@ -1037,7 +1037,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building23()
 
     def Building23(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 50, MapID: 23
-      LocalBuilding("vt_dropship", 50, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3212f, 4768f, 56.08539f), vt_dropship)))
+      LocalBuilding("vt_dropship", 50, 23, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3212f, 4768f, 56.08539f), Vector3(0f, 0f, 359f), vt_dropship)))
       LocalObject(303, Terminal.Constructor(Vector3(3188.531f, 4768.29f, 58.95339f), dropship_vehicle_terminal), owning_building_guid = 50)
       LocalObject(291, VehicleSpawnPad.Constructor(Vector3(3208.411f, 4768.042f, 52.10039f), dropship_pad_doors, Vector3(0, 0, 1)), owning_building_guid = 50, terminal_guid = 303)
     }
@@ -1045,7 +1045,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building6()
 
     def Building6(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 51, MapID: 6
-      LocalBuilding("vt_dropship", 51, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3506f, 2896f, 90.85538f), vt_dropship)))
+      LocalBuilding("vt_dropship", 51, 6, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3506f, 2896f, 90.85538f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(304, Terminal.Constructor(Vector3(3529.469f, 2895.71f, 93.72339f), dropship_vehicle_terminal), owning_building_guid = 51)
       LocalObject(292, VehicleSpawnPad.Constructor(Vector3(3509.589f, 2895.957f, 86.87038f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 51, terminal_guid = 304)
     }
@@ -1053,7 +1053,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building15()
 
     def Building15(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 52, MapID: 15
-      LocalBuilding("vt_dropship", 52, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3572f, 2652f, 90.85646f), vt_dropship)))
+      LocalBuilding("vt_dropship", 52, 15, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3572f, 2652f, 90.85646f), Vector3(0f, 0f, 224f), vt_dropship)))
       LocalObject(305, Terminal.Constructor(Vector3(3588.8f, 2668.39f, 93.72446f), dropship_vehicle_terminal), owning_building_guid = 52)
       LocalObject(293, VehicleSpawnPad.Constructor(Vector3(3574.568f, 2654.508f, 86.87146f), dropship_pad_doors, Vector3(0, 0, 136)), owning_building_guid = 52, terminal_guid = 305)
     }
@@ -1061,7 +1061,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building14()
 
     def Building14(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 53, MapID: 14
-      LocalBuilding("vt_dropship", 53, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3808f, 2654f, 90.85372f), vt_dropship)))
+      LocalBuilding("vt_dropship", 53, 14, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3808f, 2654f, 90.85372f), Vector3(0f, 0f, 314f), vt_dropship)))
       LocalObject(306, Terminal.Constructor(Vector3(3791.61f, 2670.8f, 93.72173f), dropship_vehicle_terminal), owning_building_guid = 53)
       LocalObject(294, VehicleSpawnPad.Constructor(Vector3(3805.492f, 2656.568f, 86.86872f), dropship_pad_doors, Vector3(0, 0, 46)), owning_building_guid = 53, terminal_guid = 306)
     }
@@ -1069,7 +1069,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building5()
 
     def Building5(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 54, MapID: 5
-      LocalBuilding("vt_dropship", 54, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3876f, 2896f, 90.85098f), vt_dropship)))
+      LocalBuilding("vt_dropship", 54, 5, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3876f, 2896f, 90.85098f), Vector3(0f, 0f, 359f), vt_dropship)))
       LocalObject(307, Terminal.Constructor(Vector3(3852.531f, 2896.29f, 93.71898f), dropship_vehicle_terminal), owning_building_guid = 54)
       LocalObject(295, VehicleSpawnPad.Constructor(Vector3(3872.411f, 2896.043f, 86.86597f), dropship_pad_doors, Vector3(0, 0, 1)), owning_building_guid = 54, terminal_guid = 307)
     }
@@ -1077,7 +1077,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building52()
 
     def Building52(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 55, MapID: 52
-      LocalBuilding("vt_dropship", 55, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5394f, 4238f, 103.2297f), vt_dropship)))
+      LocalBuilding("vt_dropship", 55, 52, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5394f, 4238f, 103.2297f), Vector3(0f, 0f, 179f), vt_dropship)))
       LocalObject(308, Terminal.Constructor(Vector3(5417.469f, 4237.71f, 106.0977f), dropship_vehicle_terminal), owning_building_guid = 55)
       LocalObject(296, VehicleSpawnPad.Constructor(Vector3(5397.589f, 4237.958f, 99.24469f), dropship_pad_doors, Vector3(0, 0, 181)), owning_building_guid = 55, terminal_guid = 308)
     }
@@ -1085,7 +1085,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building51()
 
     def Building51(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 56, MapID: 51
-      LocalBuilding("vt_dropship", 56, 51, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5600f, 4034f, 103.2345f), vt_dropship)))
+      LocalBuilding("vt_dropship", 56, 51, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5600f, 4034f, 103.2345f), Vector3(0f, 0f, 269f), vt_dropship)))
       LocalObject(309, Terminal.Constructor(Vector3(5600.29f, 4057.469f, 106.1025f), dropship_vehicle_terminal), owning_building_guid = 56)
       LocalObject(297, VehicleSpawnPad.Constructor(Vector3(5600.042f, 4037.589f, 99.24946f), dropship_pad_doors, Vector3(0, 0, 91)), owning_building_guid = 56, terminal_guid = 309)
     }
@@ -1093,7 +1093,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building42()
 
     def Building42(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 57, MapID: 42
-      LocalBuilding("vt_dropship", 57, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5622f, 4456f, 103.2351f), vt_dropship)))
+      LocalBuilding("vt_dropship", 57, 42, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5622f, 4456f, 103.2351f), Vector3(0f, 0f, 89f), vt_dropship)))
       LocalObject(310, Terminal.Constructor(Vector3(5621.71f, 4432.531f, 106.1031f), dropship_vehicle_terminal), owning_building_guid = 57)
       LocalObject(298, VehicleSpawnPad.Constructor(Vector3(5621.958f, 4452.411f, 99.25006f), dropship_pad_doors, Vector3(0, 0, -89)), owning_building_guid = 57, terminal_guid = 310)
     }
@@ -1101,7 +1101,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building41()
 
     def Building41(): Unit = { // Name: vt_dropship Type: vt_dropship GUID: 58, MapID: 41
-      LocalBuilding("vt_dropship", 58, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5834f, 4218f, 103.2365f), vt_dropship)))
+      LocalBuilding("vt_dropship", 58, 41, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5834f, 4218f, 103.2365f), Vector3(0f, 0f, 359f), vt_dropship)))
       LocalObject(311, Terminal.Constructor(Vector3(5810.531f, 4218.29f, 106.1045f), dropship_vehicle_terminal), owning_building_guid = 58)
       LocalObject(299, VehicleSpawnPad.Constructor(Vector3(5830.411f, 4218.042f, 99.25149f), dropship_pad_doors, Vector3(0, 0, 1)), owning_building_guid = 58, terminal_guid = 311)
     }
@@ -1109,79 +1109,79 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building30()
 
     def Building30(): Unit = { // Name: VS_NW_Tport_01 Type: vt_spawn GUID: 59, MapID: 30
-      LocalBuilding("VS_NW_Tport_01", 59, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2900f, 4758f, 56.08539f), vt_spawn)))
+      LocalBuilding("VS_NW_Tport_01", 59, 30, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2900f, 4758f, 56.08539f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building29()
 
     def Building29(): Unit = { // Name: VS_NW_Tport_02 Type: vt_spawn GUID: 60, MapID: 29
-      LocalBuilding("VS_NW_Tport_02", 60, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2940f, 4932f, 56.08539f), vt_spawn)))
+      LocalBuilding("VS_NW_Tport_02", 60, 29, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2940f, 4932f, 56.08539f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building32()
 
     def Building32(): Unit = { // Name: VS_NW_Tport_03 Type: vt_spawn GUID: 61, MapID: 32
-      LocalBuilding("VS_NW_Tport_03", 61, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3060f, 4908f, 56.08539f), vt_spawn)))
+      LocalBuilding("VS_NW_Tport_03", 61, 32, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3060f, 4908f, 56.08539f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building31()
 
     def Building31(): Unit = { // Name: VS_NW_Tport_04 Type: vt_spawn GUID: 62, MapID: 31
-      LocalBuilding("VS_NW_Tport_04", 62, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3124f, 4776f, 56.08539f), vt_spawn)))
+      LocalBuilding("VS_NW_Tport_04", 62, 31, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3124f, 4776f, 56.08539f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building19()
 
     def Building19(): Unit = { // Name: VS_S_Tport_03 Type: vt_spawn GUID: 63, MapID: 19
-      LocalBuilding("VS_S_Tport_03", 63, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3610f, 2732f, 90.85205f), vt_spawn)))
+      LocalBuilding("VS_S_Tport_03", 63, 19, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3610f, 2732f, 90.85205f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building18()
 
     def Building18(): Unit = { // Name: VS_S_Tport_01 Type: vt_spawn GUID: 64, MapID: 18
-      LocalBuilding("VS_S_Tport_01", 64, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3652f, 2908f, 90.8536f), vt_spawn)))
+      LocalBuilding("VS_S_Tport_01", 64, 18, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3652f, 2908f, 90.8536f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building21()
 
     def Building21(): Unit = { // Name: VS_S_Tport_02 Type: vt_spawn GUID: 65, MapID: 21
-      LocalBuilding("VS_S_Tport_02", 65, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3730f, 2908f, 90.8536f), vt_spawn)))
+      LocalBuilding("VS_S_Tport_02", 65, 21, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3730f, 2908f, 90.8536f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building20()
 
     def Building20(): Unit = { // Name: VS_S_Tport_04 Type: vt_spawn GUID: 66, MapID: 20
-      LocalBuilding("VS_S_Tport_04", 66, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3766f, 2732f, 90.84919f), vt_spawn)))
+      LocalBuilding("VS_S_Tport_04", 66, 20, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3766f, 2732f, 90.84919f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building45()
 
     def Building45(): Unit = { // Name: VS_NE_Tport_04 Type: vt_spawn GUID: 67, MapID: 45
-      LocalBuilding("VS_NE_Tport_04", 67, 45, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5484f, 4208f, 103.2298f), vt_spawn)))
+      LocalBuilding("VS_NE_Tport_04", 67, 45, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5484f, 4208f, 103.2298f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building44()
 
     def Building44(): Unit = { // Name: VS_NE_Tport_01 Type: vt_spawn GUID: 68, MapID: 44
-      LocalBuilding("VS_NE_Tport_01", 68, 44, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5552f, 4344f, 103.2289f), vt_spawn)))
+      LocalBuilding("VS_NE_Tport_01", 68, 44, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5552f, 4344f, 103.2289f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building46()
 
     def Building46(): Unit = { // Name: VS_NE_Tport_03 Type: vt_spawn GUID: 69, MapID: 46
-      LocalBuilding("VS_NE_Tport_03", 69, 46, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5690f, 4164f, 103.2289f), vt_spawn)))
+      LocalBuilding("VS_NE_Tport_03", 69, 46, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5690f, 4164f, 103.2289f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building47()
 
     def Building47(): Unit = { // Name: VS_NE_Tport_02 Type: vt_spawn GUID: 70, MapID: 47
-      LocalBuilding("VS_NE_Tport_02", 70, 47, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5692f, 4312f, 103.2289f), vt_spawn)))
+      LocalBuilding("VS_NE_Tport_02", 70, 47, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5692f, 4312f, 103.2289f), Vector3(0f, 0f, 360f), vt_spawn)))
     }
 
     Building26()
 
     def Building26(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 71, MapID: 26
-      LocalBuilding("vt_vehicle", 71, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2768f, 4768f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 71, 26, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2768f, 4768f, 56.08539f), Vector3(0f, 0f, 179f), vt_vehicle)))
       LocalObject(1057, Terminal.Constructor(Vector3(2782.49f, 4767.755f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 71)
       LocalObject(702, VehicleSpawnPad.Constructor(Vector3(2767.853f, 4767.976f, 54.61439f), mb_pad_creation, Vector3(0, 0, -89)), owning_building_guid = 71, terminal_guid = 1057)
     }
@@ -1189,7 +1189,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building38()
 
     def Building38(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 72, MapID: 38
-      LocalBuilding("vt_vehicle", 72, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2816f, 4700f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 72, 38, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2816f, 4700f, 56.08539f), Vector3(0f, 0f, 225f), vt_vehicle)))
       LocalObject(1058, Terminal.Constructor(Vector3(2826.242f, 4710.253f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 72)
       LocalObject(703, VehicleSpawnPad.Constructor(Vector3(2815.915f, 4699.877f, 54.61439f), mb_pad_creation, Vector3(0, 0, 225)), owning_building_guid = 72, terminal_guid = 1058)
     }
@@ -1197,7 +1197,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building28()
 
     def Building28(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 73, MapID: 28
-      LocalBuilding("vt_vehicle", 73, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2946f, 4622f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 73, 28, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(2946f, 4622f, 56.08539f), Vector3(0f, 0f, 269f), vt_vehicle)))
       LocalObject(1059, Terminal.Constructor(Vector3(2946.245f, 4636.49f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 73)
       LocalObject(704, VehicleSpawnPad.Constructor(Vector3(2946.024f, 4621.853f, 54.61439f), mb_pad_creation, Vector3(0, 0, 181)), owning_building_guid = 73, terminal_guid = 1059)
     }
@@ -1205,7 +1205,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building25()
 
     def Building25(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 74, MapID: 25
-      LocalBuilding("vt_vehicle", 74, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3000f, 5048f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 74, 25, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3000f, 5048f, 56.08539f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1060, Terminal.Constructor(Vector3(2999.755f, 5033.51f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 74)
       LocalObject(705, VehicleSpawnPad.Constructor(Vector3(2999.976f, 5048.147f, 54.61439f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 74, terminal_guid = 1060)
     }
@@ -1213,7 +1213,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building39()
 
     def Building39(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 75, MapID: 39
-      LocalBuilding("vt_vehicle", 75, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3094f, 5010f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 75, 39, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3094f, 5010f, 56.08539f), Vector3(0f, 0f, 45f), vt_vehicle)))
       LocalObject(1061, Terminal.Constructor(Vector3(3083.758f, 4999.747f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 75)
       LocalObject(706, VehicleSpawnPad.Constructor(Vector3(3094.085f, 5010.123f, 54.61439f), mb_pad_creation, Vector3(0, 0, 45)), owning_building_guid = 75, terminal_guid = 1061)
     }
@@ -1221,7 +1221,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building27()
 
     def Building27(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 76, MapID: 27
-      LocalBuilding("vt_vehicle", 76, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3212f, 4842f, 56.08539f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 76, 27, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3212f, 4842f, 56.08539f), Vector3(0f, 0f, 359f), vt_vehicle)))
       LocalObject(1062, Terminal.Constructor(Vector3(3197.51f, 4842.245f, 58.77239f), ground_vehicle_terminal), owning_building_guid = 76)
       LocalObject(707, VehicleSpawnPad.Constructor(Vector3(3212.147f, 4842.024f, 54.61439f), mb_pad_creation, Vector3(0, 0, 91)), owning_building_guid = 76, terminal_guid = 1062)
     }
@@ -1229,7 +1229,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building17()
 
     def Building17(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 77, MapID: 17
-      LocalBuilding("vt_vehicle", 77, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3506f, 2820f, 90.8536f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 77, 17, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3506f, 2820f, 90.8536f), Vector3(0f, 0f, 179f), vt_vehicle)))
       LocalObject(1063, Terminal.Constructor(Vector3(3520.49f, 2819.755f, 93.5406f), ground_vehicle_terminal), owning_building_guid = 77)
       LocalObject(708, VehicleSpawnPad.Constructor(Vector3(3505.853f, 2819.976f, 89.3826f), mb_pad_creation, Vector3(0, 0, -89)), owning_building_guid = 77, terminal_guid = 1063)
     }
@@ -1237,7 +1237,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building8()
 
     def Building8(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 78, MapID: 8
-      LocalBuilding("vt_vehicle", 78, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3658f, 3020f, 90.8536f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 78, 8, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3658f, 3020f, 90.8536f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1064, Terminal.Constructor(Vector3(3657.755f, 3005.51f, 93.5406f), ground_vehicle_terminal), owning_building_guid = 78)
       LocalObject(709, VehicleSpawnPad.Constructor(Vector3(3657.976f, 3020.147f, 89.3826f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 78, terminal_guid = 1064)
     }
@@ -1245,7 +1245,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building11()
 
     def Building11(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 79, MapID: 11
-      LocalBuilding("vt_vehicle", 79, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3660f, 2590f, 90.8536f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 79, 11, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3660f, 2590f, 90.8536f), Vector3(0f, 0f, 269f), vt_vehicle)))
       LocalObject(1065, Terminal.Constructor(Vector3(3660.245f, 2604.49f, 93.5406f), ground_vehicle_terminal), owning_building_guid = 79)
       LocalObject(710, VehicleSpawnPad.Constructor(Vector3(3660.024f, 2589.853f, 89.3826f), mb_pad_creation, Vector3(0, 0, 181)), owning_building_guid = 79, terminal_guid = 1065)
     }
@@ -1253,7 +1253,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building9()
 
     def Building9(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 80, MapID: 9
-      LocalBuilding("vt_vehicle", 80, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3722f, 3020f, 90.8536f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 80, 9, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3722f, 3020f, 90.8536f), Vector3(0f, 0f, 89f), vt_vehicle)))
       LocalObject(1066, Terminal.Constructor(Vector3(3721.755f, 3005.51f, 93.5406f), ground_vehicle_terminal), owning_building_guid = 80)
       LocalObject(711, VehicleSpawnPad.Constructor(Vector3(3721.976f, 3020.147f, 89.3826f), mb_pad_creation, Vector3(0, 0, 1)), owning_building_guid = 80, terminal_guid = 1066)
     }
@@ -1261,7 +1261,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building10()
 
     def Building10(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 81, MapID: 10
-      LocalBuilding("vt_vehicle", 81, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3724f, 2588f, 90.85265f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 81, 10, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3724f, 2588f, 90.85265f), Vector3(0f, 0f, 269f), vt_vehicle)))
       LocalObject(1067, Terminal.Constructor(Vector3(3724.245f, 2602.49f, 93.53964f), ground_vehicle_terminal), owning_building_guid = 81)
       LocalObject(712, VehicleSpawnPad.Constructor(Vector3(3724.024f, 2587.853f, 89.38165f), mb_pad_creation, Vector3(0, 0, 181)), owning_building_guid = 81, terminal_guid = 1067)
     }
@@ -1269,7 +1269,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building16()
 
     def Building16(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 82, MapID: 16
-      LocalBuilding("vt_vehicle", 82, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3878f, 2824f, 90.8536f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 82, 16, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(3878f, 2824f, 90.8536f), Vector3(0f, 0f, 359f), vt_vehicle)))
       LocalObject(1068, Terminal.Constructor(Vector3(3863.51f, 2824.245f, 93.5406f), ground_vehicle_terminal), owning_building_guid = 82)
       LocalObject(713, VehicleSpawnPad.Constructor(Vector3(3878.147f, 2824.024f, 89.3826f), mb_pad_creation, Vector3(0, 0, 91)), owning_building_guid = 82, terminal_guid = 1068)
     }
@@ -1277,7 +1277,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building55()
 
     def Building55(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 83, MapID: 55
-      LocalBuilding("vt_vehicle", 83, 55, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5420f, 4174f, 103.2318f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 83, 55, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5420f, 4174f, 103.2318f), Vector3(0f, 0f, 179f), vt_vehicle)))
       LocalObject(1069, Terminal.Constructor(Vector3(5434.49f, 4173.755f, 105.9188f), ground_vehicle_terminal), owning_building_guid = 83)
       LocalObject(714, VehicleSpawnPad.Constructor(Vector3(5419.853f, 4173.976f, 101.7608f), mb_pad_creation, Vector3(0, 0, -89)), owning_building_guid = 83, terminal_guid = 1069)
     }
@@ -1285,7 +1285,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building43()
 
     def Building43(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 84, MapID: 43
-      LocalBuilding("vt_vehicle", 84, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5420f, 4298f, 103.2333f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 84, 43, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5420f, 4298f, 103.2333f), Vector3(0f, 0f, 179f), vt_vehicle)))
       LocalObject(1070, Terminal.Constructor(Vector3(5434.49f, 4297.755f, 105.9203f), ground_vehicle_terminal), owning_building_guid = 84)
       LocalObject(715, VehicleSpawnPad.Constructor(Vector3(5419.853f, 4297.976f, 101.7623f), mb_pad_creation, Vector3(0, 0, -89)), owning_building_guid = 84, terminal_guid = 1070)
     }
@@ -1293,7 +1293,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building54()
 
     def Building54(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 85, MapID: 54
-      LocalBuilding("vt_vehicle", 85, 54, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5686f, 4420f, 103.2329f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 85, 54, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5686f, 4420f, 103.2329f), Vector3(0f, 0f, 45f), vt_vehicle)))
       LocalObject(1071, Terminal.Constructor(Vector3(5675.758f, 4409.747f, 105.9199f), ground_vehicle_terminal), owning_building_guid = 85)
       LocalObject(716, VehicleSpawnPad.Constructor(Vector3(5686.085f, 4420.123f, 101.7619f), mb_pad_creation, Vector3(0, 0, 45)), owning_building_guid = 85, terminal_guid = 1071)
     }
@@ -1301,7 +1301,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building57()
 
     def Building57(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 86, MapID: 57
-      LocalBuilding("vt_vehicle", 86, 57, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5710f, 4046f, 103.2289f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 86, 57, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5710f, 4046f, 103.2289f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1072, Terminal.Constructor(Vector3(5699.747f, 4056.242f, 105.9159f), ground_vehicle_terminal), owning_building_guid = 86)
       LocalObject(717, VehicleSpawnPad.Constructor(Vector3(5710.123f, 4045.915f, 101.7579f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 86, terminal_guid = 1072)
     }
@@ -1309,7 +1309,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building53()
 
     def Building53(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 87, MapID: 53
-      LocalBuilding("vt_vehicle", 87, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5752f, 4088f, 103.2289f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 87, 53, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5752f, 4088f, 103.2289f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1073, Terminal.Constructor(Vector3(5741.747f, 4098.242f, 105.9159f), ground_vehicle_terminal), owning_building_guid = 87)
       LocalObject(718, VehicleSpawnPad.Constructor(Vector3(5752.123f, 4087.915f, 101.7579f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 87, terminal_guid = 1073)
     }
@@ -1317,7 +1317,7 @@ object Map13 { // HOME3 (VANU SOVREIGNTY SANCTUARY)
     Building56()
 
     def Building56(): Unit = { // Name: vt_vehicle Type: vt_vehicle GUID: 88, MapID: 56
-      LocalBuilding("vt_vehicle", 88, 56, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5794f, 4132f, 103.2289f), vt_vehicle)))
+      LocalBuilding("vt_vehicle", 88, 56, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(5794f, 4132f, 103.2289f), Vector3(0f, 0f, 315f), vt_vehicle)))
       LocalObject(1074, Terminal.Constructor(Vector3(5783.747f, 4142.242f, 105.9159f), ground_vehicle_terminal), owning_building_guid = 88)
       LocalObject(719, VehicleSpawnPad.Constructor(Vector3(5794.123f, 4131.915f, 101.7579f), mb_pad_creation, Vector3(0, 0, 135)), owning_building_guid = 88, terminal_guid = 1074)
     }

--- a/pslogin/src/main/scala/zonemaps/Map96.scala
+++ b/pslogin/src/main/scala/zonemaps/Map96.scala
@@ -23,7 +23,7 @@ object Map96 { // Nexus
     Building1()
 
     def Building1(): Unit = { // Name: Nexus_Base Type: comm_station_dsp GUID: 1, MapID: 1
-      LocalBuilding("Nexus_Base", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1922f, 1940f, 35.71276f), comm_station_dsp)))
+      LocalBuilding("Nexus_Base", 1, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1922f, 1940f, 35.71276f), Vector3(0f, 0f, 360f), comm_station_dsp)))
       LocalObject(21, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(23, Door.Constructor(Vector3(1990.339f, 2010.464f, 39.09076f)), owning_building_guid = 1)
       LocalObject(36, Door.Constructor(Vector3(1862.196f, 1896.501f, 37.36376f)), owning_building_guid = 1)
@@ -170,7 +170,7 @@ object Map96 { // Nexus
     Building2()
 
     def Building2(): Unit = { // Name: North_Rim_Tower Type: tower_a GUID: 5, MapID: 2
-      LocalBuilding("North_Rim_Tower", 5, 2, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1740f, 2280f, 71.42857f), tower_a)))
+      LocalBuilding("North_Rim_Tower", 5, 2, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1740f, 2280f, 71.42857f), Vector3(0f, 0f, 10f), tower_a)))
       LocalObject(285, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 5)
       LocalObject(28, Door.Constructor(Vector3(1750.428f, 2289.962f, 72.94958f)), owning_building_guid = 5)
       LocalObject(29, Door.Constructor(Vector3(1750.428f, 2289.962f, 92.94858f)), owning_building_guid = 5)
@@ -207,7 +207,7 @@ object Map96 { // Nexus
     Building4()
 
     def Building4(): Unit = { // Name: South_Rim_Tower Type: tower_a GUID: 6, MapID: 4
-      LocalBuilding("South_Rim_Tower", 6, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1756f, 1628f, 71.42857f), tower_a)))
+      LocalBuilding("South_Rim_Tower", 6, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1756f, 1628f, 71.42857f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(286, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 6)
       LocalObject(32, Door.Constructor(Vector3(1768f, 1620f, 72.94958f)), owning_building_guid = 6)
       LocalObject(33, Door.Constructor(Vector3(1768f, 1620f, 92.94858f)), owning_building_guid = 6)
@@ -244,7 +244,7 @@ object Map96 { // Nexus
     Building3()
 
     def Building3(): Unit = { // Name: East_Rim_Tower Type: tower_a GUID: 7, MapID: 3
-      LocalBuilding("East_Rim_Tower", 7, 3, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2358f, 1940f, 71.42857f), tower_a)))
+      LocalBuilding("East_Rim_Tower", 7, 3, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2358f, 1940f, 71.42857f), Vector3(0f, 0f, 80f), tower_a)))
       LocalObject(288, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 7)
       LocalObject(61, Door.Constructor(Vector3(2352.205f, 1953.207f, 72.94958f)), owning_building_guid = 7)
       LocalObject(62, Door.Constructor(Vector3(2352.205f, 1953.207f, 92.94858f)), owning_building_guid = 7)
@@ -281,7 +281,7 @@ object Map96 { // Nexus
     Building6()
 
     def Building6(): Unit = { // Name: South_Gate_Tower Type: tower_b GUID: 8, MapID: 6
-      LocalBuilding("South_Gate_Tower", 8, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2242f, 1264f, 35.71276f), tower_b)))
+      LocalBuilding("South_Gate_Tower", 8, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2242f, 1264f, 35.71276f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(287, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 8)
       LocalObject(55, Door.Constructor(Vector3(2254f, 1256f, 37.23276f)), owning_building_guid = 8)
       LocalObject(56, Door.Constructor(Vector3(2254f, 1256f, 47.23276f)), owning_building_guid = 8)
@@ -318,7 +318,7 @@ object Map96 { // Nexus
     Building5()
 
     def Building5(): Unit = { // Name: North_Gate_Tower Type: tower_b GUID: 9, MapID: 5
-      LocalBuilding("North_Gate_Tower", 9, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2438f, 2486f, 35.71276f), tower_b)))
+      LocalBuilding("North_Gate_Tower", 9, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2438f, 2486f, 35.71276f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(289, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 9)
       LocalObject(65, Door.Constructor(Vector3(2450f, 2478f, 37.23276f)), owning_building_guid = 9)
       LocalObject(66, Door.Constructor(Vector3(2450f, 2478f, 47.23276f)), owning_building_guid = 9)

--- a/pslogin/src/main/scala/zonemaps/Map97.scala
+++ b/pslogin/src/main/scala/zonemaps/Map97.scala
@@ -23,28 +23,28 @@ object Map97 { // Desolation
     Building11()
 
     def Building11(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 1, MapID: 11
-      LocalBuilding("bunker_lg", 1, 11, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1998f, 2010f, 40.46144f), bunker_lg)))
+      LocalBuilding("bunker_lg", 1, 11, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1998f, 2010f, 40.46144f), Vector3(0f, 0f, 262f), bunker_lg)))
       LocalObject(94, Door.Constructor(Vector3(2000.169f, 2007.063f, 41.98244f)), owning_building_guid = 1)
     }
 
     Building12()
 
     def Building12(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 2, MapID: 12
-      LocalBuilding("bunker_lg", 2, 12, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2108f, 2054f, 34.09833f), bunker_lg)))
+      LocalBuilding("bunker_lg", 2, 12, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2108f, 2054f, 34.09833f), Vector3(0f, 0f, 169f), bunker_lg)))
       LocalObject(101, Door.Constructor(Vector3(2104.954f, 2051.987f, 35.61933f)), owning_building_guid = 2)
     }
 
     Building13()
 
     def Building13(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 3, MapID: 13
-      LocalBuilding("bunker_lg", 3, 13, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2114f, 1938f, 38.48689f), bunker_lg)))
+      LocalBuilding("bunker_lg", 3, 13, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2114f, 1938f, 38.48689f), Vector3(0f, 0f, 63f), bunker_lg)))
       LocalObject(102, Door.Constructor(Vector3(2112.905f, 1941.483f, 40.00789f)), owning_building_guid = 3)
     }
 
     Building1()
 
     def Building1(): Unit = { // Name: Red_Base_97 Type: tech_plant GUID: 4, MapID: 1
-      LocalBuilding("Red_Base_97", 4, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1538f, 2250f, 30.22248f), tech_plant)))
+      LocalBuilding("Red_Base_97", 4, 1, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1538f, 2250f, 30.22248f), Vector3(0f, 0f, 235f), tech_plant)))
       LocalObject(57, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 4)
       LocalObject(71, Door.Constructor(Vector3(1460.654f, 2298.537f, 31.87348f)), owning_building_guid = 4)
       LocalObject(74, Door.Constructor(Vector3(1471.089f, 2313.44f, 39.83648f)), owning_building_guid = 4)
@@ -170,7 +170,7 @@ object Map97 { // Desolation
     Building3()
 
     def Building3(): Unit = { // Name: Indigo_Base_97 Type: tech_plant GUID: 7, MapID: 3
-      LocalBuilding("Indigo_Base_97", 7, 3, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2446f, 1546f, 30.22248f), tech_plant)))
+      LocalBuilding("Indigo_Base_97", 7, 3, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2446f, 1546f, 30.22248f), Vector3(0f, 0f, 38f), tech_plant)))
       LocalObject(58, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 7)
       LocalObject(103, Door.Constructor(Vector3(2376.227f, 1519.235f, 39.72748f)), owning_building_guid = 7)
       LocalObject(104, Door.Constructor(Vector3(2387.427f, 1504.899f, 31.76448f)), owning_building_guid = 7)
@@ -296,7 +296,7 @@ object Map97 { // Desolation
     Building2()
 
     def Building2(): Unit = { // Name: Blue_Base_97 Type: tech_plant GUID: 10, MapID: 2
-      LocalBuilding("Blue_Base_97", 10, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2532f, 2426f, 30.22248f), tech_plant)))
+      LocalBuilding("Blue_Base_97", 10, 2, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2532f, 2426f, 30.22248f), Vector3(0f, 0f, 145f), tech_plant)))
       LocalObject(59, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 10)
       LocalObject(109, Door.Constructor(Vector3(2465.489f, 2468.779f, 31.76448f)), owning_building_guid = 10)
       LocalObject(111, Door.Constructor(Vector3(2475.924f, 2483.682f, 39.72748f)), owning_building_guid = 10)
@@ -422,7 +422,7 @@ object Map97 { // Desolation
     Building6()
 
     def Building6(): Unit = { // Name: Central_Indigo_Tower_97 Type: tower_a GUID: 13, MapID: 6
-      LocalBuilding("Central_Indigo_Tower_97", 13, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1660f, 1476f, 33.07596f), tower_a)))
+      LocalBuilding("Central_Indigo_Tower_97", 13, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1660f, 1476f, 33.07596f), Vector3(0f, 0f, 320f), tower_a)))
       LocalObject(629, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 13)
       LocalObject(86, Door.Constructor(Vector3(1664.05f, 1462.158f, 34.59696f)), owning_building_guid = 13)
       LocalObject(87, Door.Constructor(Vector3(1664.05f, 1462.158f, 54.59596f)), owning_building_guid = 13)
@@ -459,7 +459,7 @@ object Map97 { // Desolation
     Building4()
 
     def Building4(): Unit = { // Name: Central_Red_Tower_97 Type: tower_a GUID: 14, MapID: 4
-      LocalBuilding("Central_Red_Tower_97", 14, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1966f, 2912f, 33.54289f), tower_a)))
+      LocalBuilding("Central_Red_Tower_97", 14, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1966f, 2912f, 33.54289f), Vector3(0f, 0f, 5f), tower_a)))
       LocalObject(630, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 14)
       LocalObject(90, Door.Constructor(Vector3(1977.257f, 2921.015f, 35.06389f)), owning_building_guid = 14)
       LocalObject(91, Door.Constructor(Vector3(1977.257f, 2921.015f, 55.06289f)), owning_building_guid = 14)
@@ -496,7 +496,7 @@ object Map97 { // Desolation
     Building5()
 
     def Building5(): Unit = { // Name: Central_Blue_Tower_97 Type: tower_a GUID: 15, MapID: 5
-      LocalBuilding("Central_Blue_Tower_97", 15, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2878f, 1898f, 37.28446f), tower_a)))
+      LocalBuilding("Central_Blue_Tower_97", 15, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2878f, 1898f, 37.28446f), Vector3(0f, 0f, 33f), tower_a)))
       LocalObject(634, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 15)
       LocalObject(137, Door.Constructor(Vector3(2883.707f, 1911.245f, 38.80546f)), owning_building_guid = 15)
       LocalObject(138, Door.Constructor(Vector3(2883.707f, 1911.245f, 58.80446f)), owning_building_guid = 15)
@@ -533,7 +533,7 @@ object Map97 { // Desolation
     Building8()
 
     def Building8(): Unit = { // Name: Central_Tower_97 Type: tower_b GUID: 16, MapID: 8
-      LocalBuilding("Central_Tower_97", 16, 8, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2070f, 2002f, 26.19098f), tower_b)))
+      LocalBuilding("Central_Tower_97", 16, 8, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2070f, 2002f, 26.19098f), Vector3(0f, 0f, 310f), tower_b)))
       LocalObject(631, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 16)
       LocalObject(95, Door.Constructor(Vector3(2071.585f, 1987.665f, 27.71099f)), owning_building_guid = 16)
       LocalObject(96, Door.Constructor(Vector3(2071.585f, 1987.665f, 37.71098f)), owning_building_guid = 16)
@@ -570,7 +570,7 @@ object Map97 { // Desolation
     Building7()
 
     def Building7(): Unit = { // Name: Red_Tower_97 Type: tower_c GUID: 17, MapID: 7
-      LocalBuilding("Red_Tower_97", 17, 7, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1452f, 2600f, 37.65374f), tower_c)))
+      LocalBuilding("Red_Tower_97", 17, 7, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1452f, 2600f, 37.65374f), Vector3(0f, 0f, 57f), tower_c)))
       LocalObject(628, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 17)
       LocalObject(69, Door.Constructor(Vector3(1451.826f, 2614.421f, 39.17474f)), owning_building_guid = 17)
       LocalObject(70, Door.Constructor(Vector3(1451.826f, 2614.421f, 59.17374f)), owning_building_guid = 17)
@@ -611,7 +611,7 @@ object Map97 { // Desolation
     Building10()
 
     def Building10(): Unit = { // Name: Indigo_Tower_97 Type: tower_c GUID: 18, MapID: 10
-      LocalBuilding("Indigo_Tower_97", 18, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2760f, 1398f, 30.46968f), tower_c)))
+      LocalBuilding("Indigo_Tower_97", 18, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2760f, 1398f, 30.46968f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(632, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 18)
       LocalObject(129, Door.Constructor(Vector3(2772f, 1390f, 31.99068f)), owning_building_guid = 18)
       LocalObject(130, Door.Constructor(Vector3(2772f, 1390f, 51.98968f)), owning_building_guid = 18)
@@ -652,7 +652,7 @@ object Map97 { // Desolation
     Building9()
 
     def Building9(): Unit = { // Name: Blue_Tower_97 Type: tower_c GUID: 19, MapID: 9
-      LocalBuilding("Blue_Tower_97", 19, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2778f, 2664f, 33.75977f), tower_c)))
+      LocalBuilding("Blue_Tower_97", 19, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2778f, 2664f, 33.75977f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(633, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 19)
       LocalObject(133, Door.Constructor(Vector3(2790f, 2656f, 35.28077f)), owning_building_guid = 19)
       LocalObject(134, Door.Constructor(Vector3(2790f, 2656f, 55.27977f)), owning_building_guid = 19)

--- a/pslogin/src/main/scala/zonemaps/Map98.scala
+++ b/pslogin/src/main/scala/zonemaps/Map98.scala
@@ -24,7 +24,7 @@ object Map98 { // Ascension
     Building39()
 
     def Building39(): Unit = { // Name: Base_Charlie Type: amp_station GUID: 1, MapID: 39
-      LocalBuilding("Base_Charlie", 1, 39, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2650f, 2280f, 90.6473f), amp_station)))
+      LocalBuilding("Base_Charlie", 1, 39, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2650f, 2280f, 90.6473f), Vector3(0f, 0f, 353f), amp_station)))
       LocalObject(78, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(71, Door.Constructor(Vector3(2649.38f, 2273.22f, 103.5493f)), owning_building_guid = 1)
       LocalObject(72, Door.Constructor(Vector3(2651.042f, 2286.728f, 103.5493f)), owning_building_guid = 1)
@@ -152,7 +152,7 @@ object Map98 { // Ascension
     Building17()
 
     def Building17(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 17
-      LocalBuilding("bunker_gauntlet", 4, 17, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1222f, 1420f, 12.08533f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 17, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1222f, 1420f, 12.08533f), Vector3(0f, 0f, 238f), bunker_gauntlet)))
       LocalObject(98, Door.Constructor(Vector3(1207.181f, 1399.871f, 13.60633f)), owning_building_guid = 4)
       LocalObject(100, Door.Constructor(Vector3(1233.573f, 1442.128f, 13.60633f)), owning_building_guid = 4)
     }
@@ -160,7 +160,7 @@ object Map98 { // Ascension
     Building15()
 
     def Building15(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 15
-      LocalBuilding("bunker_gauntlet", 5, 15, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2542f, 2700f, 12.08045f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 15, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2542f, 2700f, 12.08045f), Vector3(0f, 0f, 146f), bunker_gauntlet)))
       LocalObject(184, Door.Constructor(Vector3(2522.401f, 2715.513f, 13.60145f)), owning_building_guid = 5)
       LocalObject(186, Door.Constructor(Vector3(2563.71f, 2687.662f, 13.60145f)), owning_building_guid = 5)
     }
@@ -168,7 +168,7 @@ object Map98 { // Ascension
     Building16()
 
     def Building16(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 16
-      LocalBuilding("bunker_gauntlet", 6, 16, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2612f, 1350f, 11.46977f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 16, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2612f, 1350f, 11.46977f), Vector3(0f, 0f, 323f), bunker_gauntlet)))
       LocalObject(193, Door.Constructor(Vector3(2590.965f, 1363.457f, 12.99077f)), owning_building_guid = 6)
       LocalObject(195, Door.Constructor(Vector3(2630.76f, 1333.483f, 12.99077f)), owning_building_guid = 6)
     }
@@ -176,154 +176,154 @@ object Map98 { // Ascension
     Building22()
 
     def Building22(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 7, MapID: 22
-      LocalBuilding("bunker_lg", 7, 22, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1570f, 2502f, 90.64242f), bunker_lg)))
+      LocalBuilding("bunker_lg", 7, 22, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1570f, 2502f, 90.64242f), Vector3(0f, 0f, 263f), bunker_lg)))
       LocalObject(120, Door.Constructor(Vector3(1572.22f, 2499.102f, 92.16342f)), owning_building_guid = 7)
     }
 
     Building32()
 
     def Building32(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 8, MapID: 32
-      LocalBuilding("bunker_lg", 8, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1674f, 1810f, 90.64486f), bunker_lg)))
+      LocalBuilding("bunker_lg", 8, 32, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1674f, 1810f, 90.64486f), Vector3(0f, 0f, 263f), bunker_lg)))
       LocalObject(125, Door.Constructor(Vector3(1676.22f, 1807.102f, 92.16586f)), owning_building_guid = 8)
     }
 
     Building33()
 
     def Building33(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 9, MapID: 33
-      LocalBuilding("bunker_lg", 9, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1728f, 1820f, 90.6473f), bunker_lg)))
+      LocalBuilding("bunker_lg", 9, 33, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1728f, 1820f, 90.6473f), Vector3(0f, 0f, 182f), bunker_lg)))
       LocalObject(129, Door.Constructor(Vector3(1725.485f, 1817.354f, 92.1683f)), owning_building_guid = 9)
     }
 
     Building30()
 
     def Building30(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 30
-      LocalBuilding("bunker_lg", 10, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1766f, 2594f, 90.64272f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 30, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1766f, 2594f, 90.64272f), Vector3(0f, 0f, 324f), bunker_lg)))
       LocalObject(134, Door.Constructor(Vector3(1769.611f, 2594.537f, 92.16373f)), owning_building_guid = 10)
     }
 
     Building31()
 
     def Building31(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 11, MapID: 31
-      LocalBuilding("bunker_lg", 11, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1810f, 2570f, 90.64516f), bunker_lg)))
+      LocalBuilding("bunker_lg", 11, 31, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1810f, 2570f, 90.64516f), Vector3(0f, 0f, 74f), bunker_lg)))
       LocalObject(137, Door.Constructor(Vector3(1808.26f, 2573.21f, 92.16617f)), owning_building_guid = 11)
     }
 
     Building18()
 
     def Building18(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 12, MapID: 18
-      LocalBuilding("bunker_lg", 12, 18, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2180f, 1398f, 30.41109f), bunker_lg)))
+      LocalBuilding("bunker_lg", 12, 18, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2180f, 1398f, 30.41109f), Vector3(0f, 0f, 193f), bunker_lg)))
       LocalObject(167, Door.Constructor(Vector3(2178.036f, 1394.922f, 31.93209f)), owning_building_guid = 12)
     }
 
     Building34()
 
     def Building34(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 13, MapID: 34
-      LocalBuilding("bunker_lg", 13, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2566f, 2174f, 90.6473f), bunker_lg)))
+      LocalBuilding("bunker_lg", 13, 34, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2566f, 2174f, 90.6473f), Vector3(0f, 0f, 0f), bunker_lg)))
       LocalObject(187, Door.Constructor(Vector3(2568.606f, 2176.557f, 92.1683f)), owning_building_guid = 13)
     }
 
     Building35()
 
     def Building35(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 14, MapID: 35
-      LocalBuilding("bunker_lg", 14, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2610f, 2164f, 90.6473f), bunker_lg)))
+      LocalBuilding("bunker_lg", 14, 35, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2610f, 2164f, 90.6473f), Vector3(0f, 0f, 42f), bunker_lg)))
       LocalObject(194, Door.Constructor(Vector3(2610.226f, 2167.644f, 92.1683f)), owning_building_guid = 14)
     }
 
     Building20()
 
     def Building20(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 15, MapID: 20
-      LocalBuilding("bunker_lg", 15, 20, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2784f, 1826f, 54.0495f), bunker_lg)))
+      LocalBuilding("bunker_lg", 15, 20, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2784f, 1826f, 54.0495f), Vector3(0f, 0f, 157f), bunker_lg)))
       LocalObject(208, Door.Constructor(Vector3(2780.602f, 1824.665f, 55.5705f)), owning_building_guid = 15)
     }
 
     Building36()
 
     def Building36(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 16, MapID: 36
-      LocalBuilding("bunker_sm", 16, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1220f, 1754f, 71.60863f), bunker_sm)))
+      LocalBuilding("bunker_sm", 16, 36, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1220f, 1754f, 71.60863f), Vector3(0f, 0f, 162f), bunker_sm)))
       LocalObject(99, Door.Constructor(Vector3(1218.852f, 1754.431f, 73.12963f)), owning_building_guid = 16)
     }
 
     Building19()
 
     def Building19(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 17, MapID: 19
-      LocalBuilding("bunker_sm", 17, 19, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1290f, 2306f, 55.9801f), bunker_sm)))
+      LocalBuilding("bunker_sm", 17, 19, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1290f, 2306f, 55.9801f), Vector3(0f, 0f, 89f), bunker_sm)))
       LocalObject(105, Door.Constructor(Vector3(1290.076f, 2307.224f, 57.5011f)), owning_building_guid = 17)
     }
 
     Building23()
 
     def Building23(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 18, MapID: 23
-      LocalBuilding("bunker_sm", 18, 23, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1616f, 1468f, 52.67128f), bunker_sm)))
+      LocalBuilding("bunker_sm", 18, 23, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1616f, 1468f, 52.67128f), Vector3(0f, 0f, 158f), bunker_sm)))
       LocalObject(121, Door.Constructor(Vector3(1614.885f, 1468.51f, 54.19228f)), owning_building_guid = 18)
     }
 
     Building37()
 
     def Building37(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 19, MapID: 37
-      LocalBuilding("bunker_sm", 19, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1626f, 2798f, 74.2613f), bunker_sm)))
+      LocalBuilding("bunker_sm", 19, 37, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1626f, 2798f, 74.2613f), Vector3(0f, 0f, 20f), bunker_sm)))
       LocalObject(122, Door.Constructor(Vector3(1627.17f, 2798.367f, 75.7823f)), owning_building_guid = 19)
     }
 
     Building27()
 
     def Building27(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 20, MapID: 27
-      LocalBuilding("bunker_sm", 20, 27, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1878f, 2080f, 110.9449f), bunker_sm)))
+      LocalBuilding("bunker_sm", 20, 27, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1878f, 2080f, 110.9449f), Vector3(0f, 0f, 340f), bunker_sm)))
       LocalObject(148, Door.Constructor(Vector3(1879.132f, 2079.529f, 112.4659f)), owning_building_guid = 20)
     }
 
     Building26()
 
     def Building26(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 21, MapID: 26
-      LocalBuilding("bunker_sm", 21, 26, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1908f, 2020f, 110.9848f), bunker_sm)))
+      LocalBuilding("bunker_sm", 21, 26, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1908f, 2020f, 110.9848f), Vector3(0f, 0f, 134f), bunker_sm)))
       LocalObject(155, Door.Constructor(Vector3(1907.189f, 2020.919f, 112.5058f)), owning_building_guid = 21)
     }
 
     Building24()
 
     def Building24(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 22, MapID: 24
-      LocalBuilding("bunker_sm", 22, 24, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2002f, 2332f, 114.5708f), bunker_sm)))
+      LocalBuilding("bunker_sm", 22, 24, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2002f, 2332f, 114.5708f), Vector3(0f, 0f, 348f), bunker_sm)))
       LocalObject(157, Door.Constructor(Vector3(2003.187f, 2331.691f, 116.0918f)), owning_building_guid = 22)
     }
 
     Building25()
 
     def Building25(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 23, MapID: 25
-      LocalBuilding("bunker_sm", 23, 25, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2062f, 2362f, 114.0855f), bunker_sm)))
+      LocalBuilding("bunker_sm", 23, 25, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2062f, 2362f, 114.0855f), Vector3(0f, 0f, 289f), bunker_sm)))
       LocalObject(162, Door.Constructor(Vector3(2062.347f, 2360.824f, 115.6065f)), owning_building_guid = 23)
     }
 
     Building29()
 
     def Building29(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 24, MapID: 29
-      LocalBuilding("bunker_sm", 24, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2250f, 2170f, 110.7895f), bunker_sm)))
+      LocalBuilding("bunker_sm", 24, 29, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2250f, 2170f, 110.7895f), Vector3(0f, 0f, 239f), bunker_sm)))
       LocalObject(170, Door.Constructor(Vector3(2249.322f, 2168.978f, 112.3105f)), owning_building_guid = 24)
     }
 
     Building28()
 
     def Building28(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 25, MapID: 28
-      LocalBuilding("bunker_sm", 25, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2252f, 2092f, 110.7993f), bunker_sm)))
+      LocalBuilding("bunker_sm", 25, 28, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2252f, 2092f, 110.7993f), Vector3(0f, 0f, 92f), bunker_sm)))
       LocalObject(171, Door.Constructor(Vector3(2252.012f, 2093.226f, 112.3203f)), owning_building_guid = 25)
     }
 
     Building38()
 
     def Building38(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 26, MapID: 38
-      LocalBuilding("bunker_sm", 26, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2530f, 1478f, 79.27488f), bunker_sm)))
+      LocalBuilding("bunker_sm", 26, 38, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2530f, 1478f, 79.27488f), Vector3(0f, 0f, 282f), bunker_sm)))
       LocalObject(185, Door.Constructor(Vector3(2530.201f, 1476.79f, 80.79588f)), owning_building_guid = 26)
     }
 
     Building21()
 
     def Building21(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 27, MapID: 21
-      LocalBuilding("bunker_sm", 27, 21, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2918f, 1934f, 50.3531f), bunker_sm)))
+      LocalBuilding("bunker_sm", 27, 21, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2918f, 1934f, 50.3531f), Vector3(0f, 0f, 274f), bunker_sm)))
       LocalObject(219, Door.Constructor(Vector3(2918.031f, 1932.774f, 51.8741f)), owning_building_guid = 27)
     }
 
     Building7()
 
     def Building7(): Unit = { // Name: Base_Alpha Type: comm_station GUID: 28, MapID: 7
-      LocalBuilding("Base_Alpha", 28, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1834f, 2664f, 90.6473f), comm_station)))
+      LocalBuilding("Base_Alpha", 28, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1834f, 2664f, 90.6473f), Vector3(0f, 0f, 107f), comm_station)))
       LocalObject(77, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 28)
       LocalObject(131, Door.Constructor(Vector3(1751.965f, 2672.381f, 92.3683f)), owning_building_guid = 28)
       LocalObject(132, Door.Constructor(Vector3(1763.528f, 2662.001f, 100.3613f)), owning_building_guid = 28)
@@ -442,7 +442,7 @@ object Map98 { // Ascension
     Building8()
 
     def Building8(): Unit = { // Name: Base_Bravo Type: cryo_facility GUID: 31, MapID: 8
-      LocalBuilding("Base_Bravo", 31, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1736f, 1730f, 90.6473f), cryo_facility)))
+      LocalBuilding("Base_Bravo", 31, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1736f, 1730f, 90.6473f), Vector3(0f, 0f, 57f), cryo_facility)))
       LocalObject(76, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 31)
       LocalObject(123, Door.Constructor(Vector3(1656.083f, 1731.431f, 92.1983f)), owning_building_guid = 31)
       LocalObject(124, Door.Constructor(Vector3(1665.992f, 1746.688f, 100.1623f)), owning_building_guid = 31)
@@ -590,7 +590,7 @@ object Map98 { // Ascension
     Building6()
 
     def Building6(): Unit = { // Name: Bravo_Middle Type: tower_a GUID: 34, MapID: 6
-      LocalBuilding("Bravo_Middle", 34, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1290f, 1584f, 70.50996f), tower_a)))
+      LocalBuilding("Bravo_Middle", 34, 6, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1290f, 1584f, 70.50996f), Vector3(0f, 0f, 57f), tower_a)))
       LocalObject(835, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 34)
       LocalObject(103, Door.Constructor(Vector3(1289.826f, 1598.421f, 72.03097f)), owning_building_guid = 34)
       LocalObject(104, Door.Constructor(Vector3(1289.826f, 1598.421f, 92.02997f)), owning_building_guid = 34)
@@ -627,7 +627,7 @@ object Map98 { // Ascension
     Building4()
 
     def Building4(): Unit = { // Name: Alpha_Middle Type: tower_a GUID: 35, MapID: 4
-      LocalBuilding("Alpha_Middle", 35, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1406f, 2676f, 73.84014f), tower_a)))
+      LocalBuilding("Alpha_Middle", 35, 4, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1406f, 2676f, 73.84014f), Vector3(0f, 0f, 9f), tower_a)))
       LocalObject(836, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 35)
       LocalObject(113, Door.Constructor(Vector3(1416.601f, 2685.779f, 75.36115f)), owning_building_guid = 35)
       LocalObject(114, Door.Constructor(Vector3(1416.601f, 2685.779f, 95.36014f)), owning_building_guid = 35)
@@ -664,7 +664,7 @@ object Map98 { // Ascension
     Building1()
 
     def Building1(): Unit = { // Name: Charlie_Middle Type: tower_a GUID: 36, MapID: 1
-      LocalBuilding("Charlie_Middle", 36, 1, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2494f, 1628f, 70.50996f), tower_a)))
+      LocalBuilding("Charlie_Middle", 36, 1, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2494f, 1628f, 70.50996f), Vector3(0f, 0f, 275f), tower_a)))
       LocalObject(843, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 36)
       LocalObject(180, Door.Constructor(Vector3(2487.076f, 1615.348f, 72.03097f)), owning_building_guid = 36)
       LocalObject(181, Door.Constructor(Vector3(2487.076f, 1615.348f, 92.02997f)), owning_building_guid = 36)
@@ -701,7 +701,7 @@ object Map98 { // Ascension
     Building13()
 
     def Building13(): Unit = { // Name: Alpha_Gate_Tower Type: tower_b GUID: 37, MapID: 13
-      LocalBuilding("Alpha_Gate_Tower", 37, 13, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1408f, 1176f, 12.08533f), tower_b)))
+      LocalBuilding("Alpha_Gate_Tower", 37, 13, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1408f, 1176f, 12.08533f), Vector3(0f, 0f, 27f), tower_b)))
       LocalObject(837, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 37)
       LocalObject(110, Door.Constructor(Vector3(1415.06f, 1188.576f, 13.60533f)), owning_building_guid = 37)
       LocalObject(111, Door.Constructor(Vector3(1415.06f, 1188.576f, 23.60533f)), owning_building_guid = 37)
@@ -738,7 +738,7 @@ object Map98 { // Ascension
     Building10()
 
     def Building10(): Unit = { // Name: Charlie_Gate_Tower Type: tower_b GUID: 38, MapID: 10
-      LocalBuilding("Charlie_Gate_Tower", 38, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2334f, 2784f, 12.08533f), tower_b)))
+      LocalBuilding("Charlie_Gate_Tower", 38, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2334f, 2784f, 12.08533f), Vector3(0f, 0f, 235f), tower_b)))
       LocalObject(842, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 38)
       LocalObject(174, Door.Constructor(Vector3(2320.564f, 2778.759f, 13.60533f)), owning_building_guid = 38)
       LocalObject(175, Door.Constructor(Vector3(2320.564f, 2778.759f, 23.60533f)), owning_building_guid = 38)
@@ -775,7 +775,7 @@ object Map98 { // Ascension
     Building11()
 
     def Building11(): Unit = { // Name: Bravo_Gate_Tower Type: tower_b GUID: 39, MapID: 11
-      LocalBuilding("Bravo_Gate_Tower", 39, 11, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2870f, 1410f, 14.09711f), tower_b)))
+      LocalBuilding("Bravo_Gate_Tower", 39, 11, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2870f, 1410f, 14.09711f), Vector3(0f, 0f, 125f), tower_b)))
       LocalObject(845, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 39)
       LocalObject(213, Door.Constructor(Vector3(2856.564f, 1415.241f, 15.61711f)), owning_building_guid = 39)
       LocalObject(214, Door.Constructor(Vector3(2856.564f, 1415.241f, 25.61711f)), owning_building_guid = 39)
@@ -812,7 +812,7 @@ object Map98 { // Ascension
     Building14()
 
     def Building14(): Unit = { // Name: Alpha_Bottom Type: tower_c GUID: 40, MapID: 14
-      LocalBuilding("Alpha_Bottom", 40, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1290f, 2082f, 34.21491f), tower_c)))
+      LocalBuilding("Alpha_Bottom", 40, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1290f, 2082f, 34.21491f), Vector3(0f, 0f, 61f), tower_c)))
       LocalObject(834, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 40)
       LocalObject(101, Door.Constructor(Vector3(1288.821f, 2096.374f, 35.73591f)), owning_building_guid = 40)
       LocalObject(102, Door.Constructor(Vector3(1288.821f, 2096.374f, 55.73491f)), owning_building_guid = 40)
@@ -853,7 +853,7 @@ object Map98 { // Ascension
     Building5()
 
     def Building5(): Unit = { // Name: Bravo_Top Type: tower_c GUID: 41, MapID: 5
-      LocalBuilding("Bravo_Top", 41, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1894f, 2052f, 110.9848f), tower_c)))
+      LocalBuilding("Bravo_Top", 41, 5, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1894f, 2052f, 110.9848f), Vector3(0f, 0f, 274f), tower_c)))
       LocalObject(838, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 41)
       LocalObject(149, Door.Constructor(Vector3(1886.857f, 2039.471f, 112.5058f)), owning_building_guid = 41)
       LocalObject(150, Door.Constructor(Vector3(1886.857f, 2039.471f, 132.5048f)), owning_building_guid = 41)
@@ -894,7 +894,7 @@ object Map98 { // Ascension
     Building3()
 
     def Building3(): Unit = { // Name: Alpha_Top Type: tower_c GUID: 42, MapID: 3
-      LocalBuilding("Alpha_Top", 42, 3, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2034f, 2332f, 114.5592f), tower_c)))
+      LocalBuilding("Alpha_Top", 42, 3, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2034f, 2332f, 114.5592f), Vector3(0f, 0f, 25f), tower_c)))
       LocalObject(839, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 42)
       LocalObject(158, Door.Constructor(Vector3(2041.495f, 2344.322f, 116.0802f)), owning_building_guid = 42)
       LocalObject(159, Door.Constructor(Vector3(2041.495f, 2344.322f, 136.0792f)), owning_building_guid = 42)
@@ -935,7 +935,7 @@ object Map98 { // Ascension
     Building12()
 
     def Building12(): Unit = { // Name: Bravo_Bottom Type: tower_c GUID: 43, MapID: 12
-      LocalBuilding("Bravo_Bottom", 43, 12, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2122f, 1574f, 12.09021f), tower_c)))
+      LocalBuilding("Bravo_Bottom", 43, 12, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2122f, 1574f, 12.09021f), Vector3(0f, 0f, 187f), tower_c)))
       LocalObject(840, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 43)
       LocalObject(163, Door.Constructor(Vector3(2109.115f, 1580.478f, 13.61121f)), owning_building_guid = 43)
       LocalObject(164, Door.Constructor(Vector3(2109.115f, 1580.478f, 33.61021f)), owning_building_guid = 43)
@@ -976,7 +976,7 @@ object Map98 { // Ascension
     Building2()
 
     def Building2(): Unit = { // Name: Charlie_Top Type: tower_c GUID: 44, MapID: 2
-      LocalBuilding("Charlie_Top", 44, 2, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2254f, 2136f, 110.7895f), tower_c)))
+      LocalBuilding("Charlie_Top", 44, 2, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2254f, 2136f, 110.7895f), Vector3(0f, 0f, 238f), tower_c)))
       LocalObject(841, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 44)
       LocalObject(168, Door.Constructor(Vector3(2240.856f, 2130.063f, 112.3105f)), owning_building_guid = 44)
       LocalObject(169, Door.Constructor(Vector3(2240.856f, 2130.063f, 132.3095f)), owning_building_guid = 44)
@@ -1017,7 +1017,7 @@ object Map98 { // Ascension
     Building9()
 
     def Building9(): Unit = { // Name: Charlie_Bottom Type: tower_c GUID: 45, MapID: 9
-      LocalBuilding("Charlie_Bottom", 45, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2806f, 2560f, 11.30894f), tower_c)))
+      LocalBuilding("Charlie_Bottom", 45, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2806f, 2560f, 11.30894f), Vector3(0f, 0f, 171f), tower_c)))
       LocalObject(844, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 45)
       LocalObject(209, Door.Constructor(Vector3(2792.896f, 2553.976f, 12.82994f)), owning_building_guid = 45)
       LocalObject(210, Door.Constructor(Vector3(2792.896f, 2553.976f, 32.82894f)), owning_building_guid = 45)

--- a/pslogin/src/main/scala/zonemaps/Map99.scala
+++ b/pslogin/src/main/scala/zonemaps/Map99.scala
@@ -24,7 +24,7 @@ object Map99 { // Extinction
     Building7()
 
     def Building7(): Unit = { // Name: Blue_Base Type: amp_station GUID: 1, MapID: 7
-      LocalBuilding("Blue_Base", 1, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2844f, 2746f, 88.53952f), amp_station)))
+      LocalBuilding("Blue_Base", 1, 7, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(2844f, 2746f, 88.53952f), Vector3(0f, 0f, 36f), amp_station)))
       LocalObject(59, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 1)
       LocalObject(52, Door.Constructor(Vector3(2840.173f, 2751.631f, 101.4415f)), owning_building_guid = 1)
       LocalObject(53, Door.Constructor(Vector3(2848.17f, 2740.619f, 101.4415f)), owning_building_guid = 1)
@@ -152,7 +152,7 @@ object Map99 { // Extinction
     Building2()
 
     def Building2(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 4, MapID: 2
-      LocalBuilding("bunker_gauntlet", 4, 2, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1724f, 1710f, 84.34553f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 4, 2, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1724f, 1710f, 84.34553f), Vector3(0f, 0f, 95f), bunker_gauntlet)))
       LocalObject(114, Door.Constructor(Vector3(1723.722f, 1734.994f, 85.86653f)), owning_building_guid = 4)
       LocalObject(115, Door.Constructor(Vector3(1728.075f, 1685.363f, 85.86653f)), owning_building_guid = 4)
     }
@@ -160,7 +160,7 @@ object Map99 { // Extinction
     Building6()
 
     def Building6(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 5, MapID: 6
-      LocalBuilding("bunker_gauntlet", 5, 6, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1736f, 2188f, 84.34553f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 5, 6, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1736f, 2188f, 84.34553f), Vector3(0f, 0f, 101f), bunker_gauntlet)))
       LocalObject(116, Door.Constructor(Vector3(1733.111f, 2212.828f, 85.86653f)), owning_building_guid = 5)
       LocalObject(117, Door.Constructor(Vector3(1742.628f, 2163.924f, 85.86653f)), owning_building_guid = 5)
     }
@@ -168,7 +168,7 @@ object Map99 { // Extinction
     Building1()
 
     def Building1(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 6, MapID: 1
-      LocalBuilding("bunker_gauntlet", 6, 1, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1952f, 2450f, 84.34553f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 6, 1, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1952f, 2450f, 84.34553f), Vector3(0f, 0f, 354f), bunker_gauntlet)))
       LocalObject(122, Door.Constructor(Vector3(1927.039f, 2450.701f, 85.86653f)), owning_building_guid = 6)
       LocalObject(123, Door.Constructor(Vector3(1976.588f, 2445.504f, 85.86653f)), owning_building_guid = 6)
     }
@@ -176,7 +176,7 @@ object Map99 { // Extinction
     Building5()
 
     def Building5(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 7, MapID: 5
-      LocalBuilding("bunker_gauntlet", 7, 5, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2210f, 2376f, 84.31532f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 7, 5, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2210f, 2376f, 84.31532f), Vector3(0f, 0f, 358f), bunker_gauntlet)))
       LocalObject(132, Door.Constructor(Vector3(2185.05f, 2374.958f, 85.83632f)), owning_building_guid = 7)
       LocalObject(138, Door.Constructor(Vector3(2234.841f, 2373.23f, 85.83632f)), owning_building_guid = 7)
     }
@@ -184,7 +184,7 @@ object Map99 { // Extinction
     Building3()
 
     def Building3(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 8, MapID: 3
-      LocalBuilding("bunker_gauntlet", 8, 3, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2224f, 1666f, 84.68795f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 8, 3, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2224f, 1666f, 84.68795f), Vector3(0f, 0f, 224f), bunker_gauntlet)))
       LocalObject(133, Door.Constructor(Vector3(2204.751f, 1650.054f, 86.20895f)), owning_building_guid = 8)
       LocalObject(139, Door.Constructor(Vector3(2240.582f, 1684.671f, 86.20895f)), owning_building_guid = 8)
     }
@@ -192,7 +192,7 @@ object Map99 { // Extinction
     Building4()
 
     def Building4(): Unit = { // Name: bunker_gauntlet Type: bunker_gauntlet GUID: 9, MapID: 4
-      LocalBuilding("bunker_gauntlet", 9, 4, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2326f, 2054f, 85.05051f), bunker_gauntlet)))
+      LocalBuilding("bunker_gauntlet", 9, 4, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2326f, 2054f, 85.05051f), Vector3(0f, 0f, 213f), bunker_gauntlet)))
       LocalObject(140, Door.Constructor(Vector3(2304.062f, 2042.02f, 86.57151f)), owning_building_guid = 9)
       LocalObject(141, Door.Constructor(Vector3(2345.84f, 2069.164f, 86.57151f)), owning_building_guid = 9)
     }
@@ -200,42 +200,42 @@ object Map99 { // Extinction
     Building19()
 
     def Building19(): Unit = { // Name: bunker_lg Type: bunker_lg GUID: 10, MapID: 19
-      LocalBuilding("bunker_lg", 10, 19, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2512f, 2678f, 90.57954f), bunker_lg)))
+      LocalBuilding("bunker_lg", 10, 19, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2512f, 2678f, 90.57954f), Vector3(0f, 0f, 121f), bunker_lg)))
       LocalObject(156, Door.Constructor(Vector3(2508.466f, 2678.917f, 92.10055f)), owning_building_guid = 10)
     }
 
     Building23()
 
     def Building23(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 11, MapID: 23
-      LocalBuilding("bunker_sm", 11, 23, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1328f, 2002f, 82.80465f), bunker_sm)))
+      LocalBuilding("bunker_sm", 11, 23, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(1328f, 2002f, 82.80465f), Vector3(0f, 0f, 197f), bunker_sm)))
       LocalObject(93, Door.Constructor(Vector3(1326.812f, 2001.694f, 84.32565f)), owning_building_guid = 11)
     }
 
     Building20()
 
     def Building20(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 12, MapID: 20
-      LocalBuilding("bunker_sm", 12, 20, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2410f, 2706f, 85.88767f), bunker_sm)))
+      LocalBuilding("bunker_sm", 12, 20, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2410f, 2706f, 85.88767f), Vector3(0f, 0f, 41f), bunker_sm)))
       LocalObject(148, Door.Constructor(Vector3(2410.96f, 2706.762f, 87.40868f)), owning_building_guid = 12)
     }
 
     Building21()
 
     def Building21(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 13, MapID: 21
-      LocalBuilding("bunker_sm", 13, 21, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2490f, 1330f, 90.34791f), bunker_sm)))
+      LocalBuilding("bunker_sm", 13, 21, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2490f, 1330f, 90.34791f), Vector3(0f, 0f, 238f), bunker_sm)))
       LocalObject(155, Door.Constructor(Vector3(2489.304f, 1328.99f, 91.86891f)), owning_building_guid = 13)
     }
 
     Building22()
 
     def Building22(): Unit = { // Name: bunker_sm Type: bunker_sm GUID: 14, MapID: 22
-      LocalBuilding("bunker_sm", 14, 22, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2578f, 1328f, 90.41841f), bunker_sm)))
+      LocalBuilding("bunker_sm", 14, 22, FoundationBuilder(Building.Structure(StructureType.Bunker, Vector3(2578f, 1328f, 90.41841f), Vector3(0f, 0f, 335f), bunker_sm)))
       LocalObject(157, Door.Constructor(Vector3(2579.087f, 1327.432f, 91.93941f)), owning_building_guid = 14)
     }
 
     Building8()
 
     def Building8(): Unit = { // Name: Indigo_Base Type: comm_station GUID: 15, MapID: 8
-      LocalBuilding("Indigo_Base", 15, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1488f, 1232f, 88.53511f), comm_station)))
+      LocalBuilding("Indigo_Base", 15, 8, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1488f, 1232f, 88.53511f), Vector3(0f, 0f, 70f), comm_station)))
       LocalObject(58, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 15)
       LocalObject(95, Door.Constructor(Vector3(1424.293f, 1255.719f, 90.28611f)), owning_building_guid = 15)
       LocalObject(96, Door.Constructor(Vector3(1427.528f, 1288.064f, 90.25611f)), owning_building_guid = 15)
@@ -354,7 +354,7 @@ object Map99 { // Extinction
     Building18()
 
     def Building18(): Unit = { // Name: Red_Base Type: cryo_facility GUID: 18, MapID: 18
-      LocalBuilding("Red_Base", 18, 18, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1254f, 2502f, 87.99127f), cryo_facility)))
+      LocalBuilding("Red_Base", 18, 18, FoundationBuilder(Building.Structure(StructureType.Facility, Vector3(1254f, 2502f, 87.99127f), Vector3(0f, 0f, 36f), cryo_facility)))
       LocalObject(57, CaptureTerminal.Constructor(capture_terminal), owning_building_guid = 18)
       LocalObject(83, Door.Constructor(Vector3(1179.904f, 2531.975f, 89.54227f)), owning_building_guid = 18)
       LocalObject(84, Door.Constructor(Vector3(1192.948f, 2485.693f, 97.50627f)), owning_building_guid = 18)
@@ -502,7 +502,7 @@ object Map99 { // Extinction
     Building9()
 
     def Building9(): Unit = { // Name: Red_Gun_Tower Type: tower_a GUID: 21, MapID: 9
-      LocalBuilding("Red_Gun_Tower", 21, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1876f, 2092f, 89.83428f), tower_a)))
+      LocalBuilding("Red_Gun_Tower", 21, 9, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1876f, 2092f, 89.83428f), Vector3(0f, 0f, 59f), tower_a)))
       LocalObject(705, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 21)
       LocalObject(118, Door.Constructor(Vector3(1875.323f, 2106.406f, 91.35529f)), owning_building_guid = 21)
       LocalObject(119, Door.Constructor(Vector3(1875.323f, 2106.406f, 111.3543f)), owning_building_guid = 21)
@@ -539,7 +539,7 @@ object Map99 { // Extinction
     Building12()
 
     def Building12(): Unit = { // Name: Indigo_Gun_Tower Type: tower_a GUID: 22, MapID: 12
-      LocalBuilding("Indigo_Gun_Tower", 22, 12, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2062f, 1728f, 90.51912f), tower_a)))
+      LocalBuilding("Indigo_Gun_Tower", 22, 12, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2062f, 1728f, 90.51912f), Vector3(0f, 0f, 360f), tower_a)))
       LocalObject(707, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 22)
       LocalObject(128, Door.Constructor(Vector3(2074f, 1720f, 92.04012f)), owning_building_guid = 22)
       LocalObject(129, Door.Constructor(Vector3(2074f, 1720f, 112.0391f)), owning_building_guid = 22)
@@ -576,7 +576,7 @@ object Map99 { // Extinction
     Building13()
 
     def Building13(): Unit = { // Name: Blue_Gun_Tower Type: tower_a GUID: 23, MapID: 13
-      LocalBuilding("Blue_Gun_Tower", 23, 13, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2214f, 2124f, 90.3177f), tower_a)))
+      LocalBuilding("Blue_Gun_Tower", 23, 13, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2214f, 2124f, 90.3177f), Vector3(0f, 0f, 305f), tower_a)))
       LocalObject(708, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 23)
       LocalObject(134, Door.Constructor(Vector3(2214.33f, 2109.582f, 91.8387f)), owning_building_guid = 23)
       LocalObject(135, Door.Constructor(Vector3(2214.33f, 2109.582f, 111.8377f)), owning_building_guid = 23)
@@ -613,7 +613,7 @@ object Map99 { // Extinction
     Building15()
 
     def Building15(): Unit = { // Name: Red_Watch_Tower Type: tower_b GUID: 24, MapID: 15
-      LocalBuilding("Red_Watch_Tower", 24, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1488f, 2084f, 90.30762f), tower_b)))
+      LocalBuilding("Red_Watch_Tower", 24, 15, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1488f, 2084f, 90.30762f), Vector3(0f, 0f, 336f), tower_b)))
       LocalObject(704, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 24)
       LocalObject(103, Door.Constructor(Vector3(1495.709f, 2071.811f, 91.82762f)), owning_building_guid = 24)
       LocalObject(104, Door.Constructor(Vector3(1495.709f, 2071.811f, 101.8276f)), owning_building_guid = 24)
@@ -650,7 +650,7 @@ object Map99 { // Extinction
     Building17()
 
     def Building17(): Unit = { // Name: Blue_Watch_Tower Type: tower_b GUID: 25, MapID: 17
-      LocalBuilding("Blue_Watch_Tower", 25, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2366f, 2560f, 86.32954f), tower_b)))
+      LocalBuilding("Blue_Watch_Tower", 25, 17, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2366f, 2560f, 86.32954f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(709, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 25)
       LocalObject(142, Door.Constructor(Vector3(2378f, 2552f, 87.84953f)), owning_building_guid = 25)
       LocalObject(143, Door.Constructor(Vector3(2378f, 2552f, 97.84953f)), owning_building_guid = 25)
@@ -687,7 +687,7 @@ object Map99 { // Extinction
     Building16()
 
     def Building16(): Unit = { // Name: Indigo_Watch_Tower Type: tower_b GUID: 26, MapID: 16
-      LocalBuilding("Indigo_Watch_Tower", 26, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2450f, 1678f, 82.88522f), tower_b)))
+      LocalBuilding("Indigo_Watch_Tower", 26, 16, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2450f, 1678f, 82.88522f), Vector3(0f, 0f, 360f), tower_b)))
       LocalObject(710, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 26)
       LocalObject(149, Door.Constructor(Vector3(2462f, 1670f, 84.40522f)), owning_building_guid = 26)
       LocalObject(150, Door.Constructor(Vector3(2462f, 1670f, 94.40523f)), owning_building_guid = 26)
@@ -724,7 +724,7 @@ object Map99 { // Extinction
     Building10()
 
     def Building10(): Unit = { // Name: Red_Air_Tower Type: tower_c GUID: 27, MapID: 10
-      LocalBuilding("Red_Air_Tower", 27, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1166f, 1754f, 55.62273f), tower_c)))
+      LocalBuilding("Red_Air_Tower", 27, 10, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1166f, 1754f, 55.62273f), Vector3(0f, 0f, 270f), tower_c)))
       LocalObject(703, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 27)
       LocalObject(79, Door.Constructor(Vector3(1158f, 1742f, 57.14373f)), owning_building_guid = 27)
       LocalObject(80, Door.Constructor(Vector3(1158f, 1742f, 77.14273f)), owning_building_guid = 27)
@@ -765,7 +765,7 @@ object Map99 { // Extinction
     Building14()
 
     def Building14(): Unit = { // Name: Blue_Air_Tower Type: tower_c GUID: 28, MapID: 14
-      LocalBuilding("Blue_Air_Tower", 28, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2024f, 2914f, 64.3846f), tower_c)))
+      LocalBuilding("Blue_Air_Tower", 28, 14, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2024f, 2914f, 64.3846f), Vector3(0f, 0f, 208f), tower_c)))
       LocalObject(706, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 28)
       LocalObject(124, Door.Constructor(Vector3(2009.649f, 2915.43f, 65.9056f)), owning_building_guid = 28)
       LocalObject(125, Door.Constructor(Vector3(2009.649f, 2915.43f, 85.9046f)), owning_building_guid = 28)
@@ -806,7 +806,7 @@ object Map99 { // Extinction
     Building11()
 
     def Building11(): Unit = { // Name: Indigo_Air_Tower Type: tower_c GUID: 29, MapID: 11
-      LocalBuilding("Indigo_Air_Tower", 29, 11, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2856f, 1380f, 67.77856f), tower_c)))
+      LocalBuilding("Indigo_Air_Tower", 29, 11, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(2856f, 1380f, 67.77856f), Vector3(0f, 0f, 360f), tower_c)))
       LocalObject(711, CaptureTerminal.Constructor(secondary_capture), owning_building_guid = 29)
       LocalObject(171, Door.Constructor(Vector3(2868f, 1372f, 69.29956f)), owning_building_guid = 29)
       LocalObject(172, Door.Constructor(Vector3(2868f, 1372f, 89.29855f)), owning_building_guid = 29)

--- a/pslogin/src/main/scala/zonemaps/Ugd01.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd01.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd01 { // Supai
   val ZoneMap = new ZoneMap("ugd01") {
     Scale = MapScale.Dim2560
-    Cavern = true
     Checksum = 3405929729L
 
     Building10140()
 
     def Building10140(): Unit = { // Name: ceiling_bldg_a_10140 Type: ceiling_bldg_a GUID: 1, MapID: 10140
-      LocalBuilding("ceiling_bldg_a_10140", 1, 10140, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(850.56f, 1038.27f, 170.61f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10140", 1, 10140, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(850.56f, 1038.27f, 170.61f), Vector3(0f, 0f, 0f), ceiling_bldg_a)))
       LocalObject(571, Door.Constructor(Vector3(836.576f, 1045.967f, 172.389f)), owning_building_guid = 1)
       LocalObject(580, Door.Constructor(Vector3(865.815f, 1027.238f, 177.895f)), owning_building_guid = 1)
       LocalObject(581, Door.Constructor(Vector3(865.815f, 1051.238f, 177.895f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd01 { // Supai
     Building10141()
 
     def Building10141(): Unit = { // Name: ceiling_bldg_b_10141 Type: ceiling_bldg_b GUID: 2, MapID: 10141
-      LocalBuilding("ceiling_bldg_b_10141", 2, 10141, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(950.1f, 921.84f, 163.91f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10141", 2, 10141, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(950.1f, 921.84f, 163.91f), Vector3(0f, 0f, 0f), ceiling_bldg_b)))
       LocalObject(595, Door.Constructor(Vector3(952.115f, 938.33f, 165.689f)), owning_building_guid = 2)
       LocalObject(596, Door.Constructor(Vector3(956.116f, 920.83f, 165.689f)), owning_building_guid = 2)
     }
@@ -39,7 +38,7 @@ object Ugd01 { // Supai
     Building10138()
 
     def Building10138(): Unit = { // Name: ceiling_bldg_c_10138 Type: ceiling_bldg_c GUID: 3, MapID: 10138
-      LocalBuilding("ceiling_bldg_c_10138", 3, 10138, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1077.18f, 1115.65f, 154.15f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10138", 3, 10138, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1077.18f, 1115.65f, 154.15f), Vector3(0f, 0f, 217f), ceiling_bldg_c)))
       LocalObject(620, Door.Constructor(Vector3(1033.541f, 1097.152f, 155.929f)), owning_building_guid = 3)
       LocalObject(623, Door.Constructor(Vector3(1052.197f, 1072.395f, 155.929f)), owning_building_guid = 3)
       LocalObject(624, Door.Constructor(Vector3(1080.784f, 1113.377f, 155.929f)), owning_building_guid = 3)
@@ -48,7 +47,7 @@ object Ugd01 { // Supai
     Building10312()
 
     def Building10312(): Unit = { // Name: ceiling_bldg_d_10312 Type: ceiling_bldg_d GUID: 4, MapID: 10312
-      LocalBuilding("ceiling_bldg_d_10312", 4, 10312, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(993.7f, 1408.09f, 161.96f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10312", 4, 10312, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(993.7f, 1408.09f, 161.96f), Vector3(0f, 0f, 0f), ceiling_bldg_d)))
       LocalObject(601, Door.Constructor(Vector3(976.21f, 1408.106f, 163.695f)), owning_building_guid = 4)
       LocalObject(610, Door.Constructor(Vector3(993.716f, 1390.58f, 163.695f)), owning_building_guid = 4)
       LocalObject(611, Door.Constructor(Vector3(993.716f, 1425.58f, 163.695f)), owning_building_guid = 4)
@@ -59,7 +58,7 @@ object Ugd01 { // Supai
     Building10139()
 
     def Building10139(): Unit = { // Name: ceiling_bldg_d_10139 Type: ceiling_bldg_d GUID: 5, MapID: 10139
-      LocalBuilding("ceiling_bldg_d_10139", 5, 10139, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.02f, 1242.45f, 159.65f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10139", 5, 10139, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.02f, 1242.45f, 159.65f), Vector3(0f, 0f, 0f), ceiling_bldg_d)))
       LocalObject(643, Door.Constructor(Vector3(1269.53f, 1242.466f, 161.385f)), owning_building_guid = 5)
       LocalObject(648, Door.Constructor(Vector3(1287.036f, 1224.94f, 161.385f)), owning_building_guid = 5)
       LocalObject(649, Door.Constructor(Vector3(1287.036f, 1259.94f, 161.385f)), owning_building_guid = 5)
@@ -70,7 +69,7 @@ object Ugd01 { // Supai
     Building10143()
 
     def Building10143(): Unit = { // Name: ceiling_bldg_e_10143 Type: ceiling_bldg_e GUID: 6, MapID: 10143
-      LocalBuilding("ceiling_bldg_e_10143", 6, 10143, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1408.75f, 1242.78f, 167.66f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10143", 6, 10143, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1408.75f, 1242.78f, 167.66f), Vector3(0f, 0f, 0f), ceiling_bldg_e)))
       LocalObject(685, Door.Constructor(Vector3(1396.734f, 1241.79f, 169.439f)), owning_building_guid = 6)
       LocalObject(691, Door.Constructor(Vector3(1412.734f, 1275.29f, 174.939f)), owning_building_guid = 6)
       LocalObject(693, Door.Constructor(Vector3(1427.76f, 1270.796f, 169.439f)), owning_building_guid = 6)
@@ -80,7 +79,7 @@ object Ugd01 { // Supai
     Building10142()
 
     def Building10142(): Unit = { // Name: ceiling_bldg_f_10142 Type: ceiling_bldg_f GUID: 7, MapID: 10142
-      LocalBuilding("ceiling_bldg_f_10142", 7, 10142, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1376.58f, 1348.91f, 159.37f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10142", 7, 10142, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1376.58f, 1348.91f, 159.37f), Vector3(0f, 0f, 151f), ceiling_bldg_f)))
       LocalObject(668, Door.Constructor(Vector3(1352.277f, 1329.785f, 161.149f)), owning_building_guid = 7)
       LocalObject(686, Door.Constructor(Vector3(1404.189f, 1356.455f, 161.149f)), owning_building_guid = 7)
     }
@@ -88,7 +87,7 @@ object Ugd01 { // Supai
     Building10145()
 
     def Building10145(): Unit = { // Name: ceiling_bldg_g_10145 Type: ceiling_bldg_g GUID: 8, MapID: 10145
-      LocalBuilding("ceiling_bldg_g_10145", 8, 10145, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1374.9f, 1025.85f, 162.66f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10145", 8, 10145, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1374.9f, 1025.85f, 162.66f), Vector3(0f, 0f, 41f), ceiling_bldg_g)))
       LocalObject(671, Door.Constructor(Vector3(1363.438f, 1039.06f, 164.439f)), owning_building_guid = 8)
       LocalObject(676, Door.Constructor(Vector3(1379.706f, 1008.152f, 164.439f)), owning_building_guid = 8)
     }
@@ -96,7 +95,7 @@ object Ugd01 { // Supai
     Building10146()
 
     def Building10146(): Unit = { // Name: ceiling_bldg_h_10146 Type: ceiling_bldg_h GUID: 9, MapID: 10146
-      LocalBuilding("ceiling_bldg_h_10146", 9, 10146, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1311.84f, 904.66f, 161.7f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10146", 9, 10146, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1311.84f, 904.66f, 161.7f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(650, Door.Constructor(Vector3(1295.35f, 900.676f, 163.479f)), owning_building_guid = 9)
       LocalObject(658, Door.Constructor(Vector3(1315.824f, 921.17f, 163.479f)), owning_building_guid = 9)
       LocalObject(663, Door.Constructor(Vector3(1322.925f, 893.472f, 165.979f)), owning_building_guid = 9)
@@ -105,7 +104,7 @@ object Ugd01 { // Supai
     Building10144()
 
     def Building10144(): Unit = { // Name: ceiling_bldg_i_10144 Type: ceiling_bldg_i GUID: 10, MapID: 10144
-      LocalBuilding("ceiling_bldg_i_10144", 10, 10144, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1206.94f, 1100.55f, 172.13f), ceiling_bldg_i)))
+      LocalBuilding("ceiling_bldg_i_10144", 10, 10144, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1206.94f, 1100.55f, 172.13f), Vector3(0f, 0f, 0f), ceiling_bldg_i)))
       LocalObject(636, Door.Constructor(Vector3(1182.45f, 1104.066f, 173.909f)), owning_building_guid = 10)
       LocalObject(642, Door.Constructor(Vector3(1232.45f, 1104.066f, 173.909f)), owning_building_guid = 10)
     }
@@ -113,7 +112,7 @@ object Ugd01 { // Supai
     Building10311()
 
     def Building10311(): Unit = { // Name: ceiling_bldg_j_10311 Type: ceiling_bldg_j GUID: 11, MapID: 10311
-      LocalBuilding("ceiling_bldg_j_10311", 11, 10311, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(940.03f, 1345.53f, 162.79f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10311", 11, 10311, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(940.03f, 1345.53f, 162.79f), Vector3(0f, 0f, 0f), ceiling_bldg_j)))
       LocalObject(592, Door.Constructor(Vector3(940.046f, 1333.02f, 164.569f)), owning_building_guid = 11)
       LocalObject(593, Door.Constructor(Vector3(940.046f, 1358.02f, 164.569f)), owning_building_guid = 11)
     }
@@ -121,7 +120,7 @@ object Ugd01 { // Supai
     Building10310()
 
     def Building10310(): Unit = { // Name: ceiling_bldg_z_10310 Type: ceiling_bldg_z GUID: 12, MapID: 10310
-      LocalBuilding("ceiling_bldg_z_10310", 12, 10310, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.73f, 1181.27f, 165.51f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10310", 12, 10310, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.73f, 1181.27f, 165.51f), Vector3(0f, 0f, 27f), ceiling_bldg_z)))
       LocalObject(619, Door.Constructor(Vector3(1032.086f, 1173.73f, 167.289f)), owning_building_guid = 12)
       LocalObject(625, Door.Constructor(Vector3(1082.873f, 1199.608f, 167.289f)), owning_building_guid = 12)
     }
@@ -129,7 +128,7 @@ object Ugd01 { // Supai
     Building10029()
 
     def Building10029(): Unit = { // Name: ground_bldg_b_10029 Type: ground_bldg_b GUID: 61, MapID: 10029
-      LocalBuilding("ground_bldg_b_10029", 61, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(794.78f, 864.61f, 103.74f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10029", 61, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(794.78f, 864.61f, 103.74f), Vector3(0f, 0f, 75f), ground_bldg_b)))
       LocalObject(552, Door.Constructor(Vector3(779.3734f, 870.8243f, 105.519f)), owning_building_guid = 61)
       LocalObject(554, Door.Constructor(Vector3(795.3158f, 889.8535f, 111.019f)), owning_building_guid = 61)
       LocalObject(556, Door.Constructor(Vector3(797.3127f, 870.1596f, 105.519f)), owning_building_guid = 61)
@@ -138,7 +137,7 @@ object Ugd01 { // Supai
     Building10016()
 
     def Building10016(): Unit = { // Name: ground_bldg_b_10016 Type: ground_bldg_b GUID: 62, MapID: 10016
-      LocalBuilding("ground_bldg_b_10016", 62, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(865.1f, 916.28f, 85.19f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10016", 62, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(865.1f, 916.28f, 85.19f), Vector3(0f, 0f, 215f), ground_bldg_b)))
       LocalObject(573, Door.Constructor(Vector3(848.4634f, 897.2867f, 92.469f)), owning_building_guid = 62)
       LocalObject(578, Door.Constructor(Vector3(859.5927f, 913.6567f, 86.969f)), owning_building_guid = 62)
       LocalObject(584, Door.Constructor(Vector3(872.9077f, 901.6165f, 86.969f)), owning_building_guid = 62)
@@ -147,7 +146,7 @@ object Ugd01 { // Supai
     Building10077()
 
     def Building10077(): Unit = { // Name: ground_bldg_b_10077 Type: ground_bldg_b GUID: 63, MapID: 10077
-      LocalBuilding("ground_bldg_b_10077", 63, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(998.78f, 1510.64f, 87.06f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10077", 63, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(998.78f, 1510.64f, 87.06f), Vector3(0f, 0f, 41f), ground_bldg_b)))
       LocalObject(607, Door.Constructor(Vector3(989.4824f, 1524.407f, 88.839f)), owning_building_guid = 63)
       LocalObject(614, Door.Constructor(Vector3(1003.983f, 1513.825f, 88.839f)), owning_building_guid = 63)
       LocalObject(616, Door.Constructor(Vector3(1013.34f, 1531.268f, 94.339f)), owning_building_guid = 63)
@@ -156,7 +155,7 @@ object Ugd01 { // Supai
     Building10066()
 
     def Building10066(): Unit = { // Name: ground_bldg_b_10066 Type: ground_bldg_b GUID: 64, MapID: 10066
-      LocalBuilding("ground_bldg_b_10066", 64, 10066, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1041.45f, 1317.49f, 90.89f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10066", 64, 10066, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1041.45f, 1317.49f, 90.89f), Vector3(0f, 0f, 80f), ground_bldg_b)))
       LocalObject(618, Door.Constructor(Vector3(1025.56f, 1322.338f, 92.669f)), owning_building_guid = 64)
       LocalObject(621, Door.Constructor(Vector3(1039.784f, 1342.684f, 98.169f)), owning_building_guid = 64)
       LocalObject(622, Door.Constructor(Vector3(1043.489f, 1323.239f, 92.669f)), owning_building_guid = 64)
@@ -165,7 +164,7 @@ object Ugd01 { // Supai
     Building10031()
 
     def Building10031(): Unit = { // Name: ground_bldg_b_10031 Type: ground_bldg_b GUID: 65, MapID: 10031
-      LocalBuilding("ground_bldg_b_10031", 65, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1384.96f, 1262.28f, 85.22f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10031", 65, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1384.96f, 1262.28f, 85.22f), Vector3(0f, 0f, 150f), ground_bldg_b)))
       LocalObject(670, Door.Constructor(Vector3(1360.715f, 1269.331f, 92.499f)), owning_building_guid = 65)
       LocalObject(674, Door.Constructor(Vector3(1374.97f, 1249.007f, 86.999f)), owning_building_guid = 65)
       LocalObject(677, Door.Constructor(Vector3(1380.255f, 1266.163f, 86.999f)), owning_building_guid = 65)
@@ -174,7 +173,7 @@ object Ugd01 { // Supai
     Building10025()
 
     def Building10025(): Unit = { // Name: ground_bldg_b_10025 Type: ground_bldg_b GUID: 66, MapID: 10025
-      LocalBuilding("ground_bldg_b_10025", 66, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.42f, 1346.97f, 87.93f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10025", 66, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.42f, 1346.97f, 87.93f), Vector3(0f, 0f, 250f), ground_bldg_b)))
       LocalObject(707, Door.Constructor(Vector3(1490.413f, 1341.662f, 89.709f)), owning_building_guid = 66)
       LocalObject(708, Door.Constructor(Vector3(1490.686f, 1321.869f, 95.209f)), owning_building_guid = 66)
       LocalObject(714, Door.Constructor(Vector3(1508.226f, 1339.437f, 89.709f)), owning_building_guid = 66)
@@ -183,7 +182,7 @@ object Ugd01 { // Supai
     Building10017()
 
     def Building10017(): Unit = { // Name: ground_bldg_c_10017 Type: ground_bldg_c GUID: 67, MapID: 10017
-      LocalBuilding("ground_bldg_c_10017", 67, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(786.51f, 954.37f, 105.26f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10017", 67, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(786.51f, 954.37f, 105.26f), Vector3(0f, 0f, 325f), ground_bldg_c)))
       LocalObject(553, Door.Constructor(Vector3(787.5582f, 958.4996f, 107.039f)), owning_building_guid = 67)
       LocalObject(562, Door.Constructor(Vector3(817.5875f, 918.5826f, 107.039f)), owning_building_guid = 67)
       LocalObject(570, Door.Constructor(Vector3(835.3683f, 943.9763f, 107.039f)), owning_building_guid = 67)
@@ -192,7 +191,7 @@ object Ugd01 { // Supai
     Building10030()
 
     def Building10030(): Unit = { // Name: ground_bldg_c_10030 Type: ground_bldg_c GUID: 68, MapID: 10030
-      LocalBuilding("ground_bldg_c_10030", 68, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(857.33f, 852.26f, 107.42f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10030", 68, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(857.33f, 852.26f, 107.42f), Vector3(0f, 0f, 215f), ground_bldg_c)))
       LocalObject(560, Door.Constructor(Vector3(813.0717f, 835.2968f, 109.199f)), owning_building_guid = 68)
       LocalObject(567, Door.Constructor(Vector3(830.8526f, 809.903f, 109.199f)), owning_building_guid = 68)
       LocalObject(579, Door.Constructor(Vector3(860.8521f, 849.8626f, 109.199f)), owning_building_guid = 68)
@@ -201,7 +200,7 @@ object Ugd01 { // Supai
     Building10067()
 
     def Building10067(): Unit = { // Name: ground_bldg_c_10067 Type: ground_bldg_c GUID: 69, MapID: 10067
-      LocalBuilding("ground_bldg_c_10067", 69, 10067, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.9f, 1275.59f, 108.53f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10067", 69, 10067, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.9f, 1275.59f, 108.53f), Vector3(0f, 0f, 275f), ground_bldg_c)))
       LocalObject(597, Door.Constructor(Vector3(966.4615f, 1228.78f, 110.309f)), owning_building_guid = 69)
       LocalObject(603, Door.Constructor(Vector3(977.7372f, 1277.441f, 110.309f)), owning_building_guid = 69)
       LocalObject(613, Door.Constructor(Vector3(997.3436f, 1231.481f, 110.309f)), owning_building_guid = 69)
@@ -210,7 +209,7 @@ object Ugd01 { // Supai
     Building10305()
 
     def Building10305(): Unit = { // Name: ground_bldg_c_10305 Type: ground_bldg_c GUID: 70, MapID: 10305
-      LocalBuilding("ground_bldg_c_10305", 70, 10305, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.71f, 996.36f, 107.32f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10305", 70, 10305, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.71f, 996.36f, 107.32f), Vector3(0f, 0f, 330f), ground_bldg_c)))
       LocalObject(644, Door.Constructor(Vector3(1272.394f, 1000.565f, 109.099f)), owning_building_guid = 70)
       LocalObject(653, Door.Constructor(Vector3(1305.788f, 963.4174f, 109.099f)), owning_building_guid = 70)
       LocalObject(661, Door.Constructor(Vector3(1321.288f, 990.2642f, 109.099f)), owning_building_guid = 70)
@@ -219,7 +218,7 @@ object Ugd01 { // Supai
     Building10022()
 
     def Building10022(): Unit = { // Name: ground_bldg_c_10022 Type: ground_bldg_c GUID: 71, MapID: 10022
-      LocalBuilding("ground_bldg_c_10022", 71, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1456.97f, 1345.86f, 103.88f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10022", 71, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1456.97f, 1345.86f, 103.88f), Vector3(0f, 0f, 140f), ground_bldg_c)))
       LocalObject(688, Door.Constructor(Vector3(1409.203f, 1360.472f, 105.659f)), owning_building_guid = 71)
       LocalObject(694, Door.Constructor(Vector3(1429.13f, 1384.22f, 105.659f)), owning_building_guid = 71)
       LocalObject(698, Door.Constructor(Vector3(1455.566f, 1341.837f, 105.659f)), owning_building_guid = 71)
@@ -228,7 +227,7 @@ object Ugd01 { // Supai
     Building10096()
 
     def Building10096(): Unit = { // Name: ground_bldg_c_10096 Type: ground_bldg_c GUID: 72, MapID: 10096
-      LocalBuilding("ground_bldg_c_10096", 72, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1481.1f, 1136.17f, 101.01f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10096", 72, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1481.1f, 1136.17f, 101.01f), Vector3(0f, 0f, 340f), ground_bldg_c)))
       LocalObject(703, Door.Constructor(Vector3(1481.044f, 1140.43f, 102.789f)), owning_building_guid = 72)
       LocalObject(718, Door.Constructor(Vector3(1520.381f, 1109.646f, 102.789f)), owning_building_guid = 72)
       LocalObject(719, Door.Constructor(Vector3(1530.984f, 1138.776f, 102.789f)), owning_building_guid = 72)
@@ -237,7 +236,7 @@ object Ugd01 { // Supai
     Building10027()
 
     def Building10027(): Unit = { // Name: ground_bldg_c_10027 Type: ground_bldg_c GUID: 73, MapID: 10027
-      LocalBuilding("ground_bldg_c_10027", 73, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.89f, 1467.82f, 105.26f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10027", 73, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1493.89f, 1467.82f, 105.26f), Vector3(0f, 0f, 315f), ground_bldg_c)))
       LocalObject(709, Door.Constructor(Vector3(1495.639f, 1471.705f, 107.039f)), owning_building_guid = 73)
       LocalObject(717, Door.Constructor(Vector3(1518.281f, 1427.18f, 107.039f)), owning_building_guid = 73)
       LocalObject(720, Door.Constructor(Vector3(1540.201f, 1449.1f, 107.039f)), owning_building_guid = 73)
@@ -246,7 +245,7 @@ object Ugd01 { // Supai
     Building10028()
 
     def Building10028(): Unit = { // Name: ground_bldg_d_10028 Type: ground_bldg_d GUID: 74, MapID: 10028
-      LocalBuilding("ground_bldg_d_10028", 74, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(748.19f, 914.57f, 104.86f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10028", 74, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(748.19f, 914.57f, 104.86f), Vector3(0f, 0f, 215f), ground_bldg_d)))
       LocalObject(547, Door.Constructor(Vector3(733.8558f, 904.5135f, 106.595f)), owning_building_guid = 74)
       LocalObject(548, Door.Constructor(Vector3(738.1335f, 928.9042f, 106.595f)), owning_building_guid = 74)
       LocalObject(550, Door.Constructor(Vector3(758.2087f, 900.2339f, 106.595f)), owning_building_guid = 74)
@@ -256,7 +255,7 @@ object Ugd01 { // Supai
     Building10074()
 
     def Building10074(): Unit = { // Name: ground_bldg_d_10074 Type: ground_bldg_d GUID: 75, MapID: 10074
-      LocalBuilding("ground_bldg_d_10074", 75, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.93f, 1166.25f, 99.66f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10074", 75, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.93f, 1166.25f, 99.66f), Vector3(0f, 0f, 235f), ground_bldg_d)))
       LocalObject(565, Door.Constructor(Vector3(824.5775f, 1176.28f, 101.395f)), owning_building_guid = 75)
       LocalObject(566, Door.Constructor(Vector3(828.8998f, 1151.897f, 101.395f)), owning_building_guid = 75)
       LocalObject(574, Door.Constructor(Vector3(848.975f, 1180.568f, 101.395f)), owning_building_guid = 75)
@@ -266,7 +265,7 @@ object Ugd01 { // Supai
     Building10018()
 
     def Building10018(): Unit = { // Name: ground_bldg_d_10018 Type: ground_bldg_d GUID: 76, MapID: 10018
-      LocalBuilding("ground_bldg_d_10018", 76, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.98f, 1013.84f, 90.81f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10018", 76, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(838.98f, 1013.84f, 90.81f), Vector3(0f, 0f, 160f), ground_bldg_d)))
       LocalObject(564, Door.Constructor(Vector3(822.5205f, 1019.814f, 92.545f)), owning_building_guid = 76)
       LocalObject(568, Door.Constructor(Vector3(832.983f, 997.4103f, 92.545f)), owning_building_guid = 76)
       LocalObject(572, Door.Constructor(Vector3(844.9537f, 1030.3f, 92.545f)), owning_building_guid = 76)
@@ -276,7 +275,7 @@ object Ugd01 { // Supai
     Building10078()
 
     def Building10078(): Unit = { // Name: ground_bldg_d_10078 Type: ground_bldg_d GUID: 77, MapID: 10078
-      LocalBuilding("ground_bldg_d_10078", 77, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1107.02f, 1332.16f, 95.93f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10078", 77, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1107.02f, 1332.16f, 95.93f), Vector3(0f, 0f, 229f), ground_bldg_d)))
       LocalObject(626, Door.Constructor(Vector3(1093.795f, 1343.635f, 97.665f)), owning_building_guid = 77)
       LocalObject(627, Door.Constructor(Vector3(1095.545f, 1318.935f, 97.665f)), owning_building_guid = 77)
       LocalObject(629, Door.Constructor(Vector3(1118.507f, 1345.349f, 97.665f)), owning_building_guid = 77)
@@ -286,7 +285,7 @@ object Ugd01 { // Supai
     Building10093()
 
     def Building10093(): Unit = { // Name: ground_bldg_d_10093 Type: ground_bldg_d GUID: 78, MapID: 10093
-      LocalBuilding("ground_bldg_d_10093", 78, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.91f, 1035.28f, 97.66f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10093", 78, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.91f, 1035.28f, 97.66f), Vector3(0f, 0f, 285f), ground_bldg_d)))
       LocalObject(637, Door.Constructor(Vector3(1185.001f, 1030.733f, 99.395f)), owning_building_guid = 78)
       LocalObject(638, Door.Constructor(Vector3(1197.399f, 1052.178f, 99.395f)), owning_building_guid = 78)
       LocalObject(639, Door.Constructor(Vector3(1206.457f, 1018.371f, 99.395f)), owning_building_guid = 78)
@@ -296,7 +295,7 @@ object Ugd01 { // Supai
     Building10023()
 
     def Building10023(): Unit = { // Name: ground_bldg_d_10023 Type: ground_bldg_d GUID: 79, MapID: 10023
-      LocalBuilding("ground_bldg_d_10023", 79, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1363.37f, 1403.85f, 88.96f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10023", 79, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1363.37f, 1403.85f, 88.96f), Vector3(0f, 0f, 60f), ground_bldg_d)))
       LocalObject(667, Door.Constructor(Vector3(1348.231f, 1412.609f, 90.695f)), owning_building_guid = 79)
       LocalObject(669, Door.Constructor(Vector3(1354.611f, 1388.711f, 90.695f)), owning_building_guid = 79)
       LocalObject(673, Door.Constructor(Vector3(1372.111f, 1419.022f, 90.695f)), owning_building_guid = 79)
@@ -306,7 +305,7 @@ object Ugd01 { // Supai
     Building10094()
 
     def Building10094(): Unit = { // Name: ground_bldg_d_10094 Type: ground_bldg_d GUID: 80, MapID: 10094
-      LocalBuilding("ground_bldg_d_10094", 80, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1399.93f, 1061.29f, 97.66f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10094", 80, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1399.93f, 1061.29f, 97.66f), Vector3(0f, 0f, 225f), ground_bldg_d)))
       LocalObject(680, Door.Constructor(Vector3(1387.56f, 1048.897f, 99.395f)), owning_building_guid = 80)
       LocalObject(681, Door.Constructor(Vector3(1387.537f, 1073.66f, 99.395f)), owning_building_guid = 80)
       LocalObject(689, Door.Constructor(Vector3(1412.286f, 1048.911f, 99.395f)), owning_building_guid = 80)
@@ -316,7 +315,7 @@ object Ugd01 { // Supai
     Building10026()
 
     def Building10026(): Unit = { // Name: ground_bldg_d_10026 Type: ground_bldg_d GUID: 81, MapID: 10026
-      LocalBuilding("ground_bldg_d_10026", 81, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1492.58f, 1397.16f, 90.81f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10026", 81, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1492.58f, 1397.16f, 90.81f), Vector3(0f, 0f, 60f), ground_bldg_d)))
       LocalObject(702, Door.Constructor(Vector3(1477.441f, 1405.919f, 92.545f)), owning_building_guid = 81)
       LocalObject(705, Door.Constructor(Vector3(1483.821f, 1382.021f, 92.545f)), owning_building_guid = 81)
       LocalObject(711, Door.Constructor(Vector3(1501.321f, 1412.332f, 92.545f)), owning_building_guid = 81)
@@ -326,7 +325,7 @@ object Ugd01 { // Supai
     Building10020()
 
     def Building10020(): Unit = { // Name: ground_bldg_i_10020 Type: ground_bldg_i GUID: 82, MapID: 10020
-      LocalBuilding("ground_bldg_i_10020", 82, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(745.29f, 997.76f, 95.81f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10020", 82, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(745.29f, 997.76f, 95.81f), Vector3(0f, 0f, 60f), ground_bldg_i)))
       LocalObject(546, Door.Constructor(Vector3(730.0001f, 978.309f, 97.589f)), owning_building_guid = 82)
       LocalObject(549, Door.Constructor(Vector3(755.0001f, 1021.61f, 97.589f)), owning_building_guid = 82)
     }
@@ -334,7 +333,7 @@ object Ugd01 { // Supai
     Building10019()
 
     def Building10019(): Unit = { // Name: ground_bldg_i_10019 Type: ground_bldg_i GUID: 83, MapID: 10019
-      LocalBuilding("ground_bldg_i_10019", 83, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(906.71f, 986.08f, 94.15f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10019", 83, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(906.71f, 986.08f, 94.15f), Vector3(0f, 0f, 30f), ground_bldg_i)))
       LocalObject(586, Door.Constructor(Vector3(883.743f, 976.8799f, 95.929f)), owning_building_guid = 83)
       LocalObject(591, Door.Constructor(Vector3(927.0443f, 1001.88f, 95.929f)), owning_building_guid = 83)
     }
@@ -342,7 +341,7 @@ object Ugd01 { // Supai
     Building10095()
 
     def Building10095(): Unit = { // Name: ground_bldg_i_10095 Type: ground_bldg_i GUID: 84, MapID: 10095
-      LocalBuilding("ground_bldg_i_10095", 84, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1253.14f, 913.31f, 102.44f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10095", 84, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1253.14f, 913.31f, 102.44f), Vector3(0f, 0f, 150f), ground_bldg_i)))
       LocalObject(641, Door.Constructor(Vector3(1229.29f, 923.0201f, 104.219f)), owning_building_guid = 84)
       LocalObject(645, Door.Constructor(Vector3(1272.591f, 898.0201f, 104.219f)), owning_building_guid = 84)
     }
@@ -350,7 +349,7 @@ object Ugd01 { // Supai
     Building10092()
 
     def Building10092(): Unit = { // Name: ground_bldg_i_10092 Type: ground_bldg_i GUID: 85, MapID: 10092
-      LocalBuilding("ground_bldg_i_10092", 85, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.38f, 1163.11f, 92.1f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10092", 85, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.38f, 1163.11f, 92.1f), Vector3(0f, 0f, 180f), ground_bldg_i)))
       LocalObject(647, Door.Constructor(Vector3(1281.87f, 1159.594f, 93.879f)), owning_building_guid = 85)
       LocalObject(666, Door.Constructor(Vector3(1331.87f, 1159.594f, 93.879f)), owning_building_guid = 85)
     }
@@ -358,7 +357,7 @@ object Ugd01 { // Supai
     Building10024()
 
     def Building10024(): Unit = { // Name: ground_bldg_i_10024 Type: ground_bldg_i GUID: 86, MapID: 10024
-      LocalBuilding("ground_bldg_i_10024", 86, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1439.95f, 1456.47f, 91.36f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10024", 86, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1439.95f, 1456.47f, 91.36f), Vector3(0f, 0f, 335f), ground_bldg_i)))
       LocalObject(692, Door.Constructor(Vector3(1419.24f, 1470.006f, 93.139f)), owning_building_guid = 86)
       LocalObject(700, Door.Constructor(Vector3(1464.556f, 1448.876f, 93.139f)), owning_building_guid = 86)
     }
@@ -366,7 +365,7 @@ object Ugd01 { // Supai
     Building10021()
 
     def Building10021(): Unit = { // Name: ground_bldg_i_10021 Type: ground_bldg_i GUID: 87, MapID: 10021
-      LocalBuilding("ground_bldg_i_10021", 87, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1451.54f, 1274.29f, 94.15f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10021", 87, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1451.54f, 1274.29f, 94.15f), Vector3(0f, 0f, 40f), ground_bldg_i)))
       LocalObject(695, Door.Constructor(Vector3(1430.52f, 1261.242f, 95.929f)), owning_building_guid = 87)
       LocalObject(701, Door.Constructor(Vector3(1468.822f, 1293.381f, 95.929f)), owning_building_guid = 87)
     }
@@ -374,7 +373,7 @@ object Ugd01 { // Supai
     Building10425()
 
     def Building10425(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 88, MapID: 10425
-      LocalBuilding("N_Redoubt", 88, 10425, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(882.39f, 1471.4f, 90.88f), redoubt)))
+      LocalBuilding("N_Redoubt", 88, 10425, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(882.39f, 1471.4f, 90.88f), Vector3(0f, 0f, 335f), redoubt)))
       LocalObject(832, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 88)
       LocalObject(582, Door.Constructor(Vector3(866.5455f, 1478.806f, 92.615f)), owning_building_guid = 88)
       LocalObject(585, Door.Constructor(Vector3(876.3672f, 1487.536f, 102.659f)), owning_building_guid = 88)
@@ -391,7 +390,7 @@ object Ugd01 { // Supai
     Building10883()
 
     def Building10883(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 89, MapID: 10883
-      LocalBuilding("S_Redoubt", 89, 10883, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1399.41f, 850.5f, 91.78f), redoubt)))
+      LocalBuilding("S_Redoubt", 89, 10883, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1399.41f, 850.5f, 91.78f), Vector3(0f, 0f, 72f), redoubt)))
       LocalObject(835, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 89)
       LocalObject(678, Door.Constructor(Vector3(1384.128f, 842.5555f, 103.559f)), owning_building_guid = 89)
       LocalObject(679, Door.Constructor(Vector3(1386.684f, 850.4081f, 103.539f)), owning_building_guid = 89)
@@ -408,7 +407,7 @@ object Ugd01 { // Supai
     Building10175()
 
     def Building10175(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 171, MapID: 10175
-      LocalBuilding("S_Stasis", 171, 10175, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(983.99f, 1034.17f, 94.51f), vanu_control_point)))
+      LocalBuilding("S_Stasis", 171, 10175, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(983.99f, 1034.17f, 94.51f), Vector3(0f, 0f, 281f), vanu_control_point)))
       LocalObject(833, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 171)
       LocalObject(594, Door.Constructor(Vector3(950.054f, 1050.163f, 96.289f)), owning_building_guid = 171)
       LocalObject(598, Door.Constructor(Vector3(967.2758f, 983.8116f, 96.289f)), owning_building_guid = 171)
@@ -441,7 +440,7 @@ object Ugd01 { // Supai
     Building10000()
 
     def Building10000(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 172, MapID: 10000
-      LocalBuilding("N_Stasis", 172, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1316.27f, 1321.48f, 88.98f), vanu_control_point)))
+      LocalBuilding("N_Stasis", 172, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1316.27f, 1321.48f, 88.98f), Vector3(0f, 0f, 37f), vanu_control_point)))
       LocalObject(834, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 172)
       LocalObject(646, Door.Constructor(Vector3(1280.496f, 1312.072f, 90.759f)), owning_building_guid = 172)
       LocalObject(652, Door.Constructor(Vector3(1305.138f, 1325.94f, 120.759f)), owning_building_guid = 172)
@@ -474,7 +473,7 @@ object Ugd01 { // Supai
     Building10015()
 
     def Building10015(): Unit = { // Name: Core Type: vanu_core GUID: 173, MapID: 10015
-      LocalBuilding("Core", 173, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1151.45f, 1177.46f, 95.63f), vanu_core)))
+      LocalBuilding("Core", 173, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1151.45f, 1177.46f, 95.63f), Vector3(0f, 0f, 322f), vanu_core)))
       LocalObject(628, Door.Constructor(Vector3(1118.471f, 1188.026f, 102.418f)), owning_building_guid = 173)
       LocalObject(631, Door.Constructor(Vector3(1123.351f, 1148.027f, 102.418f)), owning_building_guid = 173)
       LocalObject(632, Door.Constructor(Vector3(1123.351f, 1148.027f, 107.418f)), owning_building_guid = 173)
@@ -486,7 +485,7 @@ object Ugd01 { // Supai
     Building10001()
 
     def Building10001(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 216, MapID: 10001
-      LocalBuilding("N_ATPlant", 216, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(851.77f, 1352.04f, 100.81f), vanu_vehicle_station)))
+      LocalBuilding("N_ATPlant", 216, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(851.77f, 1352.04f, 100.81f), Vector3(0f, 0f, 321f), vanu_vehicle_station)))
       LocalObject(831, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 216)
       LocalObject(555, Door.Constructor(Vector3(795.9202f, 1354.002f, 132.589f)), owning_building_guid = 216)
       LocalObject(557, Door.Constructor(Vector3(801.1134f, 1360.407f, 132.569f)), owning_building_guid = 216)
@@ -510,7 +509,7 @@ object Ugd01 { // Supai
     Building10314()
 
     def Building10314(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 217, MapID: 10314
-      LocalBuilding("S_ATPlant", 217, 10314, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1467.03f, 931.27f, 94.78f), vanu_vehicle_station)))
+      LocalBuilding("S_ATPlant", 217, 10314, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1467.03f, 931.27f, 94.78f), Vector3(0f, 0f, 98f), vanu_vehicle_station)))
       LocalObject(836, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 217)
       LocalObject(697, Door.Constructor(Vector3(1452.924f, 924.604f, 96.559f)), owning_building_guid = 217)
       LocalObject(699, Door.Constructor(Vector3(1464.283f, 901.9645f, 116.471f)), owning_building_guid = 217)

--- a/pslogin/src/main/scala/zonemaps/Ugd02.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd02.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd02 { // Hunhau
   val ZoneMap = new ZoneMap("ugd02") {
     Scale = MapScale.Dim2560
-    Cavern = true
     Checksum = 2702486449L
 
     Building10093()
 
     def Building10093(): Unit = { // Name: ceiling_bldg_a_10093 Type: ceiling_bldg_a GUID: 1, MapID: 10093
-      LocalBuilding("ceiling_bldg_a_10093", 1, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(922.89f, 1195.49f, 317.79f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10093", 1, 10093, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(922.89f, 1195.49f, 317.79f), Vector3(0f, 0f, 330f), ceiling_bldg_a)))
       LocalObject(1080, Door.Constructor(Vector3(914.628f, 1209.148f, 319.569f)), owning_building_guid = 1)
       LocalObject(1092, Door.Constructor(Vector3(930.5852f, 1178.308f, 325.075f)), owning_building_guid = 1)
       LocalObject(1093, Door.Constructor(Vector3(939.3843f, 1190.549f, 319.569f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd02 { // Hunhau
     Building10107()
 
     def Building10107(): Unit = { // Name: ceiling_bldg_a_10107 Type: ceiling_bldg_a GUID: 2, MapID: 10107
-      LocalBuilding("ceiling_bldg_a_10107", 2, 10107, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(960.11f, 1317.32f, 314.7f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10107", 2, 10107, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(960.11f, 1317.32f, 314.7f), Vector3(0f, 0f, 330f), ceiling_bldg_a)))
       LocalObject(1097, Door.Constructor(Vector3(951.848f, 1330.978f, 316.479f)), owning_building_guid = 2)
       LocalObject(1102, Door.Constructor(Vector3(967.8052f, 1300.138f, 321.985f)), owning_building_guid = 2)
       LocalObject(1105, Door.Constructor(Vector3(976.6042f, 1312.379f, 316.479f)), owning_building_guid = 2)
@@ -41,7 +40,7 @@ object Ugd02 { // Hunhau
     Building10105()
 
     def Building10105(): Unit = { // Name: ceiling_bldg_a_10105 Type: ceiling_bldg_a GUID: 3, MapID: 10105
-      LocalBuilding("ceiling_bldg_a_10105", 3, 10105, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1178.77f, 1916.87f, 236.1f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10105", 3, 10105, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1178.77f, 1916.87f, 236.1f), Vector3(0f, 0f, 330f), ceiling_bldg_a)))
       LocalObject(1134, Door.Constructor(Vector3(1170.508f, 1930.528f, 237.879f)), owning_building_guid = 3)
       LocalObject(1137, Door.Constructor(Vector3(1186.465f, 1899.688f, 243.385f)), owning_building_guid = 3)
       LocalObject(1141, Door.Constructor(Vector3(1195.264f, 1911.929f, 237.879f)), owning_building_guid = 3)
@@ -51,7 +50,7 @@ object Ugd02 { // Hunhau
     Building10084()
 
     def Building10084(): Unit = { // Name: ceiling_bldg_a_10084 Type: ceiling_bldg_a GUID: 4, MapID: 10084
-      LocalBuilding("ceiling_bldg_a_10084", 4, 10084, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1331.57f, 907.05f, 299.45f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10084", 4, 10084, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1331.57f, 907.05f, 299.45f), Vector3(0f, 0f, 0f), ceiling_bldg_a)))
       LocalObject(1190, Door.Constructor(Vector3(1317.586f, 914.747f, 301.229f)), owning_building_guid = 4)
       LocalObject(1194, Door.Constructor(Vector3(1346.825f, 896.018f, 306.735f)), owning_building_guid = 4)
       LocalObject(1195, Door.Constructor(Vector3(1346.825f, 920.018f, 306.735f)), owning_building_guid = 4)
@@ -61,7 +60,7 @@ object Ugd02 { // Hunhau
     Building10108()
 
     def Building10108(): Unit = { // Name: ceiling_bldg_b_10108 Type: ceiling_bldg_b GUID: 5, MapID: 10108
-      LocalBuilding("ceiling_bldg_b_10108", 5, 10108, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(710.38f, 1451.92f, 264.12f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10108", 5, 10108, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(710.38f, 1451.92f, 264.12f), Vector3(0f, 0f, 315f), ceiling_bldg_b)))
       LocalObject(1017, Door.Constructor(Vector3(713.9198f, 1446.952f, 265.899f)), owning_building_guid = 5)
       LocalObject(1020, Door.Constructor(Vector3(723.465f, 1462.155f, 265.899f)), owning_building_guid = 5)
     }
@@ -69,7 +68,7 @@ object Ugd02 { // Hunhau
     Building10078()
 
     def Building10078(): Unit = { // Name: ceiling_bldg_b_10078 Type: ceiling_bldg_b GUID: 6, MapID: 10078
-      LocalBuilding("ceiling_bldg_b_10078", 6, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(861.71f, 528.17f, 218.06f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10078", 6, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(861.71f, 528.17f, 218.06f), Vector3(0f, 0f, 0f), ceiling_bldg_b)))
       LocalObject(1053, Door.Constructor(Vector3(863.725f, 544.66f, 219.839f)), owning_building_guid = 6)
       LocalObject(1056, Door.Constructor(Vector3(867.726f, 527.16f, 219.839f)), owning_building_guid = 6)
     }
@@ -77,7 +76,7 @@ object Ugd02 { // Hunhau
     Building10090()
 
     def Building10090(): Unit = { // Name: ceiling_bldg_b_10090 Type: ceiling_bldg_b GUID: 7, MapID: 10090
-      LocalBuilding("ceiling_bldg_b_10090", 7, 10090, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.1f, 1046.64f, 288.2f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10090", 7, 10090, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(973.1f, 1046.64f, 288.2f), Vector3(0f, 0f, 260f), ceiling_bldg_b)))
       LocalObject(1104, Door.Constructor(Vector3(971.0607f, 1040.891f, 289.979f)), owning_building_guid = 7)
       LocalObject(1109, Door.Constructor(Vector3(988.9896f, 1041.792f, 289.979f)), owning_building_guid = 7)
     }
@@ -85,7 +84,7 @@ object Ugd02 { // Hunhau
     Building10100()
 
     def Building10100(): Unit = { // Name: ceiling_bldg_b_10100 Type: ceiling_bldg_b GUID: 8, MapID: 10100
-      LocalBuilding("ceiling_bldg_b_10100", 8, 10100, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1217.11f, 1317.72f, 291.99f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10100", 8, 10100, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1217.11f, 1317.72f, 291.99f), Vector3(0f, 0f, 100f), ceiling_bldg_b)))
       LocalObject(1144, Door.Constructor(Vector3(1200.521f, 1316.841f, 293.769f)), owning_building_guid = 8)
       LocalObject(1150, Door.Constructor(Vector3(1217.06f, 1323.82f, 293.769f)), owning_building_guid = 8)
     }
@@ -93,7 +92,7 @@ object Ugd02 { // Hunhau
     Building10664()
 
     def Building10664(): Unit = { // Name: ceiling_bldg_b_10664 Type: ceiling_bldg_b GUID: 9, MapID: 10664
-      LocalBuilding("ceiling_bldg_b_10664", 9, 10664, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.66f, 785.69f, 273.36f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10664", 9, 10664, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.66f, 785.69f, 273.36f), Vector3(0f, 0f, 25f), ceiling_bldg_b)))
       LocalObject(1159, Door.Constructor(Vector3(1263.517f, 801.4866f, 275.139f)), owning_building_guid = 9)
       LocalObject(1168, Door.Constructor(Vector3(1274.539f, 787.3171f, 275.139f)), owning_building_guid = 9)
     }
@@ -101,7 +100,7 @@ object Ugd02 { // Hunhau
     Building10101()
 
     def Building10101(): Unit = { // Name: ceiling_bldg_c_10101 Type: ceiling_bldg_c GUID: 10, MapID: 10101
-      LocalBuilding("ceiling_bldg_c_10101", 10, 10101, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(732.43f, 973.16f, 280.28f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10101", 10, 10101, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(732.43f, 973.16f, 280.28f), Vector3(0f, 0f, 45f), ceiling_bldg_c)))
       LocalObject(1021, Door.Constructor(Vector3(728.5452f, 974.9094f, 282.059f)), owning_building_guid = 10)
       LocalObject(1024, Door.Constructor(Vector3(751.15f, 1019.471f, 282.059f)), owning_building_guid = 10)
       LocalObject(1029, Door.Constructor(Vector3(773.0703f, 997.5509f, 282.059f)), owning_building_guid = 10)
@@ -110,7 +109,7 @@ object Ugd02 { // Hunhau
     Building10095()
 
     def Building10095(): Unit = { // Name: ceiling_bldg_c_10095 Type: ceiling_bldg_c GUID: 11, MapID: 10095
-      LocalBuilding("ceiling_bldg_c_10095", 11, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(834.75f, 1318.05f, 293.22f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10095", 11, 10095, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(834.75f, 1318.05f, 293.22f), Vector3(0f, 0f, 60f), ceiling_bldg_c)))
       LocalObject(1042, Door.Constructor(Vector3(830.5447f, 1318.734f, 294.999f)), owning_building_guid = 11)
       LocalObject(1045, Door.Constructor(Vector3(840.8458f, 1367.628f, 294.999f)), owning_building_guid = 11)
       LocalObject(1054, Door.Constructor(Vector3(867.6926f, 1352.128f, 294.999f)), owning_building_guid = 11)
@@ -119,7 +118,7 @@ object Ugd02 { // Hunhau
     Building10091()
 
     def Building10091(): Unit = { // Name: ceiling_bldg_c_10091 Type: ceiling_bldg_c GUID: 12, MapID: 10091
-      LocalBuilding("ceiling_bldg_c_10091", 12, 10091, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(860.22f, 1024.66f, 306.94f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10091", 12, 10091, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(860.22f, 1024.66f, 306.94f), Vector3(0f, 0f, 45f), ceiling_bldg_c)))
       LocalObject(1049, Door.Constructor(Vector3(856.3351f, 1026.409f, 308.719f)), owning_building_guid = 12)
       LocalObject(1059, Door.Constructor(Vector3(878.9399f, 1070.971f, 308.719f)), owning_building_guid = 12)
       LocalObject(1073, Door.Constructor(Vector3(900.8602f, 1049.051f, 308.719f)), owning_building_guid = 12)
@@ -128,7 +127,7 @@ object Ugd02 { // Hunhau
     Building10085()
 
     def Building10085(): Unit = { // Name: ceiling_bldg_c_10085 Type: ceiling_bldg_c GUID: 13, MapID: 10085
-      LocalBuilding("ceiling_bldg_c_10085", 13, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1463.31f, 980.3f, 265.51f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10085", 13, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1463.31f, 980.3f, 265.51f), Vector3(0f, 0f, 55f), ceiling_bldg_c)))
       LocalObject(1209, Door.Constructor(Vector3(1459.18f, 981.3482f, 267.289f)), owning_building_guid = 13)
       LocalObject(1210, Door.Constructor(Vector3(1473.704f, 1029.158f, 267.289f)), owning_building_guid = 13)
       LocalObject(1211, Door.Constructor(Vector3(1499.097f, 1011.378f, 267.289f)), owning_building_guid = 13)
@@ -137,7 +136,7 @@ object Ugd02 { // Hunhau
     Building10094()
 
     def Building10094(): Unit = { // Name: ceiling_bldg_e_10094 Type: ceiling_bldg_e GUID: 14, MapID: 10094
-      LocalBuilding("ceiling_bldg_e_10094", 14, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(697.23f, 1294.78f, 269.71f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10094", 14, 10094, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(697.23f, 1294.78f, 269.71f), Vector3(0f, 0f, 0f), ceiling_bldg_e)))
       LocalObject(1014, Door.Constructor(Vector3(685.214f, 1293.79f, 271.489f)), owning_building_guid = 14)
       LocalObject(1016, Door.Constructor(Vector3(701.214f, 1327.29f, 276.989f)), owning_building_guid = 14)
       LocalObject(1018, Door.Constructor(Vector3(716.24f, 1322.796f, 271.489f)), owning_building_guid = 14)
@@ -147,7 +146,7 @@ object Ugd02 { // Hunhau
     Building10079()
 
     def Building10079(): Unit = { // Name: ceiling_bldg_e_10079 Type: ceiling_bldg_e GUID: 15, MapID: 10079
-      LocalBuilding("ceiling_bldg_e_10079", 15, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(866.94f, 711.23f, 240.12f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10079", 15, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(866.94f, 711.23f, 240.12f), Vector3(0f, 0f, 295f), ceiling_bldg_e)))
       LocalObject(1051, Door.Constructor(Vector3(860.9646f, 721.7018f, 241.899f)), owning_building_guid = 15)
       LocalObject(1063, Door.Constructor(Vector3(884.7747f, 691.9509f, 247.399f)), owning_building_guid = 15)
       LocalObject(1070, Door.Constructor(Vector3(898.0878f, 721.3586f, 247.399f)), owning_building_guid = 15)
@@ -157,7 +156,7 @@ object Ugd02 { // Hunhau
     Building10096()
 
     def Building10096(): Unit = { // Name: ceiling_bldg_e_10096 Type: ceiling_bldg_e GUID: 16, MapID: 10096
-      LocalBuilding("ceiling_bldg_e_10096", 16, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(907.97f, 1468.88f, 268.54f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10096", 16, 10096, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(907.97f, 1468.88f, 268.54f), Vector3(0f, 0f, 45f), ceiling_bldg_e)))
       LocalObject(1067, Door.Constructor(Vector3(887.7991f, 1494.685f, 275.819f)), owning_building_guid = 16)
       LocalObject(1071, Door.Constructor(Vector3(900.1734f, 1459.683f, 270.319f)), owning_building_guid = 16)
       LocalObject(1074, Door.Constructor(Vector3(901.6017f, 1502.132f, 270.319f)), owning_building_guid = 16)
@@ -167,7 +166,7 @@ object Ugd02 { // Hunhau
     Building10102()
 
     def Building10102(): Unit = { // Name: ceiling_bldg_e_10102 Type: ceiling_bldg_e GUID: 17, MapID: 10102
-      LocalBuilding("ceiling_bldg_e_10102", 17, 10102, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1051.15f, 1568.76f, 271.69f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10102", 17, 10102, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1051.15f, 1568.76f, 271.69f), Vector3(0f, 0f, 0f), ceiling_bldg_e)))
       LocalObject(1112, Door.Constructor(Vector3(1039.134f, 1567.77f, 273.469f)), owning_building_guid = 17)
       LocalObject(1113, Door.Constructor(Vector3(1055.134f, 1601.27f, 278.969f)), owning_building_guid = 17)
       LocalObject(1114, Door.Constructor(Vector3(1070.16f, 1596.776f, 273.469f)), owning_building_guid = 17)
@@ -177,7 +176,7 @@ object Ugd02 { // Hunhau
     Building10086()
 
     def Building10086(): Unit = { // Name: ceiling_bldg_e_10086 Type: ceiling_bldg_e GUID: 18, MapID: 10086
-      LocalBuilding("ceiling_bldg_e_10086", 18, 10086, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.98f, 1446.91f, 258.66f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10086", 18, 10086, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.98f, 1446.91f, 258.66f), Vector3(0f, 0f, 0f), ceiling_bldg_e)))
       LocalObject(1197, Door.Constructor(Vector3(1352.964f, 1445.92f, 260.439f)), owning_building_guid = 18)
       LocalObject(1199, Door.Constructor(Vector3(1368.964f, 1479.42f, 265.939f)), owning_building_guid = 18)
       LocalObject(1202, Door.Constructor(Vector3(1383.99f, 1474.926f, 260.439f)), owning_building_guid = 18)
@@ -187,7 +186,7 @@ object Ugd02 { // Hunhau
     Building10092()
 
     def Building10092(): Unit = { // Name: ceiling_bldg_f_10092 Type: ceiling_bldg_f GUID: 19, MapID: 10092
-      LocalBuilding("ceiling_bldg_f_10092", 19, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(765.59f, 1161.9f, 289.99f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10092", 19, 10092, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(765.59f, 1161.9f, 289.99f), Vector3(0f, 0f, 110f), ceiling_bldg_f)))
       LocalObject(1022, Door.Constructor(Vector3(734.7006f, 1163.41f, 291.769f)), owning_building_guid = 19)
       LocalObject(1033, Door.Constructor(Vector3(791.3768f, 1149.481f, 291.769f)), owning_building_guid = 19)
     }
@@ -195,7 +194,7 @@ object Ugd02 { // Hunhau
     Building10778()
 
     def Building10778(): Unit = { // Name: ceiling_bldg_f_10778 Type: ceiling_bldg_f GUID: 20, MapID: 10778
-      LocalBuilding("ceiling_bldg_f_10778", 20, 10778, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(822.13f, 896.66f, 253.11f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10778", 20, 10778, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(822.13f, 896.66f, 253.11f), Vector3(0f, 0f, 250f), ceiling_bldg_f)))
       LocalObject(1036, Door.Constructor(Vector3(810.3592f, 922.7492f, 254.889f)), owning_building_guid = 20)
       LocalObject(1047, Door.Constructor(Vector3(844.8219f, 875.6477f, 254.889f)), owning_building_guid = 20)
     }
@@ -203,7 +202,7 @@ object Ugd02 { // Hunhau
     Building10106()
 
     def Building10106(): Unit = { // Name: ceiling_bldg_f_10106 Type: ceiling_bldg_f GUID: 21, MapID: 10106
-      LocalBuilding("ceiling_bldg_f_10106", 21, 10106, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1198.46f, 1426.56f, 309.72f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10106", 21, 10106, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1198.46f, 1426.56f, 309.72f), Vector3(0f, 0f, 50f), ceiling_bldg_f)))
       LocalObject(1136, Door.Constructor(Vector3(1184.323f, 1454.066f, 311.499f)), owning_building_guid = 21)
       LocalObject(1145, Door.Constructor(Vector3(1200.598f, 1398.018f, 311.499f)), owning_building_guid = 21)
     }
@@ -211,7 +210,7 @@ object Ugd02 { // Hunhau
     Building10080()
 
     def Building10080(): Unit = { // Name: ceiling_bldg_g_10080 Type: ceiling_bldg_g GUID: 22, MapID: 10080
-      LocalBuilding("ceiling_bldg_g_10080", 22, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(759.5f, 747.28f, 248.37f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10080", 22, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(759.5f, 747.28f, 248.37f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(1025, Door.Constructor(Vector3(751.516f, 730.77f, 250.149f)), owning_building_guid = 22)
       LocalObject(1026, Door.Constructor(Vector3(759.516f, 764.77f, 250.149f)), owning_building_guid = 22)
     }
@@ -219,7 +218,7 @@ object Ugd02 { // Hunhau
     Building10087()
 
     def Building10087(): Unit = { // Name: ceiling_bldg_g_10087 Type: ceiling_bldg_g GUID: 23, MapID: 10087
-      LocalBuilding("ceiling_bldg_g_10087", 23, 10087, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.94f, 1287.12f, 309.56f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10087", 23, 10087, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.94f, 1287.12f, 309.56f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(1130, Door.Constructor(Vector3(1151.956f, 1270.61f, 311.339f)), owning_building_guid = 23)
       LocalObject(1131, Door.Constructor(Vector3(1159.956f, 1304.61f, 311.339f)), owning_building_guid = 23)
     }
@@ -227,7 +226,7 @@ object Ugd02 { // Hunhau
     Building10083()
 
     def Building10083(): Unit = { // Name: ceiling_bldg_g_10083 Type: ceiling_bldg_g GUID: 24, MapID: 10083
-      LocalBuilding("ceiling_bldg_g_10083", 24, 10083, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1214.34f, 914.27f, 295.15f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10083", 24, 10083, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1214.34f, 914.27f, 295.15f), Vector3(0f, 0f, 15f), ceiling_bldg_g)))
       LocalObject(1148, Door.Constructor(Vector3(1209.829f, 931.1682f, 296.929f)), owning_building_guid = 24)
       LocalObject(1149, Door.Constructor(Vector3(1210.901f, 896.2562f, 296.929f)), owning_building_guid = 24)
     }
@@ -235,7 +234,7 @@ object Ugd02 { // Hunhau
     Building10081()
 
     def Building10081(): Unit = { // Name: ceiling_bldg_h_10081 Type: ceiling_bldg_h GUID: 25, MapID: 10081
-      LocalBuilding("ceiling_bldg_h_10081", 25, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(958.95f, 790.67f, 267.91f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10081", 25, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(958.95f, 790.67f, 267.91f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(1094, Door.Constructor(Vector3(942.46f, 786.686f, 269.689f)), owning_building_guid = 25)
       LocalObject(1098, Door.Constructor(Vector3(962.934f, 807.18f, 269.689f)), owning_building_guid = 25)
       LocalObject(1103, Door.Constructor(Vector3(970.035f, 779.482f, 272.189f)), owning_building_guid = 25)
@@ -244,7 +243,7 @@ object Ugd02 { // Hunhau
     Building10097()
 
     def Building10097(): Unit = { // Name: ceiling_bldg_h_10097 Type: ceiling_bldg_h GUID: 26, MapID: 10097
-      LocalBuilding("ceiling_bldg_h_10097", 26, 10097, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(979.89f, 1487.96f, 269.47f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10097", 26, 10097, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(979.89f, 1487.96f, 269.47f), Vector3(0f, 0f, 335f), ceiling_bldg_h)))
       LocalObject(1099, Door.Constructor(Vector3(963.2613f, 1491.318f, 271.249f)), owning_building_guid = 26)
       LocalObject(1107, Door.Constructor(Vector3(985.2082f, 1473.135f, 273.749f)), owning_building_guid = 26)
       LocalObject(1110, Door.Constructor(Vector3(990.4781f, 1501.239f, 271.249f)), owning_building_guid = 26)
@@ -253,7 +252,7 @@ object Ugd02 { // Hunhau
     Building10082()
 
     def Building10082(): Unit = { // Name: ceiling_bldg_h_10082 Type: ceiling_bldg_h GUID: 27, MapID: 10082
-      LocalBuilding("ceiling_bldg_h_10082", 27, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1111.54f, 899.56f, 290.68f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10082", 27, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1111.54f, 899.56f, 290.68f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(1117, Door.Constructor(Vector3(1095.05f, 895.576f, 292.459f)), owning_building_guid = 27)
       LocalObject(1123, Door.Constructor(Vector3(1115.524f, 916.07f, 292.459f)), owning_building_guid = 27)
       LocalObject(1125, Door.Constructor(Vector3(1122.625f, 888.372f, 294.959f)), owning_building_guid = 27)
@@ -262,7 +261,7 @@ object Ugd02 { // Hunhau
     Building10088()
 
     def Building10088(): Unit = { // Name: ceiling_bldg_h_10088 Type: ceiling_bldg_h GUID: 28, MapID: 10088
-      LocalBuilding("ceiling_bldg_h_10088", 28, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1127.33f, 1060.86f, 311.15f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10088", 28, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1127.33f, 1060.86f, 311.15f), Vector3(0f, 0f, 110f), ceiling_bldg_h)))
       LocalObject(1122, Door.Constructor(Vector3(1110.453f, 1058.957f, 312.929f)), owning_building_guid = 28)
       LocalObject(1126, Door.Constructor(Vector3(1134.052f, 1075.103f, 315.429f)), owning_building_guid = 28)
       LocalObject(1128, Door.Constructor(Vector3(1136.714f, 1046.727f, 312.929f)), owning_building_guid = 28)
@@ -271,7 +270,7 @@ object Ugd02 { // Hunhau
     Building10103()
 
     def Building10103(): Unit = { // Name: ceiling_bldg_h_10103 Type: ceiling_bldg_h GUID: 29, MapID: 10103
-      LocalBuilding("ceiling_bldg_h_10103", 29, 10103, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.59f, 1648.29f, 264.54f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10103", 29, 10103, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.59f, 1648.29f, 264.54f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(1133, Door.Constructor(Vector3(1170.1f, 1644.306f, 266.319f)), owning_building_guid = 29)
       LocalObject(1139, Door.Constructor(Vector3(1190.574f, 1664.8f, 266.319f)), owning_building_guid = 29)
       LocalObject(1142, Door.Constructor(Vector3(1197.675f, 1637.102f, 268.819f)), owning_building_guid = 29)
@@ -280,7 +279,7 @@ object Ugd02 { // Hunhau
     Building10098()
 
     def Building10098(): Unit = { // Name: ceiling_bldg_h_10098 Type: ceiling_bldg_h GUID: 30, MapID: 10098
-      LocalBuilding("ceiling_bldg_h_10098", 30, 10098, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.22f, 1049.38f, 307.96f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10098", 30, 10098, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1268.22f, 1049.38f, 307.96f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(1154, Door.Constructor(Vector3(1251.73f, 1045.396f, 309.739f)), owning_building_guid = 30)
       LocalObject(1166, Door.Constructor(Vector3(1272.204f, 1065.89f, 309.739f)), owning_building_guid = 30)
       LocalObject(1173, Door.Constructor(Vector3(1279.305f, 1038.192f, 312.239f)), owning_building_guid = 30)
@@ -289,7 +288,7 @@ object Ugd02 { // Hunhau
     Building10099()
 
     def Building10099(): Unit = { // Name: ceiling_bldg_i_10099 Type: ceiling_bldg_i GUID: 31, MapID: 10099
-      LocalBuilding("ceiling_bldg_i_10099", 31, 10099, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1303.08f, 1215.7f, 303.15f), ceiling_bldg_i)))
+      LocalBuilding("ceiling_bldg_i_10099", 31, 10099, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1303.08f, 1215.7f, 303.15f), Vector3(0f, 0f, 0f), ceiling_bldg_i)))
       LocalObject(1171, Door.Constructor(Vector3(1278.59f, 1219.216f, 304.929f)), owning_building_guid = 31)
       LocalObject(1192, Door.Constructor(Vector3(1328.59f, 1219.216f, 304.929f)), owning_building_guid = 31)
     }
@@ -297,7 +296,7 @@ object Ugd02 { // Hunhau
     Building10104()
 
     def Building10104(): Unit = { // Name: ceiling_bldg_j_10104 Type: ceiling_bldg_j GUID: 32, MapID: 10104
-      LocalBuilding("ceiling_bldg_j_10104", 32, 10104, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.96f, 1794.06f, 230.84f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10104", 32, 10104, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.96f, 1794.06f, 230.84f), Vector3(0f, 0f, 65f), ceiling_bldg_j)))
       LocalObject(1124, Door.Constructor(Vector3(1117.647f, 1799.353f, 232.619f)), owning_building_guid = 32)
       LocalObject(1129, Door.Constructor(Vector3(1140.305f, 1788.788f, 232.619f)), owning_building_guid = 32)
     }
@@ -305,7 +304,7 @@ object Ugd02 { // Hunhau
     Building10089()
 
     def Building10089(): Unit = { // Name: ceiling_bldg_j_10089 Type: ceiling_bldg_j GUID: 33, MapID: 10089
-      LocalBuilding("ceiling_bldg_j_10089", 33, 10089, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1443.23f, 1163.19f, 271.2f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10089", 33, 10089, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1443.23f, 1163.19f, 271.2f), Vector3(0f, 0f, 130f), ceiling_bldg_j)))
       LocalObject(1207, Door.Constructor(Vector3(1433.652f, 1155.174f, 272.979f)), owning_building_guid = 33)
       LocalObject(1208, Door.Constructor(Vector3(1452.803f, 1171.244f, 272.979f)), owning_building_guid = 33)
     }
@@ -313,7 +312,7 @@ object Ugd02 { // Hunhau
     Building10357()
 
     def Building10357(): Unit = { // Name: ceiling_bldg_z_10357 Type: ceiling_bldg_z GUID: 34, MapID: 10357
-      LocalBuilding("ceiling_bldg_z_10357", 34, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1366.28f, 1322.62f, 306.75f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10357", 34, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1366.28f, 1322.62f, 306.75f), Vector3(0f, 0f, 0f), ceiling_bldg_z)))
       LocalObject(1193, Door.Constructor(Vector3(1341.79f, 1326.636f, 308.529f)), owning_building_guid = 34)
       LocalObject(1206, Door.Constructor(Vector3(1398.79f, 1326.636f, 308.529f)), owning_building_guid = 34)
     }
@@ -321,7 +320,7 @@ object Ugd02 { // Hunhau
     Building10016()
 
     def Building10016(): Unit = { // Name: ground_bldg_b_10016 Type: ground_bldg_b GUID: 273, MapID: 10016
-      LocalBuilding("ground_bldg_b_10016", 273, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.23f, 1439.35f, 216f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10016", 273, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.23f, 1439.35f, 216f), Vector3(0f, 0f, 140f), ground_bldg_b)))
       LocalObject(1028, Door.Constructor(Vector3(772.578f, 1450.504f, 223.279f)), owning_building_guid = 273)
       LocalObject(1030, Door.Constructor(Vector3(783.0869f, 1428.013f, 217.779f)), owning_building_guid = 273)
       LocalObject(1032, Door.Constructor(Vector3(791.2707f, 1443.991f, 217.779f)), owning_building_guid = 273)
@@ -330,7 +329,7 @@ object Ugd02 { // Hunhau
     Building10000()
 
     def Building10000(): Unit = { // Name: ground_bldg_b_10000 Type: ground_bldg_b GUID: 274, MapID: 10000
-      LocalBuilding("ground_bldg_b_10000", 274, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(817.07f, 1033.77f, 211.66f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10000", 274, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(817.07f, 1033.77f, 211.66f), Vector3(0f, 0f, 0f), ground_bldg_b)))
       LocalObject(1037, Door.Constructor(Vector3(819.085f, 1050.26f, 213.439f)), owning_building_guid = 274)
       LocalObject(1040, Door.Constructor(Vector3(823.086f, 1032.76f, 213.439f)), owning_building_guid = 274)
       LocalObject(1046, Door.Constructor(Vector3(841.592f, 1039.786f, 218.939f)), owning_building_guid = 274)
@@ -339,7 +338,7 @@ object Ugd02 { // Hunhau
     Building10021()
 
     def Building10021(): Unit = { // Name: ground_bldg_b_10021 Type: ground_bldg_b GUID: 275, MapID: 10021
-      LocalBuilding("ground_bldg_b_10021", 275, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.21f, 1419.07f, 224.66f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10021", 275, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.21f, 1419.07f, 224.66f), Vector3(0f, 0f, 178f), ground_bldg_b)))
       LocalObject(1132, Door.Constructor(Vector3(1168.493f, 1413.913f, 231.939f)), owning_building_guid = 275)
       LocalObject(1138, Door.Constructor(Vector3(1187.233f, 1420.289f, 226.439f)), owning_building_guid = 275)
       LocalObject(1140, Door.Constructor(Vector3(1190.621f, 1402.66f, 226.439f)), owning_building_guid = 275)
@@ -348,7 +347,7 @@ object Ugd02 { // Hunhau
     Building10030()
 
     def Building10030(): Unit = { // Name: ground_bldg_b_10030 Type: ground_bldg_b GUID: 276, MapID: 10030
-      LocalBuilding("ground_bldg_b_10030", 276, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.87f, 1038.08f, 216f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10030", 276, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1364.87f, 1038.08f, 216f), Vector3(0f, 0f, 329f), ground_bldg_b)))
       LocalObject(1200, Door.Constructor(Vector3(1369.506f, 1034.116f, 217.779f)), owning_building_guid = 276)
       LocalObject(1201, Door.Constructor(Vector3(1375.09f, 1051.177f, 217.779f)), owning_building_guid = 276)
       LocalObject(1203, Door.Constructor(Vector3(1388.988f, 1030.607f, 223.279f)), owning_building_guid = 276)
@@ -357,7 +356,7 @@ object Ugd02 { // Hunhau
     Building10369()
 
     def Building10369(): Unit = { // Name: ground_bldg_c_10369 Type: ground_bldg_c GUID: 277, MapID: 10369
-      LocalBuilding("ground_bldg_c_10369", 277, 10369, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(915.84f, 988.16f, 228.46f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10369", 277, 10369, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(915.84f, 988.16f, 228.46f), Vector3(0f, 0f, 225f), ground_bldg_c)))
       LocalObject(1058, Door.Constructor(Vector3(875.1998f, 963.769f, 230.239f)), owning_building_guid = 277)
       LocalObject(1068, Door.Constructor(Vector3(897.1201f, 941.8487f, 230.239f)), owning_building_guid = 277)
       LocalObject(1084, Door.Constructor(Vector3(919.7249f, 986.4106f, 230.239f)), owning_building_guid = 277)
@@ -366,7 +365,7 @@ object Ugd02 { // Hunhau
     Building10023()
 
     def Building10023(): Unit = { // Name: ground_bldg_c_10023 Type: ground_bldg_c GUID: 278, MapID: 10023
-      LocalBuilding("ground_bldg_c_10023", 278, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1266.3f, 1371.91f, 241.56f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10023", 278, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1266.3f, 1371.91f, 241.56f), Vector3(0f, 0f, 249f), ground_bldg_c)))
       LocalObject(1153, Door.Constructor(Vector3(1239.094f, 1333.098f, 243.339f)), owning_building_guid = 278)
       LocalObject(1164, Door.Constructor(Vector3(1268.035f, 1321.989f, 243.339f)), owning_building_guid = 278)
       LocalObject(1165, Door.Constructor(Vector3(1270.561f, 1371.892f, 243.339f)), owning_building_guid = 278)
@@ -375,7 +374,7 @@ object Ugd02 { // Hunhau
     Building10009()
 
     def Building10009(): Unit = { // Name: ground_bldg_d_10009 Type: ground_bldg_d GUID: 279, MapID: 10009
-      LocalBuilding("ground_bldg_d_10009", 279, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(807.17f, 1205.79f, 216.95f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10009", 279, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(807.17f, 1205.79f, 216.95f), Vector3(0f, 0f, 186f), ground_bldg_d)))
       LocalObject(1031, Door.Constructor(Vector3(789.7576f, 1203.944f, 218.685f)), owning_building_guid = 279)
       LocalObject(1034, Door.Constructor(Vector3(805.3238f, 1223.202f, 218.685f)), owning_building_guid = 279)
       LocalObject(1035, Door.Constructor(Vector3(808.9823f, 1188.394f, 218.685f)), owning_building_guid = 279)
@@ -385,7 +384,7 @@ object Ugd02 { // Hunhau
     Building10001()
 
     def Building10001(): Unit = { // Name: ground_bldg_d_10001 Type: ground_bldg_d GUID: 280, MapID: 10001
-      LocalBuilding("ground_bldg_d_10001", 280, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837f, 990.15f, 218.45f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10001", 280, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837f, 990.15f, 218.45f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(1039, Door.Constructor(Vector3(819.51f, 990.166f, 220.185f)), owning_building_guid = 280)
       LocalObject(1043, Door.Constructor(Vector3(837.016f, 972.64f, 220.185f)), owning_building_guid = 280)
       LocalObject(1044, Door.Constructor(Vector3(837.016f, 1007.64f, 220.185f)), owning_building_guid = 280)
@@ -395,7 +394,7 @@ object Ugd02 { // Hunhau
     Building10543()
 
     def Building10543(): Unit = { // Name: ground_bldg_d_10543 Type: ground_bldg_d GUID: 281, MapID: 10543
-      LocalBuilding("ground_bldg_d_10543", 281, 10543, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.03f, 1293.93f, 229f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10543", 281, 10543, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.03f, 1293.93f, 229f), Vector3(0f, 0f, 144f), ground_bldg_d)))
       LocalObject(1100, Door.Constructor(Vector3(963.8547f, 1304.209f, 230.735f)), owning_building_guid = 281)
       LocalObject(1101, Door.Constructor(Vector3(967.7367f, 1279.79f, 230.735f)), owning_building_guid = 281)
       LocalObject(1108, Door.Constructor(Vector3(988.3092f, 1308.105f, 230.735f)), owning_building_guid = 281)
@@ -405,7 +404,7 @@ object Ugd02 { // Hunhau
     Building10022()
 
     def Building10022(): Unit = { // Name: ground_bldg_d_10022 Type: ground_bldg_d GUID: 282, MapID: 10022
-      LocalBuilding("ground_bldg_d_10022", 282, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.5f, 1360.56f, 231.45f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10022", 282, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1201.5f, 1360.56f, 231.45f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(1135, Door.Constructor(Vector3(1184.01f, 1360.576f, 233.185f)), owning_building_guid = 282)
       LocalObject(1146, Door.Constructor(Vector3(1201.516f, 1343.05f, 233.185f)), owning_building_guid = 282)
       LocalObject(1147, Door.Constructor(Vector3(1201.516f, 1378.05f, 233.185f)), owning_building_guid = 282)
@@ -415,7 +414,7 @@ object Ugd02 { // Hunhau
     Building10031()
 
     def Building10031(): Unit = { // Name: ground_bldg_d_10031 Type: ground_bldg_d GUID: 283, MapID: 10031
-      LocalBuilding("ground_bldg_d_10031", 283, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1301.6f, 959.02f, 222f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10031", 283, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1301.6f, 959.02f, 222f), Vector3(0f, 0f, 11f), ground_bldg_d)))
       LocalObject(1180, Door.Constructor(Vector3(1284.428f, 955.6985f, 223.735f)), owning_building_guid = 283)
       LocalObject(1184, Door.Constructor(Vector3(1298.278f, 976.1917f, 223.735f)), owning_building_guid = 283)
       LocalObject(1186, Door.Constructor(Vector3(1304.957f, 941.8348f, 223.735f)), owning_building_guid = 283)
@@ -425,7 +424,7 @@ object Ugd02 { // Hunhau
     Building10013()
 
     def Building10013(): Unit = { // Name: ground_bldg_i_10013 Type: ground_bldg_i GUID: 284, MapID: 10013
-      LocalBuilding("ground_bldg_i_10013", 284, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(715.89f, 1024.55f, 209f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10013", 284, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(715.89f, 1024.55f, 209f), Vector3(0f, 0f, 332f), ground_bldg_i)))
       LocalObject(1015, Door.Constructor(Vector3(695.9173f, 1039.152f, 210.779f)), owning_building_guid = 284)
       LocalObject(1023, Door.Constructor(Vector3(740.0647f, 1015.678f, 210.779f)), owning_building_guid = 284)
     }
@@ -433,7 +432,7 @@ object Ugd02 { // Hunhau
     Building10018()
 
     def Building10018(): Unit = { // Name: ground_bldg_i_10018 Type: ground_bldg_i GUID: 285, MapID: 10018
-      LocalBuilding("ground_bldg_i_10018", 285, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.93f, 1513.27f, 225f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10018", 285, 10018, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(795.93f, 1513.27f, 225f), Vector3(0f, 0f, 16f), ground_bldg_i)))
       LocalObject(1027, Door.Constructor(Vector3(771.4196f, 1509.899f, 226.779f)), owning_building_guid = 285)
       LocalObject(1038, Door.Constructor(Vector3(819.4827f, 1523.681f, 226.779f)), owning_building_guid = 285)
     }
@@ -441,7 +440,7 @@ object Ugd02 { // Hunhau
     Building10032()
 
     def Building10032(): Unit = { // Name: ground_bldg_i_10032 Type: ground_bldg_i GUID: 286, MapID: 10032
-      LocalBuilding("ground_bldg_i_10032", 286, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1375.1f, 964.87f, 225f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10032", 286, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1375.1f, 964.87f, 225f), Vector3(0f, 0f, 205f), ground_bldg_i)))
       LocalObject(1198, Door.Constructor(Vector3(1353.466f, 950.9024f, 226.779f)), owning_building_guid = 286)
       LocalObject(1205, Door.Constructor(Vector3(1398.781f, 972.0333f, 226.779f)), owning_building_guid = 286)
     }
@@ -449,7 +448,7 @@ object Ugd02 { // Hunhau
     Building10748()
 
     def Building10748(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 287, MapID: 10748
-      LocalBuilding("N_Redoubt", 287, 10748, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(870.46f, 1493.53f, 214.4f), redoubt)))
+      LocalBuilding("N_Redoubt", 287, 10748, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(870.46f, 1493.53f, 214.4f), Vector3(0f, 0f, 324f), redoubt)))
       LocalObject(1393, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 287)
       LocalObject(1050, Door.Constructor(Vector3(856.3197f, 1503.823f, 216.135f)), owning_building_guid = 287)
       LocalObject(1055, Door.Constructor(Vector3(867.6268f, 1510.519f, 226.179f)), owning_building_guid = 287)
@@ -466,7 +465,7 @@ object Ugd02 { // Hunhau
     Building10751()
 
     def Building10751(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 288, MapID: 10751
-      LocalBuilding("S_Redoubt", 288, 10751, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1291.34f, 1131.64f, 216.2f), redoubt)))
+      LocalBuilding("S_Redoubt", 288, 10751, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1291.34f, 1131.64f, 216.2f), Vector3(0f, 0f, 97f), redoubt)))
       LocalObject(1397, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 288)
       LocalObject(1169, Door.Constructor(Vector3(1277.826f, 1142.317f, 227.979f)), owning_building_guid = 288)
       LocalObject(1172, Door.Constructor(Vector3(1278.836f, 1134.135f, 227.959f)), owning_building_guid = 288)
@@ -483,7 +482,7 @@ object Ugd02 { // Hunhau
     Building10354()
 
     def Building10354(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 423, MapID: 10354
-      LocalBuilding("S_Stasis", 423, 10354, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(910.38f, 1061.46f, 211.09f), vanu_control_point)))
+      LocalBuilding("S_Stasis", 423, 10354, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(910.38f, 1061.46f, 211.09f), Vector3(0f, 0f, 133f), vanu_control_point)))
       LocalObject(1394, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 423)
       LocalObject(1052, Door.Constructor(Vector3(862.2756f, 1062.809f, 212.869f)), owning_building_guid = 423)
       LocalObject(1069, Door.Constructor(Vector3(897.8686f, 1113.024f, 212.869f)), owning_building_guid = 423)
@@ -516,7 +515,7 @@ object Ugd02 { // Hunhau
     Building10020()
 
     def Building10020(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 424, MapID: 10020
-      LocalBuilding("N_Stasis", 424, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.2f, 1433.74f, 224.19f), vanu_control_point)))
+      LocalBuilding("N_Stasis", 424, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1271.2f, 1433.74f, 224.19f), Vector3(0f, 0f, 133f), vanu_control_point)))
       LocalObject(1398, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 424)
       LocalObject(1152, Door.Constructor(Vector3(1223.096f, 1435.089f, 225.969f)), owning_building_guid = 424)
       LocalObject(1155, Door.Constructor(Vector3(1258.688f, 1485.304f, 225.969f)), owning_building_guid = 424)
@@ -549,7 +548,7 @@ object Ugd02 { // Hunhau
     Building10002()
 
     def Building10002(): Unit = { // Name: Core Type: vanu_core GUID: 425, MapID: 10002
-      LocalBuilding("Core", 425, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1110.13f, 1216.96f, 266.93f), vanu_core)))
+      LocalBuilding("Core", 425, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1110.13f, 1216.96f, 266.93f), Vector3(0f, 0f, 0f), vanu_core)))
       LocalObject(1116, Door.Constructor(Vector3(1077.637f, 1204.982f, 273.718f)), owning_building_guid = 425)
       LocalObject(1118, Door.Constructor(Vector3(1106.108f, 1176.467f, 273.718f)), owning_building_guid = 425)
       LocalObject(1119, Door.Constructor(Vector3(1106.108f, 1176.467f, 278.718f)), owning_building_guid = 425)
@@ -561,7 +560,7 @@ object Ugd02 { // Hunhau
     Building10015()
 
     def Building10015(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 472, MapID: 10015
-      LocalBuilding("N_ATPlant", 472, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(877.25f, 1407.81f, 214f), vanu_vehicle_station)))
+      LocalBuilding("N_ATPlant", 472, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(877.25f, 1407.81f, 214f), Vector3(0f, 0f, 174f), vanu_vehicle_station)))
       LocalObject(1395, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 472)
       LocalObject(1060, Door.Constructor(Vector3(880.3055f, 1392.511f, 215.779f)), owning_building_guid = 472)
       LocalObject(1064, Door.Constructor(Vector3(886.2134f, 1448.72f, 235.703f)), owning_building_guid = 472)
@@ -585,7 +584,7 @@ object Ugd02 { // Hunhau
     Building10109()
 
     def Building10109(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 473, MapID: 10109
-      LocalBuilding("S_ATPlant", 473, 10109, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.08f, 1065.9f, 214f), vanu_vehicle_station)))
+      LocalBuilding("S_ATPlant", 473, 10109, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1307.08f, 1065.9f, 214f), Vector3(0f, 0f, 5f), vanu_vehicle_station)))
       LocalObject(1396, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 473)
       LocalObject(1158, Door.Constructor(Vector3(1263.409f, 1052.901f, 245.779f)), owning_building_guid = 473)
       LocalObject(1160, Door.Constructor(Vector3(1264.097f, 1044.716f, 245.759f)), owning_building_guid = 473)

--- a/pslogin/src/main/scala/zonemaps/Ugd03.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd03.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd03 { // Adlivun
   val ZoneMap = new ZoneMap("ugd03") {
     Scale = MapScale.Dim2048
-    Cavern = true
     Checksum = 1673539651L
 
     Building10020()
 
     def Building10020(): Unit = { // Name: ceiling_bldg_a_10020 Type: ceiling_bldg_a GUID: 1, MapID: 10020
-      LocalBuilding("ceiling_bldg_a_10020", 1, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(845.85f, 782.72f, 106.07f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10020", 1, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(845.85f, 782.72f, 106.07f), Vector3(0f, 0f, 304f), ceiling_bldg_a)))
       LocalObject(808, Door.Constructor(Vector3(844.4113f, 798.6173f, 107.849f)), owning_building_guid = 1)
       LocalObject(809, Door.Constructor(Vector3(845.2345f, 763.904f, 113.355f)), owning_building_guid = 1)
       LocalObject(810, Door.Constructor(Vector3(858.5089f, 771.0483f, 107.849f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd03 { // Adlivun
     Building10028()
 
     def Building10028(): Unit = { // Name: ceiling_bldg_a_10028 Type: ceiling_bldg_a GUID: 2, MapID: 10028
-      LocalBuilding("ceiling_bldg_a_10028", 2, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1089.56f, 1080.75f, 112.69f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10028", 2, 10028, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1089.56f, 1080.75f, 112.69f), Vector3(0f, 0f, 328f), ceiling_bldg_a)))
       LocalObject(846, Door.Constructor(Vector3(1081.78f, 1094.688f, 114.469f)), owning_building_guid = 2)
       LocalObject(847, Door.Constructor(Vector3(1096.651f, 1063.31f, 119.975f)), owning_building_guid = 2)
       LocalObject(848, Door.Constructor(Vector3(1105.872f, 1075.236f, 114.469f)), owning_building_guid = 2)
@@ -41,7 +40,7 @@ object Ugd03 { // Adlivun
     Building10019()
 
     def Building10019(): Unit = { // Name: ceiling_bldg_b_10019 Type: ceiling_bldg_b GUID: 3, MapID: 10019
-      LocalBuilding("ceiling_bldg_b_10019", 3, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(677.51f, 874.3f, 101.68f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10019", 3, 10019, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(677.51f, 874.3f, 101.68f), Vector3(0f, 0f, 263f), ceiling_bldg_b)))
       LocalObject(770, Door.Constructor(Vector3(675.7744f, 868.4519f, 103.459f)), owning_building_guid = 3)
       LocalObject(771, Door.Constructor(Vector3(693.6315f, 870.2904f, 103.459f)), owning_building_guid = 3)
     }
@@ -49,7 +48,7 @@ object Ugd03 { // Adlivun
     Building10029()
 
     def Building10029(): Unit = { // Name: ceiling_bldg_b_10029 Type: ceiling_bldg_b GUID: 4, MapID: 10029
-      LocalBuilding("ceiling_bldg_b_10029", 4, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.55f, 1224.66f, 101.59f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10029", 4, 10029, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.55f, 1224.66f, 101.59f), Vector3(0f, 0f, 17f), ceiling_bldg_b)))
       LocalObject(828, Door.Constructor(Vector3(1003.656f, 1241.019f, 103.369f)), owning_building_guid = 4)
       LocalObject(830, Door.Constructor(Vector3(1012.598f, 1225.453f, 103.369f)), owning_building_guid = 4)
     }
@@ -57,7 +56,7 @@ object Ugd03 { // Adlivun
     Building10011()
 
     def Building10011(): Unit = { // Name: ceiling_bldg_b_10011 Type: ceiling_bldg_b GUID: 5, MapID: 10011
-      LocalBuilding("ceiling_bldg_b_10011", 5, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1328.95f, 1247.9f, 111.73f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10011", 5, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1328.95f, 1247.9f, 111.73f), Vector3(0f, 0f, 0f), ceiling_bldg_b)))
       LocalObject(891, Door.Constructor(Vector3(1330.965f, 1264.39f, 113.509f)), owning_building_guid = 5)
       LocalObject(893, Door.Constructor(Vector3(1334.966f, 1246.89f, 113.509f)), owning_building_guid = 5)
     }
@@ -65,7 +64,7 @@ object Ugd03 { // Adlivun
     Building10301()
 
     def Building10301(): Unit = { // Name: ceiling_bldg_c_10301 Type: ceiling_bldg_c GUID: 6, MapID: 10301
-      LocalBuilding("ceiling_bldg_c_10301", 6, 10301, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.93f, 652.46f, 123.63f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10301", 6, 10301, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.93f, 652.46f, 123.63f), Vector3(0f, 0f, 39f), ceiling_bldg_c)))
       LocalObject(793, Door.Constructor(Vector3(760.2493f, 654.6059f, 125.409f)), owning_building_guid = 6)
       LocalObject(800, Door.Constructor(Vector3(787.3882f, 696.5608f, 125.409f)), owning_building_guid = 6)
       LocalObject(802, Door.Constructor(Vector3(806.8972f, 672.4693f, 125.409f)), owning_building_guid = 6)
@@ -74,7 +73,7 @@ object Ugd03 { // Adlivun
     Building10085()
 
     def Building10085(): Unit = { // Name: ceiling_bldg_d_10085 Type: ceiling_bldg_d GUID: 7, MapID: 10085
-      LocalBuilding("ceiling_bldg_d_10085", 7, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.2f, 1198.95f, 111.11f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10085", 7, 10085, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1186.2f, 1198.95f, 111.11f), Vector3(0f, 0f, 0f), ceiling_bldg_d)))
       LocalObject(853, Door.Constructor(Vector3(1168.71f, 1198.966f, 112.845f)), owning_building_guid = 7)
       LocalObject(854, Door.Constructor(Vector3(1186.216f, 1181.44f, 112.845f)), owning_building_guid = 7)
       LocalObject(855, Door.Constructor(Vector3(1186.216f, 1216.44f, 112.845f)), owning_building_guid = 7)
@@ -85,7 +84,7 @@ object Ugd03 { // Adlivun
     Building10024()
 
     def Building10024(): Unit = { // Name: ceiling_bldg_g_10024 Type: ceiling_bldg_g GUID: 8, MapID: 10024
-      LocalBuilding("ceiling_bldg_g_10024", 8, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(705.96f, 1266.02f, 88.19f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10024", 8, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(705.96f, 1266.02f, 88.19f), Vector3(0f, 0f, 219f), ceiling_bldg_g)))
       LocalObject(776, Door.Constructor(Vector3(701.7747f, 1283.875f, 89.969f)), owning_building_guid = 8)
       LocalObject(781, Door.Constructor(Vector3(716.9544f, 1252.418f, 89.969f)), owning_building_guid = 8)
     }
@@ -93,7 +92,7 @@ object Ugd03 { // Adlivun
     Building10026()
 
     def Building10026(): Unit = { // Name: ceiling_bldg_g_10026 Type: ceiling_bldg_g GUID: 9, MapID: 10026
-      LocalBuilding("ceiling_bldg_g_10026", 9, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(780.44f, 1084.53f, 99.81f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10026", 9, 10026, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(780.44f, 1084.53f, 99.81f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(796, Door.Constructor(Vector3(772.456f, 1068.02f, 101.589f)), owning_building_guid = 9)
       LocalObject(799, Door.Constructor(Vector3(780.456f, 1102.02f, 101.589f)), owning_building_guid = 9)
     }
@@ -101,7 +100,7 @@ object Ugd03 { // Adlivun
     Building10016()
 
     def Building10016(): Unit = { // Name: ceiling_bldg_g_10016 Type: ceiling_bldg_g GUID: 10, MapID: 10016
-      LocalBuilding("ceiling_bldg_g_10016", 10, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1249.74f, 1307.4f, 94.99f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10016", 10, 10016, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1249.74f, 1307.4f, 94.99f), Vector3(0f, 0f, 317f), ceiling_bldg_g)))
       LocalObject(863, Door.Constructor(Vector3(1232.641f, 1300.771f, 96.769f)), owning_building_guid = 10)
       LocalObject(871, Door.Constructor(Vector3(1261.68f, 1320.181f, 96.769f)), owning_building_guid = 10)
     }
@@ -109,7 +108,7 @@ object Ugd03 { // Adlivun
     Building10021()
 
     def Building10021(): Unit = { // Name: ceiling_bldg_g_10021 Type: ceiling_bldg_g GUID: 11, MapID: 10021
-      LocalBuilding("ceiling_bldg_g_10021", 11, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.23f, 652.87f, 88.19f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10021", 11, 10021, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.23f, 652.87f, 88.19f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(896, Door.Constructor(Vector3(1341.246f, 636.36f, 89.969f)), owning_building_guid = 11)
       LocalObject(898, Door.Constructor(Vector3(1349.246f, 670.36f, 89.969f)), owning_building_guid = 11)
     }
@@ -117,7 +116,7 @@ object Ugd03 { // Adlivun
     Building10023()
 
     def Building10023(): Unit = { // Name: ceiling_bldg_h_10023 Type: ceiling_bldg_h GUID: 12, MapID: 10023
-      LocalBuilding("ceiling_bldg_h_10023", 12, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.77f, 1249.92f, 103.44f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10023", 12, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.77f, 1249.92f, 103.44f), Vector3(0f, 0f, 58f), ceiling_bldg_h)))
       LocalObject(813, Door.Constructor(Vector3(887.8799f, 1262.048f, 105.219f)), owning_building_guid = 12)
       LocalObject(815, Door.Constructor(Vector3(894.4103f, 1233.825f, 105.219f)), owning_building_guid = 12)
       LocalObject(818, Door.Constructor(Vector3(915.1321f, 1253.392f, 107.719f)), owning_building_guid = 12)
@@ -126,7 +125,7 @@ object Ugd03 { // Adlivun
     Building10030()
 
     def Building10030(): Unit = { // Name: ceiling_bldg_h_10030 Type: ceiling_bldg_h GUID: 13, MapID: 10030
-      LocalBuilding("ceiling_bldg_h_10030", 13, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1133.55f, 738.99f, 104.66f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10030", 13, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1133.55f, 738.99f, 104.66f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(850, Door.Constructor(Vector3(1117.06f, 735.006f, 106.439f)), owning_building_guid = 13)
       LocalObject(851, Door.Constructor(Vector3(1137.534f, 755.5f, 106.439f)), owning_building_guid = 13)
       LocalObject(852, Door.Constructor(Vector3(1144.635f, 727.802f, 108.939f)), owning_building_guid = 13)
@@ -135,7 +134,7 @@ object Ugd03 { // Adlivun
     Building10017()
 
     def Building10017(): Unit = { // Name: ceiling_bldg_h_10017 Type: ceiling_bldg_h GUID: 14, MapID: 10017
-      LocalBuilding("ceiling_bldg_h_10017", 14, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1246.32f, 775.32f, 92.82f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10017", 14, 10017, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1246.32f, 775.32f, 92.82f), Vector3(0f, 0f, 199f), ceiling_bldg_h)))
       LocalObject(862, Door.Constructor(Vector3(1232.196f, 782.2896f, 97.099f)), owning_building_guid = 14)
       LocalObject(866, Door.Constructor(Vector3(1247.928f, 758.4124f, 94.599f)), owning_building_guid = 14)
       LocalObject(870, Door.Constructor(Vector3(1260.615f, 784.4556f, 94.599f)), owning_building_guid = 14)
@@ -144,7 +143,7 @@ object Ugd03 { // Adlivun
     Building10015()
 
     def Building10015(): Unit = { // Name: ceiling_bldg_h_10015 Type: ceiling_bldg_h GUID: 15, MapID: 10015
-      LocalBuilding("ceiling_bldg_h_10015", 15, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1385.18f, 1124.38f, 120.28f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10015", 15, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1385.18f, 1124.38f, 120.28f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(902, Door.Constructor(Vector3(1368.69f, 1120.396f, 122.059f)), owning_building_guid = 15)
       LocalObject(905, Door.Constructor(Vector3(1389.164f, 1140.89f, 122.059f)), owning_building_guid = 15)
       LocalObject(909, Door.Constructor(Vector3(1396.265f, 1113.192f, 124.559f)), owning_building_guid = 15)
@@ -153,7 +152,7 @@ object Ugd03 { // Adlivun
     Building10025()
 
     def Building10025(): Unit = { // Name: ceiling_bldg_j_10025 Type: ceiling_bldg_j GUID: 16, MapID: 10025
-      LocalBuilding("ceiling_bldg_j_10025", 16, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(744.75f, 1147.08f, 98.87f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10025", 16, 10025, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(744.75f, 1147.08f, 98.87f), Vector3(0f, 0f, 219f), ceiling_bldg_j)))
       LocalObject(788, Door.Constructor(Vector3(736.8647f, 1156.792f, 100.649f)), owning_building_guid = 16)
       LocalObject(791, Door.Constructor(Vector3(752.5978f, 1137.363f, 100.649f)), owning_building_guid = 16)
     }
@@ -161,7 +160,7 @@ object Ugd03 { // Adlivun
     Building10014()
 
     def Building10014(): Unit = { // Name: ceiling_bldg_j_10014 Type: ceiling_bldg_j GUID: 17, MapID: 10014
-      LocalBuilding("ceiling_bldg_j_10014", 17, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1255.3f, 1091.51f, 109.62f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10014", 17, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1255.3f, 1091.51f, 109.62f), Vector3(0f, 0f, 0f), ceiling_bldg_j)))
       LocalObject(868, Door.Constructor(Vector3(1255.316f, 1079f, 111.399f)), owning_building_guid = 17)
       LocalObject(869, Door.Constructor(Vector3(1255.316f, 1104f, 111.399f)), owning_building_guid = 17)
     }
@@ -169,7 +168,7 @@ object Ugd03 { // Adlivun
     Building10238()
 
     def Building10238(): Unit = { // Name: ceiling_bldg_j_10238 Type: ceiling_bldg_j GUID: 18, MapID: 10238
-      LocalBuilding("ceiling_bldg_j_10238", 18, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1393.65f, 837.81f, 98.87f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10238", 18, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1393.65f, 837.81f, 98.87f), Vector3(0f, 0f, 0f), ceiling_bldg_j)))
       LocalObject(907, Door.Constructor(Vector3(1393.666f, 825.3f, 100.649f)), owning_building_guid = 18)
       LocalObject(908, Door.Constructor(Vector3(1393.666f, 850.3f, 100.649f)), owning_building_guid = 18)
     }
@@ -177,7 +176,7 @@ object Ugd03 { // Adlivun
     Building10027()
 
     def Building10027(): Unit = { // Name: ceiling_bldg_z_10027 Type: ceiling_bldg_z GUID: 19, MapID: 10027
-      LocalBuilding("ceiling_bldg_z_10027", 19, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(916.61f, 913.02f, 110.84f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10027", 19, 10027, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(916.61f, 913.02f, 110.84f), Vector3(0f, 0f, 0f), ceiling_bldg_z)))
       LocalObject(814, Door.Constructor(Vector3(892.12f, 917.036f, 112.619f)), owning_building_guid = 19)
       LocalObject(823, Door.Constructor(Vector3(949.12f, 917.036f, 112.619f)), owning_building_guid = 19)
     }
@@ -185,7 +184,7 @@ object Ugd03 { // Adlivun
     Building10013()
 
     def Building10013(): Unit = { // Name: ground_bldg_a_10013 Type: ground_bldg_a GUID: 85, MapID: 10013
-      LocalBuilding("ground_bldg_a_10013", 85, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(933.13f, 698.34f, 81.85f), ground_bldg_a)))
+      LocalBuilding("ground_bldg_a_10013", 85, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(933.13f, 698.34f, 81.85f), Vector3(0f, 0f, 313f), ground_bldg_a)))
       LocalObject(820, Door.Constructor(Vector3(929.3392f, 714.15f, 83.629f)), owning_building_guid = 85)
       LocalObject(822, Door.Constructor(Vector3(947.2369f, 689.1008f, 83.629f)), owning_building_guid = 85)
     }
@@ -193,7 +192,7 @@ object Ugd03 { // Adlivun
     Building10003()
 
     def Building10003(): Unit = { // Name: ground_bldg_c_10003 Type: ground_bldg_c GUID: 86, MapID: 10003
-      LocalBuilding("ground_bldg_c_10003", 86, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(750.69f, 808.58f, 91.29f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10003", 86, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(750.69f, 808.58f, 91.29f), Vector3(0f, 0f, 152f), ground_bldg_c)))
       LocalObject(774, Door.Constructor(Vector3(700.9291f, 812.9419f, 93.069f)), owning_building_guid = 86)
       LocalObject(780, Door.Constructor(Vector3(715.4828f, 840.3133f, 93.069f)), owning_building_guid = 86)
       LocalObject(790, Door.Constructor(Vector3(750.1529f, 804.3535f, 93.069f)), owning_building_guid = 86)
@@ -202,7 +201,7 @@ object Ugd03 { // Adlivun
     Building10295()
 
     def Building10295(): Unit = { // Name: ground_bldg_c_10295 Type: ground_bldg_c GUID: 87, MapID: 10295
-      LocalBuilding("ground_bldg_c_10295", 87, 10295, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(942.14f, 752.71f, 85.39f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10295", 87, 10295, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(942.14f, 752.71f, 85.39f), Vector3(0f, 0f, 0f), ground_bldg_c)))
       LocalObject(821, Door.Constructor(Vector3(940.63f, 756.694f, 87.169f)), owning_building_guid = 87)
       LocalObject(825, Door.Constructor(Vector3(988.124f, 741.22f, 87.169f)), owning_building_guid = 87)
       LocalObject(826, Door.Constructor(Vector3(988.124f, 772.22f, 87.169f)), owning_building_guid = 87)
@@ -211,7 +210,7 @@ object Ugd03 { // Adlivun
     Building10170()
 
     def Building10170(): Unit = { // Name: ground_bldg_c_10170 Type: ground_bldg_c GUID: 88, MapID: 10170
-      LocalBuilding("ground_bldg_c_10170", 88, 10170, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1209.14f, 1162.92f, 80.39f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10170", 88, 10170, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1209.14f, 1162.92f, 80.39f), Vector3(0f, 0f, 312f), ground_bldg_c)))
       LocalObject(858, Door.Constructor(Vector3(1211.09f, 1166.708f, 82.169f)), owning_building_guid = 88)
       LocalObject(861, Door.Constructor(Vector3(1231.371f, 1121.059f, 82.169f)), owning_building_guid = 88)
       LocalObject(867, Door.Constructor(Vector3(1254.408f, 1141.802f, 82.169f)), owning_building_guid = 88)
@@ -220,7 +219,7 @@ object Ugd03 { // Adlivun
     Building10302()
 
     def Building10302(): Unit = { // Name: ground_bldg_c_10302 Type: ground_bldg_c GUID: 89, MapID: 10302
-      LocalBuilding("ground_bldg_c_10302", 89, 10302, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1236.42f, 689.57f, 84.46f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10302", 89, 10302, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1236.42f, 689.57f, 84.46f), Vector3(0f, 0f, 0f), ground_bldg_c)))
       LocalObject(864, Door.Constructor(Vector3(1234.91f, 693.554f, 86.239f)), owning_building_guid = 89)
       LocalObject(872, Door.Constructor(Vector3(1282.404f, 678.08f, 86.239f)), owning_building_guid = 89)
       LocalObject(873, Door.Constructor(Vector3(1282.404f, 709.08f, 86.239f)), owning_building_guid = 89)
@@ -229,7 +228,7 @@ object Ugd03 { // Adlivun
     Building10237()
 
     def Building10237(): Unit = { // Name: ground_bldg_d_10237 Type: ground_bldg_d GUID: 90, MapID: 10237
-      LocalBuilding("ground_bldg_d_10237", 90, 10237, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(713.63f, 978.09f, 54.81f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10237", 90, 10237, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(713.63f, 978.09f, 54.81f), Vector3(0f, 0f, 27f), ground_bldg_d)))
       LocalObject(772, Door.Constructor(Vector3(698.0391f, 970.164f, 56.545f)), owning_building_guid = 90)
       LocalObject(777, Door.Constructor(Vector3(705.704f, 993.681f, 56.545f)), owning_building_guid = 90)
       LocalObject(783, Door.Constructor(Vector3(721.5936f, 962.4958f, 56.545f)), owning_building_guid = 90)
@@ -239,7 +238,7 @@ object Ugd03 { // Adlivun
     Building10234()
 
     def Building10234(): Unit = { // Name: ground_bldg_d_10234 Type: ground_bldg_d GUID: 91, MapID: 10234
-      LocalBuilding("ground_bldg_d_10234", 91, 10234, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.49f, 732.12f, 94.62f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10234", 91, 10234, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(763.49f, 732.12f, 94.62f), Vector3(0f, 0f, 200f), ground_bldg_d)))
       LocalObject(789, Door.Constructor(Vector3(747.0414f, 726.1162f, 96.355f)), owning_building_guid = 91)
       LocalObject(792, Door.Constructor(Vector3(757.4862f, 748.5685f, 96.355f)), owning_building_guid = 91)
       LocalObject(795, Door.Constructor(Vector3(769.4569f, 715.6793f, 96.355f)), owning_building_guid = 91)
@@ -249,7 +248,7 @@ object Ugd03 { // Adlivun
     Building10357()
 
     def Building10357(): Unit = { // Name: ground_bldg_d_10357 Type: ground_bldg_d GUID: 92, MapID: 10357
-      LocalBuilding("ground_bldg_d_10357", 92, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(902.88f, 1372.77f, 43.35f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10357", 92, 10357, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(902.88f, 1372.77f, 43.35f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(812, Door.Constructor(Vector3(885.39f, 1372.786f, 45.085f)), owning_building_guid = 92)
       LocalObject(816, Door.Constructor(Vector3(902.896f, 1355.26f, 45.085f)), owning_building_guid = 92)
       LocalObject(817, Door.Constructor(Vector3(902.896f, 1390.26f, 45.085f)), owning_building_guid = 92)
@@ -259,7 +258,7 @@ object Ugd03 { // Adlivun
     Building10074()
 
     def Building10074(): Unit = { // Name: ground_bldg_d_10074 Type: ground_bldg_d GUID: 93, MapID: 10074
-      LocalBuilding("ground_bldg_d_10074", 93, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1054.39f, 1246.85f, 72.94f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10074", 93, 10074, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1054.39f, 1246.85f, 72.94f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(836, Door.Constructor(Vector3(1036.9f, 1246.866f, 74.675f)), owning_building_guid = 93)
       LocalObject(839, Door.Constructor(Vector3(1054.406f, 1229.34f, 74.675f)), owning_building_guid = 93)
       LocalObject(840, Door.Constructor(Vector3(1054.406f, 1264.34f, 74.675f)), owning_building_guid = 93)
@@ -269,7 +268,7 @@ object Ugd03 { // Adlivun
     Building10291()
 
     def Building10291(): Unit = { // Name: ground_bldg_d_10291 Type: ground_bldg_d GUID: 94, MapID: 10291
-      LocalBuilding("ground_bldg_d_10291", 94, 10291, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1226.43f, 1243.3f, 94.69f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10291", 94, 10291, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1226.43f, 1243.3f, 94.69f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(857, Door.Constructor(Vector3(1208.94f, 1243.316f, 96.425f)), owning_building_guid = 94)
       LocalObject(859, Door.Constructor(Vector3(1226.446f, 1225.79f, 96.425f)), owning_building_guid = 94)
       LocalObject(860, Door.Constructor(Vector3(1226.446f, 1260.79f, 96.425f)), owning_building_guid = 94)
@@ -279,7 +278,7 @@ object Ugd03 { // Adlivun
     Building10135()
 
     def Building10135(): Unit = { // Name: ground_bldg_e_10135 Type: ground_bldg_e GUID: 95, MapID: 10135
-      LocalBuilding("ground_bldg_e_10135", 95, 10135, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1056.2f, 739.36f, 68.24f), ground_bldg_e)))
+      LocalBuilding("ground_bldg_e_10135", 95, 10135, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1056.2f, 739.36f, 68.24f), Vector3(0f, 0f, 191f), ground_bldg_e)))
       LocalObject(835, Door.Constructor(Vector3(1033.179f, 726.7191f, 75.519f)), owning_building_guid = 95)
       LocalObject(837, Door.Constructor(Vector3(1042.885f, 708.2314f, 70.019f)), owning_building_guid = 95)
       LocalObject(842, Door.Constructor(Vector3(1058.492f, 706.6871f, 75.519f)), owning_building_guid = 95)
@@ -289,7 +288,7 @@ object Ugd03 { // Adlivun
     Building10002()
 
     def Building10002(): Unit = { // Name: ground_bldg_f_10002 Type: ground_bldg_f GUID: 96, MapID: 10002
-      LocalBuilding("ground_bldg_f_10002", 96, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(689.69f, 665.37f, 76.67f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10002", 96, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(689.69f, 665.37f, 76.67f), Vector3(0f, 0f, 333f), ground_bldg_f)))
       LocalObject(760, Door.Constructor(Vector3(662.3607f, 656.8664f, 78.449f)), owning_building_guid = 96)
       LocalObject(779, Door.Constructor(Vector3(713.3111f, 685.332f, 78.449f)), owning_building_guid = 96)
     }
@@ -297,7 +296,7 @@ object Ugd03 { // Adlivun
     Building10061()
 
     def Building10061(): Unit = { // Name: ground_bldg_f_10061 Type: ground_bldg_f GUID: 97, MapID: 10061
-      LocalBuilding("ground_bldg_f_10061", 97, 10061, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(991.58f, 1312.88f, 67.64f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10061", 97, 10061, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(991.58f, 1312.88f, 67.64f), Vector3(0f, 0f, 196f), ground_bldg_f)))
       LocalObject(824, Door.Constructor(Vector3(987.9187f, 1282.171f, 69.419f)), owning_building_guid = 97)
       LocalObject(829, Door.Constructor(Vector3(1005.768f, 1337.738f, 69.419f)), owning_building_guid = 97)
     }
@@ -305,7 +304,7 @@ object Ugd03 { // Adlivun
     Building10001()
 
     def Building10001(): Unit = { // Name: ground_bldg_f_10001 Type: ground_bldg_f GUID: 98, MapID: 10001
-      LocalBuilding("ground_bldg_f_10001", 98, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1315.3f, 1276.75f, 76.67f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10001", 98, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1315.3f, 1276.75f, 76.67f), Vector3(0f, 0f, 133f), ground_bldg_f)))
       LocalObject(876, Door.Constructor(Vector3(1286.276f, 1266.071f, 78.449f)), owning_building_guid = 98)
       LocalObject(897, Door.Constructor(Vector3(1343.89f, 1275.394f, 78.449f)), owning_building_guid = 98)
     }
@@ -313,7 +312,7 @@ object Ugd03 { // Adlivun
     Building10147()
 
     def Building10147(): Unit = { // Name: ground_bldg_g_10147 Type: ground_bldg_g GUID: 99, MapID: 10147
-      LocalBuilding("ground_bldg_g_10147", 99, 10147, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(624.24f, 967.02f, 72.09f), ground_bldg_g)))
+      LocalBuilding("ground_bldg_g_10147", 99, 10147, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(624.24f, 967.02f, 72.09f), Vector3(0f, 0f, 0f), ground_bldg_g)))
       LocalObject(752, Door.Constructor(Vector3(616.256f, 950.51f, 73.869f)), owning_building_guid = 99)
       LocalObject(754, Door.Constructor(Vector3(624.256f, 984.51f, 73.869f)), owning_building_guid = 99)
     }
@@ -321,7 +320,7 @@ object Ugd03 { // Adlivun
     Building10154()
 
     def Building10154(): Unit = { // Name: ground_bldg_h_10154 Type: ground_bldg_h GUID: 100, MapID: 10154
-      LocalBuilding("ground_bldg_h_10154", 100, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(654.94f, 1129.19f, 68.99f), ground_bldg_h)))
+      LocalBuilding("ground_bldg_h_10154", 100, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(654.94f, 1129.19f, 68.99f), Vector3(0f, 0f, 0f), ground_bldg_h)))
       LocalObject(755, Door.Constructor(Vector3(638.45f, 1125.206f, 70.769f)), owning_building_guid = 100)
       LocalObject(759, Door.Constructor(Vector3(658.924f, 1145.7f, 70.769f)), owning_building_guid = 100)
       LocalObject(764, Door.Constructor(Vector3(666.025f, 1118.002f, 73.269f)), owning_building_guid = 100)
@@ -330,7 +329,7 @@ object Ugd03 { // Adlivun
     Building10004()
 
     def Building10004(): Unit = { // Name: ground_bldg_i_10004 Type: ground_bldg_i GUID: 101, MapID: 10004
-      LocalBuilding("ground_bldg_i_10004", 101, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(641.6f, 811.71f, 80.39f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10004", 101, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(641.6f, 811.71f, 80.39f), Vector3(0f, 0f, 19f), ground_bldg_i)))
       LocalObject(753, Door.Constructor(Vector3(617.2995f, 807.0613f, 82.169f)), owning_building_guid = 101)
       LocalObject(763, Door.Constructor(Vector3(664.5754f, 823.3397f, 82.169f)), owning_building_guid = 101)
     }
@@ -338,7 +337,7 @@ object Ugd03 { // Adlivun
     Building10306()
 
     def Building10306(): Unit = { // Name: ground_bldg_i_10306 Type: ground_bldg_i GUID: 102, MapID: 10306
-      LocalBuilding("ground_bldg_i_10306", 102, 10306, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1310.62f, 1122.78f, 80.99f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10306", 102, 10306, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1310.62f, 1122.78f, 80.99f), Vector3(0f, 0f, 179f), ground_bldg_i)))
       LocalObject(875, Door.Constructor(Vector3(1285.052f, 1119.71f, 82.769f)), owning_building_guid = 102)
       LocalObject(894, Door.Constructor(Vector3(1335.045f, 1118.837f, 82.769f)), owning_building_guid = 102)
     }
@@ -346,7 +345,7 @@ object Ugd03 { // Adlivun
     Building10075()
 
     def Building10075(): Unit = { // Name: ground_bldg_j_10075 Type: ground_bldg_j GUID: 103, MapID: 10075
-      LocalBuilding("ground_bldg_j_10075", 103, 10075, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1060.18f, 1311.97f, 73.4f), ground_bldg_j)))
+      LocalBuilding("ground_bldg_j_10075", 103, 10075, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1060.18f, 1311.97f, 73.4f), Vector3(0f, 0f, 343f), ground_bldg_j)))
       LocalObject(841, Door.Constructor(Vector3(1056.538f, 1300.002f, 75.179f)), owning_building_guid = 103)
       LocalObject(843, Door.Constructor(Vector3(1063.847f, 1323.91f, 75.179f)), owning_building_guid = 103)
     }
@@ -354,7 +353,7 @@ object Ugd03 { // Adlivun
     Building10322()
 
     def Building10322(): Unit = { // Name: NW_Redoubt Type: redoubt GUID: 104, MapID: 10322
-      LocalBuilding("NW_Redoubt", 104, 10322, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(718.55f, 1209.17f, 43.36f), redoubt)))
+      LocalBuilding("NW_Redoubt", 104, 10322, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(718.55f, 1209.17f, 43.36f), Vector3(0f, 0f, 346f), redoubt)))
       LocalObject(1023, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 104)
       LocalObject(775, Door.Constructor(Vector3(701.5834f, 1213.417f, 45.095f)), owning_building_guid = 104)
       LocalObject(778, Door.Constructor(Vector3(709.5589f, 1223.861f, 55.139f)), owning_building_guid = 104)
@@ -371,7 +370,7 @@ object Ugd03 { // Adlivun
     Building10359()
 
     def Building10359(): Unit = { // Name: SE_Redoubt Type: redoubt GUID: 105, MapID: 10359
-      LocalBuilding("SE_Redoubt", 105, 10359, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1397.63f, 773.07f, 43.36f), redoubt)))
+      LocalBuilding("SE_Redoubt", 105, 10359, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1397.63f, 773.07f, 43.36f), Vector3(0f, 0f, 0f), redoubt)))
       LocalObject(1027, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 105)
       LocalObject(903, Door.Constructor(Vector3(1380.14f, 773.086f, 45.095f)), owning_building_guid = 105)
       LocalObject(904, Door.Constructor(Vector3(1385.352f, 785.149f, 55.139f)), owning_building_guid = 105)
@@ -388,7 +387,7 @@ object Ugd03 { // Adlivun
     Building10005()
 
     def Building10005(): Unit = { // Name: SW_Stasis Type: vanu_control_point GUID: 211, MapID: 10005
-      LocalBuilding("SW_Stasis", 211, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(662.53f, 731.92f, 71.25f), vanu_control_point)))
+      LocalBuilding("SW_Stasis", 211, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(662.53f, 731.92f, 71.25f), Vector3(0f, 0f, 200f), vanu_control_point)))
       LocalObject(1022, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 211)
       LocalObject(751, Door.Constructor(Vector3(610.1769f, 740.5507f, 73.029f)), owning_building_guid = 211)
       LocalObject(756, Door.Constructor(Vector3(642.492f, 688.1669f, 73.029f)), owning_building_guid = 211)
@@ -421,7 +420,7 @@ object Ugd03 { // Adlivun
     Building10173()
 
     def Building10173(): Unit = { // Name: NE_Stasis Type: vanu_control_point GUID: 212, MapID: 10173
-      LocalBuilding("NE_Stasis", 212, 10173, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1318.15f, 1204.93f, 71.05f), vanu_control_point)))
+      LocalBuilding("NE_Stasis", 212, 10173, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1318.15f, 1204.93f, 71.05f), Vector3(0f, 0f, 0f), vanu_control_point)))
       LocalObject(1026, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 212)
       LocalObject(874, Door.Constructor(Vector3(1283.918f, 1218.946f, 72.829f)), owning_building_guid = 212)
       LocalObject(877, Door.Constructor(Vector3(1295.976f, 1174.669f, 72.829f)), owning_building_guid = 212)
@@ -454,7 +453,7 @@ object Ugd03 { // Adlivun
     Building10012()
 
     def Building10012(): Unit = { // Name: Core Type: vanu_core GUID: 213, MapID: 10012
-      LocalBuilding("Core", 213, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1026.95f, 1013.73f, 97.73f), vanu_core)))
+      LocalBuilding("Core", 213, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1026.95f, 1013.73f, 97.73f), Vector3(0f, 0f, 0f), vanu_core)))
       LocalObject(827, Door.Constructor(Vector3(994.457f, 1001.752f, 104.518f)), owning_building_guid = 213)
       LocalObject(831, Door.Constructor(Vector3(1022.928f, 973.237f, 104.518f)), owning_building_guid = 213)
       LocalObject(832, Door.Constructor(Vector3(1022.928f, 973.237f, 109.518f)), owning_building_guid = 213)
@@ -466,7 +465,7 @@ object Ugd03 { // Adlivun
     Building10156()
 
     def Building10156(): Unit = { // Name: NW_ATPlant Type: vanu_vehicle_station GUID: 256, MapID: 10156
-      LocalBuilding("NW_ATPlant", 256, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(772.18f, 1217.7f, 43.18f), vanu_vehicle_station)))
+      LocalBuilding("NW_ATPlant", 256, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(772.18f, 1217.7f, 43.18f), Vector3(0f, 0f, 118f), vanu_vehicle_station)))
       LocalObject(1024, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 256)
       LocalObject(794, Door.Constructor(Vector3(761.205f, 1206.612f, 44.959f)), owning_building_guid = 256)
       LocalObject(797, Door.Constructor(Vector3(779.6216f, 1189.222f, 64.871f)), owning_building_guid = 256)
@@ -490,7 +489,7 @@ object Ugd03 { // Adlivun
     Building10007()
 
     def Building10007(): Unit = { // Name: SE_ATPlant Type: vanu_vehicle_station GUID: 257, MapID: 10007
-      LocalBuilding("SE_ATPlant", 257, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1352.53f, 780.12f, 43.78f), vanu_vehicle_station)))
+      LocalBuilding("SE_ATPlant", 257, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1352.53f, 780.12f, 43.78f), Vector3(0f, 0f, 307f), vanu_vehicle_station)))
       LocalObject(1025, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 257)
       LocalObject(878, Door.Constructor(Vector3(1298.814f, 795.5347f, 75.559f)), owning_building_guid = 257)
       LocalObject(879, Door.Constructor(Vector3(1305.402f, 800.4932f, 75.539f)), owning_building_guid = 257)

--- a/pslogin/src/main/scala/zonemaps/Ugd04.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd04.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd04 { // Byblos
   val ZoneMap = new ZoneMap("ugd04") {
     Scale = MapScale.Dim2048
-    Cavern = true
     Checksum = 3797992164L
 
     Building10076()
 
     def Building10076(): Unit = { // Name: ceiling_bldg_a_10076 Type: ceiling_bldg_a GUID: 1, MapID: 10076
-      LocalBuilding("ceiling_bldg_a_10076", 1, 10076, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1039.99f, 1095.48f, 207.81f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10076", 1, 10076, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1039.99f, 1095.48f, 207.81f), Vector3(0f, 0f, 341f), ceiling_bldg_a)))
       LocalObject(667, Door.Constructor(Vector3(1029.274f, 1107.31f, 209.589f)), owning_building_guid = 1)
       LocalObject(672, Door.Constructor(Vector3(1050.822f, 1080.083f, 215.095f)), owning_building_guid = 1)
       LocalObject(673, Door.Constructor(Vector3(1057.124f, 1093.777f, 209.589f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd04 { // Byblos
     Building10031()
 
     def Building10031(): Unit = { // Name: ceiling_bldg_b_10031 Type: ceiling_bldg_b GUID: 2, MapID: 10031
-      LocalBuilding("ceiling_bldg_b_10031", 2, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(870.26f, 1148.19f, 178.45f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10031", 2, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(870.26f, 1148.19f, 178.45f), Vector3(0f, 0f, 304f), ceiling_bldg_b)))
       LocalObject(648, Door.Constructor(Vector3(872.7868f, 1142.638f, 180.229f)), owning_building_guid = 2)
       LocalObject(652, Door.Constructor(Vector3(885.0576f, 1155.74f, 180.229f)), owning_building_guid = 2)
     }
@@ -39,7 +38,7 @@ object Ugd04 { // Byblos
     Building10290()
 
     def Building10290(): Unit = { // Name: ceiling_bldg_c_10290 Type: ceiling_bldg_c GUID: 3, MapID: 10290
-      LocalBuilding("ceiling_bldg_c_10290", 3, 10290, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.74f, 1334.76f, 162.68f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10290", 3, 10290, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.74f, 1334.76f, 162.68f), Vector3(0f, 0f, 222f), ceiling_bldg_c)))
       LocalObject(630, Door.Constructor(Vector3(786.8789f, 1312.529f, 164.459f)), owning_building_guid = 3)
       LocalObject(636, Door.Constructor(Vector3(807.6219f, 1289.492f, 164.459f)), owning_building_guid = 3)
       LocalObject(641, Door.Constructor(Vector3(832.528f, 1332.81f, 164.459f)), owning_building_guid = 3)
@@ -48,7 +47,7 @@ object Ugd04 { // Byblos
     Building10057()
 
     def Building10057(): Unit = { // Name: ceiling_bldg_d_10057 Type: ceiling_bldg_d GUID: 4, MapID: 10057
-      LocalBuilding("ceiling_bldg_d_10057", 4, 10057, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(709.3f, 999.79f, 174.85f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10057", 4, 10057, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(709.3f, 999.79f, 174.85f), Vector3(0f, 0f, 204f), ceiling_bldg_d)))
       LocalObject(621, Door.Constructor(Vector3(693.3103f, 992.6534f, 176.585f)), owning_building_guid = 4)
       LocalObject(623, Door.Constructor(Vector3(702.1634f, 1015.78f, 176.585f)), owning_building_guid = 4)
       LocalObject(625, Door.Constructor(Vector3(716.3992f, 983.8055f, 176.585f)), owning_building_guid = 4)
@@ -59,7 +58,7 @@ object Ugd04 { // Byblos
     Building10279()
 
     def Building10279(): Unit = { // Name: ceiling_bldg_d_10279 Type: ceiling_bldg_d GUID: 5, MapID: 10279
-      LocalBuilding("ceiling_bldg_d_10279", 5, 10279, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.27f, 1060.78f, 198.86f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10279", 5, 10279, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1159.27f, 1060.78f, 198.86f), Vector3(0f, 0f, 284f), ceiling_bldg_d)))
       LocalObject(688, Door.Constructor(Vector3(1142.284f, 1056.528f, 200.595f)), owning_building_guid = 5)
       LocalObject(691, Door.Constructor(Vector3(1155.054f, 1077.754f, 200.595f)), owning_building_guid = 5)
       LocalObject(692, Door.Constructor(Vector3(1163.522f, 1043.794f, 200.595f)), owning_building_guid = 5)
@@ -70,7 +69,7 @@ object Ugd04 { // Byblos
     Building10056()
 
     def Building10056(): Unit = { // Name: ceiling_bldg_e_10056 Type: ceiling_bldg_e GUID: 6, MapID: 10056
-      LocalBuilding("ceiling_bldg_e_10056", 6, 10056, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837.17f, 1077.23f, 193.72f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10056", 6, 10056, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(837.17f, 1077.23f, 193.72f), Vector3(0f, 0f, 336f), ceiling_bldg_e)))
       LocalObject(640, Door.Constructor(Vector3(825.7902f, 1081.213f, 195.499f)), owning_building_guid = 6)
       LocalObject(644, Door.Constructor(Vector3(854.0325f, 1105.309f, 200.999f)), owning_building_guid = 6)
       LocalObject(646, Door.Constructor(Vector3(863.2781f, 1074.38f, 200.999f)), owning_building_guid = 6)
@@ -80,7 +79,7 @@ object Ugd04 { // Byblos
     Building10058()
 
     def Building10058(): Unit = { // Name: ceiling_bldg_f_10058 Type: ceiling_bldg_f GUID: 7, MapID: 10058
-      LocalBuilding("ceiling_bldg_f_10058", 7, 10058, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(699.42f, 1116.72f, 164.46f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10058", 7, 10058, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(699.42f, 1116.72f, 164.46f), Vector3(0f, 0f, 233f), ceiling_bldg_f)))
       LocalObject(622, Door.Constructor(Vector3(695.7913f, 1145.111f, 166.239f)), owning_building_guid = 7)
       LocalObject(624, Door.Constructor(Vector3(714.9769f, 1089.991f, 166.239f)), owning_building_guid = 7)
     }
@@ -88,7 +87,7 @@ object Ugd04 { // Byblos
     Building10077()
 
     def Building10077(): Unit = { // Name: ceiling_bldg_g_10077 Type: ceiling_bldg_g GUID: 8, MapID: 10077
-      LocalBuilding("ceiling_bldg_g_10077", 8, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1136.66f, 968.13f, 183.11f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10077", 8, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1136.66f, 968.13f, 183.11f), Vector3(0f, 0f, 101f), ceiling_bldg_g)))
       LocalObject(685, Door.Constructor(Vector3(1119.488f, 964.8085f, 184.889f)), owning_building_guid = 8)
       LocalObject(690, Door.Constructor(Vector3(1154.39f, 963.4429f, 184.889f)), owning_building_guid = 8)
     }
@@ -96,7 +95,7 @@ object Ugd04 { // Byblos
     Building10030()
 
     def Building10030(): Unit = { // Name: ceiling_bldg_h_10030 Type: ceiling_bldg_h GUID: 9, MapID: 10030
-      LocalBuilding("ceiling_bldg_h_10030", 9, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(894.28f, 1280.67f, 179.98f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10030", 9, 10030, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(894.28f, 1280.67f, 179.98f), Vector3(0f, 0f, 320f), ceiling_bldg_h)))
       LocalObject(650, Door.Constructor(Vector3(879.0871f, 1288.218f, 181.759f)), owning_building_guid = 9)
       LocalObject(654, Door.Constructor(Vector3(895.5801f, 1264.974f, 184.259f)), owning_building_guid = 9)
       LocalObject(656, Door.Constructor(Vector3(907.9444f, 1290.757f, 181.759f)), owning_building_guid = 9)
@@ -105,7 +104,7 @@ object Ugd04 { // Byblos
     Building10283()
 
     def Building10283(): Unit = { // Name: ground_bldg_a_10283 Type: ground_bldg_a GUID: 83, MapID: 10283
-      LocalBuilding("ground_bldg_a_10283", 83, 10283, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(872.31f, 871.53f, 124f), ground_bldg_a)))
+      LocalBuilding("ground_bldg_a_10283", 83, 10283, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(872.31f, 871.53f, 124f), Vector3(0f, 0f, 0f), ground_bldg_a)))
       LocalObject(645, Door.Constructor(Vector3(858.162f, 879.54f, 125.779f)), owning_building_guid = 83)
       LocalObject(653, Door.Constructor(Vector3(888.688f, 875.546f, 125.779f)), owning_building_guid = 83)
     }
@@ -113,7 +112,7 @@ object Ugd04 { // Byblos
     Building10022()
 
     def Building10022(): Unit = { // Name: ground_bldg_a_10022 Type: ground_bldg_a GUID: 84, MapID: 10022
-      LocalBuilding("ground_bldg_a_10022", 84, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.4f, 1234.86f, 124f), ground_bldg_a)))
+      LocalBuilding("ground_bldg_a_10022", 84, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.4f, 1234.86f, 124f), Vector3(0f, 0f, 0f), ground_bldg_a)))
       LocalObject(671, Door.Constructor(Vector3(1049.252f, 1242.87f, 125.779f)), owning_building_guid = 84)
       LocalObject(679, Door.Constructor(Vector3(1079.778f, 1238.876f, 125.779f)), owning_building_guid = 84)
     }
@@ -121,7 +120,7 @@ object Ugd04 { // Byblos
     Building10288()
 
     def Building10288(): Unit = { // Name: ground_bldg_b_10288 Type: ground_bldg_b GUID: 85, MapID: 10288
-      LocalBuilding("ground_bldg_b_10288", 85, 10288, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.58f, 779.96f, 113f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10288", 85, 10288, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.58f, 779.96f, 113f), Vector3(0f, 0f, 0f), ground_bldg_b)))
       LocalObject(649, Door.Constructor(Vector3(877.595f, 796.45f, 114.779f)), owning_building_guid = 85)
       LocalObject(651, Door.Constructor(Vector3(881.596f, 778.95f, 114.779f)), owning_building_guid = 85)
       LocalObject(655, Door.Constructor(Vector3(900.102f, 785.976f, 120.279f)), owning_building_guid = 85)
@@ -130,7 +129,7 @@ object Ugd04 { // Byblos
     Building10001()
 
     def Building10001(): Unit = { // Name: ground_bldg_c_10001 Type: ground_bldg_c GUID: 86, MapID: 10001
-      LocalBuilding("ground_bldg_c_10001", 86, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(789.88f, 853.2f, 131f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10001", 86, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(789.88f, 853.2f, 131f), Vector3(0f, 0f, 270f), ground_bldg_c)))
       LocalObject(628, Door.Constructor(Vector3(778.39f, 807.216f, 132.779f)), owning_building_guid = 86)
       LocalObject(633, Door.Constructor(Vector3(793.864f, 854.71f, 132.779f)), owning_building_guid = 86)
       LocalObject(637, Door.Constructor(Vector3(809.39f, 807.216f, 132.779f)), owning_building_guid = 86)
@@ -139,7 +138,7 @@ object Ugd04 { // Byblos
     Building10222()
 
     def Building10222(): Unit = { // Name: ground_bldg_c_10222 Type: ground_bldg_c GUID: 87, MapID: 10222
-      LocalBuilding("ground_bldg_c_10222", 87, 10222, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1395.18f, 1160.54f, 130.8f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10222", 87, 10222, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1395.18f, 1160.54f, 130.8f), Vector3(0f, 0f, 45f), ground_bldg_c)))
       LocalObject(722, Door.Constructor(Vector3(1391.295f, 1162.289f, 132.579f)), owning_building_guid = 87)
       LocalObject(723, Door.Constructor(Vector3(1413.9f, 1206.851f, 132.579f)), owning_building_guid = 87)
       LocalObject(724, Door.Constructor(Vector3(1435.82f, 1184.931f, 132.579f)), owning_building_guid = 87)
@@ -148,7 +147,7 @@ object Ugd04 { // Byblos
     Building10154()
 
     def Building10154(): Unit = { // Name: ground_bldg_d_10154 Type: ground_bldg_d GUID: 88, MapID: 10154
-      LocalBuilding("ground_bldg_d_10154", 88, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(831.35f, 734.45f, 111f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10154", 88, 10154, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(831.35f, 734.45f, 111f), Vector3(0f, 0f, 63f), ground_bldg_d)))
       LocalObject(638, Door.Constructor(Vector3(815.7736f, 742.4045f, 112.735f)), owning_building_guid = 88)
       LocalObject(639, Door.Constructor(Vector3(823.3954f, 718.8736f, 112.735f)), owning_building_guid = 88)
       LocalObject(642, Door.Constructor(Vector3(839.2851f, 750.0588f, 112.735f)), owning_building_guid = 88)
@@ -158,7 +157,7 @@ object Ugd04 { // Byblos
     Building10155()
 
     def Building10155(): Unit = { // Name: ground_bldg_d_10155 Type: ground_bldg_d GUID: 89, MapID: 10155
-      LocalBuilding("ground_bldg_d_10155", 89, 10155, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1132.27f, 1293.23f, 118.79f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10155", 89, 10155, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1132.27f, 1293.23f, 118.79f), Vector3(0f, 0f, 236f), ground_bldg_d)))
       LocalObject(684, Door.Constructor(Vector3(1117.745f, 1303.008f, 120.525f)), owning_building_guid = 89)
       LocalObject(686, Door.Constructor(Vector3(1122.492f, 1278.705f, 120.525f)), owning_building_guid = 89)
       LocalObject(687, Door.Constructor(Vector3(1142.064f, 1307.721f, 120.525f)), owning_building_guid = 89)
@@ -168,7 +167,7 @@ object Ugd04 { // Byblos
     Building10023()
 
     def Building10023(): Unit = { // Name: ground_bldg_e_10023 Type: ground_bldg_e GUID: 90, MapID: 10023
-      LocalBuilding("ground_bldg_e_10023", 90, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1044.11f, 1336.51f, 116.41f), ground_bldg_e)))
+      LocalBuilding("ground_bldg_e_10023", 90, 10023, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1044.11f, 1336.51f, 116.41f), Vector3(0f, 0f, 315f), ground_bldg_e)))
       LocalObject(669, Door.Constructor(Vector3(1034.913f, 1344.307f, 118.189f)), owning_building_guid = 90)
       LocalObject(675, Door.Constructor(Vector3(1067.463f, 1324.493f, 123.689f)), owning_building_guid = 90)
       LocalObject(676, Door.Constructor(Vector3(1069.915f, 1356.681f, 123.689f)), owning_building_guid = 90)
@@ -178,7 +177,7 @@ object Ugd04 { // Byblos
     Building10156()
 
     def Building10156(): Unit = { // Name: ground_bldg_e_10156 Type: ground_bldg_e GUID: 91, MapID: 10156
-      LocalBuilding("ground_bldg_e_10156", 91, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1083.61f, 698.32f, 116.81f), ground_bldg_e)))
+      LocalBuilding("ground_bldg_e_10156", 91, 10156, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1083.61f, 698.32f, 116.81f), Vector3(0f, 0f, 315f), ground_bldg_e)))
       LocalObject(677, Door.Constructor(Vector3(1074.413f, 706.1166f, 118.589f)), owning_building_guid = 91)
       LocalObject(680, Door.Constructor(Vector3(1106.963f, 686.3034f, 124.089f)), owning_building_guid = 91)
       LocalObject(681, Door.Constructor(Vector3(1109.415f, 718.4909f, 124.089f)), owning_building_guid = 91)
@@ -188,7 +187,7 @@ object Ugd04 { // Byblos
     Building10008()
 
     def Building10008(): Unit = { // Name: ground_bldg_f_10008 Type: ground_bldg_f GUID: 92, MapID: 10008
-      LocalBuilding("ground_bldg_f_10008", 92, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1138.19f, 625.25f, 113.54f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10008", 92, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1138.19f, 625.25f, 113.54f), Vector3(0f, 0f, 305f), ground_bldg_f)))
       LocalObject(682, Door.Constructor(Vector3(1110.067f, 630.5721f, 115.319f)), owning_building_guid = 92)
       LocalObject(693, Door.Constructor(Vector3(1168.418f, 631.7859f, 115.319f)), owning_building_guid = 92)
     }
@@ -196,7 +195,7 @@ object Ugd04 { // Byblos
     Building10009()
 
     def Building10009(): Unit = { // Name: ground_bldg_g_10009 Type: ground_bldg_g GUID: 93, MapID: 10009
-      LocalBuilding("ground_bldg_g_10009", 93, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1368.37f, 871.02f, 119f), ground_bldg_g)))
+      LocalBuilding("ground_bldg_g_10009", 93, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1368.37f, 871.02f, 119f), Vector3(0f, 0f, 230f), ground_bldg_g)))
       LocalObject(720, Door.Constructor(Vector3(1360.855f, 887.7485f, 120.779f)), owning_building_guid = 93)
       LocalObject(721, Door.Constructor(Vector3(1381.758f, 859.7654f, 120.779f)), owning_building_guid = 93)
     }
@@ -204,7 +203,7 @@ object Ugd04 { // Byblos
     Building10010()
 
     def Building10010(): Unit = { // Name: ground_bldg_h_10010 Type: ground_bldg_h GUID: 94, MapID: 10010
-      LocalBuilding("ground_bldg_h_10010", 94, 10010, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1312.56f, 941.38f, 118.56f), ground_bldg_h)))
+      LocalBuilding("ground_bldg_h_10010", 94, 10010, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1312.56f, 941.38f, 118.56f), Vector3(0f, 0f, 45f), ground_bldg_h)))
       LocalObject(714, Door.Constructor(Vector3(1303.717f, 926.9027f, 120.339f)), owning_building_guid = 94)
       LocalObject(715, Door.Constructor(Vector3(1303.703f, 955.8715f, 120.339f)), owning_building_guid = 94)
       LocalObject(718, Door.Constructor(Vector3(1328.309f, 941.3072f, 122.839f)), owning_building_guid = 94)
@@ -213,7 +212,7 @@ object Ugd04 { // Byblos
     Building10298()
 
     def Building10298(): Unit = { // Name: ground_bldg_i_10298 Type: ground_bldg_i GUID: 95, MapID: 10298
-      LocalBuilding("ground_bldg_i_10298", 95, 10298, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1290.66f, 1171.46f, 134.92f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10298", 95, 10298, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1290.66f, 1171.46f, 134.92f), Vector3(0f, 0f, 55f), ground_bldg_i)))
       LocalObject(704, Door.Constructor(Vector3(1273.733f, 1153.416f, 136.699f)), owning_building_guid = 95)
       LocalObject(712, Door.Constructor(Vector3(1302.412f, 1194.373f, 136.699f)), owning_building_guid = 95)
     }
@@ -221,7 +220,7 @@ object Ugd04 { // Byblos
     Building10350()
 
     def Building10350(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 96, MapID: 10350
-      LocalBuilding("N_Redoubt", 96, 10350, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(781.91f, 1176.43f, 109.13f), redoubt)))
+      LocalBuilding("N_Redoubt", 96, 10350, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(781.91f, 1176.43f, 109.13f), Vector3(0f, 0f, 241f), redoubt)))
       LocalObject(816, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 96)
       LocalObject(627, Door.Constructor(Vector3(773.4349f, 1161.108f, 110.865f)), owning_building_guid = 96)
       LocalObject(629, Door.Constructor(Vector3(786.5674f, 1159.849f, 120.909f)), owning_building_guid = 96)
@@ -238,7 +237,7 @@ object Ugd04 { // Byblos
     Building10354()
 
     def Building10354(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 97, MapID: 10354
-      LocalBuilding("S_Redoubt", 97, 10354, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1026.2f, 729.8f, 124.4f), redoubt)))
+      LocalBuilding("S_Redoubt", 97, 10354, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1026.2f, 729.8f, 124.4f), Vector3(0f, 0f, 25f), redoubt)))
       LocalObject(817, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 97)
       LocalObject(660, Door.Constructor(Vector3(1009.968f, 735.5583f, 136.179f)), owning_building_guid = 97)
       LocalObject(661, Door.Constructor(Vector3(1010.342f, 722.4229f, 126.135f)), owning_building_guid = 97)
@@ -255,7 +254,7 @@ object Ugd04 { // Byblos
     Building10285()
 
     def Building10285(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 154, MapID: 10285
-      LocalBuilding("S_Stasis", 154, 10285, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(647.64f, 755.35f, 139.61f), vanu_control_point)))
+      LocalBuilding("S_Stasis", 154, 10285, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(647.64f, 755.35f, 139.61f), Vector3(0f, 0f, 293f), vanu_control_point)))
       LocalObject(814, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 154)
       LocalObject(601, Door.Constructor(Vector3(611.1205f, 763.9373f, 141.389f)), owning_building_guid = 154)
       LocalObject(604, Door.Constructor(Vector3(632.1003f, 755.4609f, 171.389f)), owning_building_guid = 154)
@@ -288,7 +287,7 @@ object Ugd04 { // Byblos
     Building10215()
 
     def Building10215(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 155, MapID: 10215
-      LocalBuilding("N_Stasis", 155, 10215, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1294.35f, 1355.27f, 144.89f), vanu_control_point)))
+      LocalBuilding("N_Stasis", 155, 10215, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1294.35f, 1355.27f, 144.89f), Vector3(0f, 0f, 123f), vanu_control_point)))
       LocalObject(819, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 155)
       LocalObject(703, Door.Constructor(Vector3(1247.211f, 1364.952f, 146.669f)), owning_building_guid = 155)
       LocalObject(705, Door.Constructor(Vector3(1284.874f, 1351.482f, 151.61f)), owning_building_guid = 155)
@@ -321,7 +320,7 @@ object Ugd04 { // Byblos
     Building10000()
 
     def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 156, MapID: 10000
-      LocalBuilding("Core", 156, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.99f, 1015.28f, 166.4f), vanu_core)))
+      LocalBuilding("Core", 156, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.99f, 1015.28f, 166.4f), Vector3(0f, 0f, 40f), vanu_core)))
       LocalObject(657, Door.Constructor(Vector3(972.7982f, 985.2183f, 173.188f)), owning_building_guid = 156)
       LocalObject(658, Door.Constructor(Vector3(976.3412f, 1025.357f, 178.188f)), owning_building_guid = 156)
       LocalObject(659, Door.Constructor(Vector3(976.3412f, 1025.357f, 183.188f)), owning_building_guid = 156)
@@ -333,7 +332,7 @@ object Ugd04 { // Byblos
     Building10011()
 
     def Building10011(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 183, MapID: 10011
-      LocalBuilding("N_ATPlant", 183, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(656.27f, 1262.7f, 108.8f), vanu_vehicle_station)))
+      LocalBuilding("N_ATPlant", 183, 10011, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(656.27f, 1262.7f, 108.8f), Vector3(0f, 0f, 230f), vanu_vehicle_station)))
       LocalObject(815, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 183)
       LocalObject(602, Door.Constructor(Vector3(621.247f, 1298.142f, 110.579f)), owning_building_guid = 183)
       LocalObject(603, Door.Constructor(Vector3(627.3662f, 1293.008f, 130.503f)), owning_building_guid = 183)
@@ -357,7 +356,7 @@ object Ugd04 { // Byblos
     Building10002()
 
     def Building10002(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 184, MapID: 10002
-      LocalBuilding("S_ATPlant", 184, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1188.77f, 698.47f, 110f), vanu_vehicle_station)))
+      LocalBuilding("S_ATPlant", 184, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1188.77f, 698.47f, 110f), Vector3(0f, 0f, 175f), vanu_vehicle_station)))
       LocalObject(818, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 184)
       LocalObject(695, Door.Constructor(Vector3(1192.092f, 683.2264f, 111.779f)), owning_building_guid = 184)
       LocalObject(696, Door.Constructor(Vector3(1197.018f, 739.5303f, 131.703f)), owning_building_guid = 184)

--- a/pslogin/src/main/scala/zonemaps/Ugd05.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd05.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd05 { // Annwn
   val ZoneMap = new ZoneMap("ugd05") {
     Scale = MapScale.Dim2048
-    Cavern = true
     Checksum = 1769572498L
 
     Building10116()
 
     def Building10116(): Unit = { // Name: ceiling_bldg_a_10116 Type: ceiling_bldg_a GUID: 1, MapID: 10116
-      LocalBuilding("ceiling_bldg_a_10116", 1, 10116, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.36f, 953.39f, 272.03f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10116", 1, 10116, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1287.36f, 953.39f, 272.03f), Vector3(0f, 0f, 279f), ceiling_bldg_a)))
       LocalObject(478, Door.Constructor(Vector3(1278.85f, 936.597f, 279.315f)), owning_building_guid = 1)
       LocalObject(479, Door.Constructor(Vector3(1292.775f, 968.4059f, 273.809f)), owning_building_guid = 1)
       LocalObject(480, Door.Constructor(Vector3(1293.9f, 937.462f, 273.809f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd05 { // Annwn
     Building10014()
 
     def Building10014(): Unit = { // Name: ceiling_bldg_b_10014 Type: ceiling_bldg_b GUID: 2, MapID: 10014
-      LocalBuilding("ceiling_bldg_b_10014", 2, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.8f, 980.41f, 242.69f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10014", 2, 10014, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.8f, 980.41f, 242.69f), Vector3(0f, 0f, 317f), ceiling_bldg_b)))
       LocalObject(391, Door.Constructor(Vector3(982.511f, 975.5684f, 244.469f)), owning_building_guid = 2)
       LocalObject(396, Door.Constructor(Vector3(991.5198f, 991.0958f, 244.469f)), owning_building_guid = 2)
     }
@@ -39,7 +38,7 @@ object Ugd05 { // Annwn
     Building10002()
 
     def Building10002(): Unit = { // Name: ceiling_bldg_b_10002 Type: ceiling_bldg_b GUID: 3, MapID: 10002
-      LocalBuilding("ceiling_bldg_b_10002", 3, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1192.36f, 1130.14f, 256.99f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10002", 3, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1192.36f, 1130.14f, 256.99f), Vector3(0f, 0f, 0f), ceiling_bldg_b)))
       LocalObject(445, Door.Constructor(Vector3(1194.375f, 1146.63f, 258.769f)), owning_building_guid = 3)
       LocalObject(448, Door.Constructor(Vector3(1198.376f, 1129.13f, 258.769f)), owning_building_guid = 3)
     }
@@ -47,7 +46,7 @@ object Ugd05 { // Annwn
     Building10004()
 
     def Building10004(): Unit = { // Name: ceiling_bldg_d_10004 Type: ceiling_bldg_d GUID: 4, MapID: 10004
-      LocalBuilding("ceiling_bldg_d_10004", 4, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1208.22f, 913.48f, 275.19f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10004", 4, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1208.22f, 913.48f, 275.19f), Vector3(0f, 0f, 185f), ceiling_bldg_d)))
       LocalObject(442, Door.Constructor(Vector3(1190.778f, 911.9379f, 276.925f)), owning_building_guid = 4)
       LocalObject(450, Door.Constructor(Vector3(1206.678f, 930.9219f, 276.925f)), owning_building_guid = 4)
       LocalObject(452, Door.Constructor(Vector3(1209.728f, 896.0551f, 276.925f)), owning_building_guid = 4)
@@ -58,7 +57,7 @@ object Ugd05 { // Annwn
     Building10036()
 
     def Building10036(): Unit = { // Name: ceiling_bldg_g_10036 Type: ceiling_bldg_g GUID: 5, MapID: 10036
-      LocalBuilding("ceiling_bldg_g_10036", 5, 10036, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1142.28f, 928.25f, 402.85f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10036", 5, 10036, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1142.28f, 928.25f, 402.85f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(430, Door.Constructor(Vector3(1134.296f, 911.74f, 404.629f)), owning_building_guid = 5)
       LocalObject(431, Door.Constructor(Vector3(1142.296f, 945.74f, 404.629f)), owning_building_guid = 5)
     }
@@ -66,7 +65,7 @@ object Ugd05 { // Annwn
     Building10013()
 
     def Building10013(): Unit = { // Name: ceiling_bldg_i_10013 Type: ceiling_bldg_i GUID: 6, MapID: 10013
-      LocalBuilding("ceiling_bldg_i_10013", 6, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.84f, 1093.24f, 286.02f), ceiling_bldg_i)))
+      LocalBuilding("ceiling_bldg_i_10013", 6, 10013, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(989.84f, 1093.24f, 286.02f), Vector3(0f, 0f, 0f), ceiling_bldg_i)))
       LocalObject(384, Door.Constructor(Vector3(965.35f, 1096.756f, 287.799f)), owning_building_guid = 6)
       LocalObject(408, Door.Constructor(Vector3(1015.35f, 1096.756f, 287.799f)), owning_building_guid = 6)
     }
@@ -74,7 +73,7 @@ object Ugd05 { // Annwn
     Building10117()
 
     def Building10117(): Unit = { // Name: ceiling_bldg_j_10117 Type: ceiling_bldg_j GUID: 7, MapID: 10117
-      LocalBuilding("ceiling_bldg_j_10117", 7, 10117, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1013.22f, 1222.5f, 246.4f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10117", 7, 10117, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1013.22f, 1222.5f, 246.4f), Vector3(0f, 0f, 107f), ceiling_bldg_j)))
       LocalObject(404, Door.Constructor(Vector3(1001.271f, 1218.864f, 248.179f)), owning_building_guid = 7)
       LocalObject(409, Door.Constructor(Vector3(1025.179f, 1226.173f, 248.179f)), owning_building_guid = 7)
     }
@@ -82,7 +81,7 @@ object Ugd05 { // Annwn
     Building10114()
 
     def Building10114(): Unit = { // Name: ceiling_bldg_j_10114 Type: ceiling_bldg_j GUID: 8, MapID: 10114
-      LocalBuilding("ceiling_bldg_j_10114", 8, 10114, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1048.57f, 1135.38f, 275.22f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10114", 8, 10114, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1048.57f, 1135.38f, 275.22f), Vector3(0f, 0f, 126f), ceiling_bldg_j)))
       LocalObject(411, Door.Constructor(Vector3(1038.456f, 1128.052f, 276.999f)), owning_building_guid = 8)
       LocalObject(414, Door.Constructor(Vector3(1058.681f, 1142.746f, 276.999f)), owning_building_guid = 8)
     }
@@ -90,7 +89,7 @@ object Ugd05 { // Annwn
     Building10115()
 
     def Building10115(): Unit = { // Name: ceiling_bldg_j_10115 Type: ceiling_bldg_j GUID: 9, MapID: 10115
-      LocalBuilding("ceiling_bldg_j_10115", 9, 10115, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.81f, 798.93f, 197.93f), ceiling_bldg_j)))
+      LocalBuilding("ceiling_bldg_j_10115", 9, 10115, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.81f, 798.93f, 197.93f), Vector3(0f, 0f, 0f), ceiling_bldg_j)))
       LocalObject(428, Door.Constructor(Vector3(1128.826f, 786.42f, 199.709f)), owning_building_guid = 9)
       LocalObject(429, Door.Constructor(Vector3(1128.826f, 811.42f, 199.709f)), owning_building_guid = 9)
     }
@@ -98,7 +97,7 @@ object Ugd05 { // Annwn
     Building10037()
 
     def Building10037(): Unit = { // Name: ceiling_bldg_z_10037 Type: ceiling_bldg_z GUID: 10, MapID: 10037
-      LocalBuilding("ceiling_bldg_z_10037", 10, 10037, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1015.45f, 1060.53f, 401.85f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10037", 10, 10037, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1015.45f, 1060.53f, 401.85f), Vector3(0f, 0f, 0f), ceiling_bldg_z)))
       LocalObject(395, Door.Constructor(Vector3(990.96f, 1064.546f, 403.629f)), owning_building_guid = 10)
       LocalObject(412, Door.Constructor(Vector3(1047.96f, 1064.546f, 403.629f)), owning_building_guid = 10)
     }
@@ -106,7 +105,7 @@ object Ugd05 { // Annwn
     Building10009()
 
     def Building10009(): Unit = { // Name: ceiling_bldg_z_10009 Type: ceiling_bldg_z GUID: 11, MapID: 10009
-      LocalBuilding("ceiling_bldg_z_10009", 11, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1068.84f, 852.69f, 258.04f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10009", 11, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1068.84f, 852.69f, 258.04f), Vector3(0f, 0f, 317f), ceiling_bldg_z)))
       LocalObject(413, Door.Constructor(Vector3(1053.668f, 872.3293f, 259.819f)), owning_building_guid = 11)
       LocalObject(421, Door.Constructor(Vector3(1095.355f, 833.4553f, 259.819f)), owning_building_guid = 11)
     }
@@ -114,7 +113,7 @@ object Ugd05 { // Annwn
     Building10031()
 
     def Building10031(): Unit = { // Name: ceiling_bldg_z_10031 Type: ceiling_bldg_z GUID: 12, MapID: 10031
-      LocalBuilding("ceiling_bldg_z_10031", 12, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.06f, 1036.8f, 234.92f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10031", 12, 10031, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.06f, 1036.8f, 234.92f), Vector3(0f, 0f, 0f), ceiling_bldg_z)))
       LocalObject(436, Door.Constructor(Vector3(1168.57f, 1040.816f, 236.699f)), owning_building_guid = 12)
       LocalObject(461, Door.Constructor(Vector3(1225.57f, 1040.816f, 236.699f)), owning_building_guid = 12)
     }
@@ -122,7 +121,7 @@ object Ugd05 { // Annwn
     Building10038()
 
     def Building10038(): Unit = { // Name: ground_bldg_a_10038 Type: ground_bldg_a GUID: 23, MapID: 10038
-      LocalBuilding("ground_bldg_a_10038", 23, 10038, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1235.85f, 1129.52f, 189.73f), ground_bldg_a)))
+      LocalBuilding("ground_bldg_a_10038", 23, 10038, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1235.85f, 1129.52f, 189.73f), Vector3(0f, 0f, 54f), ground_bldg_a)))
       LocalObject(457, Door.Constructor(Vector3(1221.054f, 1122.782f, 191.509f)), owning_building_guid = 23)
       LocalObject(472, Door.Constructor(Vector3(1242.228f, 1145.131f, 191.509f)), owning_building_guid = 23)
     }
@@ -130,7 +129,7 @@ object Ugd05 { // Annwn
     Building10005()
 
     def Building10005(): Unit = { // Name: ground_bldg_b_10005 Type: ground_bldg_b GUID: 24, MapID: 10005
-      LocalBuilding("ground_bldg_b_10005", 24, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1113.49f, 784.48f, 241.05f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10005", 24, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1113.49f, 784.48f, 241.05f), Vector3(0f, 0f, 39f), ground_bldg_b)))
       LocalObject(423, Door.Constructor(Vector3(1104.678f, 798.5632f, 242.829f)), owning_building_guid = 24)
       LocalObject(426, Door.Constructor(Vector3(1118.801f, 787.4811f, 242.829f)), owning_building_guid = 24)
       LocalObject(427, Door.Constructor(Vector3(1128.761f, 804.5875f, 248.329f)), owning_building_guid = 24)
@@ -139,7 +138,7 @@ object Ugd05 { // Annwn
     Building10213()
 
     def Building10213(): Unit = { // Name: ground_bldg_c_10213 Type: ground_bldg_c GUID: 25, MapID: 10213
-      LocalBuilding("ground_bldg_c_10213", 25, 10213, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(996.82f, 984.32f, 310.7f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10213", 25, 10213, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(996.82f, 984.32f, 310.7f), Vector3(0f, 0f, 192f), ground_bldg_c)))
       LocalObject(378, Door.Constructor(Vector3(949.452f, 985.9983f, 312.479f)), owning_building_guid = 25)
       LocalObject(381, Door.Constructor(Vector3(955.8972f, 955.6757f, 312.479f)), owning_building_guid = 25)
       LocalObject(401, Door.Constructor(Vector3(999.1253f, 980.737f, 312.479f)), owning_building_guid = 25)
@@ -148,7 +147,7 @@ object Ugd05 { // Annwn
     Building10006()
 
     def Building10006(): Unit = { // Name: ground_bldg_c_10006 Type: ground_bldg_c GUID: 26, MapID: 10006
-      LocalBuilding("ground_bldg_c_10006", 26, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.71f, 1059.42f, 379.18f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10006", 26, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.71f, 1059.42f, 379.18f), Vector3(0f, 0f, 192f), ground_bldg_c)))
       LocalObject(454, Door.Constructor(Vector3(1213.342f, 1061.098f, 380.959f)), owning_building_guid = 26)
       LocalObject(456, Door.Constructor(Vector3(1219.787f, 1030.776f, 380.959f)), owning_building_guid = 26)
       LocalObject(476, Door.Constructor(Vector3(1263.015f, 1055.837f, 380.959f)), owning_building_guid = 26)
@@ -157,7 +156,7 @@ object Ugd05 { // Annwn
     Building10001()
 
     def Building10001(): Unit = { // Name: ground_bldg_d_10001 Type: ground_bldg_d GUID: 27, MapID: 10001
-      LocalBuilding("ground_bldg_d_10001", 27, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.17f, 1133.19f, 320.03f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10001", 27, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1193.17f, 1133.19f, 320.03f), Vector3(0f, 0f, 0f), ground_bldg_d)))
       LocalObject(440, Door.Constructor(Vector3(1175.68f, 1133.206f, 321.765f)), owning_building_guid = 27)
       LocalObject(443, Door.Constructor(Vector3(1193.186f, 1115.68f, 321.765f)), owning_building_guid = 27)
       LocalObject(444, Door.Constructor(Vector3(1193.186f, 1150.68f, 321.765f)), owning_building_guid = 27)
@@ -167,7 +166,7 @@ object Ugd05 { // Annwn
     Building10020()
 
     def Building10020(): Unit = { // Name: ground_bldg_e_10020 Type: ground_bldg_e GUID: 28, MapID: 10020
-      LocalBuilding("ground_bldg_e_10020", 28, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.04f, 851.77f, 235.98f), ground_bldg_e)))
+      LocalBuilding("ground_bldg_e_10020", 28, 10020, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(978.04f, 851.77f, 235.98f), Vector3(0f, 0f, 0f), ground_bldg_e)))
       LocalObject(385, Door.Constructor(Vector3(966.024f, 850.78f, 237.759f)), owning_building_guid = 28)
       LocalObject(390, Door.Constructor(Vector3(982.024f, 884.28f, 243.259f)), owning_building_guid = 28)
       LocalObject(400, Door.Constructor(Vector3(997.05f, 879.786f, 237.759f)), owning_building_guid = 28)
@@ -177,7 +176,7 @@ object Ugd05 { // Annwn
     Building10007()
 
     def Building10007(): Unit = { // Name: ground_bldg_f_10007 Type: ground_bldg_f GUID: 29, MapID: 10007
-      LocalBuilding("ground_bldg_f_10007", 29, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1090.77f, 844.07f, 321.32f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10007", 29, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1090.77f, 844.07f, 321.32f), Vector3(0f, 0f, 325f), ground_bldg_f)))
       LocalObject(416, Door.Constructor(Vector3(1062.523f, 839.4526f, 323.099f)), owning_building_guid = 29)
       LocalObject(424, Door.Constructor(Vector3(1116.939f, 860.5503f, 323.099f)), owning_building_guid = 29)
     }
@@ -185,7 +184,7 @@ object Ugd05 { // Annwn
     Building10022()
 
     def Building10022(): Unit = { // Name: ground_bldg_f_10022 Type: ground_bldg_f GUID: 30, MapID: 10022
-      LocalBuilding("ground_bldg_f_10022", 30, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1123.7f, 1147.15f, 234.98f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10022", 30, 10022, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1123.7f, 1147.15f, 234.98f), Vector3(0f, 0f, 346f), ground_bldg_f)))
       LocalObject(422, Door.Constructor(Vector3(1098.984f, 1132.717f, 236.759f)), owning_building_guid = 30)
       LocalObject(432, Door.Constructor(Vector3(1142.225f, 1171.914f, 236.759f)), owning_building_guid = 30)
     }
@@ -193,7 +192,7 @@ object Ugd05 { // Annwn
     Building10024()
 
     def Building10024(): Unit = { // Name: ground_bldg_i_10024 Type: ground_bldg_i GUID: 31, MapID: 10024
-      LocalBuilding("ground_bldg_i_10024", 31, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1218.75f, 1051.94f, 287.43f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10024", 31, 10024, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1218.75f, 1051.94f, 287.43f), Vector3(0f, 0f, 24f), ground_bldg_i)))
       LocalObject(446, Door.Constructor(Vector3(1194.947f, 1045.191f, 289.209f)), owning_building_guid = 31)
       LocalObject(471, Door.Constructor(Vector3(1240.625f, 1065.528f, 289.209f)), owning_building_guid = 31)
     }
@@ -201,7 +200,7 @@ object Ugd05 { // Annwn
     Building10039()
 
     def Building10039(): Unit = { // Name: ground_bldg_z_10039 Type: ground_bldg_z GUID: 32, MapID: 10039
-      LocalBuilding("ground_bldg_z_10039", 32, 10039, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(954.47f, 849.74f, 178.4f), ground_bldg_z)))
+      LocalBuilding("ground_bldg_z_10039", 32, 10039, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(954.47f, 849.74f, 178.4f), Vector3(0f, 0f, 293f), ground_bldg_z)))
       LocalObject(372, Door.Constructor(Vector3(935.0992f, 848.0531f, 191.179f)), owning_building_guid = 32)
       LocalObject(373, Door.Constructor(Vector3(937.5516f, 869.1636f, 180.179f)), owning_building_guid = 32)
       LocalObject(376, Door.Constructor(Vector3(944.9157f, 872.2894f, 196.679f)), owning_building_guid = 32)
@@ -215,7 +214,7 @@ object Ugd05 { // Annwn
     Building10209()
 
     def Building10209(): Unit = { // Name: NW_Redoubt Type: redoubt GUID: 33, MapID: 10209
-      LocalBuilding("NW_Redoubt", 33, 10209, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(887.44f, 1064.63f, 163.23f), redoubt)))
+      LocalBuilding("NW_Redoubt", 33, 10209, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(887.44f, 1064.63f, 163.23f), Vector3(0f, 0f, 4f), redoubt)))
       LocalObject(552, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 33)
       LocalObject(363, Door.Constructor(Vector3(869.9915f, 1063.426f, 164.965f)), owning_building_guid = 33)
       LocalObject(364, Door.Constructor(Vector3(874.3493f, 1075.823f, 175.009f)), owning_building_guid = 33)
@@ -232,7 +231,7 @@ object Ugd05 { // Annwn
     Building10210()
 
     def Building10210(): Unit = { // Name: SE_Redoubt Type: redoubt GUID: 34, MapID: 10210
-      LocalBuilding("SE_Redoubt", 34, 10210, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1157.92f, 849.04f, 158.73f), redoubt)))
+      LocalBuilding("SE_Redoubt", 34, 10210, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1157.92f, 849.04f, 158.73f), Vector3(0f, 0f, 310f), redoubt)))
       LocalObject(555, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 34)
       LocalObject(433, Door.Constructor(Vector3(1146.69f, 862.4484f, 160.465f)), owning_building_guid = 34)
       LocalObject(434, Door.Constructor(Vector3(1159.281f, 866.2097f, 170.509f)), owning_building_guid = 34)
@@ -249,7 +248,7 @@ object Ugd05 { // Annwn
     Building10012()
 
     def Building10012(): Unit = { // Name: NW_Stasis Type: vanu_control_point GUID: 68, MapID: 10012
-      LocalBuilding("NW_Stasis", 68, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(995.33f, 1106.69f, 329.62f), vanu_control_point)))
+      LocalBuilding("NW_Stasis", 68, 10012, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(995.33f, 1106.69f, 329.62f), Vector3(0f, 0f, 222f), vanu_control_point)))
       LocalObject(554, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 68)
       LocalObject(375, Door.Constructor(Vector3(943.5559f, 1095.08f, 331.399f)), owning_building_guid = 68)
       LocalObject(392, Door.Constructor(Vector3(983.5845f, 1098.827f, 336.34f)), owning_building_guid = 68)
@@ -282,7 +281,7 @@ object Ugd05 { // Annwn
     Building10003()
 
     def Building10003(): Unit = { // Name: SE_Stasis Type: vanu_control_point GUID: 69, MapID: 10003
-      LocalBuilding("SE_Stasis", 69, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1232.73f, 922.42f, 322.62f), vanu_control_point)))
+      LocalBuilding("SE_Stasis", 69, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1232.73f, 922.42f, 322.62f), Vector3(0f, 0f, 224f), vanu_control_point)))
       LocalObject(557, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 69)
       LocalObject(441, Door.Constructor(Vector3(1181.393f, 909.0106f, 324.399f)), owning_building_guid = 69)
       LocalObject(458, Door.Constructor(Vector3(1221.266f, 914.1519f, 329.34f)), owning_building_guid = 69)
@@ -315,7 +314,7 @@ object Ugd05 { // Annwn
     Building10000()
 
     def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 70, MapID: 10000
-      LocalBuilding("Core", 70, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1093.35f, 991.55f, 292.73f), vanu_core)))
+      LocalBuilding("Core", 70, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1093.35f, 991.55f, 292.73f), Vector3(0f, 0f, 0f), vanu_core)))
       LocalObject(415, Door.Constructor(Vector3(1060.857f, 979.572f, 299.518f)), owning_building_guid = 70)
       LocalObject(417, Door.Constructor(Vector3(1089.328f, 951.057f, 299.518f)), owning_building_guid = 70)
       LocalObject(418, Door.Constructor(Vector3(1089.328f, 951.057f, 304.518f)), owning_building_guid = 70)
@@ -327,7 +326,7 @@ object Ugd05 { // Annwn
     Building10044()
 
     def Building10044(): Unit = { // Name: NW_ATPlant Type: vanu_vehicle_station GUID: 97, MapID: 10044
-      LocalBuilding("NW_ATPlant", 97, 10044, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(930.3f, 1141.53f, 164.95f), vanu_vehicle_station)))
+      LocalBuilding("NW_ATPlant", 97, 10044, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(930.3f, 1141.53f, 164.95f), Vector3(0f, 0f, 82f), vanu_vehicle_station)))
       LocalObject(553, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 97)
       LocalObject(369, Door.Constructor(Vector3(914.9034f, 1139.01f, 166.729f)), owning_building_guid = 97)
       LocalObject(370, Door.Constructor(Vector3(919.5815f, 1114.117f, 186.641f)), owning_building_guid = 97)
@@ -351,7 +350,7 @@ object Ugd05 { // Annwn
     Building10197()
 
     def Building10197(): Unit = { // Name: SE_ATPlant Type: vanu_vehicle_station GUID: 98, MapID: 10197
-      LocalBuilding("SE_ATPlant", 98, 10197, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1244.82f, 841.97f, 159.95f), vanu_vehicle_station)))
+      LocalBuilding("SE_ATPlant", 98, 10197, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1244.82f, 841.97f, 159.95f), Vector3(0f, 0f, 274f), vanu_vehicle_station)))
       LocalObject(556, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 98)
       LocalObject(447, Door.Constructor(Vector3(1195.006f, 843.136f, 161.729f)), owning_building_guid = 98)
       LocalObject(449, Door.Constructor(Vector3(1202.975f, 843.6932f, 181.653f)), owning_building_guid = 98)

--- a/pslogin/src/main/scala/zonemaps/Ugd06.scala
+++ b/pslogin/src/main/scala/zonemaps/Ugd06.scala
@@ -15,13 +15,12 @@ import net.psforever.types.Vector3
 object Ugd06 { // Drugaskan
   val ZoneMap = new ZoneMap("ugd06") {
     Scale = MapScale.Dim2560
-    Cavern = true
     Checksum = 4274683970L
 
     Building10077()
 
     def Building10077(): Unit = { // Name: ceiling_bldg_a_10077 Type: ceiling_bldg_a GUID: 1, MapID: 10077
-      LocalBuilding("ceiling_bldg_a_10077", 1, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.11f, 1049.16f, 170.44f), ceiling_bldg_a)))
+      LocalBuilding("ceiling_bldg_a_10077", 1, 10077, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1260.11f, 1049.16f, 170.44f), Vector3(0f, 0f, 211f), ceiling_bldg_a)))
       LocalObject(666, Door.Constructor(Vector3(1241.352f, 1050.759f, 177.725f)), owning_building_guid = 1)
       LocalObject(668, Door.Constructor(Vector3(1247.792f, 1037.129f, 172.219f)), owning_building_guid = 1)
       LocalObject(669, Door.Constructor(Vector3(1253.713f, 1030.187f, 177.725f)), owning_building_guid = 1)
@@ -31,7 +30,7 @@ object Ugd06 { // Drugaskan
     Building10079()
 
     def Building10079(): Unit = { // Name: ceiling_bldg_b_10079 Type: ceiling_bldg_b GUID: 2, MapID: 10079
-      LocalBuilding("ceiling_bldg_b_10079", 2, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1014.06f, 873.97f, 162.94f), ceiling_bldg_b)))
+      LocalBuilding("ceiling_bldg_b_10079", 2, 10079, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1014.06f, 873.97f, 162.94f), Vector3(0f, 0f, 85f), ceiling_bldg_b)))
       LocalObject(608, Door.Constructor(Vector3(997.8083f, 877.4145f, 164.719f)), owning_building_guid = 2)
       LocalObject(611, Door.Constructor(Vector3(1015.59f, 879.8751f, 164.719f)), owning_building_guid = 2)
     }
@@ -39,7 +38,7 @@ object Ugd06 { // Drugaskan
     Building10241()
 
     def Building10241(): Unit = { // Name: ceiling_bldg_c_10241 Type: ceiling_bldg_c GUID: 3, MapID: 10241
-      LocalBuilding("ceiling_bldg_c_10241", 3, 10241, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1125.87f, 1035.29f, 171.46f), ceiling_bldg_c)))
+      LocalBuilding("ceiling_bldg_c_10241", 3, 10241, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1125.87f, 1035.29f, 171.46f), Vector3(0f, 0f, 22f), ceiling_bldg_c)))
       LocalObject(638, Door.Constructor(Vector3(1122.978f, 1038.418f, 173.239f)), owning_building_guid = 3)
       LocalObject(649, Door.Constructor(Vector3(1161.197f, 1070.605f, 173.239f)), owning_building_guid = 3)
       LocalObject(651, Door.Constructor(Vector3(1172.81f, 1041.863f, 173.239f)), owning_building_guid = 3)
@@ -48,7 +47,7 @@ object Ugd06 { // Drugaskan
     Building10006()
 
     def Building10006(): Unit = { // Name: ceiling_bldg_d_10006 Type: ceiling_bldg_d GUID: 4, MapID: 10006
-      LocalBuilding("ceiling_bldg_d_10006", 4, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1196.16f, 965.32f, 165.44f), ceiling_bldg_d)))
+      LocalBuilding("ceiling_bldg_d_10006", 4, 10006, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1196.16f, 965.32f, 165.44f), Vector3(0f, 0f, 36f), ceiling_bldg_d)))
       LocalObject(653, Door.Constructor(Vector3(1182.001f, 955.0526f, 167.175f)), owning_building_guid = 4)
       LocalObject(656, Door.Constructor(Vector3(1185.893f, 979.4791f, 167.175f)), owning_building_guid = 4)
       LocalObject(659, Door.Constructor(Vector3(1206.465f, 951.1635f, 167.175f)), owning_building_guid = 4)
@@ -59,7 +58,7 @@ object Ugd06 { // Drugaskan
     Building10081()
 
     def Building10081(): Unit = { // Name: ceiling_bldg_e_10081 Type: ceiling_bldg_e GUID: 5, MapID: 10081
-      LocalBuilding("ceiling_bldg_e_10081", 5, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.06f, 914.38f, 179.45f), ceiling_bldg_e)))
+      LocalBuilding("ceiling_bldg_e_10081", 5, 10081, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1128.06f, 914.38f, 179.45f), Vector3(0f, 0f, 44f), ceiling_bldg_e)))
       LocalObject(635, Door.Constructor(Vector3(1108.343f, 940.5333f, 186.729f)), owning_building_guid = 5)
       LocalObject(636, Door.Constructor(Vector3(1120.104f, 905.3209f, 181.229f)), owning_building_guid = 5)
       LocalObject(637, Door.Constructor(Vector3(1122.273f, 947.7385f, 181.229f)), owning_building_guid = 5)
@@ -69,7 +68,7 @@ object Ugd06 { // Drugaskan
     Building10080()
 
     def Building10080(): Unit = { // Name: ceiling_bldg_f_10080 Type: ceiling_bldg_f GUID: 6, MapID: 10080
-      LocalBuilding("ceiling_bldg_f_10080", 6, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1059.44f, 1115.66f, 174.49f), ceiling_bldg_f)))
+      LocalBuilding("ceiling_bldg_f_10080", 6, 10080, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1059.44f, 1115.66f, 174.49f), Vector3(0f, 0f, 116f), ceiling_bldg_f)))
       LocalObject(618, Door.Constructor(Vector3(1028.562f, 1113.933f, 176.269f)), owning_building_guid = 6)
       LocalObject(633, Door.Constructor(Vector3(1086.384f, 1106.004f, 176.269f)), owning_building_guid = 6)
     }
@@ -77,7 +76,7 @@ object Ugd06 { // Drugaskan
     Building10078()
 
     def Building10078(): Unit = { // Name: ceiling_bldg_g_10078 Type: ceiling_bldg_g GUID: 7, MapID: 10078
-      LocalBuilding("ceiling_bldg_g_10078", 7, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.34f, 1023.68f, 163.71f), ceiling_bldg_g)))
+      LocalBuilding("ceiling_bldg_g_10078", 7, 10078, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(828.34f, 1023.68f, 163.71f), Vector3(0f, 0f, 0f), ceiling_bldg_g)))
       LocalObject(565, Door.Constructor(Vector3(820.356f, 1007.17f, 165.489f)), owning_building_guid = 7)
       LocalObject(567, Door.Constructor(Vector3(828.356f, 1041.17f, 165.489f)), owning_building_guid = 7)
     }
@@ -85,7 +84,7 @@ object Ugd06 { // Drugaskan
     Building10007()
 
     def Building10007(): Unit = { // Name: ceiling_bldg_h_10007 Type: ceiling_bldg_h GUID: 8, MapID: 10007
-      LocalBuilding("ceiling_bldg_h_10007", 8, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(904.92f, 964.1f, 173.54f), ceiling_bldg_h)))
+      LocalBuilding("ceiling_bldg_h_10007", 8, 10007, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(904.92f, 964.1f, 173.54f), Vector3(0f, 0f, 0f), ceiling_bldg_h)))
       LocalObject(581, Door.Constructor(Vector3(888.43f, 960.116f, 175.319f)), owning_building_guid = 8)
       LocalObject(591, Door.Constructor(Vector3(908.904f, 980.61f, 175.319f)), owning_building_guid = 8)
       LocalObject(593, Door.Constructor(Vector3(916.005f, 952.912f, 177.819f)), owning_building_guid = 8)
@@ -94,7 +93,7 @@ object Ugd06 { // Drugaskan
     Building10008()
 
     def Building10008(): Unit = { // Name: ceiling_bldg_i_10008 Type: ceiling_bldg_i GUID: 9, MapID: 10008
-      LocalBuilding("ceiling_bldg_i_10008", 9, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(971.61f, 1193.75f, 179.41f), ceiling_bldg_i)))
+      LocalBuilding("ceiling_bldg_i_10008", 9, 10008, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(971.61f, 1193.75f, 179.41f), Vector3(0f, 0f, 188f), ceiling_bldg_i)))
       LocalObject(597, Door.Constructor(Vector3(946.8376f, 1186.718f, 181.189f)), owning_building_guid = 9)
       LocalObject(607, Door.Constructor(Vector3(996.351f, 1193.677f, 181.189f)), owning_building_guid = 9)
     }
@@ -102,7 +101,7 @@ object Ugd06 { // Drugaskan
     Building10238()
 
     def Building10238(): Unit = { // Name: ceiling_bldg_z_10238 Type: ceiling_bldg_z GUID: 10, MapID: 10238
-      LocalBuilding("ceiling_bldg_z_10238", 10, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(925.94f, 1113.67f, 188.72f), ceiling_bldg_z)))
+      LocalBuilding("ceiling_bldg_z_10238", 10, 10238, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(925.94f, 1113.67f, 188.72f), Vector3(0f, 0f, 223f), ceiling_bldg_z)))
       LocalObject(590, Door.Constructor(Vector3(904.9026f, 1088.561f, 190.499f)), owning_building_guid = 10)
       LocalObject(596, Door.Constructor(Vector3(946.5898f, 1127.435f, 190.499f)), owning_building_guid = 10)
     }
@@ -110,7 +109,7 @@ object Ugd06 { // Drugaskan
     Building10009()
 
     def Building10009(): Unit = { // Name: ground_bldg_a_10009 Type: ground_bldg_a GUID: 34, MapID: 10009
-      LocalBuilding("ground_bldg_a_10009", 34, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.99f, 1151.14f, 89.94f), ground_bldg_a)))
+      LocalBuilding("ground_bldg_a_10009", 34, 10009, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1349.99f, 1151.14f, 89.94f), Vector3(0f, 0f, 340f), ground_bldg_a)))
       LocalObject(681, Door.Constructor(Vector3(1339.435f, 1163.506f, 91.719f)), owning_building_guid = 34)
       LocalObject(686, Door.Constructor(Vector3(1366.754f, 1149.312f, 91.719f)), owning_building_guid = 34)
     }
@@ -118,7 +117,7 @@ object Ugd06 { // Drugaskan
     Building10003()
 
     def Building10003(): Unit = { // Name: ground_bldg_b_10003 Type: ground_bldg_b GUID: 35, MapID: 10003
-      LocalBuilding("ground_bldg_b_10003", 35, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(985.91f, 922.1f, 92.93f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10003", 35, 10003, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(985.91f, 922.1f, 92.93f), Vector3(0f, 0f, 5f), ground_bldg_b)))
       LocalObject(600, Door.Constructor(Vector3(986.4801f, 938.7028f, 94.709f)), owning_building_guid = 35)
       LocalObject(603, Door.Constructor(Vector3(991.9911f, 921.6182f, 94.709f)), owning_building_guid = 35)
       LocalObject(610, Door.Constructor(Vector3(1009.814f, 930.2303f, 100.209f)), owning_building_guid = 35)
@@ -127,7 +126,7 @@ object Ugd06 { // Drugaskan
     Building10004()
 
     def Building10004(): Unit = { // Name: ground_bldg_b_10004 Type: ground_bldg_b GUID: 36, MapID: 10004
-      LocalBuilding("ground_bldg_b_10004", 36, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.48f, 1145.29f, 91.97f), ground_bldg_b)))
+      LocalBuilding("ground_bldg_b_10004", 36, 10004, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1006.48f, 1145.29f, 91.97f), Vector3(0f, 0f, 227f), ground_bldg_b)))
       LocalObject(604, Door.Constructor(Vector3(994.1558f, 1123.253f, 99.249f)), owning_building_guid = 36)
       LocalObject(609, Door.Constructor(Vector3(1001.638f, 1141.579f, 93.749f)), owning_building_guid = 36)
       LocalObject(612, Door.Constructor(Vector3(1017.166f, 1132.57f, 93.749f)), owning_building_guid = 36)
@@ -136,7 +135,7 @@ object Ugd06 { // Drugaskan
     Building10034()
 
     def Building10034(): Unit = { // Name: ground_bldg_c_10034 Type: ground_bldg_c GUID: 37, MapID: 10034
-      LocalBuilding("ground_bldg_c_10034", 37, 10034, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(825.03f, 1055.17f, 89.45f), ground_bldg_c)))
+      LocalBuilding("ground_bldg_c_10034", 37, 10034, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(825.03f, 1055.17f, 89.45f), Vector3(0f, 0f, 19f), ground_bldg_c)))
       LocalObject(566, Door.Constructor(Vector3(822.3052f, 1058.445f, 91.229f)), owning_building_guid = 37)
       LocalObject(571, Door.Constructor(Vector3(862.1569f, 1088.588f, 91.229f)), owning_building_guid = 37)
       LocalObject(576, Door.Constructor(Vector3(872.2495f, 1059.277f, 91.229f)), owning_building_guid = 37)
@@ -145,7 +144,7 @@ object Ugd06 { // Drugaskan
     Building10088()
 
     def Building10088(): Unit = { // Name: ground_bldg_d_10088 Type: ground_bldg_d GUID: 38, MapID: 10088
-      LocalBuilding("ground_bldg_d_10088", 38, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(975.7f, 689.58f, 94.32f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10088", 38, 10088, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(975.7f, 689.58f, 94.32f), Vector3(0f, 0f, 231f), ground_bldg_d)))
       LocalObject(598, Door.Constructor(Vector3(962.0821f, 700.587f, 96.055f)), owning_building_guid = 38)
       LocalObject(599, Door.Constructor(Vector3(964.6931f, 675.9621f, 96.055f)), owning_building_guid = 38)
       LocalObject(601, Door.Constructor(Vector3(986.7192f, 703.1622f, 96.055f)), owning_building_guid = 38)
@@ -155,7 +154,7 @@ object Ugd06 { // Drugaskan
     Building10304()
 
     def Building10304(): Unit = { // Name: ground_bldg_d_10304 Type: ground_bldg_d GUID: 39, MapID: 10304
-      LocalBuilding("ground_bldg_d_10304", 39, 10304, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.42f, 1071.61f, 100.3f), ground_bldg_d)))
+      LocalBuilding("ground_bldg_d_10304", 39, 10304, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1055.42f, 1071.61f, 100.3f), Vector3(0f, 0f, 190f), ground_bldg_d)))
       LocalObject(620, Door.Constructor(Vector3(1038.179f, 1068.554f, 102.035f)), owning_building_guid = 39)
       LocalObject(624, Door.Constructor(Vector3(1052.364f, 1088.851f, 102.035f)), owning_building_guid = 39)
       LocalObject(627, Door.Constructor(Vector3(1058.441f, 1054.383f, 102.035f)), owning_building_guid = 39)
@@ -165,7 +164,7 @@ object Ugd06 { // Drugaskan
     Building10015()
 
     def Building10015(): Unit = { // Name: ground_bldg_e_10015 Type: ground_bldg_e GUID: 40, MapID: 10015
-      LocalBuilding("ground_bldg_e_10015", 40, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1033.29f, 654.74f, 94.57f), ground_bldg_e)))
+      LocalBuilding("ground_bldg_e_10015", 40, 10015, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1033.29f, 654.74f, 94.57f), Vector3(0f, 0f, 240f), ground_bldg_e)))
       LocalObject(617, Door.Constructor(Vector3(1027.727f, 629.0727f, 101.849f)), owning_building_guid = 40)
       LocalObject(621, Door.Constructor(Vector3(1038.441f, 665.6412f, 96.349f)), owning_building_guid = 40)
       LocalObject(622, Door.Constructor(Vector3(1048.048f, 624.2689f, 96.349f)), owning_building_guid = 40)
@@ -175,7 +174,7 @@ object Ugd06 { // Drugaskan
     Building10386()
 
     def Building10386(): Unit = { // Name: ground_bldg_f_10386 Type: ground_bldg_f GUID: 41, MapID: 10386
-      LocalBuilding("ground_bldg_f_10386", 41, 10386, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1007.11f, 851.17f, 96.4f), ground_bldg_f)))
+      LocalBuilding("ground_bldg_f_10386", 41, 10386, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1007.11f, 851.17f, 96.4f), Vector3(0f, 0f, 250f), ground_bldg_f)))
       LocalObject(605, Door.Constructor(Vector3(995.3392f, 877.2592f, 98.179f)), owning_building_guid = 41)
       LocalObject(619, Door.Constructor(Vector3(1029.802f, 830.1577f, 98.179f)), owning_building_guid = 41)
     }
@@ -183,7 +182,7 @@ object Ugd06 { // Drugaskan
     Building10032()
 
     def Building10032(): Unit = { // Name: ground_bldg_g_10032 Type: ground_bldg_g GUID: 42, MapID: 10032
-      LocalBuilding("ground_bldg_g_10032", 42, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1263.21f, 1006.27f, 98.33f), ground_bldg_g)))
+      LocalBuilding("ground_bldg_g_10032", 42, 10032, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1263.21f, 1006.27f, 98.33f), Vector3(0f, 0f, 0f), ground_bldg_g)))
       LocalObject(671, Door.Constructor(Vector3(1255.226f, 989.76f, 100.109f)), owning_building_guid = 42)
       LocalObject(673, Door.Constructor(Vector3(1263.226f, 1023.76f, 100.109f)), owning_building_guid = 42)
     }
@@ -191,7 +190,7 @@ object Ugd06 { // Drugaskan
     Building10242()
 
     def Building10242(): Unit = { // Name: ground_bldg_h_10242 Type: ground_bldg_h GUID: 43, MapID: 10242
-      LocalBuilding("ground_bldg_h_10242", 43, 10242, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.36f, 1197.96f, 104.38f), ground_bldg_h)))
+      LocalBuilding("ground_bldg_h_10242", 43, 10242, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1063.36f, 1197.96f, 104.38f), Vector3(0f, 0f, 190f), ground_bldg_h)))
       LocalObject(623, Door.Constructor(Vector3(1050.501f, 1207.053f, 108.659f)), owning_building_guid = 43)
       LocalObject(629, Door.Constructor(Vector3(1062.303f, 1181.009f, 106.159f)), owning_building_guid = 43)
       LocalObject(632, Door.Constructor(Vector3(1078.908f, 1204.747f, 106.159f)), owning_building_guid = 43)
@@ -200,7 +199,7 @@ object Ugd06 { // Drugaskan
     Building10340()
 
     def Building10340(): Unit = { // Name: ground_bldg_i_10340 Type: ground_bldg_i GUID: 44, MapID: 10340
-      LocalBuilding("ground_bldg_i_10340", 44, 10340, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(781.58f, 1112.31f, 97.55f), ground_bldg_i)))
+      LocalBuilding("ground_bldg_i_10340", 44, 10340, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(781.58f, 1112.31f, 97.55f), Vector3(0f, 0f, 208f), ground_bldg_i)))
       LocalObject(558, Door.Constructor(Vector3(760.7067f, 1097.229f, 99.329f)), owning_building_guid = 44)
       LocalObject(564, Door.Constructor(Vector3(804.8541f, 1120.703f, 99.329f)), owning_building_guid = 44)
     }
@@ -208,7 +207,7 @@ object Ugd06 { // Drugaskan
     Building10035()
 
     def Building10035(): Unit = { // Name: ground_bldg_j_10035 Type: ground_bldg_j GUID: 45, MapID: 10035
-      LocalBuilding("ground_bldg_j_10035", 45, 10035, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(853.9f, 1131.82f, 87.35f), ground_bldg_j)))
+      LocalBuilding("ground_bldg_j_10035", 45, 10035, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(853.9f, 1131.82f, 87.35f), Vector3(0f, 0f, 78f), ground_bldg_j)))
       LocalObject(568, Door.Constructor(Vector3(841.6863f, 1134.432f, 89.129f)), owning_building_guid = 45)
       LocalObject(573, Door.Constructor(Vector3(866.14f, 1129.235f, 89.129f)), owning_building_guid = 45)
     }
@@ -216,7 +215,7 @@ object Ugd06 { // Drugaskan
     Building10005()
 
     def Building10005(): Unit = { // Name: ground_bldg_j_10005 Type: ground_bldg_j GUID: 46, MapID: 10005
-      LocalBuilding("ground_bldg_j_10005", 46, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1062.19f, 885.69f, 92.65f), ground_bldg_j)))
+      LocalBuilding("ground_bldg_j_10005", 46, 10005, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1062.19f, 885.69f, 92.65f), Vector3(0f, 0f, 330f), ground_bldg_j)))
       LocalObject(626, Door.Constructor(Vector3(1055.949f, 874.848f, 94.429f)), owning_building_guid = 46)
       LocalObject(630, Door.Constructor(Vector3(1068.449f, 896.4987f, 94.429f)), owning_building_guid = 46)
     }
@@ -224,7 +223,7 @@ object Ugd06 { // Drugaskan
     Building10229()
 
     def Building10229(): Unit = { // Name: ground_bldg_z_10229 Type: ground_bldg_z GUID: 47, MapID: 10229
-      LocalBuilding("ground_bldg_z_10229", 47, 10229, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.59f, 1275.13f, 89.54f), ground_bldg_z)))
+      LocalBuilding("ground_bldg_z_10229", 47, 10229, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(875.59f, 1275.13f, 89.54f), Vector3(0f, 0f, 300f), ground_bldg_z)))
       LocalObject(569, Door.Constructor(Vector3(856.4307f, 1292.347f, 91.319f)), owning_building_guid = 47)
       LocalObject(570, Door.Constructor(Vector3(856.5692f, 1271.095f, 102.319f)), owning_building_guid = 47)
       LocalObject(572, Door.Constructor(Vector3(863.3589f, 1296.347f, 107.819f)), owning_building_guid = 47)
@@ -238,7 +237,7 @@ object Ugd06 { // Drugaskan
     Building10082()
 
     def Building10082(): Unit = { // Name: ground_bldg_z_10082 Type: ground_bldg_z GUID: 48, MapID: 10082
-      LocalBuilding("ground_bldg_z_10082", 48, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1207.32f, 852.88f, 95.64f), ground_bldg_z)))
+      LocalBuilding("ground_bldg_z_10082", 48, 10082, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1207.32f, 852.88f, 95.64f), Vector3(0f, 0f, 180f), ground_bldg_z)))
       LocalObject(654, Door.Constructor(Vector3(1182.81f, 844.864f, 97.419f)), owning_building_guid = 48)
       LocalObject(655, Door.Constructor(Vector3(1182.81f, 852.864f, 113.919f)), owning_building_guid = 48)
       LocalObject(657, Door.Constructor(Vector3(1191.81f, 860.864f, 102.919f)), owning_building_guid = 48)
@@ -252,7 +251,7 @@ object Ugd06 { // Drugaskan
     Building10257()
 
     def Building10257(): Unit = { // Name: N_Redoubt Type: redoubt GUID: 49, MapID: 10257
-      LocalBuilding("N_Redoubt", 49, 10257, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(760.72f, 1359.42f, 99.62f), redoubt)))
+      LocalBuilding("N_Redoubt", 49, 10257, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(760.72f, 1359.42f, 99.62f), Vector3(0f, 0f, 313f), redoubt)))
       LocalObject(791, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 49)
       LocalObject(557, Door.Constructor(Vector3(748.8035f, 1372.222f, 101.355f)), owning_building_guid = 49)
       LocalObject(559, Door.Constructor(Vector3(761.1804f, 1376.637f, 111.399f)), owning_building_guid = 49)
@@ -269,7 +268,7 @@ object Ugd06 { // Drugaskan
     Building10259()
 
     def Building10259(): Unit = { // Name: S_Redoubt Type: redoubt GUID: 50, MapID: 10259
-      LocalBuilding("S_Redoubt", 50, 10259, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1253.48f, 805.8f, 85.1f), redoubt)))
+      LocalBuilding("S_Redoubt", 50, 10259, FoundationBuilder(Building.Structure(StructureType.Tower, Vector3(1253.48f, 805.8f, 85.1f), Vector3(0f, 0f, 335f), redoubt)))
       LocalObject(794, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 50)
       LocalObject(665, Door.Constructor(Vector3(1237.635f, 813.2061f, 86.835f)), owning_building_guid = 50)
       LocalObject(667, Door.Constructor(Vector3(1247.457f, 821.9362f, 96.879f)), owning_building_guid = 50)
@@ -286,7 +285,7 @@ object Ugd06 { // Drugaskan
     Building10001()
 
     def Building10001(): Unit = { // Name: S_Stasis Type: vanu_control_point GUID: 203, MapID: 10001
-      LocalBuilding("S_Stasis", 203, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.15f, 874.23f, 93.26f), vanu_control_point)))
+      LocalBuilding("S_Stasis", 203, 10001, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(899.15f, 874.23f, 93.26f), Vector3(0f, 0f, 340f), vanu_control_point)))
       LocalObject(792, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 203)
       LocalObject(574, Door.Constructor(Vector3(867.9634f, 853.3779f, 95.039f)), owning_building_guid = 203)
       LocalObject(575, Door.Constructor(Vector3(871.7762f, 899.1088f, 95.039f)), owning_building_guid = 203)
@@ -319,7 +318,7 @@ object Ugd06 { // Drugaskan
     Building10002()
 
     def Building10002(): Unit = { // Name: N_Stasis Type: vanu_control_point GUID: 204, MapID: 10002
-      LocalBuilding("N_Stasis", 204, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1149.27f, 1132.96f, 107.22f), vanu_control_point)))
+      LocalBuilding("N_Stasis", 204, 10002, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1149.27f, 1132.96f, 107.22f), Vector3(0f, 0f, 236f), vanu_control_point)))
       LocalObject(793, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 204)
       LocalObject(634, Door.Constructor(Vector3(1101.842f, 1109.17f, 108.999f)), owning_building_guid = 204)
       LocalObject(639, Door.Constructor(Vector3(1136.562f, 1139.138f, 113.94f)), owning_building_guid = 204)
@@ -352,7 +351,7 @@ object Ugd06 { // Drugaskan
     Building10000()
 
     def Building10000(): Unit = { // Name: Core Type: vanu_core GUID: 205, MapID: 10000
-      LocalBuilding("Core", 205, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1028.8f, 1012.78f, 165.78f), vanu_core)))
+      LocalBuilding("Core", 205, 10000, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1028.8f, 1012.78f, 165.78f), Vector3(0f, 0f, 0f), vanu_core)))
       LocalObject(606, Door.Constructor(Vector3(996.3071f, 1000.802f, 172.568f)), owning_building_guid = 205)
       LocalObject(613, Door.Constructor(Vector3(1024.778f, 972.287f, 172.568f)), owning_building_guid = 205)
       LocalObject(614, Door.Constructor(Vector3(1024.778f, 972.287f, 177.568f)), owning_building_guid = 205)
@@ -364,7 +363,7 @@ object Ugd06 { // Drugaskan
     Building10246()
 
     def Building10246(): Unit = { // Name: N_ATPlant Type: vanu_vehicle_station GUID: 231, MapID: 10246
-      LocalBuilding("N_ATPlant", 231, 10246, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(739.86f, 1264.38f, 82.47f), vanu_vehicle_station)))
+      LocalBuilding("N_ATPlant", 231, 10246, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(739.86f, 1264.38f, 82.47f), Vector3(0f, 0f, 329f), vanu_vehicle_station)))
       LocalObject(790, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 231)
       LocalObject(549, Door.Constructor(Vector3(684.2806f, 1258.55f, 114.249f)), owning_building_guid = 231)
       LocalObject(550, Door.Constructor(Vector3(688.5319f, 1265.615f, 114.229f)), owning_building_guid = 231)
@@ -388,7 +387,7 @@ object Ugd06 { // Drugaskan
     Building10248()
 
     def Building10248(): Unit = { // Name: S_ATPlant Type: vanu_vehicle_station GUID: 232, MapID: 10248
-      LocalBuilding("S_ATPlant", 232, 10248, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1304.12f, 799.11f, 83.07f), vanu_vehicle_station)))
+      LocalBuilding("S_ATPlant", 232, 10248, FoundationBuilder(Building.Structure(StructureType.Building, Vector3(1304.12f, 799.11f, 83.07f), Vector3(0f, 0f, 142f), vanu_vehicle_station)))
       LocalObject(795, CaptureTerminal.Constructor(vanu_control_console), owning_building_guid = 232)
       LocalObject(677, Door.Constructor(Vector3(1298.604f, 784.5164f, 84.849f)), owning_building_guid = 232)
       LocalObject(678, Door.Constructor(Vector3(1322.501f, 776.121f, 104.761f)), owning_building_guid = 232)


### PR DESCRIPTION
All pain fields were previously radius based, even those that were not supposed to be. I'm somewhat convinced they were originally line of sight based on live, but we can't replicate that since our server has no 3d model information.

Because of the above, I came to a workaround involving nearby amenities and bounding boxes. Essentially on startup a non-radius painfield will find amenities nearby, and create a bounding box around them. From that we can determine if a player is within the spawn room or not.

The caveat being that this method won't work for anything other than above ground spawn facility spawn rooms. Currently this isn't a big deal as generators pain fields aren't implemented, and I've disabled non-radius pain fields in caves as an acceptable "temporary" state.

One notable trick for the bounding box calculation is instead of rotating the bounding box to match the base rotation the player coordinates are instead rotated. This allows for the bounding box to stay XY aligned and vastly simplifies the logic for checking if the player is within the bounding box

Fixes #371