### PR TITLE
Login AFK

### DIFF
--- a/common/src/main/scala/net/psforever/objects/Player.scala
+++ b/common/src/main/scala/net/psforever/objects/Player.scala
@@ -50,6 +50,7 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
   private var jumping : Boolean = false
   private var cloaked : Boolean = false
   private var fatigued : Boolean = false // If stamina drops to 0, player is fatigued until regenerating at least 20 stamina
+  private var afk : Boolean = false
 
   private var vehicleSeated : Option[PlanetSideGUID] = None
 
@@ -402,9 +403,17 @@ class Player(private val core : Avatar) extends PlanetSideServerObject
   }
 
   def Fatigued : Boolean = fatigued
+
   def Fatigued_=(isFatigued : Boolean) : Boolean = {
     fatigued = isFatigued
     Fatigued
+  }
+
+  def AwayFromKeyboard : Boolean = afk
+
+  def AwayFromKeyboard_=(away : Boolean) : Boolean = {
+    afk = away
+    AwayFromKeyboard
   }
 
   def PersonalStyleFeatures : Option[Cosmetics] = core.PersonalStyleFeatures


### PR DESCRIPTION
Found in our logs was the instance of someone logging into the game (relogging?) and that user's client dispatching a `GenericActionMessage`-29 at the server.  The `GAM29` packet denotes a status of "away from keyboard".  However, at the time the packet was received, the user had not yet established a playable character and thus, where it would have been received well otherwise, it caused a `NullPointerException`.  A condition to catch this early "AFK" was introduced and a flag was even assigned to player characters to take advantage of the status.

I don't understand the AFK system used by the game and do not intend to implement it just yet.  This is merely to avoid raising the exception.