### PR TITLE
DO NOT MERGE - Corpseless

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -10133,16 +10133,17 @@ class WorldSessionActor extends Actor
     * @param zone na
     */
   def HandleReleaseAvatar(tplayer : Player, zone : Zone) : Unit = {
-    tplayer.Release
+    val guid = tplayer.GUID
+    tplayer.Release //neccessary to respawn properly
     tplayer.VehicleSeated match {
       case None =>
-        PrepareToTurnPlayerIntoCorpse(tplayer, zone)
+        zone.AvatarEvents ! AvatarServiceMessage(zone.Id, AvatarAction.ObjectDelete(PlanetSideGUID(0), guid))
       case Some(_) =>
         tplayer.VehicleSeated = None
-        zone.Population ! Zone.Population.Release(avatar)
-        sendResponse(ObjectDeleteMessage(tplayer.GUID, 0))
-        taskResolver ! GUIDTask.UnregisterPlayer(tplayer)(zone.GUID)
     }
+    sendResponse(ObjectDeleteMessage(guid, 0))
+    zone.Population ! Zone.Population.Release(avatar)
+    taskResolver ! GUIDTask.UnregisterPlayer(tplayer)(zone.GUID)
   }
 
   /**


### PR DESCRIPTION
Warm up a test server where player corpses do not get spawned for the purpose of crash to desktop fault isolation.

This eliminates looting, the corpse removal timing, and the part of zone population that deals with checking for corpses coming from existing players in the zone and constructing a corpse specific control agency.  Perhaps something else?

This PR is not for merging.
If this PR ends up being merged,
I will find you.