### PR TITLE
QoL: Squad Fixes

### DIFF
--- a/common/src/main/scala/services/teamwork/SquadService.scala
+++ b/common/src/main/scala/services/teamwork/SquadService.scala
@@ -2230,8 +2230,8 @@ class SquadService extends Actor {
     val leadPosition = squad.Membership(0)
     leadPosition.Name = name
     leadPosition.CharId = player.CharId
-    leadPosition.Health = player.Health
-    leadPosition.Armor = player.Armor
+    leadPosition.Health = StatConverter.Health(player.Health, player.MaxHealth, min=1, max=64)
+    leadPosition.Armor = StatConverter.Health(player.Armor, player.MaxArmor, min=1, max=64)
     leadPosition.Position = player.Position
     leadPosition.ZoneId = 1
     squadFeatures += squad.GUID -> new SquadFeatures(squad).Start

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -11254,14 +11254,7 @@ class WorldSessionActor extends Actor
     squadService ! SquadServiceMessage(
       player,
       continent,
-      continent.GUID(player.VehicleSeated) match {
-        case Some(vehicle : Vehicle) =>
-          SquadServiceAction.Update(player.CharId, vehicle.Health, vehicle.MaxHealth, vehicle.Shields, vehicle.MaxShields, vehicle.Position, continent.Number)
-        case Some(obj : PlanetSideGameObject with WeaponTurret) =>
-          SquadServiceAction.Update(player.CharId, obj.Health, obj.MaxHealth, 0, 0, obj.Position, continent.Number)
-        case _ =>
-          SquadServiceAction.Update(player.CharId, player.Health, player.MaxHealth, player.Armor, player.MaxArmor, player.Position, continent.Number)
-      }
+      SquadServiceAction.Update(player.CharId, player.Health, player.MaxHealth, player.Armor, player.MaxArmor, player.Position, continent.Number)
     )
   }
 


### PR DESCRIPTION
The original squad leader's health and armor were not properly being scaled to the number range 0-64.  The field they were being pushed into is `7u` (0-127) so health, usually a maximum of 100 still fit, but armor value could go up to 200 and that would be a problem.  Squad member self-updates would have smoothed out the number but there are no updates until the second user makes the proto-squad into a proper squad and that is where the break occurs.  I'm not going to say that this solves all of our squad problems, but it does solve some of our squad problems.

The squad UI cards will now only display health and armor related to the member reported in them and not the vehicle in which that member is sat.