### PR TITLE
Doors should no longer close if any alive player is still within range

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -8608,7 +8608,7 @@ class WorldSessionActor extends Actor
   }
 
   /**
-    * If the corpse has been well-lootedP, it has no items in its primary holsters nor any items in its inventory.
+    * If the corpse has been well-looted, it has no items in its primary holsters nor any items in its inventory.
     * @param obj the corpse
     * @return `true`, if the `obj` is actually a corpse and has no objects in its holsters or backpack;
     *        `false`, otherwise


### PR DESCRIPTION
Hold the door, please.

It turns out if you had a backpack in the zone the `DoorCloseActor` thought you were still dead, so the door would unceremoniously slam shut in your face repeatedly, until your backpack despawned.

Instead, it will now stay open until you die, or move away. If that happens and another player is nearby, they will take over chivalrous duties of holding the door open until no live players are within range of the door, at which point it will close.