### PR TITLE
Disconnect

### DIFF
--- a/common/src/main/scala/net/psforever/objects/zones/Zoning.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/Zoning.scala
@@ -10,7 +10,8 @@ object Zoning {
     val
     None,
     InstantAction,
-    Recall
+    Recall,
+    Quit
     = Value
   }
 
@@ -34,6 +35,8 @@ object Zoning {
     final val None = TimeType(20, "None")
     final val Enemy = TimeType(30, "Enemy")
   }
+
+  final case class Quit()
 
   object InstantAction {
     final case class Request(faction : PlanetSideEmpire.Value)

--- a/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
+++ b/common/src/main/scala/net/psforever/packet/game/GenericActionMessage.scala
@@ -26,9 +26,10 @@ import scodec.codecs._
   * 24 - message: you have been imprinted (updates imprinted status; does it?)<br>
   * 25 - message: you are no longer imprinted (updates imprinted status; does it?)<br>
   * 27 - event: purchase timers reset (does it?)<br>
-  * 31 - switch to first person view, attempt to deconstruct but fail;
+  * 31 - forced into first person view;
+  *      in third person view, player character sinks into the ground; green deconstruction particle effect under feet<br>
+  * 32 - forced into first person view, attempt to deconstruct but fail;
   *      event: fail to deconstruct due to having a "parent vehicle"<br>
-  * 32 - switch to first person view<br>
   * 33 - event: fail to deconstruct<br>
   * 43 - prompt: friendly fire in virtual reality zone<br>
   * 45 - ?<br>

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -96,6 +96,14 @@ class AccountPersistenceService extends Actor {
           log.warn(s"player entry for $name not found; not logged in")
       }
 
+    case msg @ AccountPersistenceService.Kick(name, _) =>
+      accounts.get(name) match {
+        case Some(ref) =>
+          ref ! msg
+        case _ =>
+          log.warn(s"player entry for $name not found; not logged in")
+      }
+
     case AccountPersistenceService.Logout(name) =>
       accounts.remove(name) match {
         case Some(ref) =>
@@ -182,6 +190,8 @@ object AccountPersistenceService {
     */
   final case class Update(name : String, zone : Zone, position : Vector3)
 
+  final case class Kick(name : String, time : Option[Long] = None)
+
   /**
     * Update the persistence monitor that was setup for a user for a custom persistence delay.
     * If set to `None`, the default persistence time should assert itself.
@@ -218,8 +228,12 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
   var inZone : Zone = Zone.Nowhere
   /** the last-reported game coordinate position of this player */
   var lastPosition : Vector3 = Vector3.Zero
+  /** */
+  var kicked : Boolean = false
+  /** */
+  var kickTime : Option[Long] = None
   /** a custom logout time for this player; 60s by default */
-  var countdown : Option[Long] = None
+  var persistTime : Option[Long] = None
   /** the ongoing amount of permissible inactivity */
   var timer : Cancellable = Default.Cancellable
   /** the sparingly-used log */
@@ -235,21 +249,44 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
 
   def receive : Receive = {
     case AccountPersistenceService.Login(_) =>
-      sender ! PlayerToken.LoginInfo(name, inZone, lastPosition)
-      UpdateTimer()
+      sender ! (if(kicked) {
+        PlayerToken.CanNotLogin(name, PlayerToken.DeniedLoginReason.Kicked)
+      }
+      else {
+        UpdateTimer()
+        PlayerToken.LoginInfo(name, inZone, lastPosition)
+      })
 
-    case AccountPersistenceService.Update(_, z, p) =>
+    case AccountPersistenceService.Update(_, z, p) if !kicked =>
       inZone = z
       lastPosition = p
       UpdateTimer()
 
-    case AccountPersistenceService.PersistDelay(_, delay) =>
-      countdown = delay
+    case AccountPersistenceService.PersistDelay(_, delay) if !kicked =>
+      persistTime = delay
       UpdateTimer()
 
+    case AccountPersistenceService.Kick(_, time) =>
+      persistTime = None
+      kickTime match {
+        case None if kicked =>
+          UpdateTimer()
+        case _ => ;
+      }
+      kicked = true
+      kickTime = time.orElse(Some(300L))
+
     case Logout(_) =>
-      context.parent ! Logout(name)
-      context.stop(self)
+      kickTime match {
+        case Some(time) =>
+          PerformLogout()
+          kickTime = None
+          timer.cancel
+          timer = context.system.scheduler.scheduleOnce(time seconds, self, Logout(name))
+        case None =>
+          context.parent ! Logout(name)
+          context.stop(self)
+      }
 
     case _ => ;
   }
@@ -259,7 +296,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     */
   def UpdateTimer() : Unit = {
     timer.cancel
-    timer = context.system.scheduler.scheduleOnce(countdown.getOrElse(60L) seconds, self, Logout(name))
+    timer = context.system.scheduler.scheduleOnce(persistTime.getOrElse(60L) seconds, self, Logout(name))
   }
 
   /**
@@ -283,7 +320,6 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     * but should be uncommon.
     */
   def PerformLogout() : Unit = {
-    log.info(s"logout of $name")
     (inZone.Players.find(p => p.name == name), inZone.LivePlayers.find(p => p.Name == name)) match {
       case (Some(avatar), Some(player)) if player.VehicleSeated.nonEmpty =>
         //alive or dead in a vehicle
@@ -371,6 +407,7 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
     squadService.tell(Service.Leave(Some(charId.toString)), parent)
     Deployables.Disown(inZone, avatar, parent)
     inZone.Population.tell(Zone.Population.Leave(avatar), parent)
+    log.info(s"logout of ${avatar.name}")
   }
 }
 
@@ -382,6 +419,13 @@ class PersistenceMonitor(name : String, squadService : ActorRef, taskResolver : 
 private[this] case class Logout(name : String)
 
 object PlayerToken {
+  object DeniedLoginReason extends Enumeration {
+    val
+    Denied, //generic
+    Kicked
+    = Value
+  }
+
   /**
     * Message dispatched to confirm that a player with given locational attributes exists.
     * Agencies outside of the `AccountPersistanceService`/`PlayerToken` system make use of this message.
@@ -391,4 +435,6 @@ object PlayerToken {
     * @param position where in the zone the player is located
     */
   final case class LoginInfo(name : String, zone : Zone, position : Vector3)
+
+  final case class CanNotLogin(name : String, reason : DeniedLoginReason.Value)
 }

--- a/common/src/main/scala/services/account/AccountPersistenceService.scala
+++ b/common/src/main/scala/services/account/AccountPersistenceService.scala
@@ -11,9 +11,8 @@ import net.psforever.objects._
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.zones.Zone
 import net.psforever.types.Vector3
-import services.{RemoverActor, Service, ServiceManager}
+import services.{Service, ServiceManager}
 import services.avatar.{AvatarAction, AvatarServiceMessage}
-import services.vehicle.VehicleServiceMessage
 
 /**
   * A global service that manages user behavior as divided into the following three categories:
@@ -87,6 +86,13 @@ class AccountPersistenceService extends Actor {
         case None =>
           log.warn(s"tried to update a player entry ($name) that did not yet exist; rebuilding entry ...")
           CreateNewPlayerToken(name).tell(msg, sender)
+      }
+
+    case AccountPersistenceService.Logout(name) =>
+      accounts.remove(name) match {
+        case Some(ref) =>
+          ref ! Logout(name)
+        case _ => ;
       }
 
     case Logout(target) => //TODO use context.watch and Terminated?
@@ -166,6 +172,12 @@ object AccountPersistenceService {
     * @param position the location of the player in game world coordinates
     */
   final case class Update(name : String, zone : Zone, position : Vector3)
+
+  /**
+    * Message that indicates that persistence is no longer necessary for this player character.
+    * @param name the unique name of the player
+    */
+  final case class Logout(name : String)
 }
 
 /**

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -2800,6 +2800,11 @@ class WorldSessionActor extends Actor
           sendResponse(VehicleStateMessage(vehicle_guid, unk1, pos, ang, vel, unk2, unk3, unk4, wheel_direction, unk5, unk6))
           if(player.VehicleSeated.contains(vehicle_guid)) {
             player.Position = pos
+            GetVehicleAndSeat() match {
+              case (Some(_), Some(seatNum)) if seatNum > 0 =>
+                turnCounter(guid)
+              case _ => ;
+            }
           }
         }
       case VehicleResponse.SendResponse(msg) =>

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -5002,7 +5002,8 @@ class WorldSessionActor extends Actor
                 val lastUse = player.GetLastUsedTime(kid)
                 val delay = delayedGratificationEntries.getOrElse(kid, 0L)
                 if((time - lastUse) < delay) {
-                  sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^${((delay / 1000) - math.ceil((time - lastUse).toDouble) / 1000)}~", None))
+                  val presentedDelay = math.max(1, ((delay.toDouble / 1000) - math.ceil((time - lastUse).toDouble) / 1000)).toInt
+                  sendResponse(ChatMsg(ChatMessageType.UNK_225, false, "", s"@TimeUntilNextUse^$presentedDelay~", None))
                 }
                 else {
                   val indexOpt = player.Find(kit)


### PR DESCRIPTION
"Your account has been logged out by a Customer Service Representative."

Of the forms of disconnect known:
1. Menu Exit
This is the count down log-out.  10 for Sanctuary and Friendly regions, 20 for Neutral regions, and 30 for Enemy regions.  Once the user logs out at the completion of the countdown, character persistence is also dropped.  Quitting is technically a form of zoning so all conditions that would cancel Instant Action or a Recall to Sanctuary action will also cancel quitting.
2. Client window close, ALT + F4, process kill, crash, closing through the launcher
Client termination is instantaneous.  Persistence for the existing player character who was in the game world is maintained for the normal amount of time so re-logging with the same character before then should not banish the user back to Sanctuary.
3. Kicking
A form of disconnect.  Most of the aspects of this moderator-driven disconnect are similar to the previous entry, asides from the length of time being customizable and an inability to return to game with this same player character despite trying to log back in.  Player characters remain completely vulnerable, kicked out of any vehicle they previously occupied, and will lay dead for an extended duration of time if they are killed.

___Features___
No new classes or entities.  Everything piggybacks off of or clarifies existing functionality.

___Caveats___
1. A number of the string resources that would had to have been written for the interactions between different zoning methods and `DeadState` statuses don't seem to exist.  The expected references don't resolve.  Custom messages are implemented in their place.  This was already in practice for some cases for Instant Action and for Recall to Sanctuary.  Almost all of the hard-coded messages are employed when first receiving the message to zone or to quit.
~~2. Measures have been erected to disallow the cadaver of a kicked player to turn into a corpse but a guarantee for all cases requires additional testing.~~
~~3. Players who are kicked still count as population on a continent, unless filtered in all instances where population is counted.~~ @jgillich

___Addenda___
1. The command syntax for kick now supports a time field.  After declaring the individual to be ejected, a number of seconds of persistence can be entered.  The persistence monitor will ensure that the individual's player character will remain in the game for that amount of time to bar the user from re-entry.  Writing anything but a numerical time, as long as something is written, results in the persistence reverting to its default value.  There is no pardon, save lowering the time and logging out.
2. The time until use for medkits is presented as an integer again.
3. Stop kicking yourself by accident.