### PR TITLE
Let's Move Item, Together

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,8 @@ lazy val commonSettings = Seq(
     "org.scala-graph"            %% "graph-core"    % "1.12.5",
     "io.kamon"                   %% "kamon-bundle" % "2.1.0",
     "io.kamon"                   %% "kamon-apm-reporter" % "2.1.0",
-    "org.json4s"                 %% "json4s-native" % "3.6.8",
-  ),
+    "org.json4s"                 %% "json4s-native" % "3.6.8"
+  )
 )
 
 lazy val pscryptoSettings = Seq(

--- a/common/src/main/scala/net/psforever/objects/Avatar.scala
+++ b/common/src/main/scala/net/psforever/objects/Avatar.scala
@@ -58,6 +58,12 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
 
   private var vehicleOwned : Option[PlanetSideGUID] = None
 
+  private var lastUsedEquipmentTimes : mutable.LongMap[Long] = mutable.LongMap[Long]()
+
+  private val lastUsedExoSuitTimes : Array[Long] = Array.fill[Long](ExoSuitType.values.size)(0L)
+
+  private val lastUsedMaxExoSuitTimes : Array[Long] = Array.fill[Long](4)(0L) //invalid, ai, av, aa
+
   def CharId : Long = char_id
 
   def BEP : Long = bep
@@ -219,6 +225,47 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
   def VehicleOwned_=(guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = {
     vehicleOwned = guid
     VehicleOwned
+  }
+
+  def GetLastUsedTime(code : Int) : Long = {
+    lastUsedEquipmentTimes.get(code) match {
+      case Some(time) => time
+      case None => 0
+    }
+  }
+
+  def GetLastUsedTime(code : ExoSuitType.Value) : Long = {
+    lastUsedExoSuitTimes(code.id)
+  }
+
+  def GetLastUsedTime(code : ExoSuitType.Value, subtype : Int) : Long = {
+    if(code == ExoSuitType.MAX) {
+      lastUsedMaxExoSuitTimes(subtype)
+    }
+    else {
+      GetLastUsedTime(code)
+    }
+  }
+
+  def SetLastUsedTime(code : Int) : Unit = SetLastUsedTime(code, System.currentTimeMillis())
+
+  def SetLastUsedTime(code : Int, time : Long) : Unit = {
+    lastUsedEquipmentTimes += code.toLong -> time
+  }
+
+  def SetLastUsedTime(code : ExoSuitType.Value) : Unit = SetLastUsedTime(code, System.currentTimeMillis())
+
+  def SetLastUsedTime(code : ExoSuitType.Value, time : Long) : Unit = {
+    lastUsedExoSuitTimes(code.id) = time
+  }
+
+  def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int) : Unit = SetLastUsedTime(code, System.currentTimeMillis())
+
+  def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int, time : Long) : Unit = {
+    if(code == ExoSuitType.MAX) {
+      lastUsedMaxExoSuitTimes(subtype) = time
+    }
+    SetLastUsedTime(code, time)
   }
 
   def Definition : AvatarDefinition = GlobalDefinitions.avatar

--- a/common/src/main/scala/net/psforever/objects/Avatar.scala
+++ b/common/src/main/scala/net/psforever/objects/Avatar.scala
@@ -57,12 +57,24 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
   private var lfs : Boolean = false
 
   private var vehicleOwned : Option[PlanetSideGUID] = None
-
-  private var lastUsedEquipmentTimes : mutable.LongMap[Long] = mutable.LongMap[Long]()
-
+  /** key - object id<br>
+    * value - time last used (ms)
+    * */
+  private var lastUsedEquipmentTimes : mutable.LongMap[Long] =  mutable.LongMap[Long]()
+  /** exo-suit times are sorted by `Enumeration` order, which was determined by packet process<br>
+    * key - exo-suit id<br>
+    * value - time last used (ms)
+    * */
   private val lastUsedExoSuitTimes : Array[Long] = Array.fill[Long](ExoSuitType.values.size)(0L)
-
+  /** mechanized exo-suit times are sorted by subtype distinction, which was determined by packet process<br>
+    * key - subtype id<br>
+    * value - time last used (ms)
+    * */
   private val lastUsedMaxExoSuitTimes : Array[Long] = Array.fill[Long](4)(0L) //invalid, ai, av, aa
+  /** key - object id<br>
+    * value - time last acquired (from a terminal) (ms)
+    * */
+  private var lastPurchaseTimes : mutable.LongMap[Long] =  mutable.LongMap[Long]()
 
   def CharId : Long = char_id
 
@@ -247,7 +259,7 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
     }
   }
 
-  def SetLastUsedTime(code : Int) : Unit = SetLastUsedTime(code, System.currentTimeMillis())
+  def GetAllLastUsedTimes : Map[Long, Long] = lastUsedEquipmentTimes.toMap
 
   def SetLastUsedTime(code : Int, time : Long) : Unit = {
     lastUsedEquipmentTimes += code.toLong -> time
@@ -259,13 +271,24 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
     lastUsedExoSuitTimes(code.id) = time
   }
 
-  def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int) : Unit = SetLastUsedTime(code, System.currentTimeMillis())
-
   def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int, time : Long) : Unit = {
     if(code == ExoSuitType.MAX) {
       lastUsedMaxExoSuitTimes(subtype) = time
     }
     SetLastUsedTime(code, time)
+  }
+
+  def GetLastPurchaseTime(code : Int) : Long = {
+    lastPurchaseTimes.get(code) match {
+      case Some(time) => time
+      case None => 0
+    }
+  }
+
+  def GetAllLastPurchaseTimes : Map[Long, Long] = lastPurchaseTimes.toMap
+
+  def SetLastPurchaseTime(code : Int, time : Long) : Unit = {
+    lastPurchaseTimes += code.toLong -> time
   }
 
   def Definition : AvatarDefinition = GlobalDefinitions.avatar

--- a/common/src/main/scala/net/psforever/objects/Avatar.scala
+++ b/common/src/main/scala/net/psforever/objects/Avatar.scala
@@ -75,6 +75,15 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
     * value - time last acquired (from a terminal) (ms)
     * */
   private var lastPurchaseTimes : mutable.LongMap[Long] =  mutable.LongMap[Long]()
+  /**
+    * To reload purchase and use timers, a string representing the item must be produced.
+    * Point directly from the object id to the object definition and get the `Name` from that definition.
+    * Allocate only when an item is purchased or used.
+    * The keys match the keys for both `lastUsedEquipmentTimes` and `lastPurchaseTimes`.<br>
+    * key - object id<br>
+    * value - most basic object definition information
+    */
+  private val objectTypeNameReference : mutable.LongMap[String] = new mutable.LongMap[String]()
 
   def CharId : Long = char_id
 
@@ -289,6 +298,18 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
 
   def SetLastPurchaseTime(code : Int, time : Long) : Unit = {
     lastPurchaseTimes += code.toLong -> time
+  }
+
+  def ObjectTypeNameReference(id : Long) : String = {
+    objectTypeNameReference.get(id) match {
+      case Some(name) => name
+      case None => ""
+    }
+  }
+
+  def ObjectTypeNameReference(id : Long, name : String) : String = {
+    objectTypeNameReference(id) = name
+    name
   }
 
   def Definition : AvatarDefinition = GlobalDefinitions.avatar

--- a/common/src/main/scala/net/psforever/objects/Avatar.scala
+++ b/common/src/main/scala/net/psforever/objects/Avatar.scala
@@ -189,7 +189,8 @@ class Avatar(private val char_id : Long, val name : String, val faction : Planet
 
   def FifthSlot : EquipmentSlot = {
     new OffhandEquipmentSlot(EquipmentSize.Inventory) {
-      Equipment = locker
+      val obj = new LockerEquipment(locker)
+      Equipment = obj
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/Deployables.scala
+++ b/common/src/main/scala/net/psforever/objects/Deployables.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.ce.{Deployable, DeployedItem}
 import net.psforever.objects.vehicles.{Utility, UtilityType}
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.{DeployableInfo, DeploymentAction}
-import net.psforever.types.PlanetSideGUID
+import net.psforever.types.{CertificationType, PlanetSideGUID}
 import services.RemoverActor
 import services.local.{LocalAction, LocalServiceMessage}
 
@@ -122,5 +122,49 @@ object Deployables {
         zone.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(telepad, zone, Some(0 seconds)))
       case _ => ;
     }
+  }
+
+
+
+  /**
+    * Initialize the deployables backend information.
+    * @param avatar the player's core
+    */
+  def InitializeDeployableQuantities(avatar : Avatar) : Boolean = {
+    log.info("Setting up combat engineering ...")
+    avatar.Deployables.Initialize(avatar.Certifications.toSet)
+  }
+
+  /**
+    * Initialize the UI elements for deployables.
+    * @param avatar the player's core
+    */
+  def InitializeDeployableUIElements(avatar : Avatar) : List[(Int,Int,Int,Int)] = {
+    log.info("Setting up combat engineering UI ...")
+    avatar.Deployables.UpdateUI()
+  }
+
+  /**
+    * The player learned a new certification.
+    * Update the deployables user interface elements if it was an "Engineering" certification.
+    * The certification "Advanced Hacking" also relates to an element.
+    * @param certification the certification that was added
+    * @param certificationSet all applicable certifications
+    */
+  def AddToDeployableQuantities(avatar : Avatar, certification : CertificationType.Value, certificationSet : Set[CertificationType.Value]) : List[(Int,Int,Int,Int)] = {
+    avatar.Deployables.AddToDeployableQuantities(certification, certificationSet)
+    avatar.Deployables.UpdateUI(certification)
+  }
+
+  /**
+    * The player forgot a certification he previously knew.
+    * Update the deployables user interface elements if it was an "Engineering" certification.
+    * The certification "Advanced Hacking" also relates to an element.
+    * @param certification the certification that was added
+    * @param certificationSet all applicable certifications
+    */
+  def RemoveFromDeployableQuantities(avatar : Avatar, certification : CertificationType.Value, certificationSet : Set[CertificationType.Value]) : List[(Int,Int,Int,Int)] = {
+    avatar.Deployables.RemoveFromDeployableQuantities(certification, certificationSet)
+    avatar.Deployables.UpdateUI(certification)
   }
 }

--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1703,11 +1703,11 @@ object GlobalDefinitions {
     plasma_grenade_ammo.Name = "plasma_grenade_ammo"
     plasma_grenade_ammo.Size = EquipmentSize.Blocked
 
-    bullet_9mm.Name = "bullet_9mm"
+    bullet_9mm.Name = "9mmbullet"
     bullet_9mm.Capacity = 50
     bullet_9mm.Tile = InventoryTile.Tile33
 
-    bullet_9mm_AP.Name="bullet_9mm_AP"
+    bullet_9mm_AP.Name="9mmbullet_AP"
     bullet_9mm_AP.Capacity = 50
     bullet_9mm_AP.Tile = InventoryTile.Tile33
 
@@ -1841,7 +1841,7 @@ object GlobalDefinitions {
     trek_ammo.Name = "trek_ammo"
     trek_ammo.Size = EquipmentSize.Blocked
 
-    bullet_35mm.Name = "bullet_35mm"
+    bullet_35mm.Name = "35mmbullet"
     bullet_35mm.Capacity = 100
     bullet_35mm.Tile = InventoryTile.Tile44
 
@@ -1889,11 +1889,11 @@ object GlobalDefinitions {
     liberator_bomb.Capacity = 20
     liberator_bomb.Tile = InventoryTile.Tile44
 
-    bullet_25mm.Name = "bullet_25mm"
+    bullet_25mm.Name = "25mmbullet"
     bullet_25mm.Capacity = 150
     bullet_25mm.Tile = InventoryTile.Tile44
 
-    bullet_75mm.Name = "bullet_75mm"
+    bullet_75mm.Name = "75mmbullet"
     bullet_75mm.Capacity = 100
     bullet_75mm.Tile = InventoryTile.Tile44
 
@@ -1913,11 +1913,11 @@ object GlobalDefinitions {
     reaver_rocket.Capacity = 12
     reaver_rocket.Tile = InventoryTile.Tile44
 
-    bullet_20mm.Name = "bullet_20mm"
+    bullet_20mm.Name = "20mmbullet"
     bullet_20mm.Capacity = 200
     bullet_20mm.Tile = InventoryTile.Tile44
 
-    bullet_12mm.Name = "bullet_12mm"
+    bullet_12mm.Name = "12mmbullet"
     bullet_12mm.Capacity = 300
     bullet_12mm.Tile = InventoryTile.Tile44
 
@@ -1929,7 +1929,7 @@ object GlobalDefinitions {
     wasp_gun_ammo.Capacity = 150
     wasp_gun_ammo.Tile = InventoryTile.Tile44
 
-    bullet_15mm.Name = "bullet_15mm"
+    bullet_15mm.Name = "15mmbullet"
     bullet_15mm.Capacity = 360
     bullet_15mm.Tile = InventoryTile.Tile44
 
@@ -1953,7 +1953,7 @@ object GlobalDefinitions {
     colossus_tank_cannon_ammo.Capacity = 110
     colossus_tank_cannon_ammo.Tile = InventoryTile.Tile44
 
-    bullet_105mm.Name = "bullet_105mm"
+    bullet_105mm.Name = "105mmbullet"
     bullet_105mm.Capacity = 100
     bullet_105mm.Tile = InventoryTile.Tile44
 
@@ -1981,7 +1981,7 @@ object GlobalDefinitions {
     peregrine_sparrow_ammo.Capacity = 150
     peregrine_sparrow_ammo.Tile = InventoryTile.Tile44
 
-    bullet_150mm.Name = "bullet_150mm"
+    bullet_150mm.Name = "150mmbullet"
     bullet_150mm.Capacity = 50
     bullet_150mm.Tile = InventoryTile.Tile44
 

--- a/common/src/main/scala/net/psforever/objects/LockerContainer.scala
+++ b/common/src/main/scala/net/psforever/objects/LockerContainer.scala
@@ -1,9 +1,12 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects
 
+import akka.actor.Actor
 import net.psforever.objects.definition.EquipmentDefinition
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.{Container, GridInventory}
+import net.psforever.objects.serverobject.{Containable, PlanetSideServerObject}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 /**
   * The companion of a `Locker` that is carried with a player
@@ -11,8 +14,17 @@ import net.psforever.objects.inventory.{Container, GridInventory}
   * The `Player` class refers to it as the "fifth slot" as its permanent slot number is encoded as `0x85`.
   * The inventory of this object is accessed using a game world `Locker` object (`mb_locker`).
   */
-class LockerContainer extends Equipment with Container {
+class LockerContainer extends PlanetSideServerObject
+  with Container {
+  private var faction : PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
   private val inventory = GridInventory(30, 20)
+
+  def Faction : PlanetSideEmpire.Value = faction
+
+  override def Faction_=(fact : PlanetSideEmpire.Value) : PlanetSideEmpire.Value = {
+    faction = fact
+    Faction
+  }
 
   def Inventory : GridInventory = inventory
 
@@ -25,4 +37,29 @@ object LockerContainer {
   def apply() : LockerContainer = {
     new LockerContainer()
   }
+}
+
+class LockerEquipment(locker : LockerContainer) extends Equipment
+  with Container {
+  private val obj = locker
+
+  override def GUID : PlanetSideGUID = obj.GUID
+
+  override def Faction : PlanetSideEmpire.Value = obj.Faction
+
+  def Inventory : GridInventory = obj.Inventory
+
+  def VisibleSlots : Set[Int] = Set.empty[Int]
+
+  def Definition : EquipmentDefinition = obj.Definition
+}
+
+class LockerContainerControl(locker : LockerContainer) extends Actor
+  with Containable {
+  def ContainerObject = locker
+
+  def receive : Receive = containerBehavior
+    .orElse {
+      case _ => ;
+    }
 }

--- a/common/src/main/scala/net/psforever/objects/LockerContainer.scala
+++ b/common/src/main/scala/net/psforever/objects/LockerContainer.scala
@@ -5,7 +5,8 @@ import akka.actor.Actor
 import net.psforever.objects.definition.EquipmentDefinition
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.{Container, GridInventory}
-import net.psforever.objects.serverobject.{Containable, PlanetSideServerObject}
+import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
 import net.psforever.packet.game.{ObjectAttachMessage, ObjectCreateDetailedMessage, ObjectDetachMessage}
 import net.psforever.packet.game.objectcreate.ObjectCreateMessageParent
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
@@ -59,7 +60,7 @@ class LockerEquipment(locker : LockerContainer) extends Equipment
 }
 
 class LockerContainerControl(locker : LockerContainer, toChannel : String) extends Actor
-  with Containable {
+  with ContainableBehavior {
   def ContainerObject = locker
 
   def receive : Receive = containerBehavior

--- a/common/src/main/scala/net/psforever/objects/LockerContainer.scala
+++ b/common/src/main/scala/net/psforever/objects/LockerContainer.scala
@@ -50,6 +50,12 @@ class LockerEquipment(locker : LockerContainer) extends Equipment
 
   override def GUID : PlanetSideGUID = obj.GUID
 
+  override def GUID_=(guid : PlanetSideGUID) : PlanetSideGUID = obj.GUID_=(guid)
+
+  override def HasGUID : Boolean = obj.HasGUID
+
+  override def Invalidate() : Unit = obj.Invalidate()
+
   override def Faction : PlanetSideEmpire.Value = obj.Faction
 
   def Inventory : GridInventory = obj.Inventory

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -610,6 +610,24 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
 
   def VehicleOwned_=(guid : Option[PlanetSideGUID]) : Option[PlanetSideGUID] = core.VehicleOwned_=(guid)
 
+  def GetLastUsedTime(code : Int) : Long = core.GetLastUsedTime(code)
+
+  def GetLastUsedTime(code : ExoSuitType.Value) : Long = core.GetLastUsedTime(code)
+
+  def GetLastUsedTime(code : ExoSuitType.Value, subtype : Int) : Long = core.GetLastUsedTime(code, subtype)
+
+  def SetLastUsedTime(code : Int): Unit = core.SetLastUsedTime(code)
+
+  def SetLastUsedTime(code : Int, time : Long) : Unit = core.SetLastUsedTime(code, time)
+
+  def SetLastUsedTime(code : ExoSuitType.Value): Unit = core.SetLastUsedTime(code)
+
+  def SetLastUsedTime(code : ExoSuitType.Value, time : Long) : Unit = core.SetLastUsedTime(code, time)
+
+  def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int): Unit = core.SetLastUsedTime(code, subtype)
+
+  def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int, time : Long) : Unit = core.SetLastUsedTime(code, subtype, time)
+
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]
 
   def Definition : AvatarDefinition = core.Definition

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -216,6 +216,8 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
 
   def Locker : LockerContainer = core.Locker
 
+  def FifthSlot : EquipmentSlot = core.FifthSlot
+
   override def Fit(obj : Equipment) : Option[Int] = {
     recursiveHolsterFit(holsters.iterator, obj.Size) match {
       case Some(index) =>

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -616,8 +616,6 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
 
   def GetLastUsedTime(code : ExoSuitType.Value, subtype : Int) : Long = core.GetLastUsedTime(code, subtype)
 
-  def SetLastUsedTime(code : Int): Unit = core.SetLastUsedTime(code)
-
   def SetLastUsedTime(code : Int, time : Long) : Unit = core.SetLastUsedTime(code, time)
 
   def SetLastUsedTime(code : ExoSuitType.Value): Unit = core.SetLastUsedTime(code)
@@ -627,6 +625,10 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
   def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int): Unit = core.SetLastUsedTime(code, subtype)
 
   def SetLastUsedTime(code : ExoSuitType.Value, subtype : Int, time : Long) : Unit = core.SetLastUsedTime(code, subtype, time)
+
+  def GetLastPurchaseTime(code : Int) : Long = core.GetLastPurchaseTime(code)
+
+  def SetLastPurchaseTime(code : Int, time : Long) : Unit = core.SetLastPurchaseTime(code, time)
 
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]
 

--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -630,6 +630,10 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
 
   def SetLastPurchaseTime(code : Int, time : Long) : Unit = core.SetLastPurchaseTime(code, time)
 
+  def ObjectTypeNameReference(id : Long) : String = core.ObjectTypeNameReference(id)
+
+  def ObjectTypeNameReference(id : Long, name : String) : String = core.ObjectTypeNameReference(id, name)
+
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]
 
   def Definition : AvatarDefinition = core.Definition

--- a/common/src/main/scala/net/psforever/objects/Players.scala
+++ b/common/src/main/scala/net/psforever/objects/Players.scala
@@ -1,9 +1,13 @@
 // Copyright (c) 2020 PSForever
 package net.psforever.objects
 
+import net.psforever.objects.equipment.EquipmentSlot
+import net.psforever.objects.inventory.InventoryItem
 import net.psforever.packet.game.{InventoryStateMessage, RepairMessage}
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
+
+import scala.annotation.tailrec
 
 object Players {
   private val log = org.log4s.getLogger("Players")
@@ -45,5 +49,59 @@ object Players {
     val name = target.Name
     log.info(s"$medic had revived $name")
     target.Zone.AvatarEvents ! AvatarServiceMessage(name, AvatarAction.Revive(target.GUID))
+  }
+
+  /**
+    * Iterate over a group of `EquipmentSlot`s, some of which may be occupied with an item.
+    * Remove any encountered items and add them to an output `List`.
+    * @param iter the `Iterator` of `EquipmentSlot`s
+    * @param index a number that equals the "current" holster slot (`EquipmentSlot`)
+    * @param list a persistent `List` of `Equipment` in the holster slots
+    * @return a `List` of `Equipment` in the holster slots
+    */
+  @tailrec def clearHolsters(iter : Iterator[EquipmentSlot], index : Int = 0, list : List[InventoryItem] = Nil) : List[InventoryItem] = {
+    if(!iter.hasNext) {
+      list
+    }
+    else {
+      val slot = iter.next
+      slot.Equipment match {
+        case Some(equipment) =>
+          slot.Equipment = None
+          clearHolsters(iter, index + 1, InventoryItem(equipment, index) +: list)
+        case None =>
+          clearHolsters(iter, index + 1, list)
+      }
+    }
+  }
+
+  /**
+    * Iterate over a group of `EquipmentSlot`s, some of which may be occupied with an item.
+    * For any slots that are not yet occupied by an item, search through the `List` and find an item that fits in that slot.
+    * Add that item to the slot and remove it from the list.
+    * @param iter the `Iterator` of `EquipmentSlot`s
+    * @param list a `List` of all `Equipment` that is not yet assigned to a holster slot or an inventory slot
+    * @return the `List` of all `Equipment` not yet assigned to a holster slot or an inventory slot
+    */
+  @tailrec def fillEmptyHolsters(iter : Iterator[EquipmentSlot], list : List[InventoryItem]) : List[InventoryItem] = {
+    if(!iter.hasNext) {
+      list
+    }
+    else {
+      val slot = iter.next
+      if(slot.Equipment.isEmpty) {
+        list.find(item => item.obj.Size == slot.Size) match {
+          case Some(obj) =>
+            val index = list.indexOf(obj)
+            slot.Equipment = obj.obj
+            fillEmptyHolsters(iter, list.take(index) ++ list.drop(index + 1))
+          case None =>
+            fillEmptyHolsters(iter, list)
+        }
+      }
+      else {
+        fillEmptyHolsters(iter, list)
+      }
+    }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/Players.scala
+++ b/common/src/main/scala/net/psforever/objects/Players.scala
@@ -1,9 +1,12 @@
 // Copyright (c) 2020 PSForever
 package net.psforever.objects
 
+import net.psforever.objects.definition.ExoSuitDefinition
 import net.psforever.objects.equipment.EquipmentSlot
 import net.psforever.objects.inventory.InventoryItem
+import net.psforever.objects.loadouts.InfantryLoadout
 import net.psforever.packet.game.{InventoryStateMessage, RepairMessage}
+import net.psforever.types.ExoSuitType
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 
@@ -102,6 +105,19 @@ object Players {
       else {
         fillEmptyHolsters(iter, list)
       }
+    }
+  }
+
+  def CertificationToUseExoSuit(player : Player, exosuit : ExoSuitType.Value, subtype : Int) : Boolean = {
+    ExoSuitDefinition.Select(exosuit, player.Faction).Permissions match {
+      case Nil =>
+        true
+      case permissions if subtype != 0 =>
+        val certs = player.Certifications
+        certs.intersect(permissions.toSet).nonEmpty &&
+          certs.intersect(InfantryLoadout.DetermineSubtypeC(subtype)).nonEmpty
+      case permissions =>
+        player.Certifications.intersect(permissions.toSet).nonEmpty
     }
   }
 }

--- a/common/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/common/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -4,7 +4,7 @@ package net.psforever.objects
 import akka.actor.ActorRef
 import net.psforever.objects.definition.VehicleDefinition
 import net.psforever.objects.equipment.{Equipment, EquipmentSize, EquipmentSlot, JammableUnit}
-import net.psforever.objects.inventory.{Container, GridInventory, InventoryTile}
+import net.psforever.objects.inventory.{Container, GridInventory, InventoryItem, InventoryTile}
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.affinity.FactionAffinity
@@ -17,6 +17,7 @@ import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{Success, Try}
 
 /**
   * The server-side support object that represents a vehicle.<br>
@@ -449,6 +450,20 @@ class Vehicle(private val vehicleDef : VehicleDefinition) extends AmenityOwner
         Some(index)
       case None =>
         Inventory.Find(guid)
+    }
+  }
+
+  override def Collisions(dest : Int, width : Int, height : Int) : Try[List[InventoryItem]] = {
+    weapons.get(dest) match {
+      case Some(slot) =>
+        slot.Equipment match {
+          case Some(item) =>
+            Success(List(InventoryItem(item, dest)))
+          case None =>
+            Success(List())
+        }
+      case None =>
+        super.Collisions(dest, width, height)
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.ballistics.{PlayerSource, ResolvedProjectile, Sourc
 import net.psforever.objects.definition.ImplantDefinition
 import net.psforever.objects.equipment.{Ammo, JammableBehavior, JammableUnit}
 import net.psforever.objects.vital.{PlayerSuicide, Vitality}
-import net.psforever.objects.serverobject.CommonMessages
+import net.psforever.objects.serverobject.{CommonMessages, Containable}
 import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.repair.Repairable
@@ -25,9 +25,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class PlayerControl(player : Player) extends Actor
   with JammableBehavior
-  with Damageable {
+  with Damageable
+  with Containable {
   def JammableObject = player
   def DamageableObject = player
+  def ContainerObject = player
 
   private [this] val log = org.log4s.getLogger(player.Name)
   private [this] val damageLog = org.log4s.getLogger(Damageable.LogChannel)
@@ -37,6 +39,7 @@ class PlayerControl(player : Player) extends Actor
 
   def receive : Receive = jammableBehavior
     .orElse(takesDamage)
+    .orElse(behavior)
     .orElse {
     case Player.ImplantActivation(slot: Int, status : Int) =>
       // todo: disable implants with stamina cost when changing armour type

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -8,8 +8,9 @@ import net.psforever.objects.definition.ImplantDefinition
 import net.psforever.objects.equipment.{Ammo, Equipment, EquipmentSize, JammableBehavior, JammableUnit}
 import net.psforever.objects.inventory.{GridInventory, InventoryItem}
 import net.psforever.objects.loadouts.Loadout
+import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
 import net.psforever.objects.vital.{PlayerSuicide, Vitality}
-import net.psforever.objects.serverobject.{CommonMessages, Containable, PlanetSideServerObject}
+import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.repair.Repairable
@@ -31,7 +32,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class PlayerControl(player : Player) extends Actor
   with JammableBehavior
   with Damageable
-  with Containable {
+  with ContainableBehavior {
   def JammableObject = player
 
   def DamageableObject = player
@@ -311,7 +312,7 @@ class PlayerControl(player : Player) extends Actor
             val originalSuit = player.ExoSuit
             val originalSubtype = Loadout.DetermineSubtype(player)
             //sanitize exo-suit for change
-            val dropPred = Containable.DropPredicate(player)
+            val dropPred = ContainableBehavior.DropPredicate(player)
             val oldHolsters = Players.clearHolsters(player.Holsters().iterator)
             val dropHolsters = oldHolsters.filter(dropPred)
             val oldInventory = player.Inventory.Clear()

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -4,13 +4,16 @@ package net.psforever.objects.avatar
 import akka.actor.{Actor, ActorRef, Props}
 import net.psforever.objects._
 import net.psforever.objects.ballistics.{PlayerSource, ResolvedProjectile}
-import net.psforever.objects.definition.ImplantDefinition
-import net.psforever.objects.equipment.{Ammo, Equipment, JammableBehavior, JammableUnit}
+import net.psforever.objects.definition.{ExoSuitDefinition, ImplantDefinition}
+import net.psforever.objects.equipment.{Ammo, Equipment, EquipmentSize, JammableBehavior, JammableUnit}
+import net.psforever.objects.inventory.{GridInventory, InventoryItem}
+import net.psforever.objects.loadouts.{InfantryLoadout, Loadout}
 import net.psforever.objects.vital.{PlayerSuicide, Vitality}
 import net.psforever.objects.serverobject.{CommonMessages, Containable, PlanetSideServerObject}
 import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.repair.Repairable
+import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.objects.vital._
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game._
@@ -74,7 +77,7 @@ class PlayerControl(player : Player) extends Actor
               // Some events such as zoning will reset the implant on the client side without sending a deactivation packet
               // But the implant will remain in an active state server side. For now, allow reactivation of the implant.
               // todo: Deactivate implants server side when actions like zoning happen. (Other actions?)
-              log.warn(s"Implant ${slot} is already active, but activating again")
+              log.warn(s"Implant $slot is already active, but activating again")
               implantSlotStaminaDrainTimers(slot).cancel()
               implantSlotStaminaDrainTimers(slot) = DefaultCancellable.obj
             }
@@ -94,12 +97,11 @@ class PlayerControl(player : Player) extends Actor
         }
       }
       else {
-        log.warn(s"Can't handle ImplantActivation: Player GUID: ${player.GUID} Slot ${slot} Status: ${status} Initialized: ${implantSlot.Initialized} Active: ${implantSlot.Active} Fatigued: ${player.Fatigued}")
+        log.warn(s"Can't handle ImplantActivation: Player GUID: ${player.GUID} Slot $slot Status: $status Initialized: ${implantSlot.Initialized} Active: ${implantSlot.Active} Fatigued: ${player.Fatigued}")
       }
 
-    case Player.UninitializeImplant(slot: Int) => {
+    case Player.UninitializeImplant(slot: Int) =>
       PlayerControl.UninitializeImplant(player, slot)
-    }
 
     case Player.ImplantInitializationStart(slot: Int) =>
       val implantSlot = player.ImplantSlot(slot)
@@ -130,16 +132,16 @@ class PlayerControl(player : Player) extends Actor
       player.Stamina -= amount
 
     case Player.StaminaChanged(currentStamina : Int) =>
-    if(currentStamina == 0) {
+      if(currentStamina == 0) {
         player.Fatigued = true
         player.skipStaminaRegenForTurns += 4
-        for(slot <- 0 to player.Implants.length - 1) { // Disable all implants
+        player.Implants.indices.foreach { slot => // Disable all implants
           self ! Player.ImplantActivation(slot, 0)
           player.Zone.AvatarEvents ! AvatarServiceMessage(player.Zone.Id, AvatarAction.SendResponseTargeted(player.GUID, AvatarImplantMessage(player.GUID, ImplantAction.OutOfStamina, slot, 1)))
         }
       } else if (player.Fatigued && currentStamina >= 20) {
         player.Fatigued = false
-        for(slot <- 0 to player.Implants.length - 1) { // Re-enable all implants
+        player.Implants.indices.foreach { slot => // Re-enable all implants
           player.Zone.AvatarEvents ! AvatarServiceMessage(player.Zone.Id, AvatarAction.SendResponseTargeted(player.GUID, AvatarImplantMessage(player.GUID, ImplantAction.OutOfStamina, slot, 0)))
         }
       }
@@ -221,6 +223,167 @@ class PlayerControl(player : Player) extends Actor
             events ! AvatarServiceMessage(uname, AvatarAction.SendResponse(Service.defaultPlayerGUID, RepairMessage(guid, player.Armor * 100 / player.MaxArmor)))
           }
         }
+
+    case Terminal.TerminalMessage(_, msg, order) =>
+      order match {
+        case Terminal.BuyExosuit(exosuit, subtype) =>
+          var toDropOrDelete : List[InventoryItem] = Nil
+          //TODO check exo-suit permissions
+          val originalSuit = player.ExoSuit
+          val originalSubtype = Loadout.DetermineSubtype(player)
+          var requestToChangeArmor = originalSuit != exosuit || originalSubtype != subtype
+          var allowedToChangeArmor : Boolean = true
+          val result = if(requestToChangeArmor && allowedToChangeArmor) {
+            log.info(s"${player.Name} wants to change to a different exo-suit - $exosuit")
+            val beforeInventory = player.Inventory.Clear()
+            val beforeHolsters = Players.clearHolsters(player.Holsters().iterator)
+            //change suit
+            val originalArmor = player.Armor
+            player.ExoSuit = exosuit //changes the value of MaxArmor to reflect the new exo-suit
+            val toMaxArmor = player.MaxArmor
+            if (originalSuit != exosuit || originalSubtype != subtype || originalArmor > toMaxArmor) {
+              player.History(HealFromExoSuitChange(PlayerSource(player), exosuit))
+              player.Armor = toMaxArmor
+            }
+            else {
+              player.Armor = originalArmor
+            }
+            //ensure arm is down, even if it needs to go back up
+            if (player.DrawnSlot != Player.HandsDownSlot) {
+              player.DrawnSlot = Player.HandsDownSlot
+            }
+            val normalHolsters = if (originalSuit == ExoSuitType.MAX) {
+              val (maxWeapons, normalWeapons) = beforeHolsters.partition(elem => elem.obj.Size == EquipmentSize.Max)
+              toDropOrDelete = toDropOrDelete ++ maxWeapons
+              normalWeapons
+            }
+            else {
+              beforeHolsters
+            }
+            //populate holsters
+            val (afterHolsters, finalInventory) = if (exosuit == ExoSuitType.MAX) {
+              (normalHolsters, Players.fillEmptyHolsters(List(player.Slot(4)).iterator, normalHolsters) ++ beforeInventory)
+            }
+            else if (originalSuit == exosuit) { //note - this will rarely be the situation
+              (normalHolsters, Players.fillEmptyHolsters(player.Holsters().iterator, normalHolsters))
+            }
+            else {
+              val (afterHolsters, toInventory) = normalHolsters.partition(elem => elem.obj.Size == player.Slot(elem.start).Size)
+              afterHolsters.foreach({ elem => player.Slot(elem.start).Equipment = elem.obj })
+              val remainder = Players.fillEmptyHolsters(player.Holsters().iterator, toInventory ++ beforeInventory)
+              (
+                player.Holsters()
+                  .zipWithIndex
+                  .map { case (slot, i) => (slot.Equipment, i) }
+                  .collect { case (Some(obj), index) => InventoryItem(obj, index) }
+                  .toList,
+                remainder
+              )
+            }
+            //put items back into inventory
+            val (stow, drop) = if (originalSuit == exosuit) {
+              (finalInventory, Nil)
+            }
+            else {
+              val (a, b) = GridInventory.recoverInventory(finalInventory, player.Inventory)
+              (a, b.map { InventoryItem(_, -1) })
+            }
+            stow.foreach { elem =>
+              player.Inventory.InsertQuickly(elem.start, elem.obj)
+            }
+            player.Zone.AvatarEvents ! AvatarServiceMessage(player.Zone.Id,
+              AvatarAction.ChangeExosuit(player.GUID, exosuit, subtype, player.LastDrawnSlot, exosuit == ExoSuitType.MAX && requestToChangeArmor, afterHolsters, stow, toDropOrDelete ++ drop)
+            )
+            true
+          }
+          else {
+            false
+          }
+          player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, result))
+
+        case Terminal.InfantryLoadout(exosuit, subtype, holsters, inventory) =>
+          log.info(s"${player.Name} wants to change equipment loadout to their option #${msg.unk1 + 1}")
+          val fallbackSubtype = 0
+          val fallbackSuit = ExoSuitType.Standard
+          val originalSuit = player.ExoSuit
+          val originalSubtype = Loadout.DetermineSubtype(player)
+          //sanitize exo-suit for change
+          val dropPred = Containable.DropPredicate(player)
+          val toDeleteOrDrop : List[InventoryItem] = (player.FreeHand.Equipment match {
+            case Some(obj) =>
+              player.FreeHand.Equipment = None
+              List(InventoryItem(obj, -1))
+            case _ =>
+              Nil
+          }) ++ Players.clearHolsters(player.Holsters().iterator) ++ player.Inventory.Clear()
+          //a loadout with a prohibited exo-suit type will result in the fallback exo-suit type
+          val (nextSuit : ExoSuitType.Value, nextSubtype : Int) =
+            if(ExoSuitDefinition.Select(exosuit, player.Faction).Permissions match {
+              case Nil =>
+                true
+              case permissions if subtype != 0 =>
+                val certs = player.Certifications
+                certs.intersect(permissions.toSet).nonEmpty &&
+                  certs.intersect(InfantryLoadout.DetermineSubtypeC(subtype)).nonEmpty
+              case permissions =>
+                player.Certifications.intersect(permissions.toSet).nonEmpty
+            }) {
+              (exosuit, subtype)
+            }
+            else {
+              log.warn(s"${player.Name} no longer has permission to wear the exo-suit type $exosuit; will wear $fallbackSuit instead")
+              (fallbackSuit, fallbackSubtype)
+            }
+          //update suit interally
+          val originalArmor = player.Armor
+          player.ExoSuit = nextSuit
+          val toMaxArmor = player.MaxArmor
+          if(originalSuit != nextSuit || originalSubtype != nextSubtype || originalArmor > toMaxArmor) {
+            player.History(HealFromExoSuitChange(PlayerSource(player), nextSuit))
+            player.Armor = toMaxArmor
+          }
+          else {
+            player.Armor = originalArmor
+          }
+          //ensure arm is down, even if it needs to go back up
+          if(player.DrawnSlot != Player.HandsDownSlot) {
+            player.DrawnSlot = Player.HandsDownSlot
+          }
+          //a change due to exo-suit permissions mismatch will result in (more) items being re-arranged and/or dropped
+          //dropped items are not registered and can just be forgotten
+          val (afterHolsters, afterInventory) = if(nextSuit == exosuit) {
+            (
+              //melee slot preservation for MAX
+              if(nextSuit == ExoSuitType.MAX) holsters.filter(_.start == 4)
+              else holsters.filterNot(dropPred),
+              inventory.filterNot(dropPred)
+            )
+          }
+          else {
+            //our exo-suit type was hijacked by changing permissions; we shouldn't even be able to use that loadout(!)
+            //holsters
+            val leftoversForInventory = Players.fillEmptyHolsters(player.Holsters().iterator, (holsters ++ inventory).filterNot(dropPred))
+            val finalHolsters = player.Holsters()
+              .zipWithIndex
+              .collect { case (slot, index) if slot.Equipment.nonEmpty => InventoryItem(slot.Equipment.get, index) }
+              .toList
+            //inventory
+            val (finalInventory, _) = GridInventory.recoverInventory(leftoversForInventory, player.Inventory)
+            (finalHolsters, finalInventory)
+          }
+          (afterHolsters ++ afterInventory).foreach { entry => entry.obj.Faction = player.Faction }
+          toDeleteOrDrop.foreach { entry => entry.obj.Faction = PlanetSideEmpire.NEUTRAL }
+
+          player.Zone.AvatarEvents ! AvatarServiceMessage(player.Zone.Id,
+            AvatarAction.ChangeLoadout(player.GUID, nextSuit, nextSubtype, player.LastDrawnSlot, exosuit == ExoSuitType.MAX, afterHolsters, afterInventory, toDeleteOrDrop)
+          )
+          player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, true))
+
+        case Terminal.NoDeal() =>
+          player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, false))
+
+        case _ => ; //not handled here
+      }
 
       case _ => ;
     }

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -379,10 +379,7 @@ class PlayerControl(player : Player) extends Actor
           )
           player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, true))
 
-        case Terminal.NoDeal() =>
-          player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, false))
-
-        case _ => ; //not handled here
+        case _ => ; //terminal messages not handled here
       }
 
       case _ => ;
@@ -438,10 +435,9 @@ class PlayerControl(player : Player) extends Actor
       //TODO these features
       val guid = obj.GUID
       val zone = obj.Zone
-      val zoneId = zone.Id
       val events = zone.AvatarEvents
 
-      for(slot <- 0 to player.Implants.length - 1) { // Deactivate & uninitialize all implants
+      player.Implants.indices.foreach { slot => // Deactivate & uninitialize all implants
         player.Zone.AvatarEvents ! AvatarServiceMessage(player.Zone.Id, AvatarAction.PlanetsideAttribute(player.GUID, 28, player.Implant(slot).id * 2)) // Deactivation sound / effect
         self ! Player.ImplantActivation(slot, 0)
         PlayerControl.UninitializeImplant(player, slot)
@@ -453,7 +449,7 @@ class PlayerControl(player : Player) extends Actor
   }
 
   override def CancelJammeredStatus(target: Any): Unit = {
-    for(slot <- 0 to player.Implants.length - 1) { // Start reinitializing all implants
+    player.Implants.indices.foreach { slot => // Start reinitializing all implants
       self ! Player.ImplantInitializationStart(slot)
     }
 

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -34,9 +34,7 @@ class PlayerControl(player : Player) extends Actor
   with Damageable
   with ContainableBehavior {
   def JammableObject = player
-
   def DamageableObject = player
-
   def ContainerObject = player
 
   private[this] val log = org.log4s.getLogger(player.Name)

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -302,7 +302,7 @@ class PlayerControl(player : Player) extends Actor
           player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, result))
 
         case Terminal.InfantryLoadout(exosuit, subtype, holsters, inventory) =>
-          log.info(s"${player.Name} wants to change equipment loadout to their option #${msg.unk1 + 1}")
+          log.info(s"wants to change equipment loadout to their option #${msg.unk1 + 1}")
           val fallbackSubtype = 0
           val fallbackSuit = ExoSuitType.Standard
           val originalSuit = player.ExoSuit

--- a/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/common/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -1,20 +1,20 @@
 // Copyright (c) 2020 PSForever
 package net.psforever.objects.avatar
 
-import akka.actor.Actor
-import net.psforever.objects.{DefaultCancellable, GlobalDefinitions, ImplantSlot, Player, Players, Tool}
-import net.psforever.objects.ballistics.{PlayerSource, ResolvedProjectile, SourceEntry}
+import akka.actor.{Actor, ActorRef, Props}
+import net.psforever.objects._
+import net.psforever.objects.ballistics.{PlayerSource, ResolvedProjectile}
 import net.psforever.objects.definition.ImplantDefinition
 import net.psforever.objects.equipment.{Ammo, JammableBehavior, JammableUnit}
 import net.psforever.objects.vital.{PlayerSuicide, Vitality}
-import net.psforever.objects.serverobject.{CommonMessages, Containable}
+import net.psforever.objects.serverobject.{CommonMessages, Containable, PlanetSideServerObject}
 import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.repair.Repairable
 import net.psforever.objects.vital._
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game._
-import net.psforever.types.{ExoSuitType, ImplantType, PlanetSideGUID, Vector3}
+import net.psforever.types.{ExoSuitType, Vector3}
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
 
@@ -36,10 +36,22 @@ class PlayerControl(player : Player) extends Actor
 
   // A collection of timers for each slot to trigger stamina drain on an interval
   val implantSlotStaminaDrainTimers = mutable.HashMap(0 -> DefaultCancellable.obj, 1 -> DefaultCancellable.obj, 2 -> DefaultCancellable.obj)
+  // control agency for the player's locker container (dedicated inventory slot #5)
+  val lockerControlAgent : ActorRef = {
+    val locker = player.Locker
+    locker.Zone = player.Zone
+    locker.Actor = context.actorOf(Props(classOf[LockerContainerControl], locker), PlanetSideServerObject.UniqueActorName(locker))
+  }
+
+  override def postStop() : Unit = {
+    context.stop(lockerControlAgent)
+    player.Locker.Actor = ActorRef.noSender
+    implantSlotStaminaDrainTimers.values.foreach { _.cancel }
+  }
 
   def receive : Receive = jammableBehavior
     .orElse(takesDamage)
-    .orElse(behavior)
+    .orElse(containerBehavior)
     .orElse {
     case Player.ImplantActivation(slot: Int, status : Int) =>
       // todo: disable implants with stamina cost when changing armour type

--- a/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/LockerContainerConverter.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.definition.converter
 
-import net.psforever.objects.LockerContainer
+import net.psforever.objects.LockerEquipment
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.GridInventory
 import net.psforever.packet.game.objectcreate._
@@ -9,8 +9,8 @@ import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
 
 import scala.util.{Success, Try}
 
-class LockerContainerConverter extends ObjectCreateConverter[LockerContainer]() {
-  override def ConstructorData(obj : LockerContainer) : Try[LockerContainerData] = {
+class LockerContainerConverter extends ObjectCreateConverter[LockerEquipment]() {
+  override def ConstructorData(obj : LockerEquipment) : Try[LockerContainerData] = {
     MakeInventory(obj.Inventory) match {
       case Nil =>
         Success(LockerContainerData(None))
@@ -19,7 +19,7 @@ class LockerContainerConverter extends ObjectCreateConverter[LockerContainer]() 
     }
   }
 
-  override def DetailedConstructorData(obj : LockerContainer) : Try[DetailedLockerContainerData] = {
+  override def DetailedConstructorData(obj : LockerEquipment) : Try[DetailedLockerContainerData] = {
     if(obj.Inventory.Size > 0) {
       Success(DetailedLockerContainerData(
         CommonFieldData(PlanetSideEmpire.NEUTRAL, false, false, true, None, false, None, None, PlanetSideGUID(0)),

--- a/common/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
@@ -86,12 +86,11 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
   }
   
   private def MakeMountings(obj : Vehicle) : List[InventoryItemData.InventoryItem] = {
-    obj.Weapons.map({
-      case(index, slot) =>
-        val equip : Equipment = slot.Equipment.get
-        val equipDef = equip.Definition
-        InventoryItemData(equipDef.ObjectId, equip.GUID, index, equipDef.Packet.ConstructorData(equip).get)
-    }).toList
+    obj.Weapons.collect { case (index, slot) if slot.Equipment.nonEmpty =>
+      val equip : Equipment = slot.Equipment.get
+      val equipDef = equip.Definition
+      InventoryItemData(equipDef.ObjectId, equip.GUID, index, equipDef.Packet.ConstructorData(equip).get)
+    }.toList
   }
 
   protected def MakeUtilities(obj : Vehicle) : List[InventoryItemData.InventoryItem] = {

--- a/common/src/main/scala/net/psforever/objects/guid/GUIDTask.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/GUIDTask.scala
@@ -90,6 +90,9 @@ object GUIDTask {
   def RegisterLocker(obj : LockerContainer)(implicit guid : ActorRef) : TaskResolver.GiveTask = {
     TaskResolver.GiveTask(RegisterObjectTask(obj).task, RegisterInventory(obj))
   }
+  def RegisterLocker(obj : LockerEquipment)(implicit guid : ActorRef) : TaskResolver.GiveTask = {
+    TaskResolver.GiveTask(RegisterObjectTask(obj).task, RegisterInventory(obj))
+  }
 
   /**
     * Construct tasking that registers the objects that are within the given container's inventory
@@ -124,8 +127,6 @@ object GUIDTask {
     obj match {
       case tool : Tool =>
         RegisterTool(tool)
-      case locker : LockerContainer =>
-        RegisterLocker(locker)
       case _ =>
         RegisterObjectTask(obj)
     }
@@ -254,6 +255,9 @@ object GUIDTask {
   def UnregisterLocker(obj : LockerContainer)(implicit guid : ActorRef) : TaskResolver.GiveTask = {
     TaskResolver.GiveTask(UnregisterObjectTask(obj).task, UnregisterInventory(obj))
   }
+  def UnregisterLocker(obj : LockerEquipment)(implicit guid : ActorRef) : TaskResolver.GiveTask = {
+    TaskResolver.GiveTask(RegisterObjectTask(obj).task, RegisterInventory(obj))
+  }
 
   /**
     * Construct tasking that unregisters the objects that are within the given container's inventory
@@ -282,8 +286,6 @@ object GUIDTask {
     obj match {
       case tool : Tool =>
         UnregisterTool(tool)
-      case locker : LockerContainer =>
-        UnregisterLocker(locker)
       case _ =>
         UnregisterObjectTask(obj)
     }

--- a/common/src/main/scala/net/psforever/objects/guid/GUIDTask.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/GUIDTask.scala
@@ -43,6 +43,8 @@ object GUIDTask {
         private val localObject = obj
         private val localAccessor = guid
 
+        override def Description : String = s"register $localObject"
+
         override def isComplete : Task.Resolution.Value = if(localObject.HasGUID) {
           Task.Resolution.Success
         }
@@ -215,6 +217,8 @@ object GUIDTask {
       new Task() {
         private val localObject = obj
         private val localAccessor = guid
+
+        override def Description : String = s"unregister $localObject"
 
         override def isComplete : Task.Resolution.Value = if(!localObject.HasGUID) {
           Task.Resolution.Success

--- a/common/src/main/scala/net/psforever/objects/guid/Task.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/Task.scala
@@ -4,6 +4,7 @@ package net.psforever.objects.guid
 import akka.actor.ActorRef
 
 trait Task {
+  def Description : String = "write_descriptive_task_message"
   def Execute(resolver : ActorRef) : Unit
   def isComplete : Task.Resolution.Value = Task.Resolution.Incomplete
   def Timeout : Long = 200L //milliseconds

--- a/common/src/main/scala/net/psforever/objects/guid/TaskResolver.scala
+++ b/common/src/main/scala/net/psforever/objects/guid/TaskResolver.scala
@@ -82,7 +82,7 @@ class TaskResolver() extends Actor {
   private def GiveTask(aTask : Task) : Unit = {
     val entry : TaskResolver.TaskEntry = TaskResolver.TaskEntry(aTask)
     tasks += entry
-    trace(s"enqueue and start task $aTask")
+    trace(s"enqueue and start task ${aTask.Description}")
     entry.Execute(self)
     StartTimeoutCheck()
   }
@@ -112,12 +112,13 @@ class TaskResolver() extends Actor {
   private def QueueSubtasks(task : Task, subtasks : List[TaskResolver.GiveTask], resolver : ActorRef = Actor.noSender) : Unit = {
     val entry : TaskResolver.TaskEntry = TaskResolver.TaskEntry(task, subtasks.map(task => task.task), resolver)
     tasks += entry
-    trace(s"enqueue task $task")
+    trace(s"enqueue task ${task.Description}")
     if(subtasks.isEmpty) { //a leaf in terms of task dependency; so, not dependent on any other work
-      trace(s"start task $task")
+      trace(s"start task ${task.Description}")
       entry.Execute(self)
     }
     else {
+      trace(s"enqueuing ${subtasks.length} substask(s) belonging to ${task.Description}")
       subtasks.foreach({subtask =>
         context.parent ! TaskResolver.GiveSubtask(subtask.task, subtask.subs, self) //route back to submit subtask to pool
       })
@@ -160,7 +161,7 @@ class TaskResolver() extends Actor {
   private def GeneralOnSuccess(index : Int) : Unit = {
     val entry = tasks(index)
     entry.task.onSuccess()
-    trace(s"success with this task ${entry.task}")
+    trace(s"success with task ${entry.task.Description}")
     if(entry.supertaskRef != ActorRef.noSender) {
       entry.supertaskRef ! TaskResolver.CompletedSubtask(entry.task) //alert our dependent task's resolver that we have completed
     }
@@ -177,7 +178,7 @@ class TaskResolver() extends Actor {
       case Some(index) =>
         val entry = tasks(index)
         if(TaskResolver.filterCompletionMatch(entry.subtasks.iterator, Task.Resolution.Success)) {
-          trace(s"start new task ${entry.task}")
+          trace(s"start new task ${entry.task.Description}")
           entry.Execute(self)
           StartTimeoutCheck()
         }
@@ -224,7 +225,7 @@ class TaskResolver() extends Actor {
   private def GeneralOnFailure(index : Int, ex  : Throwable) : Unit = {
     val entry = tasks(index)
     val task = entry.task
-    trace(s"failure with this task $task")
+    trace(s"failure with task ${task.Description}")
     task.onAbort(ex)
     task.onFailure(ex)
     if(entry.supertaskRef != ActorRef.noSender) {
@@ -267,7 +268,7 @@ class TaskResolver() extends Actor {
   private def PropagateAbort(index : Int, ex : Throwable) : Unit = {
     tasks(index).subtasks.foreach({subtask =>
       if(subtask.isComplete == Task.Resolution.Success) {
-        trace(s"aborting task $subtask")
+        trace(s"aborting task ${subtask.Description}")
         subtask.onAbort(ex)
       }
       context.parent ! Broadcast(TaskResolver.AbortTask(subtask, ex))

--- a/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -109,7 +109,7 @@ class GridInventory extends Container {
     * Test whether a given piece of `Equipment` would collide with any stowed content in the inventory.<br>
     * <br>
     * A "collision" is considered a situation where the stowed placards of two items would overlap in some way.
-    * The gridkeeps track of the location of items by storing the primitive of their GUID in one or more cells.
+    * The grid keeps track of the location of items by storing the primitive of their GUID in one or more cells.
     * Two primitives can not be stored in the same cell.
     * If placing two items into the same inventory leads to a situation where two primitive values might be in the same cell,
     * that is a collision.
@@ -187,17 +187,19 @@ class GridInventory extends Container {
     }
     else {
       val collisions : mutable.Set[InventoryItem] = mutable.Set[InventoryItem]()
-      items.values.foreach({ item : InventoryItem =>
-        val actualItemStart : Int = item.start - offset
-        val itemx : Int = actualItemStart % width
-        val itemy : Int = actualItemStart / width
-        val tile = item.obj.Tile
-        val clipsOnX : Boolean = if(itemx < startx) { itemx + tile.Width > startx } else { itemx <= startw }
-        val clipsOnY : Boolean = if(itemy < starty) { itemy + tile.Height > starty } else { itemy <= starth }
-        if(clipsOnX && clipsOnY) {
-          collisions += item
+      items
+        .map { case (_, item : InventoryItem) => item }
+        .foreach { item : InventoryItem =>
+          val actualItemStart : Int = item.start - offset
+          val itemx : Int = actualItemStart % width
+          val itemy : Int = actualItemStart / width
+          val tile = item.obj.Tile
+          val clipsOnX : Boolean = if(itemx < startx) { itemx + tile.Width > startx } else { itemx <= startw }
+          val clipsOnY : Boolean = if(itemy < starty) { itemy + tile.Height > starty } else { itemy <= starth }
+          if(clipsOnX && clipsOnY) {
+            collisions += item
+          }
         }
-      })
       Success(collisions.toList)
     }
   }

--- a/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/common/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -577,7 +577,7 @@ class GridInventory extends Container {
   def Clear() : List[InventoryItem] = {
     val list = items.values.toList
     items.clear
-    //entryIndex.set(0)
+    entryIndex.set(0)
     grid = SetCellsOnlyNoOffset(0, width, height)
     list
   }
@@ -777,5 +777,18 @@ object GridInventory {
     node.Split()
     node.down.get(node.x, node.y + height, node.width, node.height - height)
     node.right.get(node.x + width, node.y, node.width - width, height)
+  }
+
+  def toPrintedList(inv : GridInventory) : String = {
+    val list = new StringBuilder
+    list.append("\n")
+    inv.Items.zipWithIndex.foreach { case (InventoryItem(obj, start), index) =>
+      list.append(s"${index+1}: ${obj.Definition.Name}@${obj.GUID} -> $start\n")
+    }
+    list.toString
+  }
+
+  def toPrintedGrid(inv : GridInventory) : String = {
+    new StringBuilder().append("\n").append(inv.grid.toSeq.grouped(inv.width).mkString("\n")).toString
   }
 }

--- a/common/src/main/scala/net/psforever/objects/loadouts/Loadout.scala
+++ b/common/src/main/scala/net/psforever/objects/loadouts/Loadout.scala
@@ -53,7 +53,9 @@ object Loadout {
   def Create(vehicle : Vehicle, label : String) : Loadout = {
     VehicleLoadout(
       label,
-      packageSimplifications(vehicle.Weapons.map({ case (index, weapon) => InventoryItem(weapon.Equipment.get, index) }).toList),
+      packageSimplifications(vehicle.Weapons.collect { case (index, slot) if slot.Equipment.nonEmpty =>
+        InventoryItem(slot.Equipment.get, index) }.toList
+      ),
       packageSimplifications(vehicle.Trunk.Items),
       vehicle.Definition
     )

--- a/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
@@ -13,10 +13,26 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Success
 
+/**
+  * A mixin for handling synchronized movement of `Equipment` items into or out from `Container` entities.
+  * The most important feature of this synchronization is the movmement of equipment
+  * out from one container into another container
+  * without causing representation overlap, overwriting, or unintended stacking of other equipment
+  * including equipment that has nort yet been inserted.
+  */
 trait Containable {
   _ : Actor =>
   def ContainerObject : PlanetSideServerObject with Container
 
+  /**
+    * A flag for handling deferred messages during an attempt at complicated item movement (`MoveItem`) procedures.
+    * Complicated item movement procedures generally occur when the source and the destination are not the same container.
+    * The flag is set to `1` on the destination and is designed to block interference other normal insertion messages
+    * by taking those messages and pushing them back into the mailbox after a short delay.
+    * If two attempts on the same destination occur due to extremely coincidental item movement messages,
+    * the flag is set to `2` and most all messages involving item movement and item insertion are deferred.
+    * The destination is set back to normal - flag to `0` - when both of the attempts short-circuit due to timeout.
+    */
   private var waitOnMoveItemOps : Int = 0
 
   final val containerBehavior : Receive = {
@@ -26,6 +42,7 @@ trait Containable {
     case Containable.Resume() => Resume()
 
     case repeatMsg @ Containable.Defer(msg, sentBy) =>
+      //received a previously blocked message; is it still blocked?
       msg match {
         case _ : Containable.ContainableMsg if waitOnMoveItemOps == 2 => RepeatMessageLater(repeatMsg)
         case _ : Containable.DeferrableMessage if waitOnMoveItemOps == 1 => RepeatMessageLater(repeatMsg)
@@ -33,10 +50,12 @@ trait Containable {
       }
 
     case msg : Containable.ContainableMsg if waitOnMoveItemOps == 2 =>
+      //all standard messages are blocked
       RepeatMessageLater(Containable.Defer(msg, sender))
       MessageDeferredCallback(msg)
 
     case msg : Containable.DeferrableMessage if waitOnMoveItemOps == 1 =>
+      //insertion messages not related to an item move attempt are blocked
       RepeatMessageLater(Containable.Defer(msg, sender))
       MessageDeferredCallback(msg)
 
@@ -50,6 +69,9 @@ trait Containable {
     case Containable.PutItemInSlot(item, dest) => /* can be deferred */
       sender ! LocalPutItemInSlot(item, dest)
 
+    case Containable.PutItemInSlotOnly(item, dest) => /* can be deferred */
+      sender ! LocalPutItemInSlotOnly(item, dest)
+
     case Containable.PutItemAway(item) => /* can be deferred */
       sender ! LocalPutItemAway(item)
 
@@ -57,7 +79,7 @@ trait Containable {
       sender ! LocalPutItemInSlotOrAway(item, dest)
 
     case msg @ Containable.MoveItem(destination, equipment, destSlot) => /* can be deferred */
-      if(Containable.TestPutItemInSlot(destination, equipment, destSlot)) { //test early, before we try to move the item
+      if(Containable.TestPutItemInSlot(destination, equipment, destSlot).nonEmpty) { //test early, before we try to move the item
         val to = sender
         val source = ContainerObject
         val item = equipment
@@ -69,9 +91,8 @@ trait Containable {
               LocalPutItemInSlot(item, dest) match {
                 case Containable.ItemPutInSlot(_, _, _, None) => ; //success
                 case Containable.ItemPutInSlot(_, _, _, Some(swapItem)) => //success, but with swap item
-                  Containable.TryPutItemInSlotOrAway(source, swapItem, slot) match {
-                    case (Some(swapSlot), _) =>
-                      PutItemInSlotCallback(swapItem, swapSlot) //depict swapped item placement
+                  LocalPutItemInSlotOnlyOrAway(swapItem, slot) match {
+                    case Containable.ItemPutInSlot(_, _, _, None) => ;
                     case _ =>
                       source.Zone.Ground.tell(Zone.Ground.DropItem(swapItem, source.Position, Vector3.z(source.Orientation.z)), to) //drop it
                   }
@@ -117,37 +138,50 @@ trait Containable {
         sender ! LocalPutItemInSlotOrAway(item, dest)
   }
 
-  /**/
+  /* Functions (message control) */
 
+  /**
+    * Defer a message until later.
+    * @see `Containable.Defer`
+    * @see `Containable.DeferrableMessage`
+    * @param msg the message to defer
+    */
   def RepeatMessageLater(msg : Any) : Unit = {
     import scala.concurrent.ExecutionContext.Implicits.global
     context.system.scheduler.scheduleOnce(100 milliseconds, self, msg)
   }
 
+  /**
+    * Increment the flag for blocking messages.
+    */
   def Wait() : Unit = {
     waitOnMoveItemOps = math.min(waitOnMoveItemOps + 1, 2)
   }
 
+  /**
+    * Decrement the flag for blocking messages.
+    */
   def Resume() : Unit = {
     waitOnMoveItemOps = math.max(0, waitOnMoveItemOps - 1)
   }
 
+  /**
+    * Stop blocking messages.
+    */
   def Reset() : Unit = {
     waitOnMoveItemOps = 0
   }
 
-  /**/
-
-  /**/
+  /* Functions (item transfer) */
 
   private def LocalRemoveItemFromSlot(slot : Int) : Any = {
     val source = ContainerObject
-    val (_, item) = Containable.TryRemoveItemFromSlot(source, slot)
+    val (outSlot, item) = Containable.TryRemoveItemFromSlot(source, slot)
     item match {
-      case Some(thing) => RemoveItemFromSlotCallback(thing, slot)
+      case Some(thing) => RemoveItemFromSlotCallback(thing, outSlot.get)
       case None => ;
     }
-    Containable.ItemFromSlot(source, item, Some(slot))
+    Containable.ItemFromSlot(source, item, outSlot)
   }
 
   private def LocalRemoveItemFromSlot(item : Equipment) : Any = {
@@ -172,6 +206,17 @@ trait Containable {
         Containable.ItemPutInSlot(destination, item, dest, swapItem)
       case (false, _) =>
         Containable.CanNotPutItemInSlot(destination, item, dest)
+    }
+  }
+
+  private def LocalPutItemInSlotOnly(item : Equipment, dest : Int) : Any = {
+    val destination = ContainerObject
+    if(Containable.TryPutItemInSlotOnly(destination, item, dest)) {
+      PutItemInSlotCallback(item, dest)
+      Containable.ItemPutInSlot(destination, item, dest, None)
+    }
+    else {
+      Containable.CanNotPutItemInSlot(destination, item, dest)
     }
   }
 
@@ -201,6 +246,30 @@ trait Containable {
     }
   }
 
+  private def LocalPutItemInSlotOnlyOrAway(item : Equipment, dest : Option[Int]) : Any = {
+    val destination = ContainerObject
+    Containable.TryPutItemInSlotOnlyOrAway(destination, item, dest) match {
+      case (Some(slot), None) =>
+        PutItemInSlotCallback(item, slot)
+        Containable.ItemPutInSlot(destination, item, slot, None)
+      case _ =>
+        Containable.CanNotPutItemInSlot(destination, item, dest.getOrElse(-1))
+    }
+  }
+
+  /**
+    * A controlled response where, in certain situations,
+    * it is appropriate to attempt to place an item into a specific container,
+    * first testing a specific slot,
+    * and attempting anywhere available in the container if not that slot,
+    * and, if nowhere is available, then it gets dropped on the ground.
+    * The inserted item is not permitted to swap places with another item in this case.
+    * @param container the container
+    * @param item the item to be inserted
+    * @param slot in which slot the insertion is prioritized (upper left corner of item)
+    * @param to a recipient to redirect the response message
+    * @param timeout how long the request has to complete before expiring
+    */
   private def PutItBackOrDropIt(container : PlanetSideServerObject with Container, item : Equipment, slot : Option[Int], to : ActorRef)(implicit timeout : Timeout) : Unit = {
     val restore = ask(container.Actor, Containable.MoveItemPutItemInSlotOrAway(item, slot))
     restore.onSuccess {
@@ -214,24 +283,47 @@ trait Containable {
     }
   }
 
+  /**
+    * Reaction to the initial deferrence of a message that should handle the visual aspects of not immediately addressing the message.
+    * To be implemented.
+    * @param msg the deferred message
+    */
   def MessageDeferredCallback(msg : Any) : Unit
 
+  /**
+    * Reaction to an item being removed a container.
+    * To be implemented.
+    * @param item the item that was removed
+    * @param slot the slot from which is was removed
+    */
   def RemoveItemFromSlotCallback(item : Equipment, slot : Int) : Unit
 
+  /**
+    * Reaction to an item being placed into a container.
+    * To be implemented.
+    * @param item the item that was removed
+    * @param slot the slot from which is was removed
+    */
   def PutItemInSlotCallback(item : Equipment, slot : Int) : Unit
 
+  /**
+    * Reaction to the existence of a swap item being produced from a container into the environment.
+    * To be implemented.
+    * @param item the item that was removed
+    */
   def SwapItemCallback(item : Equipment) : Unit
 }
 
 object Containable {
+  /** Parent of all standard (input) messages handled by a `Containable` object for the purposes of item transfer */
   sealed trait ContainableMsg
-
+  /** `Containable` messages that are allowed to be temporarily blocked in event of a complicated item transfer */
   sealed trait DeferrableMessage extends ContainableMsg
-
+  /** Control message for temporarily blocking some messages to maintain integrity of underlying `Container` object */
   private case class Wait()
-
+  /** Control message for unblocking all messages */
   private case class Resume()
-
+  /** Internal message for the purpose of refreshing a blocked message in the mailbox */
   private case class Defer(msg : Any, from : ActorRef)
 
   final case class RemoveItemFromSlot(item : Option[Equipment], slot : Option[Int]) extends ContainableMsg
@@ -242,79 +334,159 @@ object Containable {
     def apply(item : Equipment) : RemoveItemFromSlot = RemoveItemFromSlot(Some(item), None)
   }
 
+  /**
+    * A response for the `RemoveItemFromSlot` message.
+    * It serves the dual purpose of reporting a missing item (by not reporting any slot information)
+    * and reporting no item ata given position (by not reporting any item information).
+    * @param obj the container
+    * @param item the equipment that was removed
+    * @param slot the index position from which any item was removed
+    */
   final case class ItemFromSlot(obj : PlanetSideServerObject with Container, item : Option[Equipment], slot : Option[Int])
 
-  final case class PutItemInSlot(item : Equipment, dest : Int) extends DeferrableMessage
+  final case class PutItemInSlot(item : Equipment, slot : Int) extends DeferrableMessage
+
+  final case class PutItemInSlotOnly(item : Equipment, slot : Int) extends DeferrableMessage
 
   final case class PutItemAway(item : Equipment) extends DeferrableMessage
 
-  final case class PutItemInSlotOrAway(item : Equipment, dest : Option[Int]) extends DeferrableMessage
+  final case class PutItemInSlotOrAway(item : Equipment, slot : Option[Int]) extends DeferrableMessage
 
-  final case class ItemPutInSlot(obj : PlanetSideServerObject with Container, item : Equipment, dest : Int, swapped_item : Option[Equipment])
+  /**
+    * A "successful insertion" response for the variety message of messages that attempt to insert an item into a container.
+    * @param obj the container
+    * @param item the equipment that was inserted
+    * @param slot the slot position into which the item was inserted
+    * @param swapped_item any other item, previously in the container, that was displaced to make room for this insertion
+    */
+  final case class ItemPutInSlot(obj : PlanetSideServerObject with Container, item : Equipment, slot : Int, swapped_item : Option[Equipment])
 
-  final case class CanNotPutItemInSlot(obj : PlanetSideServerObject with Container, item : Equipment, dest : Int)
+  /**
+    * A "failed insertion" response for the variety message of messages that attempt to insert an item into a container.
+    * @param obj the container
+    * @param item the equipment that was not inserted
+    * @param slot the slot position into which the item should have been inserted;
+    *             `-1` if no insertion slot was reported in the original message or discovered in the process of inserting
+    */
+  final case class CanNotPutItemInSlot(obj : PlanetSideServerObject with Container, item : Equipment, slot : Int)
 
-  final case class MoveItem(source : PlanetSideServerObject with Container, item : Equipment, dest : Int) extends DeferrableMessage
+  /**
+    * The item should already be contained by us.
+    * The item is being removed from our containment and placed into a fixed slot position in another container.
+    * `MoveItem` is a process that may be complicated and is one reason why `DeferrableMessage`s are employed.
+    * @param destination the container into which the item is being placed
+    * @param item the item
+    * @param destination_slot where in the destination container the item is being placed
+    */
+  final case class MoveItem(destination : PlanetSideServerObject with Container, item : Equipment, destination_slot : Int) extends DeferrableMessage
+  /* The same as `PutItemInSlot`, but is not a `DeferrableMessage` for the purposes of completing a `MoveItem` */
+  private case class MoveItemPutItemInSlot(item : Equipment, slot : Int) extends ContainableMsg
+  /* The same as `PutItemInSlotOrAway`, but is not a `DeferrableMessage` for the purposes of completing a `MoveItem` */
+  private case class MoveItemPutItemInSlotOrAway(item : Equipment, slot : Option[Int]) extends ContainableMsg
 
-  private case class MoveItemPutItemInSlot(item : Equipment, dest : Int) extends ContainableMsg
+  /* Functions */
 
-  private case class MoveItemPutItemInSlotOrAway(item : Equipment, dest : Option[Int]) extends ContainableMsg
-
-  //-//
-
+  /**
+    * If the target item can be found in a container, remove the item from the container.
+    * This process can fail if the item can not be found or if it can not be removed for some reason.
+    * @see `Container.Find`
+    * @see `EquipmentSlot.Equipment`
+    * @param source the container in which the `item` is currently located
+    * @param item the item to be removed
+    * @return a `Tuple` of two optional values;
+    *         the first is from what index in the container the `item` was removed, if it was removed;
+    *         the second is the item again, if it has been removed;
+    *         will use `(None, None)` to report failure
+    */
   def TryRemoveItemFromSlot(source : PlanetSideServerObject with Container, item : Equipment) : (Option[Int], Option[Equipment]) = {
     source.Find(item) match {
       case slot @ Some(index) =>
         source.Slot(index).Equipment = None
-        (slot, Some(item))
+        if(source.Slot(index).Equipment.isEmpty) {
+          (slot, Some(item))
+        }
+        else {
+          (None, None)
+        }
       case None =>
         (None, None)
     }
   }
 
+  /**
+    * If the target slot of a container contains an item, remove that item from the container
+    * fromthe upper left corner position of the item as found in the container.
+    * This process can fail if no item can be found or if it can not be removed for some reason.
+    * @see `Container.Find`
+    * @see `EquipmentSlot.Equipment`
+    * @param source the container in which the `slot` is to be searched
+    * @param slot where the container will be searched
+    * @return a `Tuple` of two values;
+    *         the first is from what `slot` in the container an `item` was removed, if any item removed;
+    *         the second is the item, if it has been removed;
+    *         will use `(None, None)` to report failure
+    */
   def TryRemoveItemFromSlot(source : PlanetSideServerObject with Container, slot : Int) : (Option[Int], Option[Equipment]) = {
-    val item = source.Slot(slot).Equipment
+    val (item, outSlot) = source.Slot(slot).Equipment match {
+      case Some(thing) => (Some(thing), source.Find(thing))
+      case None => (None, None)
+    }
     source.Slot(slot).Equipment = None
     item match {
-      case Some(_) =>
-        (Some(slot), item)
+      case Some(_) if item.nonEmpty && source.Slot(slot).Equipment.isEmpty =>
+        (outSlot, item)
       case None =>
         (None, None)
     }
   }
 
-  def TestPutItemInSlot(destination : PlanetSideServerObject with Container, item : Equipment, dest : Int, permittedCollision : Boolean = true) : Boolean = {
+  /**
+    * Are the conditions for an item insertion acceptable?
+    * If another item occupies the expected region of insertion (collision of bounding regions),
+    * the insertion can still be permitted with the assumption that
+    * the displaced item ("swap item") will have to be put somewhere else.
+    * @see `Containable.PermitEquipmentStow`
+    * @see `Container.Collisions`
+    * @see `InventoryTile`
+    * @param destination the container
+    * @param item the item to be tested for insertion
+    * @param dest the upper left corner of the insertion position
+    * @return the results of the insertion test, if an insertion can be permitted;
+    *         `None`, otherwise, and the insertion is not permitted
+    */
+  def TestPutItemInSlot(destination : PlanetSideServerObject with Container, item : Equipment, dest : Int) : Option[List[InventoryItem]] = {
     if(Containable.PermitEquipmentStow(destination, item)) {
       val tile = item.Definition.Tile
       val destinationCollisionTest = destination.Collisions(dest, tile.Width, tile.Height)
       destinationCollisionTest match {
-        case Success(Nil) => true //no item to swap
-        case Success(List(_)) => permittedCollision //one item to swap, if permitted
-        case _ => false //abort when too many items at destination or other failure case
+        case Success(Nil) => Some(Nil) //no item to swap
+        case Success(out @ List(_)) => Some(out) //one item to swap
+        case _ => None //abort when too many items at destination or other failure case
       }
     }
     else {
-      //blocked insertion (object type not permitted in container)
-      false
+      None //blocked insertion (object type not permitted in container)
     }
   }
 
+  /**
+    * Put an item in a container at the given position.
+    * The inserted item may swap places with another item.
+    * If the new item can not be inserted, the swap item is kept in its original position.
+    * @param destination the container
+    * @param item the item to be inserted
+    * @param dest in which slot the insertion is expected to occur (upper left corner of item)
+    * @return a `Tuple` of two values;
+    *         the first is `true` if the insertion occurred; and, `false`, otherwise
+    *         the second is an optional item that was removed from a coincidental position in the container ("swap item")
+    */
   def TryPutItemInSlot(destination : PlanetSideServerObject with Container, item : Equipment, dest : Int) : (Boolean, Option[Equipment]) = {
-    if(Containable.PermitEquipmentStow(destination, item)) {
-      val tile = item.Definition.Tile
-      val destinationCollisionTest = destination.Collisions(dest, tile.Width, tile.Height)
-      if(
-        destinationCollisionTest match {
-          case Success(Nil) | Success(List(_)) => true //no item or one item to swap
-          case _ => false //abort when too many items at destination or other failure case
-        }
-      ) {
+    Containable.TestPutItemInSlot(destination, item, dest) match {
+      case Some(results) =>
         //insert and swap, if applicable
-        val (swapItem, swapSlot) = destinationCollisionTest match {
-          case Success(List(InventoryItem(obj, start))) =>
-            (Some(obj), start)
-          case _ =>
-            (None, dest)
+        val (swapItem, swapSlot) = results match {
+          case List(InventoryItem(obj, start)) => (Some(obj), start)
+          case _ => (None, dest)
         }
         destination.Slot(swapSlot).Equipment = None
         if((destination.Slot(dest).Equipment = item).contains(item)) {
@@ -325,74 +497,108 @@ object Containable {
           destination.Slot(swapSlot).Equipment = swapItem
           (false, None)
         }
-      }
-      else {
-        //can not insert at destination
+      case None =>
         (false, None)
-      }
-    }
-    else {
-      //blocked insertion (object type not permitted in container)
-      (false, None)
     }
   }
 
+  /**
+    * Put an item in a container at the given position.
+    * The inserted item is not permitted to swap places with another item in this case.
+    * @param destination the container
+    * @param item the item to be inserted
+    * @param dest in which slot the insertion is expected to occur (upper left corner of item)
+    * @return `true` if the insertion occurred;
+    *        `false`, otherwise
+    */
+  def TryPutItemInSlotOnly(destination : PlanetSideServerObject with Container, item : Equipment, dest : Int) : Boolean = {
+    Containable.TestPutItemInSlot(destination, item, dest).contains(Nil) && (destination.Slot(dest).Equipment = item).contains(item)
+  }
+
+  /**
+    * Put an item in a container in the whatever position it cleanly fits.
+    * The inserted item will not swap places with another item in this case.
+    * @param destination the container
+    * @param item the item to be inserted
+    * @return the slot index of the insertion point;
+    *         `None`, if a clean insertion is not possible
+    */
   def TryPutItemAway(destination : PlanetSideServerObject with Container, item : Equipment) : Option[Int] = {
     destination.Fit(item) match {
-      case out @ Some(dest) =>
-        destination.Slot(dest).Equipment = item
+      case out @ Some(dest)
+        if Containable.PermitEquipmentStow(destination, item) && (destination.Slot(dest).Equipment = item).contains(item) =>
         out
       case _ =>
         None
     }
   }
 
-  def TryFitItemInSlot(destination : PlanetSideServerObject with Container, item : Equipment) : Option[Int] = {
-    destination.Fit(item) match {
-      case Some(slot) =>
-        TryPutItemInSlot(destination, item, slot) match {
-          case (true, _) => Some(slot)
-          case (false, _) => None
-        }
-      case None =>
-        None
-    }
-  }
-
+  /**
+    * Attempt to put an item in a container at the given position.
+    * The inserted item may swap places with another item at this time.
+    * If the targeted insertion at this position fails,
+    * attempt to put the item in the container in the whatever position it cleanly fits.
+    * @param destination the container
+    * @param item the item to be inserted
+    * @param dest in which specific slot the insertion is first tested (upper left corner of item)
+    * @return na
+    */
   def TryPutItemInSlotOrAway(destination : PlanetSideServerObject with Container, item : Equipment, dest : Option[Int]) : (Option[Int], Option[Equipment]) = {
     (dest match {
-      case Some(destSlot) if Containable.TestPutItemInSlot(destination, item, destSlot, permittedCollision = false) =>
-        Containable.TryPutItemInSlot(destination, item, destSlot) match {
-          case (true, None) =>
-            dest
-          case _ =>
-            None
-        }
-      case None =>
-        None
+      case Some(slot) => Containable.TryPutItemInSlot(destination, item, slot)
+      case None => (false, None)
     }) match {
-      case out @ Some(_) =>
-        (out, Some(item))
-      case None =>
-        Containable.TryFitItemInSlot(destination, item) match {
-          case out @ Some(_) =>
-            (out, None)
-          case None =>
-            (None, None)
+      case (true, swapItem) =>
+        (dest, swapItem)
+      case _ =>
+        Containable.TryPutItemAway(destination, item) match {
+          case out @ Some(_) => (out, None)
+          case None => (None, None)
         }
     }
   }
 
   /**
-    * na
-    * @param equipment na
-    * @return `true`, if the object is allowed to contain the type of equipment object
+    * Attempt to put an item in a container at the given position.
+    * The inserted item may not swap places with another item at this time.
+    * If the targeted insertion at this position fails,
+    * attempt to put the item in the container in the whatever position it cleanly fits.
+    * @param destination the container
+    * @param item the item to be inserted
+    * @param dest in which specific slot the insertion is first tested (upper left corner of item)
+    * @return na
     */
-  def PermitEquipmentStow(obj : PlanetSideServerObject with Container, equipment : Equipment) : Boolean = {
+  def TryPutItemInSlotOnlyOrAway(destination : PlanetSideServerObject with Container, item : Equipment, dest : Option[Int]) : (Option[Int], Option[Equipment]) = {
+    (dest match {
+      case Some(slot) if Containable.TestPutItemInSlot(destination, item, slot).contains(Nil) => Containable.TryPutItemInSlot(destination, item, slot)
+      case None => (false, None)
+    }) match {
+      case (true, swapItem) =>
+        (dest, swapItem)
+      case _ =>
+        Containable.TryPutItemAway(destination, item) match {
+          case out @ Some(_) => (out, None)
+          case None => (None, None)
+        }
+    }
+  }
+
+  /**
+    * Apply incontestable, arbitrary limitations
+    * whereby certain items are denied insertion into certain containers
+    * for vaguely documented but assuredly fantastic excuses on the part of the developer.
+    * @param destination the container
+    * @param equipment the item to be inserted
+    * @return `true`, if the object is allowed to contain the type of equipment object;
+    *        `false`, otherwise
+    */
+  def PermitEquipmentStow(destination : PlanetSideServerObject with Container, equipment : Equipment) : Boolean = {
     import net.psforever.objects.{BoomerTrigger, Player}
     equipment match {
       case _ : BoomerTrigger =>
-        obj.isInstanceOf[Player] //a BoomerTrigger can only be stowed in a player's holsters or inventory
+        //a BoomerTrigger can only be stowed in a player's holsters or inventory
+        //this is only a requirement until they, and their Boomer explosive complement, are cleaned-up properly
+        destination.isInstanceOf[Player]
       case _ =>
         true
     }

--- a/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
@@ -1,0 +1,275 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects.serverobject
+
+import akka.actor.Actor
+import akka.pattern.ask
+import akka.util.Timeout
+import net.psforever.objects.{BoomerTrigger, PlanetSideGameObject, Player}
+import net.psforever.objects.equipment.Equipment
+import net.psforever.objects.inventory.{Container, InventoryItem}
+import net.psforever.packet.game.{ObjectCreateDetailedMessage, ObjectDetachMessage}
+import net.psforever.packet.game.objectcreate.ObjectCreateMessageParent
+import net.psforever.types.Vector3
+import services.Service
+import services.avatar.{AvatarAction, AvatarServiceMessage}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Success
+
+trait Containable {
+  _ : Actor =>
+  //val log = org.log4s.getLogger("Container.behavior")
+  var movingItem : Boolean = false
+
+  def ContainerObject : PlanetSideServerObject with Container
+
+  def behavior : Receive = {
+    case Containable.RemoveItemFromSlot(None, Some(slot)) =>
+      val source = ContainerObject
+      val(_, item) = Containable.TryRemoveItemFromSlot(source, slot)
+      sender ! Containable.ItemFromSlot(source, item, Some(slot))
+
+    case Containable.RemoveItemFromSlot(Some(item), _) =>
+      val source = ContainerObject
+      val(slot, _) = Containable.TryRemoveItemFromSlot(source, item)
+      sender ! Containable.ItemFromSlot(source, Some(item), slot)
+
+    case Containable.PutItemInSlot(item, dest) =>
+      val destination = ContainerObject
+      Containable.PutItemInSlot(destination, item, dest) match {
+        case (true, swapItem) =>
+          movingItem = false
+          sender ! Containable.ItemPutInSlot(destination, item, dest, swapItem)
+        case (false, _) =>
+          movingItem = false
+          sender ! Containable.CanNotItemPutInSlot(destination, item, dest)
+      }
+
+    case Containable.PutItemAway(item) =>
+      val destination = ContainerObject
+      Containable.PutItemAway(destination, item) match {
+        case Some(dest) =>
+          movingItem = false
+          sender ! Containable.ItemPutInSlot(destination, item, dest, None)
+        case _ =>
+          movingItem = false
+          sender ! Containable.CanNotItemPutInSlot(destination, item, -1)
+      }
+
+    case Containable.PutItemInSlotOrAway(item, dest) =>
+      val destination = ContainerObject
+      Containable.PutItemInSlotOrAway(destination, item, dest) match {
+        case (Some(slot), swapItem) =>
+          movingItem = false
+          sender ! Containable.ItemPutInSlot(destination, item, slot, swapItem)
+        case (None, _) =>
+          movingItem = false
+          sender ! Containable.CanNotItemPutInSlot(destination, item, dest.getOrElse(-1))
+      }
+
+    case msg : Containable.MoveItem if movingItem =>
+      import scala.concurrent.ExecutionContext.Implicits.global
+      context.system.scheduler.scheduleOnce(100 milliseconds, self, msg)
+
+    case Containable.MoveItem(source, equipment, destSlot) =>
+      val destination = ContainerObject
+      val item = equipment
+      val dest = destSlot
+      val sourceIsDestination = source == destination
+      implicit val timeout = Timeout(1000 milliseconds)
+      movingItem = true
+      val result = if(sourceIsDestination) {
+        val(slot, _) = Containable.TryRemoveItemFromSlot(source, item)
+        Future { Containable.ItemFromSlot(source, Some(item), slot) }
+      }
+      else {
+        ask(source.Actor, Containable.RemoveItemFromSlot(item))
+      }
+      result.onSuccess {
+        case Containable.ItemFromSlot(_, Some(thing), Some(slot)) if thing == item =>
+          Containable.PutItemInSlot(destination, item, dest) match {
+            case (true, Some(swapItem)) =>
+              if(sourceIsDestination) {
+                Containable.PutItemInSlot(source, swapItem, slot)
+                movingItem = false
+              }
+              else {
+                source.Actor forward Containable.PutItemInSlot(swapItem, slot)
+              }
+            case (true, None) =>
+              movingItem = false
+            case _ => ;
+          }
+        case _ => ;
+      }
+  }
+}
+
+object Containable {
+
+  final case class RemoveItemFromSlot(item : Option[Equipment], slot : Option[Int])
+
+  object RemoveItemFromSlot {
+    def apply(slot : Int) : RemoveItemFromSlot = RemoveItemFromSlot(None, Some(slot))
+
+    def apply(item : Equipment) : RemoveItemFromSlot = RemoveItemFromSlot(Some(item), None)
+  }
+
+  final case class ItemFromSlot(obj : PlanetSideServerObject with Container, item : Option[Equipment], slot : Option[Int])
+
+  final case class PutItemInSlot(item : Equipment, dest : Int)
+
+  final case class PutItemAway(item : Equipment)
+
+  final case class PutItemInSlotOrAway(item : Equipment, dest : Option[Int])
+
+  final case class ItemPutInSlot(obj : PlanetSideServerObject with Container, item : Equipment, dest : Int, swapped_item : Option[Equipment])
+
+  final case class CanNotItemPutInSlot(obj : PlanetSideServerObject with Container, item : Equipment, dest : Int)
+
+  final case class MoveItem(source : PlanetSideServerObject with Container, item : Equipment, dest : Int)
+
+  //-//
+
+  def TryRemoveItemFromSlot(source : PlanetSideServerObject with Container, item : Equipment) : (Option[Int], Option[Equipment]) = {
+    source.Find(item) match {
+      case slot @ Some(index) =>
+        source.Slot(index).Equipment = None
+        source.Zone.AvatarEvents ! AvatarServiceMessage(source.Zone.Id, AvatarAction.ObjectDelete(Service.defaultPlayerGUID, item.GUID))
+        (slot, Some(item))
+      case None =>
+        (None, None)
+    }
+  }
+
+  def TryRemoveItemFromSlot(source : PlanetSideServerObject with Container, slot : Int) : (Option[Int], Option[Equipment]) = {
+    val item = source.Slot(slot).Equipment
+    source.Slot(slot).Equipment = None
+    item match {
+      case Some(thing) =>
+        source.Zone.AvatarEvents ! AvatarServiceMessage(source.Zone.Id, AvatarAction.ObjectDelete(Service.defaultPlayerGUID, thing.GUID))
+        (Some(slot), item)
+      case None =>
+        (None, None)
+    }
+  }
+
+  def PutItemInSlot(destination : PlanetSideServerObject with Container, item : Equipment, dest : Int) : (Boolean, Option[Equipment]) = {
+    if(Containable.PermitEquipmentStow(item, destination)) {
+      val tile = item.Definition.Tile
+      val destinationCollisionTest = destination.Collisions(dest, tile.Width, tile.Height)
+      if(
+        destinationCollisionTest match {
+          case Success(Nil) | Success(List(_)) => true //no item or one item to swap
+          case _ => false //abort when too many items at destination or other failure case
+        }
+      ) {
+        //insert and swap, if applicable
+        val destSlot = destination.Slot(dest)
+        val (swapItem, swapSlot) = destinationCollisionTest match {
+          case Success(List(InventoryItem(obj, start))) =>
+            (Some(obj), start)
+          case _ =>
+            (None, dest)
+        }
+        swapItem match {
+          case Some(swap) =>
+            destination.Zone.AvatarEvents ! AvatarServiceMessage(destination.Zone.Id, AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectDetachMessage(destination.GUID, swap.GUID, Vector3.Zero, 0f)))
+          case None =>
+        }
+        destination.Slot(swapSlot).Equipment = None
+        if((destination.Slot(dest).Equipment = item).contains(item)) {
+          destination.Zone.AvatarEvents ! AvatarServiceMessage(
+            destination.Zone.Id,
+            AvatarAction.SendResponse(
+              Service.defaultPlayerGUID,
+              ObjectCreateDetailedMessage(
+                item.Definition.ObjectId,
+                item.GUID,
+                ObjectCreateMessageParent(destination.GUID, dest),
+                item.Definition.Packet.DetailedConstructorData(item).get
+              )
+            )
+          )
+          (true, swapItem)
+        }
+        else {
+          //put the swapItem back
+          destSlot.Equipment = swapItem
+          (false, None)
+        }
+      }
+      else {
+        //can not insert at destination
+        (false, None)
+      }
+    }
+    else {
+      //blocked insertion (object type not permitted in container)
+      (false, None)
+    }
+  }
+
+  def PutItemAway(destination : PlanetSideServerObject with Container, item : Equipment) : Option[Int] = {
+    destination.Fit(item) match {
+      case out @ Some(dest) =>
+        destination.Slot(dest).Equipment = item
+        out
+      case _ =>
+        None
+    }
+  }
+
+  def FitItemIntSlot(destination : PlanetSideServerObject with Container, item : Equipment) : Option[Int] = {
+    destination.Fit(item) match {
+      case Some(slot) =>
+        PutItemInSlot(destination, item, slot) match {
+          case (true, _) => Some(slot)
+          case (false, _) => None
+        }
+      case None =>
+        None
+    }
+  }
+
+  def PutItemInSlotOrAway(destination : PlanetSideServerObject with Container, item : Equipment, dest : Option[Int]) : (Option[Int], Option[Equipment]) = {
+    dest match {
+      case Some(destSlot) =>
+        Containable.PutItemInSlot(destination, item, destSlot) match {
+          case (true, swapItem) =>
+            (dest, swapItem)
+          case (false, _) =>
+            Containable.FitItemIntSlot(destination, item) match {
+              case out @ Some(_) =>
+                (out, None)
+              case None =>
+                (None, None)
+            }
+        }
+      case None =>
+        Containable.FitItemIntSlot(destination, item) match {
+          case out @ Some(_) =>
+            (out, None)
+          case None =>
+            (None, None)
+        }
+    }
+  }
+
+  /**
+    * na
+    * @param equipment na
+    * @param obj na
+    * @return `true`, if the object is allowed to contain the type of equipment object
+    */
+  def PermitEquipmentStow(equipment : Equipment, obj : PlanetSideGameObject with Container) : Boolean = {
+    equipment match {
+      case _ : BoomerTrigger =>
+        obj.isInstanceOf[Player] //a BoomerTrigger can only be stowed in a player's holsters or inventory
+      case _ =>
+        true
+    }
+  }
+}

--- a/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/Containable.scala
@@ -4,10 +4,11 @@ package net.psforever.objects.serverobject
 import akka.actor.{Actor, ActorRef}
 import akka.pattern.ask
 import akka.util.Timeout
+import net.psforever.objects.{BoomerTrigger, GlobalDefinitions, Player}
 import net.psforever.objects.equipment.Equipment
 import net.psforever.objects.inventory.{Container, InventoryItem}
 import net.psforever.objects.zones.Zone
-import net.psforever.types.Vector3
+import net.psforever.types.{PlanetSideEmpire, Vector3}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -602,5 +603,25 @@ object Containable {
       case _ =>
         true
     }
+  }
+
+  /**
+    * A predicate used to determine if an `InventoryItem` object contains `Equipment` that should be dropped.
+    * Used to filter through lists of object data before it is placed into a player's inventory.
+    * Drop the item if:<br>
+    * - the item is cavern equipment<br>
+    * - the item is a `BoomerTrigger` type object<br>
+    * - the item is a `router_telepad` type object<br>
+    * - the item is another faction's exclusive equipment
+    * @param tplayer the player
+    * @return true if the item is to be dropped; false, otherwise
+    */
+  def DropPredicate(tplayer : Player) : InventoryItem => Boolean = entry => {
+    val objDef = entry.obj.Definition
+    val faction = GlobalDefinitions.isFactionEquipment(objDef)
+    GlobalDefinitions.isCavernEquipment(objDef) ||
+      objDef == GlobalDefinitions.router_telepad ||
+      entry.obj.isInstanceOf[BoomerTrigger] ||
+      (faction != tplayer.Faction && faction != PlanetSideEmpire.NEUTRAL)
   }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -92,8 +92,8 @@ trait ContainableBehavior {
         val dest = destSlot
         LocalRemoveItemFromSlot(item) match {
           case Containable.ItemFromSlot(_, Some(_), slot @ Some(originalSlot)) =>
-            if(source == destination) {
-              //when source == destination, moving the item can be performed in one pass
+            if(source eq destination) {
+              //when source and destination are the same, moving the item can be performed in one pass
               LocalPutItemInSlot(item, dest) match {
                 case Containable.ItemPutInSlot(_, _, _, None) => ; //success
                 case Containable.ItemPutInSlot(_, _, _, Some(swapItem)) => //success, but with swap item

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals
 
-import akka.actor.ActorContext
+import akka.actor.{ActorContext, ActorRef}
 import net.psforever.objects.definition.ImplantDefinition
 import net.psforever.objects.{Player, Vehicle}
 import net.psforever.objects.equipment.Equipment
@@ -92,6 +92,14 @@ class OrderTerminalDefinition(objId : Int) extends TerminalDefinition(objId) {
       }
     }
   }
+
+  override def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+    tabs.get(msg.msg.item_page) match {
+      case Some(page) =>
+        page.Dispatch(sender, terminal, msg)
+      case _ => ;
+    }
+  }
 }
 
 object OrderTerminalDefinition {
@@ -100,8 +108,9 @@ object OrderTerminalDefinition {
     * @see `ItemTransactionMessage`
     */
   sealed trait Tab {
-    def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = Terminal.NoDeal()
+    def Buy(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange
     def Sell(player : Player, msg : ItemTransactionMessage) : Terminal.Exchange = Terminal.NoDeal()
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit
   }
 
   /**
@@ -118,6 +127,10 @@ object OrderTerminalDefinition {
         case _ =>
           Terminal.NoDeal()
       }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      msg.player.Actor ! msg
     }
   }
 
@@ -142,6 +155,13 @@ object OrderTerminalDefinition {
             case _ =>
               Terminal.NoDeal()
           }
+      }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      msg.response match {
+        case _ : Terminal.BuyExosuit => msg.player.Actor ! msg
+        case _ => sender ! msg
       }
     }
   }
@@ -171,6 +191,10 @@ object OrderTerminalDefinition {
           Terminal.NoDeal()
       }
     }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      sender ! msg
+    }
   }
 
   /**
@@ -186,6 +210,10 @@ object OrderTerminalDefinition {
         case _ =>
           Terminal.NoDeal()
       }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      sender ! msg
     }
   }
 
@@ -214,6 +242,10 @@ object OrderTerminalDefinition {
         case None =>
           Terminal.NoDeal()
       }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      sender ! msg
     }
   }
 
@@ -272,6 +304,10 @@ object OrderTerminalDefinition {
           Terminal.NoDeal()
       }
     }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      msg.player.Actor ! msg
+    }
   }
 
   /**
@@ -299,6 +335,10 @@ object OrderTerminalDefinition {
         case _ =>
           Terminal.NoDeal()
       }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      sender ! msg
     }
   }
 
@@ -330,6 +370,10 @@ object OrderTerminalDefinition {
         case None =>
           Terminal.NoDeal()
       }
+    }
+
+    def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+      sender ! msg
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/OrderTerminalDefinition.scala
@@ -338,7 +338,11 @@ object OrderTerminalDefinition {
     }
 
     def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
-      sender ! msg
+      val player = msg.player
+      player.Zone.GUID(player.VehicleOwned) match {
+        case Some(vehicle : Vehicle) => vehicle.Actor ! msg
+        case _ => sender ! Terminal.TerminalMessage(player, msg.msg, Terminal.NoDeal())
+      }
     }
   }
 

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals
 
-import akka.actor.Actor
+import akka.actor.{Actor, ActorRef}
 import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
@@ -30,9 +30,10 @@ class TerminalControl(term : Terminal) extends Actor
     .orElse(canBeRepairedByNanoDispenser)
     .orElse {
       case Terminal.Request(player, msg) =>
-        val response = Terminal.TerminalMessage(player, msg, term.Request(player, msg))
-        player.Actor ! response
-        sender ! response
+        TerminalControl.Dispatch(
+          sender,
+          term,
+          Terminal.TerminalMessage(player, msg, term.Request(player, msg)))
 
       case CommonMessages.Use(player, Some(item : SimpleItem)) if item.Definition == GlobalDefinitions.remote_electronics_kit =>
         //TODO setup certifications check
@@ -48,5 +49,16 @@ class TerminalControl(term : Terminal) extends Actor
       case _ => ;
     }
 
+
   override def toString : String = term.Definition.Name
+}
+
+object TerminalControl {
+  def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = {
+    msg.response match {
+      case Terminal.NoDeal() => sender ! msg
+      case _ =>
+        terminal.Definition.Dispatch(sender, terminal, msg)
+    }
+  }
 }

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -30,7 +30,9 @@ class TerminalControl(term : Terminal) extends Actor
     .orElse(canBeRepairedByNanoDispenser)
     .orElse {
       case Terminal.Request(player, msg) =>
-        sender ! Terminal.TerminalMessage(player, msg, term.Request(player, msg))
+        val response = Terminal.TerminalMessage(player, msg, term.Request(player, msg))
+        player.Actor ! response
+        sender ! response
 
       case CommonMessages.Use(player, Some(item : SimpleItem)) if item.Definition == GlobalDefinitions.remote_electronics_kit =>
         //TODO setup certifications check

--- a/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalDefinition.scala
+++ b/common/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalDefinition.scala
@@ -1,6 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals
 
+import akka.actor.ActorRef
 import net.psforever.objects.Player
 import net.psforever.objects.definition.converter.TerminalConverter
 import net.psforever.objects.serverobject.structures.AmenityDefinition
@@ -22,4 +23,6 @@ abstract class TerminalDefinition(objectId : Int) extends AmenityDefinition(obje
     * @return a message that resolves the transaction
     */
   def Request(player : Player, msg : Any) : Terminal.Exchange
+
+  def Dispatch(sender : ActorRef, terminal : Terminal, msg : Terminal.TerminalMessage) : Unit = { }
 }

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 PSForever
+// Copyright (c) 2017-2020 PSForever
 package net.psforever.objects.vehicles
 
 import akka.actor.{Actor, ActorRef, Cancellable}
@@ -14,8 +14,8 @@ import net.psforever.objects.serverobject.hackable.GenericHackables
 import net.psforever.objects.serverobject.repair.RepairableVehicle
 import net.psforever.objects.vital.VehicleShieldCharge
 import net.psforever.objects.zones.Zone
-import net.psforever.types.{DriveState, ExoSuitType, PlanetSideGUID, Vector3}
-import services.{RemoverActor, Service}
+import net.psforever.types.DriveState
+import services.RemoverActor
 import net.psforever.packet.game.{ObjectAttachMessage, ObjectCreateDetailedMessage, ObjectDetachMessage}
 import net.psforever.packet.game.objectcreate.ObjectCreateMessageParent
 import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}

--- a/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/common/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -6,9 +6,10 @@ import net.psforever.objects._
 import net.psforever.objects.ballistics.{ResolvedProjectile, VehicleSource}
 import net.psforever.objects.equipment.{Equipment, JammableMountedWeapons}
 import net.psforever.objects.inventory.{GridInventory, InventoryItem}
-import net.psforever.objects.serverobject.{CommonMessages, Containable}
+import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
 import net.psforever.objects.serverobject.damage.DamageableVehicle
 import net.psforever.objects.serverobject.deploy.DeploymentBehavior
 import net.psforever.objects.serverobject.hackable.GenericHackables
@@ -43,7 +44,7 @@ class VehicleControl(vehicle : Vehicle) extends Actor
   with DamageableVehicle
   with RepairableVehicle
   with JammableMountedWeapons
-  with Containable {
+  with ContainableBehavior {
 
   //make control actors belonging to utilities when making control actor belonging to vehicle
   vehicle.Utilities.foreach({case (_, util) => util.Setup })
@@ -137,7 +138,7 @@ class VehicleControl(vehicle : Vehicle) extends Actor
             //remove old inventory
             val oldInventory = vehicle.Inventory.Clear().map { case InventoryItem(obj, _) => (obj, obj.GUID) }
             //"dropped" items are lost; if it doesn't go in the trunk, it vanishes into the nanite cloud
-            val (_, afterInventory) = inventory.partition(Containable.DropPredicate(player))
+            val (_, afterInventory) = inventory.partition(ContainableBehavior.DropPredicate(player))
             val (oldWeapons, newWeapons, finalInventory) = if(vehicle.Definition == definition) {
               //vehicles are the same type
               //TODO want to completely swap weapons, but holster icon vanishes temporarily after swap

--- a/common/src/main/scala/net/psforever/objects/zones/ZoneGroundActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZoneGroundActor.scala
@@ -2,13 +2,10 @@
 package net.psforever.objects.zones
 
 import akka.actor.Actor
-import net.psforever.objects.{BoomerDeployable, BoomerTrigger}
 import net.psforever.objects.equipment.Equipment
-import net.psforever.packet.game._
-import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
-import services.{RemoverActor, Service}
+import net.psforever.types.PlanetSideGUID
+import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
-import services.local.{LocalAction, LocalServiceMessage}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -35,20 +32,26 @@ class ZoneGroundActor(zone : Zone, equipmentOnGround : ListBuffer[Equipment]) ex
         equipmentOnGround += item
         item.Position = pos
         item.Orientation = orient
-        ZoneGroundActor.PutItemOnGround(zone, item)
+        zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.DropItem(Service.defaultPlayerGUID, item))
         Zone.Ground.ItemOnGround(item, pos, orient)
       })
 
     case Zone.Ground.PickupItem(item_guid) =>
       sender ! (FindItemOnGround(item_guid) match {
         case Some(item) =>
+          zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.PickupItem(Service.defaultPlayerGUID, item, 0))
           Zone.Ground.ItemInHand(item)
         case None =>
           Zone.Ground.CanNotPickupItem(zone, item_guid, "can not find")
       })
 
     case Zone.Ground.RemoveItem(item_guid) =>
-      FindItemOnGround(item_guid) //intentionally no callback
+      //intentionally no callback
+      FindItemOnGround(item_guid) match {
+        case Some(item) =>
+          zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.PickupItem(Service.defaultPlayerGUID, item, 0))
+        case None => ;
+      }
 
     case _ => ;
   }
@@ -89,47 +92,5 @@ class ZoneGroundActor(zone : Zone, equipmentOnGround : ListBuffer[Equipment]) ex
         recursiveFindItemOnGround(iter, item_guid, index + 1)
       }
     }
-  }
-}
-
-object ZoneGroundActor {
-  /**
-    * Primary functionality for tranferring a piece of equipment from a player's hands or his inventory to the ground.
-    * Items are always dropped at player's feet because for simplicity's sake
-    * because, by virtue of already standing there, the stability of the surface has been proven.
-    * The only exception to this is dropping items while falling.
-    * We have no case for that yet, so the item hangs in midair, typically unreachable.
-    * @see `Player.Find`<br>
-    *       `ObjectDetachMessage`
-    * @param item the `Equipment` object in the player's hand
-    */
-  def PutItemOnGround(zone : Zone, item : Equipment) : Unit = {
-    item match {
-      case trigger : BoomerTrigger =>
-        //dropped the trigger, no longer own the boomer; make certain whole faction is aware of that
-        zone.GUID(trigger.Companion) match {
-          case Some(obj : BoomerDeployable) =>
-            val guid = obj.GUID
-            val factionChannel = obj.Faction.toString
-            val owner = obj.OwnerName.getOrElse("")
-            val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, PlanetSideGUID(0))
-            zone.LocalEvents ! LocalServiceMessage(owner, LocalAction.AlertDestroyDeployable(Service.defaultPlayerGUID, obj))
-            obj.AssignOwnership(None)
-            obj.Faction = PlanetSideEmpire.NEUTRAL
-            zone.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(obj, zone))
-            zone.LocalEvents ! LocalServiceMessage(factionChannel, LocalAction.DeployableMapIcon(Service.defaultPlayerGUID, DeploymentAction.Dismiss, info))
-            zone.AvatarEvents ! AvatarServiceMessage(factionChannel, AvatarAction.SetEmpire(Service.defaultPlayerGUID, guid, PlanetSideEmpire.NEUTRAL))
-          case Some(_) | None =>
-            //TODO pointless trigger
-            println("[ERROR] Ground: you have a pointless boomer trigger that I can't clean up")
-//            val guid = item.GUID
-//            zone.Ground ! Zone.Ground.RemoveItem(guid) //undo; no callback
-//            zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
-//            taskResolver ! GUIDTask.UnregisterObjectTask(item)(zone.GUID)
-        }
-      case _ => ;
-    }
-    item.Faction = PlanetSideEmpire.NEUTRAL
-    zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.DropItem(Service.defaultPlayerGUID, item, zone))
   }
 }

--- a/common/src/main/scala/services/avatar/AvatarService.scala
+++ b/common/src/main/scala/services/avatar/AvatarService.scala
@@ -242,13 +242,13 @@ class AvatarService(zone : Zone) extends Actor {
           AvatarEvents.publish(
             AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.TerminalOrderResult(terminal, term_action, result))
           )
-        case AvatarAction.ChangeExosuit(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop) =>
+        case AvatarAction.ChangeExosuit(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drop, delete) =>
           AvatarEvents.publish(
-            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeExosuit(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop))
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeExosuit(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drop, delete))
           )
-        case AvatarAction.ChangeLoadout(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop) =>
+        case AvatarAction.ChangeLoadout(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drop) =>
           AvatarEvents.publish(
-            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeLoadout(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop))
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeLoadout(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drop))
           )
 
         case _ => ;

--- a/common/src/main/scala/services/avatar/AvatarService.scala
+++ b/common/src/main/scala/services/avatar/AvatarService.scala
@@ -238,6 +238,19 @@ class AvatarService(zone : Zone) extends Actor {
             AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.TeardownConnection())
           )
 
+        case AvatarAction.TerminalOrderResult(terminal, term_action, result) =>
+          AvatarEvents.publish(
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.TerminalOrderResult(terminal, term_action, result))
+          )
+        case AvatarAction.ChangeExosuit(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop) =>
+          AvatarEvents.publish(
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeExosuit(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop))
+          )
+        case AvatarAction.ChangeLoadout(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop) =>
+          AvatarEvents.publish(
+            AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.ChangeLoadout(target, exosuit, subtype, slot, maxhand, holsters, inventory, drop))
+          )
+
         case _ => ;
     }
 
@@ -259,6 +272,7 @@ class AvatarService(zone : Zone) extends Actor {
         ))
       }
       */
+
     case msg =>
       log.warn(s"Unhandled message $msg from $sender")
   }

--- a/common/src/main/scala/services/avatar/AvatarService.scala
+++ b/common/src/main/scala/services/avatar/AvatarService.scala
@@ -94,7 +94,7 @@ class AvatarService(zone : Zone) extends Actor {
           AvatarEvents.publish(
             AvatarServiceResponse(s"/$forChannel/Avatar", Service.defaultPlayerGUID, AvatarResponse.DestroyDisplay(killer, victim, method, unk))
           )
-        case AvatarAction.DropItem(player_guid, item, _) =>
+        case AvatarAction.DropItem(player_guid, item) =>
           val definition = item.Definition
           val objectData = DroppedItemData(
             PlacementData(item.Position, item.Orientation),
@@ -179,21 +179,10 @@ class AvatarService(zone : Zone) extends Actor {
           AvatarEvents.publish(
             AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.ProjectileState(projectile_guid, shot_pos, shot_vel, shot_orient, sequence, end, target))
           )
-        case AvatarAction.PickupItem(player_guid, _, target, slot, item, unk) =>
+        case AvatarAction.PickupItem(player_guid, item, unk) =>
           janitor forward RemoverActor.ClearSpecific(List(item), zone)
           AvatarEvents.publish(
-            AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, {
-              val itemGUID = item.GUID
-              if(target.VisibleSlots.contains(slot)) {
-                val definition = item.Definition
-                val containerData = ObjectCreateMessageParent(target.GUID, slot)
-                val objectData = definition.Packet.ConstructorData(item).get
-                AvatarResponse.EquipmentInHand(ObjectCreateMessage(definition.ObjectId, itemGUID, containerData, objectData))
-              }
-              else {
-                AvatarResponse.ObjectDelete(itemGUID, unk)
-              }
-            })
+            AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.ObjectDelete(item.GUID, unk))
           )
         case AvatarAction.PutDownFDU(player_guid) =>
           AvatarEvents.publish(

--- a/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
@@ -5,12 +5,11 @@ import net.psforever.objects.{PlanetSideGameObject, Player}
 import net.psforever.objects.ballistics.{Projectile, SourceEntry}
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.equipment.Equipment
-import net.psforever.objects.inventory.Container
+import net.psforever.objects.inventory.{Container, InventoryItem}
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.PlanetSideGamePacket
-import net.psforever.packet.game.ImplantAction
 import net.psforever.packet.game.objectcreate.{ConstructorData, ObjectCreateMessageParent}
-import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}
+import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, TransactionType, Vector3}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -63,6 +62,10 @@ object AvatarAction {
 
   final case class SendResponse(player_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
   final case class SendResponseTargeted(target_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
+
+  final case class TerminalOrderResult(terminal_guid : PlanetSideGUID, action : TransactionType.Value, result : Boolean) extends Action
+  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Action
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Action
 
   final case class TeardownConnection() extends Action
   //  final case class PlayerStateShift(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action

--- a/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
@@ -35,7 +35,7 @@ object AvatarAction {
   final case class ActivateImplantSlot(player_guid : PlanetSideGUID, slot : Int) extends Action
   final case class Destroy(victim : PlanetSideGUID, killer : PlanetSideGUID, weapon : PlanetSideGUID, pos : Vector3) extends Action
   final case class DestroyDisplay(killer : SourceEntry, victim : SourceEntry, method : Int, unk : Int = 121) extends Action
-  final case class DropItem(player_guid : PlanetSideGUID, item : Equipment, zone : Zone) extends Action
+  final case class DropItem(player_guid : PlanetSideGUID, item : Equipment) extends Action
   final case class EquipmentInHand(player_guid : PlanetSideGUID, target_guid : PlanetSideGUID, slot : Int, item : Equipment) extends Action
   final case class GenericObjectAction(player_guid : PlanetSideGUID, object_guid : PlanetSideGUID, action_code : Int) extends Action
   final case class HitHint(source_guid : PlanetSideGUID, player_guid : PlanetSideGUID) extends Action
@@ -48,7 +48,7 @@ object AvatarAction {
   final case class PlanetsideAttributeToAll(player_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Long) extends Action
   final case class PlanetsideAttributeSelf(player_guid : PlanetSideGUID, attribute_type : Int, attribute_value : Long) extends Action
   final case class PlayerState(player_guid : PlanetSideGUID, pos : Vector3, vel : Option[Vector3], facingYaw : Float, facingPitch : Float, facingYawUpper : Float, timestamp : Int, is_crouching : Boolean, is_jumping : Boolean, jump_thrust : Boolean, is_cloaked : Boolean, spectator : Boolean, weaponInHand : Boolean) extends Action
-  final case class PickupItem(player_guid : PlanetSideGUID, zone : Zone, target : PlanetSideGameObject with Container, slot : Int, item : Equipment, unk : Int = 0) extends Action
+  final case class PickupItem(player_guid : PlanetSideGUID, item : Equipment, unk : Int = 0) extends Action
   final case class ProjectileAutoLockAwareness(mode : Int) extends Action
   final case class ProjectileExplodes(player_guid : PlanetSideGUID, projectile_guid : PlanetSideGUID, projectile : Projectile) extends Action
   final case class ProjectileState(player_guid : PlanetSideGUID, projectile_guid : PlanetSideGUID, shot_pos : Vector3, shot_vel : Vector3, shot_orient : Vector3, sequence : Int, end : Boolean, hit_target : PlanetSideGUID) extends Action

--- a/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceMessage.scala
@@ -64,8 +64,8 @@ object AvatarAction {
   final case class SendResponseTargeted(target_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
 
   final case class TerminalOrderResult(terminal_guid : PlanetSideGUID, action : TransactionType.Value, result : Boolean) extends Action
-  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Action
-  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Action
+  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, old_holsters : List[(Equipment, PlanetSideGUID)], holsters : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], inventory : List[InventoryItem], drop : List[InventoryItem], delete : List[(Equipment, PlanetSideGUID)]) extends Action
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, old_holsters : List[(Equipment, PlanetSideGUID)], holsters : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Action
 
   final case class TeardownConnection() extends Action
   //  final case class PlayerStateShift(killer : PlanetSideGUID, victim : PlanetSideGUID) extends Action

--- a/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
@@ -4,10 +4,11 @@ package services.avatar
 import net.psforever.objects.Player
 import net.psforever.objects.ballistics.{Projectile, SourceEntry}
 import net.psforever.objects.equipment.Equipment
+import net.psforever.objects.inventory.InventoryItem
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.objectcreate.ConstructorData
-import net.psforever.packet.game.{ImplantAction, ObjectCreateMessage}
-import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}
+import net.psforever.packet.game.ObjectCreateMessage
+import net.psforever.types.{ExoSuitType, PlanetSideEmpire, PlanetSideGUID, TransactionType, Vector3}
 import services.GenericEventBusMsg
 
 final case class AvatarServiceResponse(toChannel : String,
@@ -55,6 +56,10 @@ object AvatarResponse {
 
   final case class SendResponse(msg: PlanetSideGamePacket) extends Response
   final case class SendResponseTargeted(target_guid : PlanetSideGUID, msg: PlanetSideGamePacket) extends Response
+
+  final case class TerminalOrderResult(terminal_guid : PlanetSideGUID, action : TransactionType.Value, result : Boolean) extends Response
+  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Response
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Response
 
   final case class TeardownConnection() extends Response
   //  final case class PlayerStateShift(itemID : PlanetSideGUID) extends Response

--- a/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
+++ b/common/src/main/scala/services/avatar/AvatarServiceResponse.scala
@@ -58,8 +58,8 @@ object AvatarResponse {
   final case class SendResponseTargeted(target_guid : PlanetSideGUID, msg: PlanetSideGamePacket) extends Response
 
   final case class TerminalOrderResult(terminal_guid : PlanetSideGUID, action : TransactionType.Value, result : Boolean) extends Response
-  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Response
-  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, holsters : List[InventoryItem], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Response
+  final case class ChangeExosuit(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, old_holsters : List[(Equipment, PlanetSideGUID)], holsters : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], inventory : List[InventoryItem], drop : List[InventoryItem], delete : List[(Equipment, PlanetSideGUID)]) extends Response
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, exosuit : ExoSuitType.Value, subtype : Int, last_drawn_slot : Int, new_max_hand : Boolean, old_holsters : List[(Equipment, PlanetSideGUID)], holsters : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], inventory : List[InventoryItem], drop : List[InventoryItem]) extends Response
 
   final case class TeardownConnection() extends Response
   //  final case class PlayerStateShift(itemID : PlanetSideGUID) extends Response

--- a/common/src/main/scala/services/vehicle/VehicleService.scala
+++ b/common/src/main/scala/services/vehicle/VehicleService.scala
@@ -141,6 +141,11 @@ class VehicleService(zone : Zone) extends Actor {
           VehicleEvents.publish(
             VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.KickCargo(cargo, speed, delay))
           )
+
+          case VehicleAction.ChangeLoadout(target_guid, removed_weapons, new_weapons, old_inventory, new_inventory) =>
+            VehicleEvents.publish(
+              VehicleServiceResponse(s"/$forChannel/Vehicle", Service.defaultPlayerGUID, VehicleResponse.ChangeLoadout(target_guid, removed_weapons, new_weapons, old_inventory, new_inventory))
+            )
         case _ => ;
     }
 

--- a/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceMessage.scala
@@ -3,6 +3,7 @@ package services.vehicle
 
 import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.equipment.Equipment
+import net.psforever.objects.inventory.InventoryItem
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.objectcreate.ConstructorData
@@ -47,4 +48,6 @@ object VehicleAction {
   final case class TransferPassengerChannel(player_guid : PlanetSideGUID, temp_channel : String, new_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Action
 
   final case class KickCargo(player_guid : PlanetSideGUID, cargo : Vehicle, speed : Int, delay : Long) extends Action
+
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, removed_weapons : List[(Equipment, PlanetSideGUID)], new_weapons : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], new_inventory : List[InventoryItem]) extends Action
 }

--- a/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
+++ b/common/src/main/scala/services/vehicle/VehicleServiceResponse.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2017 PSForever
 package services.vehicle
 
+import net.psforever.objects.equipment.Equipment
+import net.psforever.objects.inventory.InventoryItem
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad.Reminders
 import net.psforever.objects.{PlanetSideGameObject, Vehicle}
@@ -53,4 +55,6 @@ object VehicleResponse {
   final case class TransferPassengerChannel(old_channel : String, temp_channel : String, vehicle : Vehicle, vehicle_to_delete : PlanetSideGUID) extends Response
 
   final case class KickCargo(cargo : Vehicle, speed : Int, delay : Long) extends Response
+
+  final case class ChangeLoadout(target_guid : PlanetSideGUID, removed_weapons : List[(Equipment, PlanetSideGUID)], new_weapons : List[InventoryItem], old_inventory : List[(Equipment, PlanetSideGUID)], new_inventory : List[InventoryItem]) extends Response
 }

--- a/common/src/test/scala/objects/AvatarTest.scala
+++ b/common/src/test/scala/objects/AvatarTest.scala
@@ -389,7 +389,10 @@ class AvatarTest extends Specification {
 
   "the fifth slot is the locker wrapped in an EquipmentSlot" in {
     val (_, avatar) = CreatePlayer()
-    avatar.FifthSlot.Equipment.contains(avatar.Locker)
+    avatar.FifthSlot.Equipment match {
+      case Some(slot : LockerEquipment) => slot.Inventory mustEqual avatar.Locker.Inventory
+      case _ => ko
+    }
   }
 
   "toString" in {

--- a/common/src/test/scala/objects/ConverterTest.scala
+++ b/common/src/test/scala/objects/ConverterTest.scala
@@ -631,7 +631,7 @@ class ConverterTest extends Specification {
 
   "LockerContainer" should {
     "convert to packet (empty)" in {
-      val obj = LockerContainer()
+      val obj = new LockerEquipment(LockerContainer())
       obj.Definition.Packet.DetailedConstructorData(obj) match {
         case Success(pkt) =>
           pkt mustEqual DetailedLockerContainerData(CommonFieldData(PlanetSideEmpire.NEUTRAL, false, false, true, None, false, None, None, PlanetSideGUID(0)), None)
@@ -648,7 +648,7 @@ class ConverterTest extends Specification {
 
     "convert to packet (occupied)" in {
       import GlobalDefinitions._
-      val obj = LockerContainer()
+      val obj = new LockerEquipment(LockerContainer())
       val rek = SimpleItem(remote_electronics_kit)
       rek.GUID = PlanetSideGUID(1)
       obj.Inventory += 0 -> rek

--- a/common/src/test/scala/objects/InventoryTest.scala
+++ b/common/src/test/scala/objects/InventoryTest.scala
@@ -525,4 +525,136 @@ class InventoryTest extends Specification {
       ok
     }
   }
+
+  "InventoryEquiupmentSlot" should {
+    "insert, collide, insert" in {
+      val obj : GridInventory = GridInventory(7, 7)
+      obj.Slot(16).Equipment = bullet9mmBox1
+      //confirm all squares
+      obj.Slot( 8).Equipment.nonEmpty mustEqual false
+      obj.Slot( 9).Equipment.nonEmpty mustEqual false
+      obj.Slot( 10).Equipment.nonEmpty mustEqual false
+      obj.Slot( 11).Equipment.nonEmpty mustEqual false
+      obj.Slot( 12).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(15).Equipment.nonEmpty mustEqual false
+      obj.Slot(16).Equipment.nonEmpty mustEqual true
+      obj.Slot(17).Equipment.nonEmpty mustEqual true
+      obj.Slot(18).Equipment.nonEmpty mustEqual true
+      obj.Slot(19).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(22).Equipment.nonEmpty mustEqual false
+      obj.Slot(23).Equipment.nonEmpty mustEqual true
+      obj.Slot(24).Equipment.nonEmpty mustEqual true
+      obj.Slot(25).Equipment.nonEmpty mustEqual true
+      obj.Slot(26).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(29).Equipment.nonEmpty mustEqual false
+      obj.Slot(30).Equipment.nonEmpty mustEqual true
+      obj.Slot(31).Equipment.nonEmpty mustEqual true
+      obj.Slot(32).Equipment.nonEmpty mustEqual true
+      obj.Slot(33).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(36).Equipment.nonEmpty mustEqual false
+      obj.Slot(37).Equipment.nonEmpty mustEqual false
+      obj.Slot(38).Equipment.nonEmpty mustEqual false
+      obj.Slot(39).Equipment.nonEmpty mustEqual false
+      obj.Slot(40).Equipment.nonEmpty mustEqual false
+      //
+      //remove
+      obj.Slot(16).Equipment = None
+      obj.Slot( 8).Equipment.nonEmpty mustEqual false
+      obj.Slot( 9).Equipment.nonEmpty mustEqual false
+      obj.Slot( 10).Equipment.nonEmpty mustEqual false
+      obj.Slot( 11).Equipment.nonEmpty mustEqual false
+      obj.Slot( 12).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(15).Equipment.nonEmpty mustEqual false
+      obj.Slot(16).Equipment.nonEmpty mustEqual false
+      obj.Slot(17).Equipment.nonEmpty mustEqual false
+      obj.Slot(18).Equipment.nonEmpty mustEqual false
+      obj.Slot(19).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(22).Equipment.nonEmpty mustEqual false
+      obj.Slot(23).Equipment.nonEmpty mustEqual false
+      obj.Slot(24).Equipment.nonEmpty mustEqual false
+      obj.Slot(25).Equipment.nonEmpty mustEqual false
+      obj.Slot(26).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(29).Equipment.nonEmpty mustEqual false
+      obj.Slot(30).Equipment.nonEmpty mustEqual false
+      obj.Slot(31).Equipment.nonEmpty mustEqual false
+      obj.Slot(32).Equipment.nonEmpty mustEqual false
+      obj.Slot(33).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(36).Equipment.nonEmpty mustEqual false
+      obj.Slot(37).Equipment.nonEmpty mustEqual false
+      obj.Slot(38).Equipment.nonEmpty mustEqual false
+      obj.Slot(39).Equipment.nonEmpty mustEqual false
+      obj.Slot(40).Equipment.nonEmpty mustEqual false
+      //insert again
+      obj.Slot(16).Equipment = bullet9mmBox2
+      obj.Slot( 8).Equipment.nonEmpty mustEqual false
+      obj.Slot( 9).Equipment.nonEmpty mustEqual false
+      obj.Slot( 10).Equipment.nonEmpty mustEqual false
+      obj.Slot( 11).Equipment.nonEmpty mustEqual false
+      obj.Slot( 12).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(15).Equipment.nonEmpty mustEqual false
+      obj.Slot(16).Equipment.nonEmpty mustEqual true
+      obj.Slot(17).Equipment.nonEmpty mustEqual true
+      obj.Slot(18).Equipment.nonEmpty mustEqual true
+      obj.Slot(19).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(22).Equipment.nonEmpty mustEqual false
+      obj.Slot(23).Equipment.nonEmpty mustEqual true
+      obj.Slot(24).Equipment.nonEmpty mustEqual true
+      obj.Slot(25).Equipment.nonEmpty mustEqual true
+      obj.Slot(26).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(29).Equipment.nonEmpty mustEqual false
+      obj.Slot(30).Equipment.nonEmpty mustEqual true
+      obj.Slot(31).Equipment.nonEmpty mustEqual true
+      obj.Slot(32).Equipment.nonEmpty mustEqual true
+      obj.Slot(33).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(36).Equipment.nonEmpty mustEqual false
+      obj.Slot(37).Equipment.nonEmpty mustEqual false
+      obj.Slot(38).Equipment.nonEmpty mustEqual false
+      obj.Slot(39).Equipment.nonEmpty mustEqual false
+      obj.Slot(40).Equipment.nonEmpty mustEqual false
+      //
+      //remove
+      obj.Slot(16).Equipment = None
+      obj.Slot( 8).Equipment.nonEmpty mustEqual false
+      obj.Slot( 9).Equipment.nonEmpty mustEqual false
+      obj.Slot( 10).Equipment.nonEmpty mustEqual false
+      obj.Slot( 11).Equipment.nonEmpty mustEqual false
+      obj.Slot( 12).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(15).Equipment.nonEmpty mustEqual false
+      obj.Slot(16).Equipment.nonEmpty mustEqual false
+      obj.Slot(17).Equipment.nonEmpty mustEqual false
+      obj.Slot(18).Equipment.nonEmpty mustEqual false
+      obj.Slot(19).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(22).Equipment.nonEmpty mustEqual false
+      obj.Slot(23).Equipment.nonEmpty mustEqual false
+      obj.Slot(24).Equipment.nonEmpty mustEqual false
+      obj.Slot(25).Equipment.nonEmpty mustEqual false
+      obj.Slot(26).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(29).Equipment.nonEmpty mustEqual false
+      obj.Slot(30).Equipment.nonEmpty mustEqual false
+      obj.Slot(31).Equipment.nonEmpty mustEqual false
+      obj.Slot(32).Equipment.nonEmpty mustEqual false
+      obj.Slot(33).Equipment.nonEmpty mustEqual false
+      //
+      obj.Slot(36).Equipment.nonEmpty mustEqual false
+      obj.Slot(37).Equipment.nonEmpty mustEqual false
+      obj.Slot(38).Equipment.nonEmpty mustEqual false
+      obj.Slot(39).Equipment.nonEmpty mustEqual false
+      obj.Slot(40).Equipment.nonEmpty mustEqual false
+    }
+  }
 }

--- a/common/src/test/scala/objects/PlayerControlTest.scala
+++ b/common/src/test/scala/objects/PlayerControlTest.scala
@@ -32,10 +32,12 @@ class PlayerControlHealTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2, 0, 0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
   val player2 = Player(Avatar("TestCharacter2", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=2
   player2.Zone = zone
   player2.Spawn
+  guid.register(player2.Locker, 6)
   player2.Actor = system.actorOf(Props(classOf[PlayerControl], player2), "player2-control")
 
   val tool = Tool(GlobalDefinitions.medicalapplicator) //guid=3 & 4
@@ -102,6 +104,7 @@ class PlayerControlHealSelfTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2, 0, 0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
 
   val tool = Tool(GlobalDefinitions.medicalapplicator) //guid=3 & 4
@@ -167,10 +170,12 @@ class PlayerControlRepairTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2, 0, 0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
   val player2 = Player(Avatar("TestCharacter2", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=2
   player2.Zone = zone
   player2.Spawn
+  guid.register(player2.Locker, 6)
   player2.Actor = system.actorOf(Props(classOf[PlayerControl], player2), "player2-control")
 
   val tool = Tool(GlobalDefinitions.bank) //guid=3 & 4
@@ -243,6 +248,7 @@ class PlayerControlRepairSelfTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2, 0, 0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
 
   val tool = Tool(GlobalDefinitions.bank) //guid=3 & 4
@@ -309,10 +315,12 @@ class PlayerControlDamageTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2, 0, 0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
   val player2 = Player(Avatar("TestCharacter2", PlanetSideEmpire.NC, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=2
   player2.Zone = zone
   player2.Spawn
+  guid.register(player2.Locker, 6)
   player2.Actor = system.actorOf(Props(classOf[PlayerControl], player2), "player2-control")
   val tool = Tool(GlobalDefinitions.suppressor) //guid 3 & 4
   val projectile = tool.Projectile
@@ -385,10 +393,12 @@ class PlayerControlDeathStandingTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2,0,0)
+  guid.register(player1.Locker, 5)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
   val player2 = Player(Avatar("TestCharacter2", PlanetSideEmpire.NC, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=2
   player2.Zone = zone
   player2.Spawn
+  guid.register(player2.Locker, 6)
   player2.Actor = system.actorOf(Props(classOf[PlayerControl], player2), "player2-control")
 
   val tool = Tool(GlobalDefinitions.suppressor) //guid 3 & 4
@@ -493,10 +503,12 @@ class PlayerControlDeathSeatedTest extends ActorTest {
   player1.Zone = zone
   player1.Spawn
   player1.Position = Vector3(2,0,0)
+  guid.register(player1.Locker, 6)
   player1.Actor = system.actorOf(Props(classOf[PlayerControl], player1), "player1-control")
   val player2 = Player(Avatar("TestCharacter2", PlanetSideEmpire.NC, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=2
   player2.Zone = zone
   player2.Spawn
+  guid.register(player2.Locker, 7)
   player2.Actor = system.actorOf(Props(classOf[PlayerControl], player2), "player2-control")
 
   val vehicle = Vehicle(GlobalDefinitions.quadstealth) //guid=5
@@ -594,6 +606,5 @@ class PlayerControlDeathSeatedTest extends ActorTest {
     }
   }
 }
-
 
 object PlayerControlTest { }

--- a/common/src/test/scala/objects/PlayerTest.scala
+++ b/common/src/test/scala/objects/PlayerTest.scala
@@ -279,7 +279,7 @@ class PlayerTest extends Specification {
 
     "can access the player's locker-space" in {
       val obj = TestPlayer("Chord", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Voice5)
-      obj.Slot(5).Equipment.get.isInstanceOf[LockerContainer] mustEqual true
+      obj.Slot(5).Equipment.get.isInstanceOf[LockerEquipment] mustEqual true
     }
 
     "can find equipment" in {

--- a/common/src/test/scala/objects/guidtask/GUIDTaskRegisterAvatarTest.scala
+++ b/common/src/test/scala/objects/guidtask/GUIDTaskRegisterAvatarTest.scala
@@ -18,7 +18,7 @@ class GUIDTaskRegisterAvatarTest extends ActorTest {
     obj.Slot(6).Equipment = obj_inv_ammo
     val obj_locker = obj.Slot(5).Equipment.get
     val obj_locker_ammo = AmmoBox(GlobalDefinitions.energy_cell)
-    obj_locker.asInstanceOf[LockerContainer].Inventory += 0 -> obj_locker_ammo
+    obj_locker.asInstanceOf[LockerEquipment].Inventory += 0 -> obj_locker_ammo
 
     assert(!obj.HasGUID)
     assert(!obj_wep.HasGUID)

--- a/common/src/test/scala/objects/guidtask/GUIDTaskRegisterPlayerTest.scala
+++ b/common/src/test/scala/objects/guidtask/GUIDTaskRegisterPlayerTest.scala
@@ -18,7 +18,7 @@ class GUIDTaskRegisterPlayerTest extends ActorTest {
     obj.Slot(6).Equipment = obj_inv_ammo
     val obj_locker = obj.Slot(5).Equipment.get
     val obj_locker_ammo = AmmoBox(GlobalDefinitions.energy_cell)
-    obj_locker.asInstanceOf[LockerContainer].Inventory += 0 -> obj_locker_ammo
+    obj_locker.asInstanceOf[LockerEquipment].Inventory += 0 -> obj_locker_ammo
 
     assert(!obj.HasGUID)
     assert(!obj_wep.HasGUID)

--- a/common/src/test/scala/objects/guidtask/GUIDTaskUnregisterAvatarTest.scala
+++ b/common/src/test/scala/objects/guidtask/GUIDTaskUnregisterAvatarTest.scala
@@ -18,7 +18,7 @@ class GUIDTaskUnregisterAvatarTest extends ActorTest {
     obj.Slot(6).Equipment = obj_inv_ammo
     val obj_locker = obj.Slot(5).Equipment.get
     val obj_locker_ammo = AmmoBox(GlobalDefinitions.energy_cell)
-    obj_locker.asInstanceOf[LockerContainer].Inventory += 0 -> obj_locker_ammo
+    obj_locker.asInstanceOf[LockerEquipment].Inventory += 0 -> obj_locker_ammo
     guid.register(obj, "dynamic")
     guid.register(obj_wep, "dynamic")
     guid.register(obj_wep_ammo, "dynamic")

--- a/common/src/test/scala/objects/guidtask/GUIDTaskUnregisterPlayerTest.scala
+++ b/common/src/test/scala/objects/guidtask/GUIDTaskUnregisterPlayerTest.scala
@@ -18,7 +18,7 @@ class GUIDTaskUnregisterPlayerTest extends ActorTest {
     obj.Slot(6).Equipment = obj_inv_ammo
     val obj_locker = obj.Slot(5).Equipment.get
     val obj_locker_ammo = AmmoBox(GlobalDefinitions.energy_cell)
-    obj_locker.asInstanceOf[LockerContainer].Inventory += 0 -> obj_locker_ammo
+    obj_locker.asInstanceOf[LockerEquipment].Inventory += 0 -> obj_locker_ammo
     guid.register(obj, "dynamic")
     guid.register(obj_wep, "dynamic")
     guid.register(obj_wep_ammo, "dynamic")

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -149,8 +149,9 @@ object WorldSession {
         private val localContainer = obj
         private val localItem = item
         private val localSlot = slot
-        //private val localResolver = taskResolver
         private val localFunc : (Equipment,Int)=>Future[Any] = PutEquipmentInInventorySlot(obj, taskResolver)
+
+        override def Timeout : Long = 1000
 
         override def isComplete : Task.Resolution.Value = {
           if(localItem.HasGUID && localContainer.Find(localItem).nonEmpty)
@@ -201,6 +202,8 @@ object WorldSession {
         private val localPlayer = player
         private val localResolver = taskResolver
         private val localTermMsg : Boolean=>Unit = TerminalResult(term, localPlayer, TransactionType.Buy)
+
+        override def Timeout : Long = 1000
 
         override def isComplete : Task.Resolution.Value = {
           if(localItem.HasGUID && localContainer.Find(localItem).nonEmpty)
@@ -281,6 +284,8 @@ object WorldSession {
           private val localItem = item
           private val localSlot = slot
           private val localResolver = taskResolver
+
+          override def Timeout : Long = 1000
 
           override def isComplete : Task.Resolution.Value = {
             if(localPlayer.DrawnSlot == localSlot)

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -1,0 +1,311 @@
+// Copyright (c) 2017-2020 PSForever
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
+import net.psforever.objects._
+import net.psforever.objects.equipment.{Ammo, Equipment}
+import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
+import net.psforever.objects.inventory.{Container, InventoryItem}
+import net.psforever.objects.serverobject.{Containable, PlanetSideServerObject}
+import net.psforever.objects.zones.Zone
+import net.psforever.packet.game.{ItemTransactionResultMessage, ObjectHeldMessage}
+import net.psforever.types._
+import services.Service
+import services.avatar.{AvatarAction, AvatarServiceMessage}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+
+object WorldSession {
+  /**
+    * Convert a boolean value into an integer value.
+    * Use: `true:Int` or `false:Int`
+    * @param b `true` or `false` (or `null`)
+    * @return 1 for `true`; 0 for `false`
+    */
+  implicit def boolToInt(b : Boolean) : Int = if(b) 1 else 0
+  private implicit val timeout = new Timeout(1000 milliseconds)
+
+  def PutEquipmentInInventorySlot(obj : PlanetSideServerObject with Container, taskResolver : ActorRef)(item : Equipment, slot : Int) : Unit = {
+    val localContainer = obj
+    val localItem = item
+    val localResolver = taskResolver
+    implicit val timeout = new Timeout(1000 milliseconds)
+    ask(localContainer.Actor, Containable.PutItemInSlotOnly(localItem, slot)).onComplete {
+      case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+        localResolver ! GUIDTask.UnregisterEquipment(localItem)(localContainer.Zone.GUID)
+      case _ => ;
+    }
+  }
+
+  def PutEquipmentInInventoryOrDrop(obj : PlanetSideServerObject with Container, to : ActorRef)(item : Equipment, slot : Int) : Unit = {
+    val localContainer = obj
+    val localItem = item
+    val sendTo = to
+    ask(localContainer.Actor, Containable.PutItemAway(localItem)).onComplete {
+      case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+        localContainer.Zone.Ground.tell(Zone.Ground.DropItem(localItem, localContainer.Position, Vector3.z(localContainer.Orientation.z)), sendTo)
+      case _ => ;
+    }
+  }
+
+  def PutNewEquipmentInInventory(obj : PlanetSideServerObject with Container, taskResolver : ActorRef)(item : Equipment, slot : Int) : TaskResolver.GiveTask = {
+    val localZone = obj.Zone
+    TaskResolver.GiveTask(
+      new Task() {
+        private val localContainer = obj
+        private val localItem = item
+        private val localResolver = taskResolver
+
+        override def isComplete : Task.Resolution.Value = Task.Resolution.Success
+
+        def Execute(resolver : ActorRef) : Unit = {
+          ask(localContainer.Actor, Containable.PutItemAway(localItem)).onComplete {
+            case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+              localResolver ! GUIDTask.UnregisterEquipment(localItem)(localContainer.Zone.GUID)
+            case _ => ;
+          }
+          resolver ! scala.util.Success(this)
+        }
+      },
+      List(GUIDTask.RegisterEquipment(item)(localZone.GUID))
+    )
+  }
+
+  def PutLoadoutEquipmentInInventory(obj : PlanetSideServerObject with Container, taskResolver : ActorRef)(item : Equipment, slot : Int) : TaskResolver.GiveTask = {
+    val localZone = obj.Zone
+    TaskResolver.GiveTask(
+      new Task() {
+        private val localContainer = obj
+        private val localItem = item
+        private val localSlot = slot
+        private val localResolver = taskResolver
+
+        override def isComplete : Task.Resolution.Value = Task.Resolution.Success
+
+        def Execute(resolver : ActorRef) : Unit = {
+          ask(localContainer.Actor, Containable.PutItemInSlotOnly(localItem, localSlot)).onComplete {
+            case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+              localResolver ! GUIDTask.UnregisterEquipment(localItem)(localContainer.Zone.GUID)
+            case _ => ;
+          }
+          resolver ! scala.util.Success(this)
+        }
+      },
+      List(GUIDTask.RegisterEquipment(item)(localZone.GUID))
+    )
+  }
+
+  def BuyNewEquipmentPutInInventory(obj : PlanetSideServerObject with Container, taskResolver : ActorRef, player : Player, term : PlanetSideGUID)(item : Equipment) : TaskResolver.GiveTask = {
+    val localZone = obj.Zone
+    TaskResolver.GiveTask(
+      new Task() {
+        private val localContainer = obj
+        private val localItem = item
+        private val localPlayer = player
+        private val localResolver = taskResolver
+        private val localTermMsg : Boolean=>Unit = TerminalResult(term, localPlayer)
+
+        override def isComplete : Task.Resolution.Value = Task.Resolution.Success
+
+        def Execute(resolver : ActorRef) : Unit = {
+          ask(localContainer.Actor, Containable.PutItemAway(localItem)).onComplete {
+            case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+              ask(localPlayer.Actor, Containable.PutItemInSlotOnly(localItem, Player.FreeHandSlot)).onComplete {
+                case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+                  localResolver ! GUIDTask.UnregisterEquipment(localItem)(localContainer.Zone.GUID)
+                  localTermMsg(false)
+                case _ =>
+                  localTermMsg(true)
+              }
+            case _ =>
+              localTermMsg(true)
+          }
+          resolver ! scala.util.Success(this)
+        }
+      },
+      List(GUIDTask.RegisterEquipment(item)(localZone.GUID))
+    )
+  }
+
+  def SellEquipmentFromInventory(obj : PlanetSideServerObject with Container, taskResolver : ActorRef, player : Player, term : PlanetSideGUID)(slot : Int) : Unit = {
+    val localContainer = obj
+    val localPlayer = player
+    val localSlot = slot
+    val localResolver = taskResolver
+    val localTermMsg : Boolean=>Unit = TerminalResult(term, localPlayer)
+
+    ask(localContainer.Actor, Containable.RemoveItemFromSlot(localSlot)).onComplete {
+      case scala.util.Success(Containable.ItemFromSlot(_, Some(item), Some(_))) =>
+        localResolver ! GUIDTask.UnregisterEquipment(item)(localContainer.Zone.GUID)
+        localTermMsg(true)
+      case _ =>
+        localTermMsg(false)
+    }
+  }
+
+  def DropEquipmentFromInventory(obj : PlanetSideServerObject with Container, to : ActorRef)(item : Equipment, pos : Option[Vector3] = None) : Unit = {
+    val localContainer = obj
+    val localItem = item
+    val localPos = pos
+    val sendTo = to
+
+    ask(localContainer.Actor, Containable.RemoveItemFromSlot(localItem)).onComplete {
+      case scala.util.Success(Containable.ItemFromSlot(_, Some(_), Some(_))) =>
+        localContainer.Zone.Ground.tell(Zone.Ground.DropItem(localItem, localPos.getOrElse(localContainer.Position), Vector3.z(localContainer.Orientation.z)), sendTo)
+      case _ => ;
+    }
+  }
+
+  def RemoveOldEquipmentFromInventory(obj : PlanetSideServerObject with Container, taskResolver : ActorRef)(item : Equipment) : Unit = {
+    val localContainer = obj
+    val localItem = item
+    val localResolver = taskResolver
+
+    ask(localContainer.Actor, Containable.RemoveItemFromSlot(localItem)).onComplete {
+      case scala.util.Success(Containable.ItemFromSlot(_, Some(_), Some(_))) =>
+        localResolver ! GUIDTask.UnregisterEquipment(localItem)(localContainer.Zone.GUID)
+      case _ =>
+    }
+  }
+
+  def HoldNewEquipmentUp(player : Player, taskResolver : ActorRef)(item : Equipment, slot : Int) : TaskResolver.GiveTask = {
+    if(player.VisibleSlots.contains(slot)) {
+      val localZone = player.Zone
+      TaskResolver.GiveTask(
+        new Task() {
+          private val localPlayer = player
+          private val localGUID = player.GUID
+          private val localItem = item
+          private val localSlot = slot
+          private val localResolver = taskResolver
+
+          override def isComplete : Task.Resolution.Value = Task.Resolution.Success
+
+          def Execute(resolver : ActorRef) : Unit = {
+            ask(localPlayer.Actor, Containable.PutItemInSlotOnly(localItem, localSlot)).onComplete {
+              case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
+                localResolver ! GUIDTask.UnregisterEquipment(localItem)(localZone.GUID)
+              case _ =>
+                localPlayer.DrawnSlot = localSlot
+                localZone.AvatarEvents ! AvatarServiceMessage(localPlayer.Name,
+                  AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectHeldMessage(localGUID, localSlot, true))
+                )
+                localZone.AvatarEvents ! AvatarServiceMessage(localZone.Id,
+                  AvatarAction.ObjectHeld(localGUID, localSlot)
+                )
+            }
+            resolver ! scala.util.Success(this)
+          }
+        },
+        List(GUIDTask.RegisterEquipment(item)(localZone.GUID))
+      )
+    }
+    else {
+      //TODO log.error rather than println
+      println(s"HoldNewEquipmentUp: slot $slot is not visible for player model")
+      //TODO null is okay?
+      null
+    }
+  }
+
+  def TerminalResult(guid : PlanetSideGUID, player : Player)(result : Boolean) : Unit = {
+    player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name,
+      AvatarAction.SendResponse(Service.defaultPlayerGUID, ItemTransactionResultMessage(guid, TransactionType.Buy, result))
+    )
+  }
+
+  /**
+    * Within a specified `Container`, find the smallest number of `Equipment` objects of a certain qualifying type
+    * whose sum count is greater than, or equal to, a `desiredAmount` based on an accumulator method.<br>
+    * <br>
+    * In an occupied `List` of returned `Inventory` entries, all but the last entry is typically considered "emptied."
+    * For objects with contained quantities, the last entry may require having that quantity be set to a non-zero number.
+    * @param obj the `Container` to search
+    * @param filterTest test used to determine inclusivity of `Equipment` collection
+    * @param desiredAmount how much is requested
+    * @param counting test used to determine value of found `Equipment`;
+    *                 defaults to one per entry
+    * @return a `List` of all discovered entries totaling approximately the amount requested
+    */
+  def FindEquipmentStock(obj : Container,
+                         filterTest : Equipment=>Boolean,
+                         desiredAmount : Int,
+                         counting : Equipment=>Int = DefaultCount) : List[InventoryItem] = {
+    var currentAmount : Int = 0
+    obj.Inventory.Items
+      .filter(item => filterTest(item.obj))
+      .sortBy(_.start)
+      .takeWhile(entry => {
+        val previousAmount = currentAmount
+        currentAmount += counting(entry.obj)
+        previousAmount < desiredAmount
+      })
+  }
+
+
+  /**
+    * The default counting function for an item.
+    * Counts the number of item(s).
+    * @param e the `Equipment` object
+    * @return the quantity;
+    *         always one
+    */
+  def DefaultCount(e : Equipment) : Int = 1
+
+  /**
+    * The counting function for an item of `AmmoBox`.
+    * Counts the `Capacity` of the ammunition.
+    * @param e the `Equipment` object
+    * @return the quantity
+    */
+  def CountAmmunition(e : Equipment) : Int = {
+    e match {
+      case a : AmmoBox => a.Capacity
+      case _ => 0
+    }
+  }
+
+  /**
+    * The counting function for an item of `Tool` where the item is also a grenade.
+    * Counts the number of grenades.
+    * @see `GlobalDefinitions.isGrenade`
+    * @param e the `Equipment` object
+    * @return the quantity
+    */
+  def CountGrenades(e : Equipment) : Int = {
+    e match {
+      case t : Tool => (GlobalDefinitions.isGrenade(t.Definition):Int) * t.Magazine
+      case _ => 0
+    }
+  }
+
+  /**
+    * Flag an `AmmoBox` object that matches for the given ammunition type.
+    * @param ammo the type of `Ammo` to check
+    * @param e the `Equipment` object
+    * @return `true`, if the object is an `AmmoBox` of the correct ammunition type; `false`, otherwise
+    */
+  def FindAmmoBoxThatUses(ammo : Ammo.Value)(e : Equipment) : Boolean = {
+    e match {
+      case t : AmmoBox => t.AmmoType == ammo
+      case _ => false
+    }
+  }
+
+  /**
+    * Flag a `Tool` object that matches for loading the given ammunition type.
+    * @param ammo the type of `Ammo` to check
+    * @param e the `Equipment` object
+    * @return `true`, if the object is a `Tool` that loads the correct ammunition type; `false`, otherwise
+    */
+  def FindToolThatUses(ammo : Ammo.Value)(e : Equipment) : Boolean = {
+    e match {
+      case t : Tool =>
+        t.Definition.AmmoTypes.map { _.AmmoType }.contains(ammo)
+      case _ =>
+        false
+    }
+  }
+}

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -300,9 +300,15 @@ object WorldSession {
                 case scala.util.Failure(_) | scala.util.Success(_ : Containable.CanNotPutItemInSlot) =>
                   localResolver ! GUIDTask.UnregisterEquipment(localItem)(localZone.GUID)
                 case _ =>
+                  if(localPlayer.DrawnSlot != Player.HandsDownSlot) {
+                    localPlayer.DrawnSlot = Player.HandsDownSlot
+                    localZone.AvatarEvents ! AvatarServiceMessage(localPlayer.Name,
+                      AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectHeldMessage(localGUID, Player.HandsDownSlot, false))
+                    )
+                    localZone.AvatarEvents ! AvatarServiceMessage(localZone.Id, AvatarAction.ObjectHeld(localGUID, localPlayer.LastDrawnSlot))
+                  }
                   localPlayer.DrawnSlot = localSlot
-                  localZone.AvatarEvents ! AvatarServiceMessage(localZone.Id, AvatarAction.ObjectHeld(localGUID, localPlayer.LastDrawnSlot))
-                  localZone.AvatarEvents ! AvatarServiceMessage(localPlayer.Name,
+                  localZone.AvatarEvents ! AvatarServiceMessage(localZone.Id,
                     AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectHeldMessage(localGUID, localSlot, false))
                   )
               }

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -2,11 +2,12 @@
 import akka.actor.ActorRef
 import akka.pattern.{AskTimeoutException, ask}
 import akka.util.Timeout
-import net.psforever.objects._
+import net.psforever.objects.{AmmoBox, GlobalDefinitions, Player, Tool}
 import net.psforever.objects.equipment.{Ammo, Equipment}
 import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
 import net.psforever.objects.inventory.{Container, InventoryItem}
-import net.psforever.objects.serverobject.{Containable, PlanetSideServerObject}
+import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.containable.Containable
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.ObjectHeldMessage
 import net.psforever.types.{PlanetSideGUID, TransactionType, Vector3}

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -211,9 +211,7 @@ object WorldSession {
   }
 
   def TerminalResult(guid : PlanetSideGUID, player : Player, transaction : TransactionType.Value)(result : Boolean) : Unit = {
-    player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name,
-      AvatarAction.SendResponse(Service.defaultPlayerGUID, ItemTransactionResultMessage(guid, transaction, result))
-    )
+    player.Zone.AvatarEvents ! AvatarServiceMessage(player.Name, AvatarAction.TerminalOrderResult(guid, transaction, true))
   }
 
   /**

--- a/pslogin/src/main/scala/WorldSession.scala
+++ b/pslogin/src/main/scala/WorldSession.scala
@@ -8,7 +8,7 @@ import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
 import net.psforever.objects.inventory.{Container, InventoryItem}
 import net.psforever.objects.serverobject.{Containable, PlanetSideServerObject}
 import net.psforever.objects.zones.Zone
-import net.psforever.packet.game.{ItemTransactionResultMessage, ObjectHeldMessage}
+import net.psforever.packet.game.ObjectHeldMessage
 import net.psforever.types.{PlanetSideGUID, TransactionType, Vector3}
 import services.Service
 import services.avatar.{AvatarAction, AvatarServiceMessage}
@@ -218,17 +218,13 @@ object WorldSession {
     * na
     * @param dropOrDelete na
     */
-  def DropOrDeleteLeftovers(player : Player, taskResolver : ActorRef)(dropOrDelete : List[InventoryItem]) : Unit = {
+  def DropLeftovers(container : PlanetSideServerObject with Container)(dropOrDelete : List[InventoryItem]) : Unit = {
     //drop or retire
-    val zone = player.Zone
-    val pos = player.Position
-    val orient = Vector3.z(player.Orientation.z)
-    val (finalDroppedItems, retiredItems) = dropOrDelete.partition(Containable.DropPredicate(player))
-    //drop special items on ground
+    val zone = container.Zone
+    val pos = container.Position
+    val orient = Vector3.z(container.Orientation.z)
     //TODO make a sound when dropping stuff?
-    finalDroppedItems.foreach { entry => zone.Ground ! Zone.Ground.DropItem(entry.obj, pos, orient) }
-    //deconstruct normal items
-    retiredItems.foreach{ entry => taskResolver ! GUIDTask.UnregisterEquipment(entry.obj)(zone.GUID) }
+    dropOrDelete.foreach { entry => zone.Ground ! Zone.Ground.DropItem(entry.obj, pos, orient) }
   }
 
   /**

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -2465,6 +2465,10 @@ class WorldSessionActor extends Actor
             msg.terminal_guid
           )(item)
         }
+        else {
+          lastTerminalOrderFulfillment = true
+          sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, false))
+        }
 
       case Terminal.SellEquipment() =>
         SellEquipmentFromInventory(tplayer, taskResolver, tplayer, msg.terminal_guid)(Player.FreeHandSlot)

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-2020 PSForever
 //language imports
 import akka.actor.{Actor, ActorRef, Cancellable, MDCContextAware}
+import akka.pattern.ask
+import akka.util.Timeout
 import com.github.mauricio.async.db.general.ArrayRowData
 import com.github.mauricio.async.db.{Connection, QueryResult}
 import java.util.concurrent.TimeUnit
@@ -75,6 +77,7 @@ class WorldSessionActor extends Actor
   with MDCContextAware {
 
   import WorldSessionActor._
+  import WorldSession._
 
   private[this] val log = org.log4s.getLogger
   private[this] val damageLog = org.log4s.getLogger(Damageable.LogChannel)
@@ -149,7 +152,7 @@ class WorldSessionActor extends Actor
   var squad_supplement_id : Int = 0
   /**
     * When joining or creating a squad, the original state of the avatar's internal LFS variable is blanked.
-    * This `WSA`-local variable is then used to indicate the ongoing state of the LFS UI component,
+    * This `WorldSessionActor`-local variable is then used to indicate the ongoing state of the LFS UI component,
     * now called "Looking for Squad Member."
     * Only the squad leader may toggle the LFSM marquee.
     * Upon leaving or disbanding a squad, this value is made false.
@@ -182,17 +185,6 @@ class WorldSessionActor extends Actor
   var antDischargingTick : Cancellable = DefaultCancellable.obj
   var zoningTimer : Cancellable = DefaultCancellable.obj
   var zoningReset : Cancellable = DefaultCancellable.obj
-  /**
-    * Convert a boolean value into an integer value.
-    * Use: `true:Int` or `false:Int`
-    * @param b `true` or `false` (or `null`)
-    * @return 1 for `true`; 0 for `false`
-    */
-
-  import scala.language.implicitConversions
-
-  implicit def boolToInt(b : Boolean) : Int = if(b) 1
-  else 0
 
   override def postStop() : Unit = {
     //normally, the player avatar persists a minute or so after disconnect; we are subject to the SessionReaper
@@ -881,40 +873,8 @@ class WorldSessionActor extends Actor
     case msg@Zone.Vehicle.CanNotDespawn(zone, vehicle, reason) =>
       log.warn(s"$msg")
 
-    case Zone.Ground.ItemOnGround(item : BoomerTrigger, pos, orient) =>
-      //dropped the trigger, no longer own the boomer; make certain whole faction is aware of that
-      val playerGUID = player.GUID
-      continent.GUID(item.Companion) match {
-        case Some(obj : BoomerDeployable) =>
-          val guid = obj.GUID
-          val factionChannel = s"${player.Faction}"
-          obj.AssignOwnership(None)
-          avatar.Deployables.Remove(obj)
-          UpdateDeployableUIElements(avatar.Deployables.UpdateUIElement(obj.Definition.Item))
-          continent.LocalEvents ! LocalServiceMessage.Deployables(RemoverActor.AddTask(obj, continent))
-          obj.Faction = PlanetSideEmpire.NEUTRAL
-          sendResponse(SetEmpireMessage(guid, PlanetSideEmpire.NEUTRAL))
-          continent.AvatarEvents ! AvatarServiceMessage(factionChannel, AvatarAction.SetEmpire(playerGUID, guid, PlanetSideEmpire.NEUTRAL))
-          val info = DeployableInfo(guid, DeployableIcon.Boomer, obj.Position, PlanetSideGUID(0))
-          sendResponse(DeployableObjectsInfoMessage(DeploymentAction.Dismiss, info))
-          continent.LocalEvents ! LocalServiceMessage(factionChannel, LocalAction.DeployableMapIcon(playerGUID, DeploymentAction.Dismiss, info))
-          PutItemOnGround(item, pos, orient)
-        case Some(_) | None =>
-          //pointless trigger
-          val guid = item.GUID
-          continent.Ground ! Zone.Ground.RemoveItem(guid) //undo; no callback
-          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
-          taskResolver ! GUIDTask.UnregisterObjectTask(item)(continent.GUID)
-      }
-
-    case Zone.Ground.ItemOnGround(item : ConstructionItem, pos, orient) =>
-      //defensively, reset CItem configuration
-      item.FireModeIndex = 0
-      item.AmmoTypeIndex = 0
-      PutItemOnGround(item, pos, orient)
-
     case Zone.Ground.ItemOnGround(item : PlanetSideGameObject, pos, orient) =>
-      PutItemOnGround(item, pos, orient)
+      CancelZoningProcessWithDescriptiveReason("cancel_use")
 
     case Zone.Ground.CanNotDropItem(zone, item, reason) =>
       log.warn(s"DropItem: $player tried to drop a $item on the ground, but $reason")
@@ -983,7 +943,7 @@ class WorldSessionActor extends Actor
         )
       }
       else {
-        TryDropConstructionTool(tool, index, obj.Position)
+        TryDropFDU(tool, index, obj.Position)
         sendResponse(ObjectDeployedMessage.Failure(obj.Definition.Name))
         obj.Position = Vector3.Zero
         obj.AssignOwnership(None)
@@ -1013,11 +973,11 @@ class WorldSessionActor extends Actor
       val holster = player.Slot(index)
       if(holster.Equipment.contains(tool)) {
         holster.Equipment = None
-        taskResolver ! DelayedObjectHeld(player, index, List(PutEquipmentInSlot(player, trigger, index)))
+        taskResolver ! HoldNewEquipmentUp(player, taskResolver)(trigger, index)
       }
       else {
         //don't know where boomer trigger should go; drop it on the ground
-        taskResolver ! NewItemDrop(player, continent, continent.AvatarEvents)(trigger)
+        taskResolver ! NewItemDrop(player, continent)(trigger)
       }
       StopBundlingPackets()
 
@@ -1056,7 +1016,7 @@ class WorldSessionActor extends Actor
               log.info(s"FinalizeDeployable: setup for telepad #${guid.guid} in zone ${continent.Id}")
               obj.Router = routerGUID //necessary; forwards link to the router
               DeployableBuildActivity(obj)
-              CommonDestroyConstructionItem(tool, index)
+              RemoveOldEquipmentFromInventory(player, taskResolver)(tool)
               StopBundlingPackets()
               //it takes 60s for the telepad to become properly active
               continent.LocalEvents ! LocalServiceMessage.Telepads(RouterTelepadActivation.AddTask(obj, continent))
@@ -1078,16 +1038,16 @@ class WorldSessionActor extends Actor
       sendResponse(ObjectDeployedMessage.Failure(definition.Name))
       log.warn(s"FinalizeDeployable: deployable ${definition.asInstanceOf[BaseDeployableDefinition].Item}@$guid not handled by specific case")
       log.warn(s"FinalizeDeployable: deployable will be cleaned up, but may not get unregistered properly")
-      TryDropConstructionTool(tool, index, obj.Position)
+      TryDropFDU(tool, index, obj.Position)
       obj.Position = Vector3.Zero
       continent.Deployables ! Zone.Deployable.Dismiss(obj)
       StopBundlingPackets()
 
-    //!!only dispatch Zone.Deployable.Dismiss from WSA as cleanup if the target deployable was never fully introduced
+    //!!only dispatch Zone.Deployable.Dismiss from WorldSessionActor as cleanup if the target deployable was never fully introduced
     case Zone.Deployable.DeployableIsDismissed(obj : TurretDeployable) =>
       taskResolver ! GUIDTask.UnregisterDeployableTurret(obj)(continent.GUID)
 
-    //!!only dispatch Zone.Deployable.Dismiss from WSA as cleanup if the target deployable was never fully introduced
+    //!!only dispatch Zone.Deployable.Dismiss from WorldSessionActor as cleanup if the target deployable was never fully introduced
     case Zone.Deployable.DeployableIsDismissed(obj) =>
       taskResolver ! GUIDTask.UnregisterObjectTask(obj)(continent.GUID)
 
@@ -1342,7 +1302,7 @@ class WorldSessionActor extends Actor
       //        avatar.Certifications += BattleFrameRobotics
       //        avatar.Certifications += BFRAntiInfantry
       //        avatar.Certifications += BFRAntiAircraft
-      InitializeDeployableQuantities(avatar) //set deployables ui elements
+      Deployables.InitializeDeployableQuantities(avatar) //set deployables ui elements
       AwardBattleExperiencePoints(avatar, 20000000L)
       avatar.CEP = 600000
       avatar.Implants(0).Unlocked = true
@@ -1369,7 +1329,7 @@ class WorldSessionActor extends Actor
     case PlayerToken.LoginInfo(playerName, inZone, pos) =>
       log.info(s"LoginInfo: player $playerName is already logged in zone ${inZone.Id}; rejoining that character")
       persist = UpdatePersistence(sender)
-      //tell the old WSA to kill itself by using its own subscriptions against itself
+      //tell the old WorldSessionActor to kill itself by using its own subscriptions against itself
       inZone.AvatarEvents ! AvatarServiceMessage(playerName, AvatarAction.TeardownConnection())
       //find and reload previous player
       (inZone.Players.find(p => p.name.equals(playerName)), inZone.LivePlayers.find(p => p.Name.equals(playerName))) match {
@@ -2452,7 +2412,7 @@ class WorldSessionActor extends Actor
           }
           //populate holsters
           val finalInventory = if(exosuit == ExoSuitType.MAX) {
-            taskResolver ! DelayedObjectHeld(tplayer, 0, List(PutEquipmentInSlot(tplayer, Tool(GlobalDefinitions.MAXArms(subtype, tplayer.Faction)), 0)))
+            taskResolver ! HoldNewEquipmentUp(tplayer, taskResolver)(Tool(GlobalDefinitions.MAXArms(subtype, tplayer.Faction)), 0)
             fillEmptyHolsters(List(tplayer.Slot(4)).iterator, normalHolsters) ++ beforeInventory
           }
           else if(originalSuit == exosuit) { //note - this will rarely be the situation
@@ -2533,47 +2493,16 @@ class WorldSessionActor extends Actor
         lastTerminalOrderFulfillment = true
 
       case Terminal.BuyEquipment(item) =>
-        continent.GUID(tplayer.VehicleSeated) match {
-          //vehicle trunk
-          case Some(vehicle : Vehicle) =>
-            vehicle.Fit(item) match {
-              case Some(index) =>
-                item.Faction = tplayer.Faction
-                sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, true))
-                taskResolver ! StowNewEquipmentInVehicle(vehicle)(index, item)
-              case None => //player free hand?
-                tplayer.FreeHand.Equipment match {
-                  case None =>
-                    item.Faction = tplayer.Faction
-                    sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, true))
-                    taskResolver ! PutEquipmentInSlot(tplayer, item, Player.FreeHandSlot)
-                  case Some(_) =>
-                    sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, false))
-                }
-            }
-          //player backpack or free hand
-          case _ =>
-            tplayer.Fit(item) match {
-              case Some(index) =>
-                item.Faction = tplayer.Faction
-                sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, true))
-                taskResolver ! PutEquipmentInSlot(tplayer, item, index)
-              case None =>
-                sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, false))
-            }
-        }
+        taskResolver ! BuyNewEquipmentPutInInventory(
+          continent.GUID(tplayer.VehicleSeated) match { case Some(v : Vehicle) => v; case _ => player },
+          taskResolver,
+          tplayer,
+          msg.terminal_guid
+        )(item)
         lastTerminalOrderFulfillment = true
 
       case Terminal.SellEquipment() =>
-        tplayer.FreeHand.Equipment match {
-          case Some(item) =>
-            if(item.GUID == msg.item_guid) {
-              sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Sell, true))
-              taskResolver ! RemoveEquipmentFromSlot(tplayer, item, Player.FreeHandSlot)
-            }
-          case None =>
-            sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Sell, false))
-        }
+        SellEquipmentFromInventory(tplayer, taskResolver, tplayer, msg.terminal_guid)(Player.FreeHandSlot)
         lastTerminalOrderFulfillment = true
 
       case Terminal.InfantryLoadout(exosuit, subtype, holsters, inventory) =>
@@ -2588,7 +2517,7 @@ class WorldSessionActor extends Actor
         val (dropHolsters, beforeHolsters) = clearHolsters(tplayer.Holsters().iterator).partition(dropPred)
         val (dropInventory, beforeInventory) = tplayer.Inventory.Clear().partition(dropPred)
         tplayer.FreeHand.Equipment = None //terminal and inventory will close, so prematurely dropping should be fine
-      val fallbackSuit = ExoSuitType.Standard
+        val fallbackSuit = ExoSuitType.Standard
         val fallbackSubtype = 0
         //a loadout with a prohibited exo-suit type will result in a fallback exo-suit type
         val (nextSuit : ExoSuitType.Value, nextSubtype : Int) =
@@ -2688,6 +2617,7 @@ class WorldSessionActor extends Actor
         //report change
         sendResponse(ArmorChangedMessage(tplayer.GUID, nextSuit, nextSubtype))
         continent.AvatarEvents ! AvatarServiceMessage(tplayer.Continent, AvatarAction.ArmorChanged(tplayer.GUID, nextSuit, nextSubtype))
+        val putItemInSlot : (Equipment,Int)=>Unit = PutEquipmentInInventorySlot(tplayer, taskResolver)
         if(nextSuit == ExoSuitType.MAX) {
           val (maxWeapons, otherWeapons) = afterHolsters.partition(entry => {
             entry.obj.Size == EquipmentSize.Max
@@ -2698,19 +2628,19 @@ class WorldSessionActor extends Actor
             case None =>
               Tool(GlobalDefinitions.MAXArms(nextSubtype, tplayer.Faction))
           }
-          taskResolver ! DelayedObjectHeld(tplayer, 0, List(PutEquipmentInSlot(tplayer, weapon, 0)))
+          taskResolver ! HoldNewEquipmentUp(tplayer, taskResolver)(weapon, 0)
           otherWeapons
         }
         else {
           afterHolsters
         }.foreach(entry => {
           entry.obj.Faction = tplayer.Faction
-          taskResolver ! PutEquipmentInSlot(tplayer, entry.obj, entry.start)
+          taskResolver ! putItemInSlot(entry.obj, entry.start)
         })
         //put items into inventory
         afterInventory.foreach(entry => {
           entry.obj.Faction = tplayer.Faction
-          taskResolver ! PutEquipmentInSlot(tplayer, entry.obj, entry.start)
+          taskResolver ! putItemInSlot(entry.obj, entry.start)
         })
         //drop stuff on ground
         val pos = tplayer.Position
@@ -2732,9 +2662,9 @@ class WorldSessionActor extends Actor
             val (_, afterInventory) = inventory.partition(DropPredicate(tplayer))
             //dropped items are lost
             //remove old inventory
-            val deleteEquipment : (Int, Equipment) => Unit = DeleteEquipmentFromVehicle(vehicle)
-            vehicle.Inventory.Clear().foreach({ case InventoryItem(obj, index) => deleteEquipment(index, obj) })
-            val stowEquipment : (Int, Equipment) => TaskResolver.GiveTask = StowNewEquipmentInVehicle(vehicle)
+            val deleteEquipment : (Equipment) => Unit = RemoveOldEquipmentFromInventory(vehicle, taskResolver)
+            vehicle.Inventory.Clear().foreach({ case InventoryItem(obj, index) => deleteEquipment(obj) })
+            val stowEquipment : (Equipment,Int) => TaskResolver.GiveTask = PutLoadoutEquipmentInInventory(vehicle, taskResolver)
             (if(vehicle.Definition == definition) {
               //vehicles are the same type; transfer over weapon ammo
               //TODO ammo switching? no vehicle weapon does that currently but ...
@@ -2765,7 +2695,7 @@ class WorldSessionActor extends Actor
               }
             }).foreach({ case InventoryItem(obj, index) =>
               obj.Faction = tplayer.Faction
-              taskResolver ! stowEquipment(index, obj)
+              taskResolver ! stowEquipment(obj, index)
             })
           case None =>
             log.error(s"can not apply the loadout - can not find a vehicle")
@@ -2780,7 +2710,7 @@ class WorldSessionActor extends Actor
           log.info(s"$name is learning the $cert certification for ${Certification.Cost.Of(cert)} points")
           avatar.Certifications += cert
           StartBundlingPackets()
-          AddToDeployableQuantities(cert, player.Certifications)
+          UpdateDeployableUIElements(Deployables.AddToDeployableQuantities(avatar, cert, player.Certifications))
           sendResponse(PlanetsideAttributeMessage(guid, 24, cert.id))
           tplayer.Certifications.intersect(Certification.Dependencies.Like(cert)).foreach(entry => {
             log.info(s"$cert replaces the learned certification $entry that cost ${Certification.Cost.Of(entry)} points")
@@ -2803,12 +2733,12 @@ class WorldSessionActor extends Actor
           log.info(s"$name is forgetting the $cert certification for ${Certification.Cost.Of(cert)} points")
           avatar.Certifications -= cert
           StartBundlingPackets()
-          RemoveFromDeployablesQuantities(cert, player.Certifications)
+          UpdateDeployableUIElements(Deployables.RemoveFromDeployableQuantities(avatar, cert, player.Certifications))
           sendResponse(PlanetsideAttributeMessage(guid, 25, cert.id))
           tplayer.Certifications.intersect(Certification.Dependencies.FromAll(cert)).foreach(entry => {
             log.info(s"$name is also forgetting the ${Certification.Cost.Of(entry)}-point $entry certification which depends on $cert")
             avatar.Certifications -= entry
-            RemoveFromDeployablesQuantities(entry, player.Certifications)
+            UpdateDeployableUIElements(Deployables.RemoveFromDeployableQuantities(avatar, entry, player.Certifications))
             sendResponse(PlanetsideAttributeMessage(guid, 25, entry.id))
           })
           StopBundlingPackets()
@@ -3354,7 +3284,7 @@ class WorldSessionActor extends Actor
     player = tplayer
     val guid = tplayer.GUID
     StartBundlingPackets()
-    InitializeDeployableUIElements(avatar)
+    UpdateDeployableUIElements(Deployables.InitializeDeployableUIElements(avatar))
     sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 75, 0))
     sendResponse(SetCurrentAvatarMessage(guid, 0, 0))
     sendResponse(ChatMsg(ChatMessageType.CMT_EXPANSIONS, true, "", "1 on", None)) //CC on //TODO once per respawn?
@@ -4947,14 +4877,16 @@ class WorldSessionActor extends Actor
               case Nil =>
                 log.warn(s"ReloadMessage: no ammunition could be found for $item_guid")
               case x :: xs =>
-                val (deleteFunc, modifyFunc) : ((Int, AmmoBox) => Unit, (AmmoBox, Int) => Unit) = obj match {
+                val (deleteFunc, modifyFunc) : (Equipment=>Unit, (AmmoBox, Int) => Unit) = obj match {
                   case (veh : Vehicle) =>
-                    (DeleteEquipmentFromVehicle(veh), ModifyAmmunitionInVehicle(veh))
+                    (RemoveOldEquipmentFromInventory(veh, taskResolver), ModifyAmmunitionInVehicle(veh))
+                  case o : PlanetSideServerObject with Container =>
+                    (RemoveOldEquipmentFromInventory(o, taskResolver), ModifyAmmunition(o))
                   case _ =>
-                    (DeleteEquipment(obj), ModifyAmmunition(obj))
+                    throw new Exception("ReloadMessage: should be a server object, not a regular game object")
                 }
                 xs.foreach(item => {
-                  deleteFunc(item.start, item.obj.asInstanceOf[AmmoBox])
+                  deleteFunc(item.obj)
                 })
                 val box = x.obj.asInstanceOf[AmmoBox]
                 val tailReloadValue : Int = if(xs.isEmpty) {
@@ -4965,7 +4897,7 @@ class WorldSessionActor extends Actor
                 }
                 val sumReloadValue : Int = box.Capacity + tailReloadValue
                 val actualReloadValue = (if(sumReloadValue <= reloadValue) {
-                  deleteFunc(x.start, box)
+                  deleteFunc(box)
                   sumReloadValue
                 }
                 else {
@@ -6277,97 +6209,6 @@ class WorldSessionActor extends Actor
   }
 
   /**
-    * Construct tasking that coordinates the following:<br>
-    * 1) Accept a new piece of `Equipment` and register it with a globally unique identifier.<br>
-    * 2) Once it is registered, give the `Equipment` to `target`.
-    * @param target what object will accept the new `Equipment`
-    * @param obj the new `Equipment`
-    * @param index the slot where the new `Equipment` will be placed
-    * @see `GUIDTask.RegisterEquipment`
-    * @see `PutInSlot`
-    * @return a `TaskResolver.GiveTask` message
-    */
-  private def PutEquipmentInSlot(target : PlanetSideGameObject with Container, obj : Equipment, index : Int) : TaskResolver.GiveTask = {
-    val regTask = GUIDTask.RegisterEquipment(obj)(continent.GUID)
-    obj match {
-      case tool : Tool =>
-        val linearToolTask = TaskResolver.GiveTask(regTask.task) +: regTask.subs
-        TaskResolver.GiveTask(PutInSlot(target, tool, index).task, linearToolTask)
-      case _ =>
-        TaskResolver.GiveTask(PutInSlot(target, obj, index).task, List(regTask))
-    }
-  }
-
-  /**
-    * Construct tasking that coordinates the following:<br>
-    * 1) Remove a new piece of `Equipment` from where it is currently stored.<br>
-    * 2) Once it is removed, un-register the `Equipment`'s globally unique identifier.
-    * @param target the object that currently possesses the `Equipment`
-    * @param obj the `Equipment`
-    * @param index the slot from where the `Equipment` will be removed
-    * @see `GUIDTask.UnregisterEquipment`
-    * @see `RemoveFromSlot`
-    * @return a `TaskResolver.GiveTask` message
-    */
-  private def RemoveEquipmentFromSlot(target : PlanetSideGameObject with Container, obj : Equipment, index : Int) : TaskResolver.GiveTask = {
-    val regTask = GUIDTask.UnregisterEquipment(obj)(continent.GUID)
-    //to avoid an error from a GUID-less object from being searchable, it is removed from the inventory first
-    obj match {
-      case _ : Tool =>
-        TaskResolver.GiveTask(regTask.task, RemoveFromSlot(target, obj, index) +: regTask.subs)
-      case _ =>
-        TaskResolver.GiveTask(regTask.task, List(RemoveFromSlot(target, obj, index)))
-    }
-  }
-
-  /**
-    * Construct tasking that gives the `Equipment` to `target`.
-    * @param target what object will accept the new `Equipment`
-    * @param obj the new `Equipment`
-    * @param index the slot where the new `Equipment` will be placed
-    * @return a `TaskResolver.GiveTask` message
-    */
-  private def PutInSlot(target : PlanetSideGameObject with Container, obj : Equipment, index : Int) : TaskResolver.GiveTask = {
-    TaskResolver.GiveTask(
-      new Task() {
-        private val localTarget = target
-        private val localIndex = index
-        private val localObject = obj
-        private val localAnnounce = self
-        private val localService = continent.AvatarEvents
-
-        override def isComplete : Task.Resolution.Value = {
-          if(localTarget.Slot(localIndex).Equipment.contains(localObject)) {
-            Task.Resolution.Success
-          }
-          else {
-            Task.Resolution.Incomplete
-          }
-        }
-
-        def Execute(resolver : ActorRef) : Unit = {
-          localTarget.Slot(localIndex).Equipment = localObject
-          resolver ! scala.util.Success(this)
-        }
-
-        override def onSuccess() : Unit = {
-          val definition = localObject.Definition
-          localAnnounce ! ResponseToSelf(
-            ObjectCreateDetailedMessage(
-              definition.ObjectId,
-              localObject.GUID,
-              ObjectCreateMessageParent(localTarget.GUID, localIndex),
-              definition.Packet.DetailedConstructorData(localObject).get
-            )
-          )
-          if(localTarget.VisibleSlots.contains(localIndex)) {
-            localService ! AvatarServiceMessage(continent.Id, AvatarAction.EquipmentInHand(localTarget.GUID, localTarget.GUID, localIndex, localObject))
-          }
-        }
-      })
-  }
-
-  /**
     * Construct tasking that registers all aspects of a `Player` avatar.
     * `Players` are complex objects that contain a variety of other register-able objects and each of these objects much be handled.
     * @param tplayer the avatar `Player`
@@ -6391,11 +6232,11 @@ class WorldSessionActor extends Actor
         def Execute(resolver : ActorRef) : Unit = {
           log.info(s"Player $localPlayer is registered")
           resolver ! scala.util.Success(this)
-          localAnnounce ! NewPlayerLoaded(localPlayer) //alerts WSA
+          localAnnounce ! NewPlayerLoaded(localPlayer) //alerts WorldSessionActor
         }
 
         override def onFailure(ex : Throwable) : Unit = {
-          localAnnounce ! PlayerFailedToLoad(localPlayer) //alerts WSA
+          localAnnounce ! PlayerFailedToLoad(localPlayer) //alerts WorldSessionActor
         }
       }, List(GUIDTask.RegisterAvatar(tplayer)(continent.GUID))
     )
@@ -6425,11 +6266,11 @@ class WorldSessionActor extends Actor
         def Execute(resolver : ActorRef) : Unit = {
           log.info(s"Player $localPlayer is registered")
           resolver ! scala.util.Success(this)
-          localAnnounce ! PlayerLoaded(localPlayer) //alerts WSA
+          localAnnounce ! PlayerLoaded(localPlayer) //alerts WorldSessionActor
         }
 
         override def onFailure(ex : Throwable) : Unit = {
-          localAnnounce ! PlayerFailedToLoad(localPlayer) //alerts WSA
+          localAnnounce ! PlayerFailedToLoad(localPlayer) //alerts WorldSessionActor
         }
       }, List(GUIDTask.RegisterPlayer(tplayer)(continent.GUID))
     )
@@ -6460,7 +6301,7 @@ class WorldSessionActor extends Actor
         def Execute(resolver : ActorRef) : Unit = {
           log.info(s"Vehicle $localVehicle is registered")
           resolver ! scala.util.Success(this)
-          localAnnounce ! VehicleLoaded(localVehicle) //alerts WSA
+          localAnnounce ! VehicleLoaded(localVehicle) //alerts WorldSessionActor
         }
       }, List(GUIDTask.RegisterVehicle(vehicle)(continent.GUID))
     )
@@ -6574,12 +6415,12 @@ class WorldSessionActor extends Actor
         def Execute(resolver : ActorRef) : Unit = {
           localDriver.VehicleSeated = localVehicle.GUID
           Vehicles.Own(localVehicle, localDriver)
-          localAnnounce ! NewPlayerLoaded(localDriver) //alerts WSA
+          localAnnounce ! NewPlayerLoaded(localDriver) //alerts WorldSessionActor
           resolver ! scala.util.Success(this)
         }
 
         override def onFailure(ex : Throwable) : Unit = {
-          localAnnounce ! PlayerFailedToLoad(localDriver) //alerts WSA
+          localAnnounce ! PlayerFailedToLoad(localDriver) //alerts WorldSessionActor
         }
       }, List(GUIDTask.RegisterAvatar(driver)(continent.GUID), GUIDTask.RegisterVehicle(obj)(continent.GUID)))
   }
@@ -6668,48 +6509,6 @@ class WorldSessionActor extends Actor
   }
 
   /**
-    * Construct tasking that removes the `Equipment` to `target`.
-    * @param target what object that contains the `Equipment`
-    * @param obj the `Equipment`
-    * @param index the slot where the `Equipment` is stored
-    * @return a `TaskResolver.GiveTask` message
-    */
-  private def RemoveFromSlot(target : PlanetSideGameObject with Container, obj : Equipment, index : Int) : TaskResolver.GiveTask = {
-    TaskResolver.GiveTask(
-      new Task() {
-        private val localTarget = target
-        private val localIndex = index
-        private val localObject = obj
-        private val localObjectGUID = obj.GUID
-        private val localAnnounce = self //self may not be the same when it executes
-        private val localService = continent.AvatarEvents
-        private val localContinent = continent.Id
-
-        override def isComplete : Task.Resolution.Value = {
-          if(localTarget.Slot(localIndex).Equipment.contains(localObject)) {
-            Task.Resolution.Incomplete
-          }
-          else {
-            Task.Resolution.Success
-          }
-        }
-
-        def Execute(resolver : ActorRef) : Unit = {
-          localTarget.Slot(localIndex).Equipment = None
-          resolver ! scala.util.Success(this)
-        }
-
-        override def onSuccess() : Unit = {
-          localAnnounce ! ResponseToSelf( ObjectDeleteMessage(localObjectGUID, 0))
-          if(localTarget.VisibleSlots.contains(localIndex)) {
-            localService ! AvatarServiceMessage(localContinent, AvatarAction.ObjectDelete(localTarget.GUID, localObjectGUID))
-          }
-        }
-      }
-    )
-  }
-
-  /**
     * If the projectile object is unregistered, register it.
     * If the projectile object is already registered, unregister it and then register it again.
     * @see `RegisterProjectile(Projectile)`
@@ -6733,44 +6532,44 @@ class WorldSessionActor extends Actor
     }
   }
 
-  /**
-    * After some subtasking is completed, draw a particular slot, as if an `ObjectHeldMessage` packet was sent/received.<br>
-    * <br>
-    * The resulting `Task` is most useful for sequencing MAX weaponry when combined with the proper subtasks.
-    * @param player the player
-    * @param index the slot to be drawn
-    * @param priorTasking subtasks that needs to be accomplished first
-    * @return a `TaskResolver.GiveTask` message
-    */
-  private def DelayedObjectHeld(player : Player, index : Int, priorTasking : List[TaskResolver.GiveTask]) : TaskResolver.GiveTask = {
-    TaskResolver.GiveTask(
-      new Task() {
-        private val localPlayer = player
-        private val localSlot = index
-        private val localAnnounce = self
-        private val localService = continent.AvatarEvents
-
-        override def isComplete : Task.Resolution.Value = {
-          if(localPlayer.DrawnSlot == localSlot) {
-            Task.Resolution.Success
-          }
-          else {
-            Task.Resolution.Incomplete
-          }
-        }
-
-        def Execute(resolver : ActorRef) : Unit = {
-          localPlayer.DrawnSlot = localSlot
-          resolver ! scala.util.Success(this)
-        }
-
-        override def onSuccess() : Unit = {
-          localAnnounce ! ResponseToSelf( ObjectHeldMessage(localPlayer.GUID, localSlot, true))
-          localService ! AvatarServiceMessage(localPlayer.Continent, AvatarAction.ObjectHeld(localPlayer.GUID, localSlot))
-        }
-      }, priorTasking
-    )
-  }
+//  /**
+//    * After some subtasking is completed, draw a particular slot, as if an `ObjectHeldMessage` packet was sent/received.<br>
+//    * <br>
+//    * The resulting `Task` is most useful for sequencing MAX weaponry when combined with the proper subtasks.
+//    * @param player the player
+//    * @param index the slot to be drawn
+//    * @param priorTasking subtasks that needs to be accomplished first
+//    * @return a `TaskResolver.GiveTask` message
+//    */
+//  private def DelayedObjectHeld(player : Player, index : Int, priorTasking : List[TaskResolver.GiveTask]) : TaskResolver.GiveTask = {
+//    TaskResolver.GiveTask(
+//      new Task() {
+//        private val localPlayer = player
+//        private val localSlot = index
+//        private val localAnnounce = self
+//        private val localService = continent.AvatarEvents
+//
+//        override def isComplete : Task.Resolution.Value = {
+//          if(localPlayer.DrawnSlot == localSlot) {
+//            Task.Resolution.Success
+//          }
+//          else {
+//            Task.Resolution.Incomplete
+//          }
+//        }
+//
+//        def Execute(resolver : ActorRef) : Unit = {
+//          localPlayer.DrawnSlot = localSlot
+//          resolver ! scala.util.Success(this)
+//        }
+//
+//        override def onSuccess() : Unit = {
+//          localAnnounce ! ResponseToSelf( ObjectHeldMessage(localPlayer.GUID, localSlot, true))
+//          localService ! AvatarServiceMessage(localPlayer.Continent, AvatarAction.ObjectHeld(localPlayer.GUID, localSlot))
+//        }
+//      }, priorTasking
+//    )
+//  }
 
   /**
     * Before calling `Interstellar.GetWorld` to change zones, perform the following task (which can be a nesting of subtasks).
@@ -7037,105 +6836,6 @@ class WorldSessionActor extends Actor
   def FindWeapon : Option[Tool] = FindContainedWeapon._2
 
   /**
-    * Within a specified `Container`, find the smallest number of `Equipment` objects of a certain qualifying type
-    * whose sum count is greater than, or equal to, a `desiredAmount` based on an accumulator method.<br>
-    * <br>
-    * In an occupied `List` of returned `Inventory` entries, all but the last entry is typically considered "emptied."
-    * For objects with contained quantities, the last entry may require having that quantity be set to a non-zero number.
-    * @param obj the `Container` to search
-    * @param filterTest test used to determine inclusivity of `Equipment` collection
-    * @param desiredAmount how much is requested
-    * @param counting test used to determine value of found `Equipment`;
-    *                 defaults to one per entry
-    * @return a `List` of all discovered entries totaling approximately the amount requested
-    */
-  def FindEquipmentStock(obj : Container,
-                         filterTest : (Equipment)=>Boolean,
-                         desiredAmount : Int,
-                         counting : (Equipment)=>Int = DefaultCount) : List[InventoryItem] = {
-    var currentAmount : Int = 0
-    obj.Inventory.Items
-      .filter(item => filterTest(item.obj))
-      .toList
-      .sortBy(_.start)
-      .takeWhile(entry => {
-        val previousAmount = currentAmount
-        currentAmount += counting(entry.obj)
-        previousAmount < desiredAmount
-      })
-  }
-
-  /**
-    * The default counting function for an item.
-    * Counts the number of item(s).
-    * @param e the `Equipment` object
-    * @return the quantity;
-    *         always one
-    */
-  def DefaultCount(e : Equipment) : Int = 1
-
-  /**
-    * The counting function for an item of `AmmoBox`.
-    * Counts the `Capacity` of the ammunition.
-    * @param e the `Equipment` object
-    * @return the quantity
-    */
-  def CountAmmunition(e : Equipment) : Int = {
-    e match {
-      case a : AmmoBox =>
-        a.Capacity
-      case _ =>
-        0
-    }
-  }
-
-  /**
-    * The counting function for an item of `Tool` where the item is also a grenade.
-    * Counts the number of grenades.
-    * @see `GlobalDefinitions.isGrenade`
-    * @param e the `Equipment` object
-    * @return the quantity
-    */
-  def CountGrenades(e : Equipment) : Int = {
-    e match {
-      case t : Tool =>
-        (GlobalDefinitions.isGrenade(t.Definition):Int) * t.Magazine
-      case _ =>
-        0
-    }
-  }
-
-  /**
-    * Flag an `AmmoBox` object that matches for the given ammunition type.
-    * @param ammo the type of `Ammo` to check
-    * @param e the `Equipment` object
-    * @return `true`, if the object is an `AmmoBox` of the correct ammunition type; `false`, otherwise
-    */
-  def FindAmmoBoxThatUses(ammo : Ammo.Value)(e : Equipment) : Boolean = {
-    e match {
-      case t : AmmoBox =>
-        t.AmmoType == ammo
-      case _ =>
-        false
-    }
-  }
-
-  /**
-    * Flag a `Tool` object that matches for loading the given ammunition type.
-    * @param ammo the type of `Ammo` to check
-    * @param e the `Equipment` object
-    * @return `true`, if the object is a `Tool` that loads the correct ammunition type; `false`, otherwise
-    */
-  def FindToolThatUses(ammo : Ammo.Value)(e : Equipment) : Boolean = {
-    e match {
-      case t : Tool =>
-        t.Definition.AmmoTypes.map { _.AmmoType }.contains(ammo)
-      case _ =>
-        false
-    }
-  }
-
-  /**
     * Get the current `Vehicle` object that the player is riding/driving.
     * The vehicle must be found solely through use of `player.VehicleSeated`.
     * @return the vehicle
@@ -7152,37 +6852,6 @@ class WorldSessionActor extends Actor
       case None =>
         None
     }
-  }
-
-  /**
-    * Given an object that contains an item (`Equipment`) in its `Inventory` at a certain location,
-    * remove it permanently.
-    * @param obj the `Container`
-    * @param start where the item can be found
-    * @param item an object to unregister;
-    *             not explicitly checked
-    */
-  private def DeleteEquipment(obj : PlanetSideGameObject with Container)(start : Int, item : Equipment) : Unit = {
-    val item_guid = item.GUID
-    obj.Slot(start).Equipment = None
-    //obj.Inventory -= start
-    taskResolver ! GUIDTask.UnregisterEquipment(item)(continent.GUID)
-    sendResponse(ObjectDeleteMessage(item_guid, 0))
-  }
-
-  /**
-    * Given a vehicle that contains an item (`Equipment`) in its `Trunk` at a certain location,
-    * remove it permanently.
-    * @see `DeleteEquipment`
-    * @param obj the `Vehicle`
-    * @param start where the item can be found
-    * @param item an object to unregister;
-    *             not explicitly checked
-    */
-  private def DeleteEquipmentFromVehicle(obj : Vehicle)(start : Int, item : Equipment) : Unit = {
-    val item_guid = item.GUID
-    DeleteEquipment(obj)(start, item)
-    continent.VehicleEvents ! VehicleServiceMessage(s"${obj.Actor}", VehicleAction.UnstowEquipment(player.GUID, item_guid))
   }
 
   /**
@@ -7217,81 +6886,6 @@ class WorldSessionActor extends Actor
   }
 
   /**
-    * Announce that an already-registered `AmmoBox` object exists in a given position in some `Container` object's inventory.
-    * @see `StowEquipmentInVehicles`
-    * @see `ChangeAmmoMessage`
-    * @param obj the `Container` object
-    * @param index an index in `obj`'s inventory
-    * @param item an `AmmoBox`
-    */
-  def StowEquipment(obj : PlanetSideGameObject with Container)(index : Int, item : AmmoBox) : Unit = {
-    obj.Inventory += index -> item
-    sendResponse(ObjectAttachMessage(obj.GUID, item.GUID, index))
-  }
-
-  /**
-    * Announce that an already-registered `AmmoBox` object exists in a given position in some vehicle's inventory.
-    * @see `StowEquipment`
-    * @see `ChangeAmmoMessage`
-    * @param obj the `Vehicle` object
-    * @param index an index in `obj`'s inventory
-    * @param item an `AmmoBox`
-    */
-  def StowEquipmentInVehicles(obj : Vehicle)(index : Int, item : AmmoBox) : Unit = {
-    StowEquipment(obj)(index, item)
-    continent.VehicleEvents ! VehicleServiceMessage(s"${obj.Actor}", VehicleAction.StowEquipment(player.GUID, obj.GUID, index, item))
-  }
-
-  /**
-    * Prepare tasking that registers an `AmmoBox` object
-    * and announces that it exists in a given position in some `Container` object's inventory.
-    * `PutEquipmentInSlot` is the fastest way to achieve these goals.
-    * @see `StowNewEquipmentInVehicle`
-    * @see `ChangeAmmoMessage`
-    * @param obj the `Container` object
-    * @param index an index in `obj`'s inventory
-    * @param item the `Equipment` item
-    * @return a `TaskResolver.GiveTask` chain that executes the action
-    */
-  def StowNewEquipment(obj : PlanetSideGameObject with Container)(index : Int, item : Equipment) : TaskResolver.GiveTask = {
-    PutEquipmentInSlot(obj, item, index)
-  }
-
-  /**
-    * Prepare tasking that registers an `AmmoBox` object
-    * and announces that it exists in a given position in some vehicle's inventory.
-    * `PutEquipmentInSlot` is the fastest way to achieve these goals.
-    * @see `StowNewEquipment`
-    * @see `ChangeAmmoMessage`
-    * @param obj the `Container` object
-    * @param index an index in `obj`'s inventory
-    * @param item the `Equipment` item
-    * @return a `TaskResolver.GiveTask` chain that executes the action
-    */
-  def StowNewEquipmentInVehicle(obj : Vehicle)(index : Int, item : Equipment) : TaskResolver.GiveTask = {
-    TaskResolver.GiveTask(
-      new Task() {
-        private val localService = continent.VehicleEvents
-        private val localPlayer = player
-        private val localVehicle = obj
-        private val localIndex = index
-        private val localItem = item
-
-        override def isComplete : Task.Resolution.Value = Task.Resolution.Success
-
-        def Execute(resolver : ActorRef) : Unit = {
-          localService ! VehicleServiceMessage(
-            s"${localVehicle.Actor}",
-            VehicleAction.StowEquipment(localPlayer.GUID, localVehicle.GUID, localIndex, localItem)
-          )
-          resolver ! scala.util.Success(this)
-        }
-      },
-      List(StowNewEquipment(obj)(index, item))
-    )
-  }
-
-  /**
     * na
     * @param tool na
     * @param obj na
@@ -7305,21 +6899,23 @@ class WorldSessionActor extends Actor
         FindEquipmentStock(obj, FindAmmoBoxThatUses(requestedAmmoType), fullMagazine, CountAmmunition).reverse match {
           case Nil => ;
           case x :: xs =>
-            val (deleteFunc, modifyFunc) : ((Int, AmmoBox)=>Unit, (AmmoBox, Int)=>Unit) = obj match {
+            val (deleteFunc, modifyFunc) : (Equipment=>Unit, (AmmoBox, Int) => Unit) = obj match {
               case (veh : Vehicle) =>
-                (DeleteEquipmentFromVehicle(veh), ModifyAmmunitionInVehicle(veh))
+                (RemoveOldEquipmentFromInventory(veh, taskResolver), ModifyAmmunitionInVehicle(veh))
+              case o : PlanetSideServerObject with Container =>
+                (RemoveOldEquipmentFromInventory(o, taskResolver), ModifyAmmunition(o))
               case _ =>
-                (DeleteEquipment(obj), ModifyAmmunition(obj))
+                throw new Exception("PerformToolAmmoChange: (remove/modify) should be a server object, not a regular game object")
             }
-            val (stowFuncTask, stowFunc) : ((Int, AmmoBox)=>TaskResolver.GiveTask, (Int, AmmoBox)=>Unit) = obj match {
-              case (veh : Vehicle) =>
-                (StowNewEquipmentInVehicle(veh), StowEquipmentInVehicles(veh))
+            val (stowNewFunc, stowFunc) : ((Equipment,Int)=>TaskResolver.GiveTask, (Equipment, Int)=>Unit) = obj match {
+              case o : PlanetSideServerObject with Container =>
+                (PutNewEquipmentInInventory(o, taskResolver), PutEquipmentInInventoryOrDrop(o, self))
               case _ =>
-                (StowNewEquipment(obj), StowEquipment(obj))
+                throw new Exception("PerformToolAmmoChange: (new/put) should be a server object, not a regular game object")
             }
             xs.foreach(item => {
               obj.Inventory -= x.start
-              deleteFunc(item.start, item.obj.asInstanceOf[AmmoBox])
+              deleteFunc(item.obj)
             })
 
             //box will be the replacement ammo; give it the discovered magazine and load it into the weapon @ 0
@@ -7351,8 +6947,7 @@ class WorldSessionActor extends Actor
               val splitReloadAmmo : Int = sumReloadValue - fullMagazine
               log.info(s"ChangeAmmo: taking ${originalBoxCapacity - splitReloadAmmo} from a box of ${originalBoxCapacity} $requestedAmmoType")
               val boxForInventory = AmmoBox(box.Definition, splitReloadAmmo)
-              obj.Inventory += x.start -> boxForInventory //block early; assumption warning: swappable ammo types have the same icon size
-              taskResolver ! stowFuncTask(x.start, boxForInventory)
+              taskResolver ! stowNewFunc(boxForInventory, x.start)
               fullMagazine
             })
             sendResponse(InventoryStateMessage(box.GUID, tool.GUID, box.Capacity)) //should work for both players and vehicles
@@ -7387,24 +6982,15 @@ class WorldSessionActor extends Actor
               //split previousBox into AmmoBox objects of appropriate max capacity, e.g., 100 9mm -> 2 x 50 9mm
               obj.Inventory.Fit(previousBox) match {
                 case Some(index) =>
-                  stowFunc(index, previousBox)
+                  stowFunc(previousBox, index)
                 case None =>
-                  NormalItemDrop(player, continent, continent.AvatarEvents)(previousBox)
+                  NormalItemDrop(player, continent)(previousBox)
               }
-              val dropFunc : (Equipment)=>TaskResolver.GiveTask = NewItemDrop(player, continent, continent.AvatarEvents)
               AmmoBox.Split(previousBox) match {
-                case Nil  | _ :: Nil => ; //done (the former case is technically not possible)
+                case Nil  | List(_) => ; //done (the former case is technically not possible)
                 case _ :: xs =>
                   modifyFunc(previousBox, 0) //update to changed capacity value
-                  xs.foreach(box => {
-                    obj.Inventory.Fit(box) match {
-                      case Some(index) =>
-                        obj.Inventory += index -> box //block early, for purposes of Fit
-                        taskResolver ! stowFuncTask(index, box)
-                      case None =>
-                        taskResolver ! dropFunc(box)
-                    }
-                  })
+                  xs.foreach(box => { taskResolver ! stowNewFunc(box, -1) })
               }
             }
             else {
@@ -7425,13 +7011,10 @@ class WorldSessionActor extends Actor
     *            curried for callback
     * @param zone the continent in which the item is being dropped;
     *             curried for callback
-    * @param service a reference to the event system that announces that the item has been dropped on the ground;
-    *                "AvatarService";
-    *                curried for callback
     * @param item the item
     */
-  def NormalItemDrop(obj : PlanetSideGameObject with Container, zone : Zone, service : ActorRef)(item : Equipment) : Unit = {
-    continent.Ground ! Zone.Ground.DropItem(item, obj.Position, Vector3.z(obj.Orientation.z))
+  def NormalItemDrop(obj : PlanetSideGameObject with Container, zone : Zone)(item : Equipment) : Unit = {
+    zone.Ground ! Zone.Ground.DropItem(item, obj.Position, Vector3.z(obj.Orientation.z))
   }
 
   /**
@@ -7441,16 +7024,13 @@ class WorldSessionActor extends Actor
     *            curried for callback
     * @param zone the continent in which the item is being dropped;
     *             curried for callback
-    * @param service a reference to the event system that announces that the item has been dropped on the ground;
-    *                "AvatarService";
-    *                curried for callback
     * @param item the item
     */
-  def NewItemDrop(obj : PlanetSideGameObject with Container, zone : Zone, service : ActorRef)(item : Equipment) : TaskResolver.GiveTask = {
+  def NewItemDrop(obj : PlanetSideGameObject with Container, zone : Zone)(item : Equipment) : TaskResolver.GiveTask = {
     TaskResolver.GiveTask(
       new Task() {
         private val localItem = item
-        private val localFunc : (Equipment)=>Unit = NormalItemDrop(obj, zone, service)
+        private val localFunc : (Equipment)=>Unit = NormalItemDrop(obj, zone)
 
         def Execute(resolver : ActorRef) : Unit = {
           localFunc(localItem)
@@ -7472,14 +7052,14 @@ class WorldSessionActor extends Actor
       FindEquipmentStock(player, FindToolThatUses(ammoType), 3, CountGrenades).reverse match { //do not search sidearm holsters
         case Nil =>
           log.info(s"no more $ammoType grenades")
-          taskResolver ! RemoveEquipmentFromSlot(player, tool, player.Find(tool).get)
+          RemoveOldEquipmentFromInventory(player, taskResolver)(tool)
 
         case x :: xs => //this is similar to ReloadMessage
           val box = x.obj.asInstanceOf[Tool]
           val tailReloadValue : Int = if(xs.isEmpty) { 0 } else { xs.map(_.obj.asInstanceOf[Tool].Magazine).reduce(_ + _) }
           val sumReloadValue : Int = box.Magazine + tailReloadValue
           val actualReloadValue = (if(sumReloadValue <= 3) {
-            taskResolver ! RemoveEquipmentFromSlot(player, x.obj, x.start)
+            RemoveOldEquipmentFromInventory(player, taskResolver)(x.obj)
             sumReloadValue
           }
           else {
@@ -7488,13 +7068,11 @@ class WorldSessionActor extends Actor
           })
           log.info(s"found $actualReloadValue more $ammoType grenades to throw")
           ModifyAmmunition(player)(tool.AmmoSlot.Box, -actualReloadValue) //grenade item already in holster (negative because empty)
-          xs.foreach(item => {
-            taskResolver ! RemoveEquipmentFromSlot(player, item.obj, item.start)
-          })
+          xs.foreach(item => { RemoveOldEquipmentFromInventory(player, taskResolver)(item.obj) })
       }
     }
     else if(tdef == GlobalDefinitions.phoenix) {
-      taskResolver ! RemoveEquipmentFromSlot(player, tool, player.Find(tool).get)
+      RemoveOldEquipmentFromInventory(player, taskResolver)(tool)
     }
   }
 
@@ -7570,14 +7148,14 @@ class WorldSessionActor extends Actor
         else if(vehicle.Definition == GlobalDefinitions.ant) {
           state match {
             case DriveState.Deployed =>
-              // We only want this WSA (not other player's WSA) to manage timers
+              // We only want this WorldSessionActor (not other player's WorldSessionActor) to manage timers
               if(vehicle.Seats(0).Occupant.contains(player)){
                 // Start ntu regeneration
                 // If vehicle sends UseItemMessage with silo as target NTU regeneration will be disabled and orb particles will be disabled
                 antChargingTick = context.system.scheduler.scheduleOnce(1000 milliseconds, self, NtuCharging(player, vehicle))
               }
             case DriveState.Undeploying =>
-              // We only want this WSA (not other player's WSA) to manage timers
+              // We only want this WorldSessionActor (not other player's WorldSessionActor) to manage timers
               if(vehicle.Seats(0).Occupant.contains(player)){
                 antChargingTick.cancel() // Stop charging NTU if charging
               }
@@ -7967,7 +7545,7 @@ class WorldSessionActor extends Actor
   /**
     * A part of the process of spawning the player into the game world.
     * The function should work regardless of whether the player is alive or dead - it will make them alive.
-    * It adds the `WSA`-current `Player` to the current zone and sends out the expected packets.<br>
+    * It adds the `WorldSessionActor`-current `Player` to the current zone and sends out the expected packets.<br>
     * <br>
     * If that player is in a vehicle, it will construct that vehicle.
     * If the player is the driver of the vehicle,
@@ -8325,14 +7903,12 @@ class WorldSessionActor extends Actor
       obj.Slot(4).Equipment match {
         case None => ;
         case Some(knife) =>
-          obj.Slot(4).Equipment = None
-          taskResolver ! RemoveEquipmentFromSlot(obj, knife, 4)
+          RemoveOldEquipmentFromInventory(obj, taskResolver)(knife)
       }
       obj.Slot(0).Equipment match {
         case Some(arms : Tool) =>
           if(GlobalDefinitions.isMaxArms(arms.Definition)) {
-            obj.Slot(0).Equipment = None
-            taskResolver ! RemoveEquipmentFromSlot(obj, arms, 0)
+            RemoveOldEquipmentFromInventory(obj, taskResolver)(arms)
           }
         case _ => ;
       }
@@ -8347,7 +7923,7 @@ class WorldSessionActor extends Actor
         }
       })
       val triggers = RemoveBoomerTriggersFromInventory()
-      triggers.foreach(trigger => { NormalItemDrop(obj, continent, continent.AvatarEvents)(trigger) })
+      triggers.foreach(trigger => { NormalItemDrop(obj, continent)(trigger) })
     }
   }
 
@@ -8834,7 +8410,7 @@ class WorldSessionActor extends Actor
       case obj : ComplexDeployable if obj.CanDamage => obj.Actor ! Vitality.Damage(func)
 
       case obj : SimpleDeployable if obj.CanDamage =>
-        //damage is synchronized on `LSA` (results returned to and distributed from this `WSA`)
+        //damage is synchronized on `LSA` (results returned to and distributed from this `WorldSessionActor`)
         continent.LocalEvents ! Vitality.DamageOn(obj, func)
       case _ => ;
     }
@@ -8868,52 +8444,10 @@ class WorldSessionActor extends Actor
   }
 
   /**
-    * Initialize the deployables backend information.
-    * @param avatar the player's core
-    */
-  def InitializeDeployableQuantities(avatar : Avatar) : Unit = {
-    log.info("Setting up combat engineering ...")
-    avatar.Deployables.Initialize(avatar.Certifications.toSet)
-  }
-
-  /**
-    * Initialize the UI elements for deployables.
-    * @param avatar the player's core
-    */
-  def InitializeDeployableUIElements(avatar : Avatar) : Unit = {
-    log.info("Setting up combat engineering UI ...")
-    UpdateDeployableUIElements(avatar.Deployables.UpdateUI())
-  }
-
-  /**
-    * The player learned a new certification.
-    * Update the deployables user interface elements if it was an "Engineering" certification.
-    * The certification "Advanced Hacking" also relates to an element.
-    * @param certification the certification that was added
-    * @param certificationSet all applicable certifications
-    */
-  def AddToDeployableQuantities(certification : CertificationType.Value, certificationSet : Set[CertificationType.Value]) : Unit = {
-    avatar.Deployables.AddToDeployableQuantities(certification, certificationSet)
-    UpdateDeployableUIElements(avatar.Deployables.UpdateUI(certification))
-  }
-
-  /**
-    * The player forgot a certification he previously knew.
-    * Update the deployables user interface elements if it was an "Engineering" certification.
-    * The certification "Advanced Hacking" also relates to an element.
-    * @param certification the certification that was added
-    * @param certificationSet all applicable certifications
-    */
-  def RemoveFromDeployablesQuantities(certification : CertificationType.Value, certificationSet : Set[CertificationType.Value]) : Unit = {
-    avatar.Deployables.RemoveFromDeployableQuantities(certification, certificationSet)
-    UpdateDeployableUIElements(avatar.Deployables.UpdateUI(certification))
-  }
-
-  /**
     * Initialize the deployables user interface elements.<br>
     * <br>
     * All element initializations require both the maximum deployable amount and the current deployables active counts.
-    * Until initialized, all elements will be RED 0/0 as if the cooresponding certification were not `learn`ed.
+    * Until initialized, all elements will be RED 0/0 as if the corresponding certification were not `learn`ed.
     * The respective element will become a pair of numbers, the second always being non-zero, when properly initialized.
     * The numbers will appear GREEN when more deployables of that type can be placed.
     * The numbers will appear RED if the player can not place any more of that type of deployable.
@@ -9141,10 +8675,9 @@ class WorldSessionActor extends Actor
     * @param index the slot index
     * @param pos where to drop the object in the game world
     */
-  def TryDropConstructionTool(tool : ConstructionItem, index : Int, pos : Vector3) : Unit = {
-    if(tool.Definition == GlobalDefinitions.advanced_ace &&
-      SafelyRemoveConstructionItemFromSlot(tool, index, "TryDropConstructionTool")) {
-      continent.Ground ! Zone.Ground.DropItem(tool, pos, Vector3.Zero)
+  def TryDropFDU(tool : ConstructionItem, index : Int, pos : Vector3) : Unit = {
+    if(tool.Definition == GlobalDefinitions.advanced_ace) {
+      DropEquipmentFromInventory(player, self)(tool, Some(pos))
     }
   }
 
@@ -9292,7 +8825,7 @@ class WorldSessionActor extends Actor
     match {
       case Some((parent, Some(slot))) =>
         obj.Position = Vector3.Zero
-        taskResolver ! RemoveEquipmentFromSlot(parent, obj, slot)
+        RemoveOldEquipmentFromInventory(parent, taskResolver)(obj)
         log.info(s"RequestDestroy: equipment $obj")
         true
 
@@ -9701,38 +9234,6 @@ class WorldSessionActor extends Actor
     Deployables.Disown(continent, avatar, self)
     drawDeloyableIcon = RedrawDeployableIcons //important for when SetCurrentAvatar initializes the UI next zone
     squadSetup = ZoneChangeSquadSetup
-  }
-
-  /**
-    * Primary functionality for tranferring a piece of equipment from a player's hands or his inventory to the ground.
-    * Items are always dropped at player's feet because for simplicity's sake
-    * because, by virtue of already standing there, the stability of the surface has been proven.
-    * The only exception to this is dropping items while falling.
-    * @see `Player.Find`<br>
-    *       `ObjectDetachMessage`
-    * @param item the `Equipment` object in the player's hand
-    * @param pos the game world coordinates where the object will be dropped
-    * @param orient a suggested orientation in which the object will settle when on the ground;
-    *               as indicated, the simulation is only concerned with certain angles
-    */
-  def PutItemOnGround(item : Equipment, pos : Vector3, orient : Vector3) : Unit = {
-    CancelZoningProcessWithDescriptiveReason("cancel_use")
-    //TODO delay or reverse dropping item when player is falling down
-    item.Position = pos
-    item.Orientation = Vector3.z(orient.z)
-    item.Faction = PlanetSideEmpire.NEUTRAL
-    //dropped items rotate towards the user's standing direction
-    val exclusionId = player.Find(item) match {
-      //if the item is in our hands ...
-      case Some(slotNum) =>
-        player.Slot(slotNum).Equipment = None
-        sendResponse(ObjectDetachMessage(player.GUID, item.GUID, pos, orient.z))
-        sendResponse(ActionResultMessage.Pass)
-        player.GUID //we're dropping the item; don't need to see it dropped again
-      case None =>
-        PlanetSideGUID(0) //item is being introduced into the world upon drop
-    }
-    continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.DropItem(exclusionId, item, continent))
   }
 
   /**

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -1297,12 +1297,11 @@ class WorldSessionActor extends Actor
           player.Zone = inZone
           setupAvatarFunc = AvatarDeploymentPassOver
           beginZoningSetCurrentAvatarFunc = SetCurrentAvatarUponDeployment
-          p.Release
-          inZone.Population ! Zone.Population.Release(avatar)
           if(p.VehicleSeated.isEmpty) {
             PrepareToTurnPlayerIntoCorpse(p, inZone)
           }
           else {
+            inZone.Population ! Zone.Population.Release(avatar)
             inZone.GUID(p.VehicleSeated) match {
               case Some(v : Vehicle) if v.Destroyed =>
                 v.Actor ! Vehicle.Deconstruct(
@@ -3970,13 +3969,13 @@ class WorldSessionActor extends Actor
       log.info(s"ReleaseAvatarRequest: ${player.GUID} on ${continent.Id} has released")
       reviveTimer.cancel
       GoToDeploymentMap()
-      continent.Population ! Zone.Population.Release(avatar)
       player.VehicleSeated match {
         case None =>
           PrepareToTurnPlayerIntoCorpse(player, continent)
 
         case Some(_) =>
           val player_guid = player.GUID
+          continent.Population ! Zone.Population.Release(avatar)
           sendResponse(ObjectDeleteMessage(player_guid, 0))
           GetMountableAndSeat(None, player) match {
             case (Some(obj), Some(seatNum)) =>
@@ -5228,7 +5227,6 @@ class WorldSessionActor extends Actor
               CancelZoningProcessWithDescriptiveReason("cancel_use")
               PlayerActionsToCancel()
               CancelAllProximityUnits()
-              continent.Population ! Zone.Population.Release(avatar)
               GoToDeploymentMap()
             case _ => ;
           }
@@ -7629,7 +7627,7 @@ class WorldSessionActor extends Actor
     * @param obj the player to be turned into a corpse
     */
   def FriskDeadBody(obj : Player) : Unit = {
-    if(obj.isBackpack) {
+    if(!obj.isAlive) {
       obj.Slot(4).Equipment match {
         case None => ;
         case Some(knife) =>
@@ -7675,13 +7673,15 @@ class WorldSessionActor extends Actor
   def PrepareToTurnPlayerIntoCorpse(tplayer : Player, zone : Zone) : Unit = {
     FriskDeadBody(tplayer)
     if(!WellLootedDeadBody(tplayer)) {
-      TurnPlayerIntoCorpse(tplayer)
+      tplayer.Release
       zone.Population ! Zone.Corpse.Add(tplayer)
+      TurnPlayerIntoCorpse(tplayer)
       zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.Release(tplayer, zone))
     }
     else {
       //no items in inventory; leave no corpse
       val pguid = tplayer.GUID
+      zone.Population ! Zone.Population.Release(avatar)
       sendResponse(ObjectDeleteMessage(pguid, 0))
       zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.ObjectDelete(pguid, pguid, 0))
       taskResolver ! GUIDTask.UnregisterPlayer(tplayer)(zone.GUID)
@@ -7708,7 +7708,7 @@ class WorldSessionActor extends Actor
     *        `false`, otherwise
     */
   def WellLootedDeadBody(obj : Player) : Boolean = {
-    obj.isBackpack && obj.Holsters().count(_.Equipment.nonEmpty) == 0 && obj.Inventory.Size == 0
+    !obj.isAlive && obj.Holsters().count(_.Equipment.nonEmpty) == 0 && obj.Inventory.Size == 0
   }
 
   /**
@@ -7718,7 +7718,7 @@ class WorldSessionActor extends Actor
     *        `false`, otherwise
     */
   def TryDisposeOfLootedCorpse(obj : Player) : Boolean = {
-    if(WellLootedDeadBody(obj)) {
+    if(obj.isBackpack && WellLootedDeadBody(obj)) {
       continent.AvatarEvents ! AvatarServiceMessage.Corpse(RemoverActor.HurrySpecific(List(obj), continent))
       true
     }
@@ -8699,7 +8699,7 @@ class WorldSessionActor extends Actor
         case Some(vehicle : Vehicle) => //driver or passenger in vehicle using a warp gate, or a droppod
           LoadZoneInVehicle(vehicle, pos, ori, zone_id)
 
-        case _ if player.HasGUID => //player is deconstructing self
+        case _ if player.HasGUID => //player is deconstructing self or instant action
           val player_guid = player.GUID
           sendResponse(ObjectDeleteMessage(player_guid, 4))
           continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.ObjectDelete(player_guid, player_guid, 4))
@@ -9804,8 +9804,7 @@ class WorldSessionActor extends Actor
     * @see `Player.Release`
     */
   def GoToDeploymentMap() : Unit = {
-    player.Release
-    deadState = DeadState.Release
+    deadState = DeadState.Release //we may be alive or dead, may or may not be a corpse
     sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, player.Position, player.Faction, true))
     DrawCurrentAmsSpawnPoint()
   }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -4870,7 +4870,7 @@ class WorldSessionActor extends Actor
 
     case msg@MoveItemMessage(item_guid, source_guid, destination_guid, dest, _) =>
       log.info(s"MoveItem: $msg")
-      (continent.GUID(source_guid), continent.GUID(destination_guid), continent.GUID(item_guid)) match {
+      (continent.GUID(source_guid), continent.GUID(destination_guid), ValidObject(item_guid)) match {
         case (Some(source : PlanetSideServerObject with Container), Some(destination : PlanetSideServerObject with Container), Some(item : Equipment)) =>
           source.Actor ! Containable.MoveItem(destination, item, dest)
         case (None, _, _) =>
@@ -4885,7 +4885,7 @@ class WorldSessionActor extends Actor
 
     case msg@LootItemMessage(item_guid, target_guid) =>
       log.info(s"LootItem: $msg")
-      (ValidObject(item_guid), ValidObject(target_guid)) match {
+      (ValidObject(item_guid), continent.GUID(target_guid)) match {
         case (Some(item : Equipment), Some(destination : PlanetSideServerObject with Container)) =>
           //figure out the source
           ( {

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -30,9 +30,10 @@ import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
 import net.psforever.objects.inventory.{Container, GridInventory, InventoryItem}
 import net.psforever.objects.loadouts.{InfantryLoadout, Loadout, SquadLoadout, VehicleLoadout}
-import net.psforever.objects.serverobject.{CommonMessages, Containable, PlanetSideServerObject}
+import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.serverobject.damage.Damageable
+import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
 import net.psforever.objects.serverobject.deploy.Deployment
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.serverobject.generator.Generator

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -28,7 +28,7 @@ import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.guid.{GUIDTask, Task, TaskResolver}
 import net.psforever.objects.inventory.{Container, GridInventory, InventoryItem}
 import net.psforever.objects.loadouts.{InfantryLoadout, Loadout, SquadLoadout, VehicleLoadout}
-import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
+import net.psforever.objects.serverobject.{CommonMessages, Containable, PlanetSideServerObject}
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.serverobject.deploy.Deployment
@@ -5152,49 +5152,51 @@ class WorldSessionActor extends Actor
     case msg@MoveItemMessage(item_guid, source_guid, destination_guid, dest, _) =>
       log.info(s"MoveItem: $msg")
       (continent.GUID(source_guid), continent.GUID(destination_guid), continent.GUID(item_guid)) match {
-        case (Some(source : Container), Some(destination : Container), Some(item : Equipment)) =>
-          source.Find(item_guid) match {
-            case Some(index) =>
-              val indexSlot = source.Slot(index)
-              val tile = item.Definition.Tile
-              val destinationCollisionTest = destination.Collisions(dest, tile.Width, tile.Height)
-              val destItemEntry = destinationCollisionTest match {
-                case Success(entry :: Nil) =>
-                  Some(entry)
-                case _ =>
-                  None
-              }
-              if( {
-                destinationCollisionTest match {
-                  case Success(Nil) | Success(_ :: Nil) =>
-                    true //no item or one item to swap
-                  case _ =>
-                    false //abort when too many items at destination or other failure case
-                }
-              } && indexSlot.Equipment.contains(item)) {
-                if(PermitEquipmentStow(item, destination)) {
-                  StartBundlingPackets()
-                  PerformMoveItem(item, source, index, destination, dest, destItemEntry)
-                  StopBundlingPackets()
-                }
-                else {
-                  log.error(s"MoveItem: $item disallowed storage in $destination")
-                }
-              }
-              else if(!indexSlot.Equipment.contains(item)) {
-                log.error(s"MoveItem: wanted to move $item_guid, but found unexpected ${indexSlot.Equipment} at source location")
-              }
-              else {
-                destinationCollisionTest match {
-                  case Success(_) =>
-                    log.error(s"MoveItem: wanted to move $item_guid, but multiple unexpected items at destination blocked progress")
-                  case scala.util.Failure(err) =>
-                    log.error(s"MoveItem: wanted to move $item_guid, but $err")
-                }
-              }
-            case _ =>
-              log.error(s"MoveItem: wanted to move $item_guid, but could not find it")
-          }
+        case (Some(source : PlanetSideServerObject with Container), Some(destination : PlanetSideServerObject with Container), Some(item : Equipment)) =>
+          destination.Actor ! Containable.MoveItem(source, item, dest)
+//          source.Find(item_guid) match {
+//            case Some(index) =>
+//              destination.Actor ! Containable.MoveItem(source, item, index)
+//              val indexSlot = source.Slot(index)
+//              val tile = item.Definition.Tile
+//              val destinationCollisionTest = destination.Collisions(dest, tile.Width, tile.Height)
+//              val destItemEntry = destinationCollisionTest match {
+//                case Success(entry :: Nil) =>
+//                  Some(entry)
+//                case _ =>
+//                  None
+//              }
+//              if( {
+//                destinationCollisionTest match {
+//                  case Success(Nil) | Success(_ :: Nil) =>
+//                    true //no item or one item to swap
+//                  case _ =>
+//                    false //abort when too many items at destination or other failure case
+//                }
+//              } && indexSlot.Equipment.contains(item)) {
+//                if(PermitEquipmentStow(item, destination)) {
+//                  StartBundlingPackets()
+//                  PerformMoveItem(item, source, index, destination, dest, destItemEntry)
+//                  StopBundlingPackets()
+//                }
+//                else {
+//                  log.error(s"MoveItem: $item disallowed storage in $destination")
+//                }
+//              }
+//              else if(!indexSlot.Equipment.contains(item)) {
+//                log.error(s"MoveItem: wanted to move $item_guid, but found unexpected ${indexSlot.Equipment} at source location")
+//              }
+//              else {
+//                destinationCollisionTest match {
+//                  case Success(_) =>
+//                    log.error(s"MoveItem: wanted to move $item_guid, but multiple unexpected items at destination blocked progress")
+//                  case scala.util.Failure(err) =>
+//                    log.error(s"MoveItem: wanted to move $item_guid, but $err")
+//                }
+//              }
+//            case _ =>
+//              log.error(s"MoveItem: wanted to move $item_guid, but could not find it")
+//          }
         case (None, _, _) =>
           log.error(s"MoveItem: wanted to move $item_guid from $source_guid, but could not find source object")
         case (_, None, _) =>

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -111,17 +111,8 @@ class WorldSessionActor extends Actor
   //keep track of avatar's ServerVehicleOverride state
   var traveler : Traveler = null
   var deadState : DeadState.Value = DeadState.Dead
-  var whenUsedLastAAMAX : Long = 0
-  var whenUsedLastAIMAX : Long = 0
-  var whenUsedLastAVMAX : Long = 0
-  var whenUsedLastMAX : Array[Long] = Array.fill[Long](4)(0L)
   var whenUsedLastMAXName : Array[String] = Array.fill[String](4)("")
-  var whenUsedLastItem : Array[Long] = Array.fill[Long](1020)(0L)
-  var whenUsedLastItemName : Array[String] = Array.fill[String](1020)("")
-  var whenUsedLastKit : Long = 0
-  var whenUsedLastSMKit : Long = 0
-  var whenUsedLastSAKit : Long = 0
-  var whenUsedLastSSKit : Long = 0
+  val objectTypeNameReference : LongMap[String] = new LongMap[String]()
   val projectiles : Array[Option[Projectile]] = Array.fill[Option[Projectile]](Projectile.RangeUID - Projectile.BaseUID)(None)
   val projectilesToCleanUp : Array[Boolean] = Array.fill[Boolean](Projectile.RangeUID - Projectile.BaseUID)(false)
   var drawDeloyableIcon : PlanetSideGameObject with Deployable => Unit = RedrawDeployableIcons
@@ -1939,11 +1930,21 @@ class WorldSessionActor extends Actor
         sendResponse(ItemTransactionResultMessage(terminal_guid, action, result))
         lastTerminalOrderFulfillment = true
 
-      case AvatarResponse.ChangeExosuit(target, exosuit, subtype, slot, maxhand, holsters, inventory, dropOrDelete) =>
+      case AvatarResponse.ChangeExosuit(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drop, delete) =>
+        StartBundlingPackets()
         sendResponse(ArmorChangedMessage(target, exosuit, subtype))
         sendResponse(PlanetsideAttributeMessage(target, 4, player.Armor))
         if(tplayer_guid == target) {
+          //happening to this player
+          if(exosuit == ExoSuitType.MAX) {
+            sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastMAXName(subtype), 300, true))
+          }
+          //cleanup
           sendResponse(ObjectHeldMessage(target, Player.HandsDownSlot, false))
+          (old_holsters ++ old_inventory ++ delete).foreach { case (_, guid) => sendResponse(ObjectDeleteMessage(guid, 0)) }
+          //functionally delete
+          delete.foreach { case (obj, _) => taskResolver ! GUIDTask.UnregisterEquipment(obj)(continent.GUID) }
+          //redraw
           if(maxhand) {
             taskResolver ! HoldNewEquipmentUp(player, taskResolver)(Tool(GlobalDefinitions.MAXArms(subtype, player.Faction)), 0)
           }
@@ -1973,10 +1974,13 @@ class WorldSessionActor extends Actor
               )
             )
           }
-          DropOrDeleteLeftovers(player, taskResolver)(dropOrDelete)
+          DropLeftovers(player)(drop)
         }
         else {
+          //happening to some other player
           sendResponse(ObjectHeldMessage(target, slot, false))
+          //cleanup
+          (old_holsters ++ delete).foreach { case (_, guid) => sendResponse(ObjectDeleteMessage(guid, 0)) }
           //draw holsters
           holsters.foreach { case InventoryItem(obj, index) =>
             val definition = obj.Definition
@@ -1990,26 +1994,81 @@ class WorldSessionActor extends Actor
             )
           }
         }
+        StopBundlingPackets()
 
-      case AvatarResponse.ChangeLoadout(target, exosuit, subtype, slot, maxhand, holsters, inventory, dropOrDelete) =>
+      case AvatarResponse.ChangeLoadout(target, exosuit, subtype, slot, maxhand, old_holsters, holsters, old_inventory, inventory, drops) =>
+        StartBundlingPackets()
         sendResponse(ArmorChangedMessage(target, exosuit, subtype))
         sendResponse(PlanetsideAttributeMessage(target, 4, player.Armor))
         if(tplayer_guid == target) {
+          //happening to this player
+          if(exosuit == ExoSuitType.MAX) {
+            sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastMAXName(subtype), 300, true))
+          }
           sendResponse(ObjectHeldMessage(target, Player.HandsDownSlot, false))
+          //cleanup
+          (old_holsters ++ old_inventory).foreach { case (obj, guid) =>
+            sendResponse(ObjectDeleteMessage(guid, 0))
+            taskResolver ! GUIDTask.UnregisterEquipment(obj)(continent.GUID)
+          }
+          //redraw
           if(maxhand) {
             taskResolver ! HoldNewEquipmentUp(player, taskResolver)(Tool(GlobalDefinitions.MAXArms(subtype, player.Faction)), 0)
           }
-          //depiction of holsters and inventory is handled by callbacks
-          val loadoutEquipmentFunc : (Equipment, Int)=>TaskResolver.GiveTask = PutLoadoutEquipmentInInventory(player, taskResolver)
-          (holsters ++ inventory).foreach { case InventoryItem(obj, slot) => taskResolver ! loadoutEquipmentFunc(obj, slot) }
-          DropOrDeleteLeftovers(player, taskResolver)(dropOrDelete)
+          ApplyPurchaseTimersBeforePackingLoadout(player, player, holsters ++ inventory)
+          DropLeftovers(player)(drops)
         }
         else {
+          //happening to some other player
           sendResponse(ObjectHeldMessage(target, slot, false))
-          //holster depiction is handled by callbacks
+          //cleanup
+          old_holsters.foreach { case (_, guid) => sendResponse(ObjectDeleteMessage(guid, 0)) }
+          //redraw handled by callback
         }
+        StopBundlingPackets()
 
       case _ => ;
+    }
+  }
+
+  /**
+    * Enforce constraints on bulk purchases as determined by a given player's previous purchase times and hard acquisition delays.
+    * Intended to assist in sanitizing loadout information from the perspectvie of the player, or target owner.
+    * The equipment is expected to be unregistered and already fitted to their ultimate slot in the target container.
+    * @see `AvatarVehicleTimerMessage`
+    * @see `Container`
+    * @see `delayedPurchaseEntries`
+    * @see `InventoryItem`
+    * @see `objectTypeNameReference`
+    * @see `Player.GetLastUsedTime`
+    * @see `Player.SetLastUsedTime`
+    * @see `TaskResolver.GiveTask`
+    * @see `WorldSession.PutLoadoutEquipmentInInventory`
+    * @param player the player whose purchasing constraints are to be tested
+    * @param target the location in which the equipment will be stowed
+    * @param slots the equipment, in the standard object-slot format container
+    */
+  def ApplyPurchaseTimersBeforePackingLoadout(player : Player, target : PlanetSideServerObject with Container, slots : List[InventoryItem]) : Unit = {
+    //depiction of packed equipment is handled through callbacks
+    val loadoutEquipmentFunc : (Equipment, Int)=>TaskResolver.GiveTask = PutLoadoutEquipmentInInventory(target, taskResolver)
+    val time = System.currentTimeMillis
+    slots.collect { case InventoryItem(obj, slot)
+      if {
+        val id = obj.Definition.ObjectId
+        val lastUse = player.GetLastPurchaseTime(id)
+        val delay = delayedPurchaseEntries.getOrElse(id, 0L)
+        time - lastUse > delay
+      } =>
+      val definition = obj.Definition
+      val id = definition.ObjectId
+      player.SetLastPurchaseTime(id, time)
+      objectTypeNameReference += id.toLong -> definition.Name //may need to set Descriptor to be purchase name instead
+      delayedPurchaseEntries.get(id) match {
+        case Some(delay) =>
+          sendResponse(AvatarVehicleTimerMessage(player.GUID, definition.Name, delay / 1000, true))
+        case _ => ;
+      }
+      taskResolver ! loadoutEquipmentFunc(obj, slot)
     }
   }
 
@@ -2425,12 +2484,26 @@ class WorldSessionActor extends Actor
   def HandleTerminalMessage(tplayer : Player, msg : ItemTransactionMessage, order : Terminal.Exchange) : Unit = {
     order match {
       case Terminal.BuyEquipment(item) =>
-        taskResolver ! BuyNewEquipmentPutInInventory(
-          continent.GUID(tplayer.VehicleSeated) match { case Some(v : Vehicle) => v; case _ => player },
-          taskResolver,
-          tplayer,
-          msg.terminal_guid
-        )(item)
+        val itemid = item.Definition.ObjectId
+        val time = System.currentTimeMillis
+        if(delayedPurchaseEntries.get(itemid) match {
+          case Some(delay) if time - tplayer.GetLastPurchaseTime(itemid) > delay =>
+            player.SetLastPurchaseTime(itemid, time)
+            objectTypeNameReference += itemid.toLong -> msg.item_name
+            sendResponse(AvatarVehicleTimerMessage(tplayer.GUID, msg.item_name, delay / 1000, true))
+            true
+          case Some(_) =>
+            false
+          case _ => ;
+            true
+        }) {
+          taskResolver ! BuyNewEquipmentPutInInventory(
+            continent.GUID(tplayer.VehicleSeated) match { case Some(v : Vehicle) => v; case _ => player },
+            taskResolver,
+            tplayer,
+            msg.terminal_guid
+          )(item)
+        }
 
       case Terminal.SellEquipment() =>
         SellEquipmentFromInventory(tplayer, taskResolver, tplayer, msg.terminal_guid)(Player.FreeHandSlot)
@@ -2565,11 +2638,19 @@ class WorldSessionActor extends Actor
       case Terminal.BuyVehicle(vehicle, weapons, trunk) =>
         continent.Map.TerminalToSpawnPad.get(msg.terminal_guid.guid) match {
           case Some(pad_guid) =>
-            val lTime = System.currentTimeMillis
-            if(lTime - whenUsedLastItem(vehicle.Definition.ObjectId) > 300000) {
-              whenUsedLastItem(vehicle.Definition.ObjectId) = lTime
-              whenUsedLastItemName(vehicle.Definition.ObjectId) = msg.item_name
-              sendResponse(AvatarVehicleTimerMessage(tplayer.GUID, msg.item_name, 300, true))
+            val vid = vehicle.Definition.ObjectId
+            val time = System.currentTimeMillis
+            if(delayedPurchaseEntries.get(vid) match {
+              case Some(delay) if time - tplayer.GetLastPurchaseTime(vid) > delay =>
+                tplayer.SetLastPurchaseTime(vid, time)
+                objectTypeNameReference += vid.toLong -> msg.item_name
+                sendResponse(AvatarVehicleTimerMessage(tplayer.GUID, msg.item_name, delay / 1000, true))
+                true
+              case Some(_) =>
+                false
+              case None => ;
+                true
+            }) {
               val toFaction = tplayer.Faction
               val pad = continent.GUID(pad_guid).get.asInstanceOf[VehicleSpawnPad]
               vehicle.Faction = toFaction
@@ -2834,13 +2915,14 @@ class WorldSessionActor extends Actor
         //TODO when vehicle weapons can be changed without visual glitches, rewrite this
         continent.GUID(target) match {
           case Some(vehicle : Vehicle) =>
+            StartBundlingPackets()
             if(player.VehicleOwned.contains(target)) {
               //owner: must unregister old equipment, and register and install new equipment
               (old_weapons ++ old_inventory).foreach { case (obj, guid) =>
+                sendResponse(ObjectDeleteMessage(guid, 0))
                 taskResolver ! GUIDTask.UnregisterEquipment(obj)(continent.GUID)
               }
-              val stowEquipment : (Equipment,Int) => TaskResolver.GiveTask = PutLoadoutEquipmentInInventory(vehicle, taskResolver)
-              (added_weapons ++ new_inventory).foreach { case InventoryItem(obj, slot) => taskResolver ! stowEquipment(obj, slot) }
+              ApplyPurchaseTimersBeforePackingLoadout(player, vehicle, added_weapons ++ new_inventory)
             }
             else if(accessedContainer.contains(target)) {
               //external participant: observe changes to equipment
@@ -2855,6 +2937,7 @@ class WorldSessionActor extends Actor
                 //observer: observe changes to external equipment
                 old_weapons.foreach { case (_, guid) => sendResponse(ObjectDeleteMessage(guid, 0)) }
             }
+            StopBundlingPackets()
           case _ => ;
         }
 
@@ -3431,9 +3514,10 @@ class WorldSessionActor extends Actor
                       log.info(s"CharacterRequest/Select: character $lName found in records")
                       avatar = new Avatar(charId, lName, lFaction, lGender, lHead, lVoice)
                       var faction : String = lFaction.toString.toLowerCase
-                      whenUsedLastMAXName(2) = faction + "hev_antipersonnel"
-                      whenUsedLastMAXName(3) = faction + "hev_antivehicular"
-                      whenUsedLastMAXName(1) = faction + "hev_antiaircraft"
+                      whenUsedLastMAXName(0) = faction + "hev"
+                      whenUsedLastMAXName(1) = faction + "hev_antipersonnel"
+                      whenUsedLastMAXName(2) = faction + "hev_antivehicular"
+                      whenUsedLastMAXName(3) = faction + "hev_antiaircraft"
                       avatar.FirstTimeEvents = ftes
                       accountPersistence ! AccountPersistenceService.Login(lName)
                     case _ =>
@@ -4959,88 +5043,86 @@ class WorldSessionActor extends Actor
           else if(!unk3 && player.isAlive) { //potential kit use
             ValidObject(item_used_guid) match {
               case Some(kit : Kit) =>
-                player.Find(kit) match {
-                  case Some(index) =>
-                    if(kit.Definition == GlobalDefinitions.medkit) {
-                      if(player.Health == player.MaxHealth) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "@HealComplete", None))
-                      }
-                      else if(System.currentTimeMillis - whenUsedLastKit < 5000) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${5 - (System.currentTimeMillis - whenUsedLastKit) / 1000}~", None))
-                      }
-                      else {
-                        whenUsedLastKit = System.currentTimeMillis
-                        player.Slot(index).Equipment = None //remove from slot immediately; must exist on client for next packet
-                        sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, 0, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
-                        sendResponse(ObjectDeleteMessage(kit.GUID, 0))
-                        taskResolver ! GUIDTask.UnregisterEquipment(kit)(continent.GUID)
-                        player.History(HealFromKit(PlayerSource(player), 25, kit.Definition))
-                        player.Health = player.Health + 25
-                        sendResponse(PlanetsideAttributeMessage(avatar_guid, 0, player.Health))
-                        continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 0, player.Health))
-                      }
-                    }
-                    else if(kit.Definition == GlobalDefinitions.super_medkit) {
-                      if(player.Health == player.MaxHealth) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "@HealComplete", None))
-                      }
-                      else if(System.currentTimeMillis - whenUsedLastSMKit < 1200000) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${1200 - (System.currentTimeMillis - whenUsedLastSMKit) / 1000}~", None))
-                      }
-                      else {
-                        whenUsedLastSMKit = System.currentTimeMillis
-                        player.Slot(index).Equipment = None //remove from slot immediately; must exist on client for next packet
-                        sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, 0, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
-                        sendResponse(ObjectDeleteMessage(kit.GUID, 0))
-                        taskResolver ! GUIDTask.UnregisterEquipment(kit)(continent.GUID)
-                        player.History(HealFromKit(PlayerSource(player), 100, kit.Definition))
-                        player.Health = player.Health + 100
-                        sendResponse(PlanetsideAttributeMessage(avatar_guid, 0, player.Health))
-                        continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 0, player.Health))
-                      }
-                    }
-                    else if(kit.Definition == GlobalDefinitions.super_armorkit) {
-                      if(player.Armor == player.MaxArmor) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "Armor at maximum - No repairing required.", None))
-                      }
-                      else if(System.currentTimeMillis - whenUsedLastSAKit < 1200000) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${1200 - (System.currentTimeMillis - whenUsedLastSAKit) / 1000}~", None))
-                      }
-                      else {
-                        whenUsedLastSAKit = System.currentTimeMillis
-                        player.Slot(index).Equipment = None //remove from slot immediately; must exist on client for next packet
-                        sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, 0, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
-                        sendResponse(ObjectDeleteMessage(kit.GUID, 0))
-                        taskResolver ! GUIDTask.UnregisterEquipment(kit)(continent.GUID)
-                        player.History(RepairFromKit(PlayerSource(player), 200, kit.Definition))
-                        player.Armor = player.Armor + 200
-                        sendResponse(PlanetsideAttributeMessage(avatar_guid, 4, player.Armor))
-                        continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 4, player.Armor))
-                      }
-                    }
-                    else if(kit.Definition == GlobalDefinitions.super_staminakit) {
-                      if(player.Stamina == player.MaxStamina) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "Stamina at maximum - No recharge required.", None))
-                      }
-                      else if(System.currentTimeMillis - whenUsedLastSSKit < 1200000) {
-                        sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${300 - (System.currentTimeMillis - whenUsedLastSSKit) / 1200}~", None))
-                      }
-                      else {
-                        whenUsedLastSSKit = System.currentTimeMillis
-                        player.Slot(index).Equipment = None //remove from slot immediately; must exist on client for next packet
-                        sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, 0, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
-                        sendResponse(ObjectDeleteMessage(kit.GUID, 0))
-                        taskResolver ! GUIDTask.UnregisterEquipment(kit)(continent.GUID)
-                        player.Stamina = player.Stamina + 100
-                      }
-                    }
-                    else {
-                      log.warn(s"UseItem: $kit behavior not supported")
-                    }
-
-                  case None =>
-                    log.error(s"UseItem: anticipated a $kit, but can't find it")
+                val kid = kit.Definition.ObjectId
+                val time = System.currentTimeMillis
+                val lastUse = player.GetLastUsedTime(kid)
+                val delay = delayedGratificationEntries.getOrElse(kid, 0L)
+                if((time - lastUse) < delay) {
+                  sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${((delay / 1000) - math.ceil((time - lastUse) / 1000))}~", None))
                 }
+                else {
+                  val indexOpt = player.Find(kit)
+                  val kitIsUsed = indexOpt match {
+                    case Some(index) =>
+                      if(kit.Definition == GlobalDefinitions.medkit) {
+                        if(player.Health == player.MaxHealth) {
+                          sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "@HealComplete", None))
+                          false
+                        }
+                        else {
+                          player.History(HealFromKit(PlayerSource(player), 25, kit.Definition))
+                          player.Health = player.Health + 25
+                          sendResponse(PlanetsideAttributeMessage(avatar_guid, 0, player.Health))
+                          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 0, player.Health))
+                          true
+                        }
+                      }
+                      else if(kit.Definition == GlobalDefinitions.super_medkit) {
+                        if(player.Health == player.MaxHealth) {
+                          sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "@HealComplete", None))
+                          false
+                        }
+                        else {
+                          player.History(HealFromKit(PlayerSource(player), 100, kit.Definition))
+                          player.Health = player.Health + 100
+                          sendResponse(PlanetsideAttributeMessage(avatar_guid, 0, player.Health))
+                          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 0, player.Health))
+                          true
+                        }
+                      }
+                      else if(kit.Definition == GlobalDefinitions.super_armorkit) {
+                        if(player.Armor == player.MaxArmor) {
+                          sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "Armor at maximum - No repairing required.", None))
+                          false
+                        }
+                        else {
+                          player.History(RepairFromKit(PlayerSource(player), 200, kit.Definition))
+                          player.Armor = player.Armor + 200
+                          sendResponse(PlanetsideAttributeMessage(avatar_guid, 4, player.Armor))
+                          continent.AvatarEvents ! AvatarServiceMessage(continent.Id, AvatarAction.PlanetsideAttribute(avatar_guid, 4, player.Armor))
+                          true
+                        }
+                      }
+                      else if(kit.Definition == GlobalDefinitions.super_staminakit) {
+                        if(player.Stamina == player.MaxStamina) {
+                          sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", "Stamina at maximum - No recharge required.", None))
+                          false
+                        }
+                        else {
+                          player.Stamina = player.Stamina + 100
+                          sendResponse(PlanetsideAttributeMessage(avatar_guid, 2, player.Stamina))
+                          true
+                        }
+                      }
+                      else {
+                        log.warn(s"UseItem: $kit behavior not supported")
+                        false
+                      }
+
+                    case None =>
+                      log.error(s"UseItem: anticipated a $kit, but can't find it")
+                      false
+                  }
+                  if(kitIsUsed) {
+                    //kit was found belonging to player and was used
+                    player.SetLastUsedTime(kid, time)
+                    player.Slot(indexOpt.get).Equipment = None //remove from slot immediately; must exist on client for next packet
+                    sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, 0, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
+                    sendResponse(ObjectDeleteMessage(kit.GUID, 0))
+                    taskResolver ! GUIDTask.UnregisterEquipment(kit)(continent.GUID)
+                  }
+                }
+
               case Some(item) =>
                 log.warn(s"UseItem: looking for Kit to use, but found $item instead")
               case None =>
@@ -7246,7 +7328,7 @@ class WorldSessionActor extends Actor
     * @see `GetKnownVehicleAndSeat`
     * @see `LoadZoneTransferPassengerMessages`
     * @see `Player.Spawn`
-    * @see `ReloadUsedLastCoolDownTimes`
+    * @see `ReloadItemCoolDownTimes`
     * @see `Vehicles.Own`
     * @see `Vehicles.ReloadAccessPermissions`
     */
@@ -7333,19 +7415,7 @@ class WorldSessionActor extends Actor
     continent.Population ! Zone.Population.Spawn(avatar, player)
     //cautious redundancy
     deadState = DeadState.Alive
-    ReloadUsedLastCoolDownTimes()
-
-    val lTime = System.currentTimeMillis // PTS v3
-    for (i <- 0 to whenUsedLastItem.length-1) {
-      if (lTime - whenUsedLastItem(i) < 300000) {
-        sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastItemName(i), 300 - ((lTime - whenUsedLastItem(i)) / 1000 toInt), true))
-      }
-    }
-    for (i <- 1 to 3) {
-      if (lTime - whenUsedLastMAX(i) < 300000) {
-        sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastMAXName(i), 300 - ((lTime - whenUsedLastMAX(i)) / 1000 toInt), true))
-      }
-    }
+    ReloadItemCoolDownTimes()
   }
 
   /**
@@ -7478,7 +7548,7 @@ class WorldSessionActor extends Actor
     * @see `ObjectAttachMessage`
     * @see `ObjectCreateMessage`
     * @see `PlayerInfo.LoginInfo`
-    * @see `ReloadUsedLastCoolDownTimes`
+    * @see `ReloadItemCoolDownTimes`
     * @see `UpdateWeaponAtSeatPosition`
     * @see `Vehicles.ReloadAccessPermissions`
     */
@@ -7525,7 +7595,7 @@ class WorldSessionActor extends Actor
     }
     //cautious redundancy
     deadState = DeadState.Alive
-    ReloadUsedLastCoolDownTimes()
+    ReloadItemCoolDownTimes()
     setupAvatarFunc = AvatarCreate
   }
 
@@ -7537,10 +7607,10 @@ class WorldSessionActor extends Actor
     * and this routine's normal operation when it revisits the same code.
     * @see `avatarSetupFunc`
     * @see `AvatarCreate`
-    * @see `ReloadUsedLastCoolDownTimes`
+    * @see `ReloadItemCoolDownTimes`
     */
   def AvatarDeploymentPassOver() : Unit = {
-    ReloadUsedLastCoolDownTimes()
+    ReloadItemCoolDownTimes()
     setupAvatarFunc = AvatarCreate
   }
 
@@ -7549,16 +7619,31 @@ class WorldSessionActor extends Actor
     * This is called "skill".
     * @see `AvatarVehicleTimerMessage`
     */
-  def ReloadUsedLastCoolDownTimes() : Unit = {
-    val lTime = System.currentTimeMillis
-    for (i <- 0 to whenUsedLastItem.length-1) {
-      if (lTime - whenUsedLastItem(i) < 300000) {
-        sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastItemName(i), 300 - ((lTime - whenUsedLastItem(i)) / 1000 toInt), true))
+  def ReloadItemCoolDownTimes() : Unit = {
+    val time = System.currentTimeMillis
+    //purchases
+    val lastPurchases = avatar.GetAllLastPurchaseTimes
+    delayedPurchaseEntries.collect { case (id, delay) if lastPurchases.contains(id) =>
+      val lastTime = lastPurchases.getOrElse(id, 0L)
+      val delay = delayedPurchaseEntries(id.toInt)
+      if (time - lastTime < delay) {
+        sendResponse(AvatarVehicleTimerMessage(player.GUID, objectTypeNameReference.getOrElse(id, ""), ((delay - (time - lastTime)) / 1000) toInt, true))
       }
     }
-    for (i <- 1 to 3) {
-      if (lTime - whenUsedLastMAX(i) < 300000) {
-        sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastMAXName(i), 300 - ((lTime - whenUsedLastMAX(i)) / 1000 toInt), true))
+    //uses
+    val lastUses = avatar.GetAllLastUsedTimes
+    delayedGratificationEntries.collect { case (id, delay) if lastUses.contains(id) =>
+      val lastTime = lastUses.getOrElse(id, 0L)
+      val delay = delayedGratificationEntries(id.toInt)
+      if (time - lastTime < delay) {
+        sendResponse(AvatarVehicleTimerMessage(player.GUID, objectTypeNameReference.getOrElse(id, ""), ((delay - (time - lastTime)) / 1000) toInt, true))
+      }
+    }
+    //max exo-suits (specifically)
+    (1 to 3).foreach { subtype =>
+      val maxTime = player.GetLastUsedTime(ExoSuitType.MAX, subtype)
+      if (maxTime > 0 && time - maxTime < 300000) { //5min
+        sendResponse(AvatarVehicleTimerMessage(player.GUID, whenUsedLastMAXName(subtype), 300 - ((time - maxTime) / 1000 toInt), true))
       }
     }
   }
@@ -10191,6 +10276,57 @@ class WorldSessionActor extends Actor
 }
 
 object WorldSessionActor {
+  /** Object purchasing cooldowns.<br>
+    * key - object id<br>
+    * value - time last used (ms)
+    * */
+  val delayedPurchaseEntries : Map[Int, Long] = Map(
+    GlobalDefinitions.ams.ObjectId -> 300000, //5min
+    GlobalDefinitions.ant.ObjectId -> 300000, //5min
+    GlobalDefinitions.apc_nc.ObjectId -> 300000, //5min
+    GlobalDefinitions.apc_tr.ObjectId -> 300000, //5min
+    GlobalDefinitions.apc_vs.ObjectId -> 300000, //5min
+    GlobalDefinitions.aurora.ObjectId -> 300000, //5min
+    GlobalDefinitions.battlewagon.ObjectId -> 300000, //5min
+    GlobalDefinitions.dropship.ObjectId -> 300000, //5min
+    GlobalDefinitions.flail.ObjectId -> 300000, //5min
+    GlobalDefinitions.fury.ObjectId -> 300000, //5min
+    GlobalDefinitions.galaxy_gunship.ObjectId -> 600000, //10min
+    GlobalDefinitions.lodestar.ObjectId -> 300000, //5min
+    GlobalDefinitions.liberator.ObjectId -> 300000, //5min
+    GlobalDefinitions.lightgunship.ObjectId -> 300000, //5min
+    GlobalDefinitions.lightning.ObjectId -> 300000, //5min
+    GlobalDefinitions.magrider.ObjectId -> 300000, //5min
+    GlobalDefinitions.mediumtransport.ObjectId -> 300000, //5min
+    GlobalDefinitions.mosquito.ObjectId -> 300000, //5min
+    GlobalDefinitions.phantasm.ObjectId -> 300000, //5min
+    GlobalDefinitions.prowler.ObjectId -> 300000, //5min
+    GlobalDefinitions.quadassault.ObjectId -> 300000, //5min
+    GlobalDefinitions.quadstealth.ObjectId -> 300000, //5min
+    GlobalDefinitions.router.ObjectId -> 300000, //5min
+    GlobalDefinitions.switchblade.ObjectId -> 300000, //5min
+    GlobalDefinitions.skyguard.ObjectId -> 300000, //5min
+    GlobalDefinitions.threemanheavybuggy.ObjectId -> 300000, //5m
+    GlobalDefinitions.thunderer.ObjectId -> 300000, //5min
+    GlobalDefinitions.two_man_assault_buggy.ObjectId -> 300000, //5min
+    GlobalDefinitions.twomanhoverbuggy.ObjectId -> 300000, //5min
+    GlobalDefinitions.twomanheavybuggy.ObjectId -> 300000, //5min
+    GlobalDefinitions.vanguard.ObjectId -> 300000, //5min
+    GlobalDefinitions.vulture.ObjectId -> 300000, //5min
+    GlobalDefinitions.wasp.ObjectId -> 300000, //5min
+    GlobalDefinitions.flamethrower.ObjectId -> 180000 //3min
+  )
+  /** Object use cooldowns.<br>
+    * key - object id<br>
+    * value - time last used (ms)
+    * */
+  val delayedGratificationEntries : Map[Int, Long] = Map(
+    GlobalDefinitions.medkit.ObjectId -> 5000, //5s
+    GlobalDefinitions.super_armorkit.ObjectId -> 1200000, //20min
+    GlobalDefinitions.super_medkit.ObjectId -> 1200000, //20min
+    GlobalDefinitions.super_staminakit.ObjectId -> 1200000 //20min
+  )
+
   final case class ResponseToSelf(pkt : PlanetSideGamePacket)
 
   private final case class PokeClient()

--- a/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
+++ b/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
@@ -264,37 +264,12 @@ class PlayerStateTest extends ActorTest {
   }
 }
 
-class PickupItemATest extends ActorTest {
-  val obj = Player(Avatar("TestCharacter", PlanetSideEmpire.VS, CharacterGender.Female, 1, CharacterVoice.Voice1))
-  obj.GUID = PlanetSideGUID(10)
-  obj.Slot(5).Equipment.get.GUID = PlanetSideGUID(11)
-
-  val toolDef = GlobalDefinitions.beamer
-  val tool = Tool(toolDef)
-  tool.GUID = PlanetSideGUID(40)
-  tool.AmmoSlots.head.Box.GUID = PlanetSideGUID(41)
-  val pkt = ObjectCreateMessage(
-    toolDef.ObjectId,
-    tool.GUID,
-    ObjectCreateMessageParent(PlanetSideGUID(10), 0),
-    toolDef.Packet.ConstructorData(tool).get
-  )
-
-  "pass PickUpItem as EquipmentInHand (visible pistol slot)" in {
-    ServiceManager.boot(system)
-    val service = system.actorOf(Props(classOf[AvatarService], Zone.Nowhere), AvatarServiceTest.TestName)
-    service ! Service.Join("test")
-    service ! AvatarServiceMessage("test", AvatarAction.PickupItem(PlanetSideGUID(10), tool))
-    expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.EquipmentInHand(pkt)))
-  }
-}
-
-class PickupItemBTest extends ActorTest {
+class PickupItemTest extends ActorTest {
   val obj = Player(Avatar("TestCharacter", PlanetSideEmpire.VS, CharacterGender.Female, 1, CharacterVoice.Voice1))
   val tool = Tool(GlobalDefinitions.beamer)
   tool.GUID = PlanetSideGUID(40)
 
-  "pass PickUpItem as ObjectDelete (not visible inventory space)" in {
+  "pass PickUpItem" in {
     ServiceManager.boot(system)
     val service = system.actorOf(Props(classOf[AvatarService], Zone.Nowhere), AvatarServiceTest.TestName)
     service ! Service.Join("test")

--- a/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
+++ b/pslogin/src/test/scala/actor/service/AvatarServiceTest.scala
@@ -163,7 +163,7 @@ class DroptItemTest extends ActorTest {
   "AvatarService" should {
     "pass DropItem" in {
       service ! Service.Join("test")
-      service ! AvatarServiceMessage("test", AvatarAction.DropItem(PlanetSideGUID(10), tool, Zone.Nowhere))
+      service ! AvatarServiceMessage("test", AvatarAction.DropItem(PlanetSideGUID(10), tool))
       expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.DropItem(pkt)))
     }
   }
@@ -284,7 +284,7 @@ class PickupItemATest extends ActorTest {
     ServiceManager.boot(system)
     val service = system.actorOf(Props(classOf[AvatarService], Zone.Nowhere), AvatarServiceTest.TestName)
     service ! Service.Join("test")
-    service ! AvatarServiceMessage("test", AvatarAction.PickupItem(PlanetSideGUID(10), Zone.Nowhere, obj, 0, tool))
+    service ! AvatarServiceMessage("test", AvatarAction.PickupItem(PlanetSideGUID(10), tool))
     expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.EquipmentInHand(pkt)))
   }
 }
@@ -298,7 +298,7 @@ class PickupItemBTest extends ActorTest {
     ServiceManager.boot(system)
     val service = system.actorOf(Props(classOf[AvatarService], Zone.Nowhere), AvatarServiceTest.TestName)
     service ! Service.Join("test")
-    service ! AvatarServiceMessage("test", AvatarAction.PickupItem(PlanetSideGUID(10), Zone.Nowhere, obj, 6, tool))
+    service ! AvatarServiceMessage("test", AvatarAction.PickupItem(PlanetSideGUID(10), tool))
     expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.ObjectDelete(tool.GUID, 0)))
   }
 }


### PR DESCRIPTION
At first, it was only a remote electronics kit that did not like playing by the rules.  It violated boundaries and placed itself wherever it wanted, overlapping whatever other object's personal space that it wanted.

For a while, it seemed to settle, and no grave concerns could be perceived.

Then, like wildfire, the flagrant abuse of trust and encroachment began, as if every inventory was possessed by a malevolent spirit of disorder!  Things were going everywhere they should not have been in the backpacks of all players.  The bullets were getting in the rocket launchers.  The medkits were getting into the bullets.  Items were jumping out of people's hands, lost somewhere between the hand and ground, to be replaced by another item of unfair distribution.  Rifle and shell alike were stacking up to the high heavens, beyond what was reasonable.  The item blamed the container and the container blamed the item, each only arguing that one was not right.  In all this tumult, the world ended many times.

And, now, like a thunder crack, the codebase is shattered and rebuilt.  All objects must now exist in harmony.

And that's enough of that malarkey.

Serious now.  I have made all item insertion and removal processes require some synchronization between the source container and the destination container to ensure that all moved entities are properly shifted from one spot to the next without violating numerical limits or bounded limits and without eradicating another entity already in the same position.  The change crept over to affect every aspect of container item manipulation, since it's all just a syncrhonized insertion or removal.  Buy equipment, sell equipment, drop equipment, pick up equipment, move items from one hand to the next, move items from one container to the next, request loadouts: try all of these behaviors and more and tell me where any of it goes pear-shaped.

But do not tell me that the vehicle terminal is broke again.

___Features___
__`Containable` and `ContainableBehavior`__
The central logic for handling synchronized container activity.  The main selling point is the handling of `MoveItemMessage` logic for and between: `Player` objects, `Vehicle` objects, and `Locker` objects (the storage component of `Lockers` anyway, not the kind you find in spawn rooms).  These are the only object types that support container interaction in the game.  A fast-forward approach when moving items from one hand to the other exists and a tiered structure allows for object-specific callbacks to be written, greatly benefitting the variety of perspectives offered by the affected containers.  The basic put cases and removal cases, however, offer a springboard for writing whatever sort of inventory logic is necessary.

__`WorldSession`__
Specific write-ups for logics for manipulating items and inventory have been carefully transitioned out of `WorldSessionActor` itself and placed here.  While this does result in an exceptional amount of logic that hooks in resources that were collected for the benefit of `WorldSessionActor` to facilitate the same operations that `WorldSessionActor` had performed on its own, the resulting item manipulations function smoothly enough.

__`LockerContainer`, `LockerEquipment`, and `LockerContainerControl`__
Originally, `LockerContainer` was a flat simple object designed only to handle the portable inventory portion of a user's locker.  It was `Equipment` since it was technically in an "equipment slot" between the holsters and the formal backpack inventory.  The arrangement is ill-suited for `ContainableBehavior` adaptation so `LockerContainer` objects now exist to wrap around `LockerEquipment` objects and extend to the latter these new `Containable` capabilities.

__`ZoneGroundActor`__
All messages for items coming and going from the ground previously needed to swing back to the `WorldSessionActor` that contracted the pick up or drop action.  Originally, this was just for logging messages; but, later, this endpoint had to be leveraged to make certain `BoomerDeployable` objects and `BoomerTrigger` objects worked correctly.  To avoid constantly passing `ActorRef` references to that player endpoint whenever interacting with the ground, the process was simplified in a way that eliminated the last endpoint.  The callbacks for the `ContainableBehavior` objects now handle anything that must be collected or deposited with care, such as `BoomerTrigger` items.  The Ground is much more generic now and deals only with managing the objects that are available, no longer being used for depiction.

__`InfantryLoadout` and `VehicleLoadout`__
Both are now functationally sorted either by the player that will affected by the loadout or by the vehicle that will be affected by the loadout, respectively.  The only communication they have with `WorldSessionActor` is for visualization and entity registration.

__`Avatar`__
As a sacrifice to the god of technical debt, the way items were logged as purchased at certain times had to be changed.  Previously, `WorldSessionActor` maintained the said purchasing cooldowns, mainly for `Vehicle` objects and for equipping the mechanized assault exo-suit and did so at the time of callback.  This way fine when that given player's `WSA` was the recipient of the terminal message that brough the goods and services to the player's feet, then unloaded and set up the player's backpack.  The inventory now being handled internally by individual control agencies, it was necessary to localize the cooldown timers into the yuser's avatar (the part of the player character that persists as long as the user is logged in).  Additionally, this system was extended to be made capable of ingesting "use" timers (such as seen with `Medkit` items).  Game objects are still remembered by their global object id; exo-suits are kept separate, remembered by the organization of their `Enumeration` object and, then, the different mechanized assault exo-suits separate from normal exo-suits.

__`OrderTerminalDefinition.Tab`__
To allow for terminals to send targetted messages directly to the control agency that will sort the products of the message - individual beings of equipment for `BuyEquipment`, or loadouts information - different tabs now direct to which of a number of targets its output should be dispatched.  For example, infantry loadout information can be sent directly to the infantry player that will use it, while vehicle loadout information will be sent directly to the vehicle that will use it.  (For the moment, only the affected inventory logic is redirected.  Other outlet for this redirection is not explored.)

___Caveats___
1.  `TaskResolver` objects and the `ask` pattern mix as per needs of the logic.  As these are both stark contrasts of synchronicity in the Akka system, they don't visually blend together well, even if they work ...
2.  While most of the extraction moved into `WorldSession` might have a return type, only the ones that return `TaskResolver.GiveTask` require that return.  To run the code, this object has to be passed to--you guess it--a task resolver object.  Some of these functions also pass in their own reference to a task resolver object for the purposes of registering or unregistering an entity in the course of execution or as recovery from a failed execution.  Putting that aside, most of the return that is `Future[Any]` is underutilized.  The primary purpose also yields to internal logic that is administered but never properly reported, e.g., removing an entity from a slot (outer) and, upon successful removal, unregistering it (inner).  In any case, making the output of these functions more useful for statusing the outcome is a definite place to grow.
3.  The error catching is not where I'd like it to be, and this is especially true for instances where `ask` logics might go into a request timeout (`AskTimeoutException`).  That's a risk... almost everwhere.  I am actually wary of writing logic for these failures until I see them in the wild.  I hope the 5s timeout countdown makes it extremely unlikely to encounter such an issue from a task not being completed.  The main issue warded by current methods involve not blocking future terminal interaction.
4.  Anything that can be inherit `Container` interaction must be a `PlanetSideServerObject` type of game object to take advantage of `ContainableBehavior`.  The logic for handling an object without a control agency but still being a container doesn't currently exist.
5.  It's not a problem that the case for `VehicleLoadout` doesn't actually return the mounted weapons of the loadout for depiction.  Although mounted weapon swapping actually works in all ways except the UI, failure of the UI upon update happens regardless of how the matter is currently sorted and is a showstopper for the feature.  We can't advise people to keep getting in and out of their vehicle to correct the issue.  Ignoring "old" and "new" weapon data and just updating all weapon magazines is the safest thing to do in the meanwhile.  The vehicles that are known to swap their mounted weapons aren't yet implemented anyway.
6.  `MoveItemMessage` handling code has a 1s timeout for each stage of its operation (`ContainableBehavior`), measly compared to the 5s timeout for other forms of item manipulation (`WorldSession`).  This is the result of me being miserly earlier in the development of this branch but paranoid during later development and not actually reflective of a well-planned out strategy.  Do tell me which of these groups of behaviors are more prone to failure - basic move item requests, or more complicated item manipulations - that which is given tigher constraints or that which is granted more lenient time budgeting.
~7.  The mappings for purchase and use cooldowns are not going to be where they are now, in the `object` of `WorldSessionActor`, so one should not get comfortable with them being there.  They're eyesores.~ This is now located in `Avatar` and also accessible through `Player`.

___Addenda___
1.  For anything that looks like it should have been changed to reflect the new way that objects are added or removed from containers, that pathway most likely is considered existing at the terminal end of the lifespan of that entity and is not governed by manual item manipulation.  The more expedient, straightforward approach is acceptable until failure becomes apparent.
2.  For the part where the page/tab system for order terminals allows local redirection of the response message, a more optimal solution would be to let external configuration of the redirection be allowed using function literals.  It's not necessary right now but shall be considered in the future.
3.  The repair rearm silos in sanctuary flanking the HART buildings are still busted as far as I can tell.