### PR TITLE
Temp Changes 1 (AMS & Galaxy Gunship)

### DIFF
--- a/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/common/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -5746,11 +5746,11 @@ object GlobalDefinitions {
     ant.JackingDuration = Array (0, 60, 20, 15)
 
     ams.Name = "ams"
-    ams.MaxHealth = 3000
+    ams.MaxHealth = 5000
     ams.Damageable = true
     ams.Repairable = true
     ams.RepairIfDestroyed = false
-    ams.MaxShields = 600 + 1
+    ams.MaxShields = 1000 + 1
     ams.Seats += 0 -> new SeatDefinition()
     ams.Seats(0).ArmorRestriction = SeatArmorRestriction.NoReinforcedOrMax
     ams.MountPoints += 1 -> 0
@@ -5767,7 +5767,7 @@ object GlobalDefinitions {
     ams.Packet = utilityConverter
     ams.DestroyedModel = Some(DestroyedVehicle.Ams)
     ams.Subtract.Damage1 = 10
-    ams.JackingDuration = Array(0, 60, 20, 15)
+    ams.JackingDuration = Array(0, 0, 0, 0)
 
     val variantConverter = new VariantVehicleConverter
     router.Name = "router"
@@ -6024,7 +6024,7 @@ object GlobalDefinitions {
     dropship.JackingDuration = Array(0, 60, 20, 10)
 
     galaxy_gunship.Name = "galaxy_gunship"
-    galaxy_gunship.MaxHealth = 6000
+    galaxy_gunship.MaxHealth = 9500
     galaxy_gunship.Damageable = true
     galaxy_gunship.Repairable = true
     galaxy_gunship.RepairDistance = 20

--- a/pslogin/src/main/resources/game_objects0.adb.lst
+++ b/pslogin/src/main/resources/game_objects0.adb.lst
@@ -6,6 +6,8 @@ add_property ace_deployable equiptime 500
 add_property ace_deployable holstertime 500
 add_property advanced_ace equiptime 750
 add_property advanced_ace holstertime 750
+add_property ams jacking_duration 0 0 0 0
+add_property ams maxhealth 5000
 add_property anniversary_gun equiptime 500
 add_property anniversary_gun holstertime 500
 add_property anniversary_guna equiptime 500
@@ -44,6 +46,7 @@ add_property flechette equiptime 600
 add_property flechette holstertime 600
 add_property forceblade equiptime 250
 add_property forceblade holstertime 250
+add_property galaxy_gunship maxhealth 9500
 add_property gauss equiptime 600
 add_property gauss holstertime 600
 add_property ilc9 equiptime 500


### PR DESCRIPTION
Some temporary buffs to the AMS, which make it impossible to jack, increases the max health from 3000 to 5000, and increases the max shields from 600 + 1 to 1000 + 1.

Also a temporary buff to Galaxy Gunship health (6000 to 9500) while it lacks it's damage reduction mechanic.