### PR TITLE
Safeguard against trying to send messages to a vehicle actor that no longer exists

### DIFF
--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -309,7 +309,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     player.Position = Vector3.Zero
     player.Health = 0
     inZone.GUID(player.VehicleOwned) match {
-      case Some(vehicle : Vehicle) if vehicle.OwnerName.contains(player.Name) =>
+      case Some(vehicle : Vehicle) if vehicle.OwnerName.contains(player.Name) && vehicle.Actor != ActorRef.noSender =>
         vehicle.Actor ! Vehicle.Ownership(None)
       case _ => ;
     }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -9324,7 +9324,7 @@ class WorldSessionActor extends Actor
   def HandleDealingDamage(target : PlanetSideGameObject with Vitality, data : ResolvedProjectile) : Unit = {
     val func = data.damage_model.Calculate(data)
     target match {
-      case obj : Player if obj.CanDamage =>
+      case obj : Player if obj.CanDamage && obj.Actor != ActorRef.noSender =>
         if(obj.spectator) {
           player.death_by = -1 // little thing for auto kick
         }

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -10199,7 +10199,7 @@ class WorldSessionActor extends Actor
   def LoadZoneCommonTransferActivity() : Unit = {
     if(player.VehicleOwned.nonEmpty && player.VehicleSeated != player.VehicleOwned) {
       continent.GUID(player.VehicleOwned) match {
-        case Some(vehicle : Vehicle) =>
+        case Some(vehicle : Vehicle) if vehicle.Actor != ActorRef.noSender =>
           vehicle.Actor ! Vehicle.Ownership(None)
         case _ => ;
       }


### PR DESCRIPTION
Was causing exceptions to be thrown, preventing cleanup of logged out players or during zone transfers, both in rare cases.

```
2020-05-17 21:48:57,068  INFO "" services.account.PersistenceMonitor - logout of Hehateme1xandPutZx
2020-05-17 21:48:57,069 ERROR "sourceThread=PsLogin-akka.actor.default-dispatcher-85, akkaSource=akka://PsLogin/user/service/accountPersistence/Hehateme1xandPutZx-1, sourceActorSystem=PsLogin, akkaTimestamp=19:48:57.069UTC" services.account.PersistenceMonitor - null
java.lang.NullPointerException: null
    at services.account.PersistenceMonitor.PerformLogout(AccountPersistenceService.scala:280)
    at services.account.PersistenceMonitor.postStop(AccountPersistenceService.scala:202)
    at akka.actor.Actor$class.aroundPostStop(Actor.scala:494)
    at services.account.PersistenceMonitor.aroundPostStop(AccountPersistenceService.scala:187)
```

```
2020-05-17 21:44:00,168  INFO "" services.account.PersistenceMonitor - logout of Gustavo
2020-05-17 21:44:00,170 ERROR "sourceThread=PsLogin-akka.actor.default-dispatcher-79, akkaSource=akka://PsLogin/user/service/accountPersistence/Gustavo-4, sourceActorSystem=PsLogin, akkaTimestamp=19:44:00.170UTC" services.account.PersistenceMonitor - null
java.lang.NullPointerException: null
    at services.account.PersistenceMonitor.PlayerAvatarLogout(AccountPersistenceService.scala:313)
    at services.account.PersistenceMonitor.PerformLogout(AccountPersistenceService.scala:271)
    at services.account.PersistenceMonitor.postStop(AccountPersistenceService.scala:202)
    at akka.actor.Actor$class.aroundPostStop(Actor.scala:494)
    at services.account.PersistenceMonitor.aroundPostStop(AccountPersistenceService.scala:187)
```

```
2020-05-17 21:47:57,350 ERROR "sourceThread=PsLogin-world-session-router-44, akkaSource=akka://PsLogin/user/world-udp-endpoint/world-session-router/world-session-807, sourceActorSystem=PsLogin, akkaTimestamp=19:47:57.349UTC" akka.actor.OneForOneStrategy - null
java.lang.NullPointerException: null
	at WorldSessionActor.LoadZoneCommonTransferActivity(WorldSessionActor.scala:10203)
	at WorldSessionActor.LoadZoneAsPlayer(WorldSessionActor.scala:9991)
	at WorldSessionActor.LoadZonePhysicalSpawnPoint(WorldSessionActor.scala:9948)
	at WorldSessionActor.SpawnThroughZoningProcess(WorldSessionActor.scala:1916)
	at WorldSessionActor$$anonfun$Started$1.applyOrElse(WorldSessionActor.scala:1463)
	at akka.actor.Actor$class.aroundReceive(Actor.scala:484)
	at WorldSessionActor.akka$actor$MDCContextAware$$super$aroundReceive(WorldSessionActor.scala:74)
	at akka.actor.MDCContextAware$class.aroundReceive(MDCContextAware.scala:25)
	at WorldSessionActor.aroundReceive(WorldSessionActor.scala:74)
```