### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt
+FROM mozilla/sbt
 
 EXPOSE 51000
 EXPOSE 51001


### PR DESCRIPTION
The scala-sbt image no longer has a latest tag so we must
provide a tag.

I've picked Java 8 and the latest SBT / Scala version, hope that's right. This is what's available: https://hub.docker.com/r/hseeberger/scala-sbt/tags (java_sbt_scala)