### PR TITLE
Stale velocity fixes

### DIFF
--- a/common/src/main/scala/net/psforever/objects/serverobject/repair/RepairableEntity.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/repair/RepairableEntity.scala
@@ -80,7 +80,7 @@ trait RepairableEntity extends Repairable {
     val name = player.Name
     val tguid = target.GUID
     val originalHealth = target.Health
-    val updatedHealth = if(!(player.isMoving || target.isMoving)) { //only allow stationary repairs
+    val updatedHealth = if(!(player.isMoving(1f) || target.isMoving(1f))) { //only allow stationary repairs within margin of error
       val newHealth = target.Health = originalHealth + Repairable.Quality + RepairValue(item) + definition.RepairMod
       val zoneId = zone.Id
       val magazine = item.Discharge

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -83,6 +83,12 @@ class VehicleControl(vehicle : Vehicle) extends Actor
       case msg : Mountable.TryDismount =>
         dismountBehavior.apply(msg)
         val obj = MountableObject
+
+        // Reset velocity to zero when driver dismounts, to allow jacking/repair if vehicle was moving slightly before dismount
+        if(!obj.Seats(0).isOccupied) {
+          obj.Velocity = Some(Vector3.Zero)
+        }
+
         if(!decaying && obj.Owner.isEmpty && obj.Seats.values.forall(!_.isOccupied)) {
           decaying = true
           decayTimer = context.system.scheduler.scheduleOnce(MountableObject.Definition.DeconstructionTime.getOrElse(5 minutes), self, VehicleControl.PrepareForDeletion())

--- a/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/VehicleStateMessage.scala
@@ -25,7 +25,7 @@ import scodec.codecs._
   *                        30 for hard left;
   *                        values in between are possible;
   *                        vehicles that hover also influence this field as expected
-  * @param unk5 na - Possibly a flag to indicate the vehicle is attached to something else e.g. is in a galaxy/lodestar cargo bay
+  * @param is_decelerating If the vehicle is decelerating (in any direction), i.e. if the brake lights are on.
   * @param is_cloaked vehicle is cloaked by virtue of being a Wraith or a Phantasm
   * @see `PlacementData`
   */
@@ -53,7 +53,7 @@ final case class VehicleStateMessage(vehicle_guid : PlanetSideGUID,
                                      unk3 : Int,
                                      unk4 : Int,
                                      wheel_direction : Int,
-                                     unk5 : Boolean,
+                                     is_decelerating : Boolean,
                                      is_cloaked : Boolean
                                     ) extends PlanetSideGamePacket {
   type Packet = VehicleStateMessage


### PR DESCRIPTION
Add some extra checks to ensure velocity is set to zero for deployed or undriven vehicles, to allow repairing/jacking when deployed on a slope as the client reports the last known velocity before deployment in VehicleStateMessage

Fixes #410
Fixes #383