### PR TITLE
Revert "Bundling Amenity Information (Again)"

### DIFF
--- a/pslogin/src/main/scala/WorldSessionActor.scala
+++ b/pslogin/src/main/scala/WorldSessionActor.scala
@@ -3545,13 +3545,11 @@ class WorldSessionActor extends Actor
       continent.VehicleEvents ! Service.Join(avatar.name)
       continent.VehicleEvents ! Service.Join(continentId)
       continent.VehicleEvents ! Service.Join(factionChannel)
-      //zone config
-      StartBundlingPackets()
       if(connectionState != 100) configZone(continent)
       sendResponse(TimeOfDayMessage(1191182336))
+      //custom
       sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
       sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
-      StopBundlingPackets()
 
       //find and reclaim own deployables, if any
       val guid = player.GUID


### PR DESCRIPTION
Reverts psforever/PSF-LoginServer#495

This needs more investigation before leaving it re-enabled. I'm seeing all kinds of issues now with zoning that weren't present before.

Examples:

1) A brief connection lost message at the end of zoning
2) Many, many packets failing to be received and resent
3) Quite often other avatars not appearing at all, as if the `OCM` packet has been lost. Also applies to things like vehicles, turret weapons etc.