### PR TITLE
DO NOT MERGE - No Autopsies

### DIFF
--- a/common/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
+++ b/common/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
@@ -76,7 +76,7 @@ class ZonePopulationActor(zone : Zone, playerMap : TrieMap[Avatar, Option[Player
           (player.Zone == Zone.Nowhere || player.Zone == zone, None)
       }
       if(canBeCorpse && CorpseAdd(player, corpseList)) {
-        player.Actor = context.actorOf(Props(classOf[CorpseControl], player), name = s"corpse_of_${GetPlayerControlName(player, control)}")
+//        player.Actor = context.actorOf(Props(classOf[CorpseControl], player), name = s"corpse_of_${GetPlayerControlName(player, control)}")
         player.Zone = zone
       }
 

--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -5048,11 +5048,11 @@ class WorldSessionActor extends Actor
         case Some(obj : Player) =>
           CancelZoningProcessWithDescriptiveReason("cancel_use")
           if(obj.isBackpack) {
-            if(equipment.isEmpty) {
-              log.info(s"UseItem: ${player.Name} looting the corpse of $obj")
-              sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, unk2, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
-              accessedContainer = Some(obj)
-            }
+//            if(equipment.isEmpty) {
+//              log.info(s"UseItem: ${player.Name} looting the corpse of $obj")
+//              sendResponse(UseItemMessage(avatar_guid, item_used_guid, object_guid, unk2, unk3, unk4, unk5, unk6, unk7, unk8, itemType))
+//              accessedContainer = Some(obj)
+//            }
           }
           else if(!unk3 && player.isAlive) { //potential kit use
             ValidObject(item_used_guid) match {


### PR DESCRIPTION
Warm up a test server where player corpses are not lootable for the purpose of crash to desktop fault isolation.

This eliminates looting and constructing a corpse-specific control agency.  Everything else continues to operate like normal.

This PR is not for merging.