### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The Login and World servers require PostgreSQL for persistence.
 The default database is named `psforever` and the credentials are
 `psforever:psforever`. To change these, create a configuration file at
 `config/psforever.conf`. For configuration options and their defaults, see
-[`pslogin/src/main/resources/application.conf`]. This database user will need
+[`application.conf`](/pslogin/src/main/resources/application.conf). This database user will need
 ALL access to tables, sequences, and functions.
 The permissions required can be summarized by the SQL below.
 Loading this in requires access to a graphical tool such as [pgAdmin](https://www.pgadmin.org/download/) (highly recommended) or a PostgreSQL terminal (`psql`) for advanced users.

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ lazy val commonSettings = Seq(
     "com.github.pureconfig"      %% "pureconfig"              % "0.13.0",
     "com.beachape"               %% "enumeratum"              % "1.6.1",
     "joda-time"                   % "joda-time"               % "2.10.6",
-    "commons-io"                  % "commons-io"              % "2.6"
+    "commons-io"                  % "commons-io"              % "2.6",
+    "com.github.scopt"           %% "scopt"                   % "4.0.0-RC2"
   )
 )
 
@@ -131,8 +132,7 @@ lazy val decodePackets = (project in file("tools/decode-packets"))
   .settings(decodePacketsPackSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
-      "com.github.scopt"       %% "scopt"                      % "4.0.0-RC2"
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0"
     )
   )
   .dependsOn(common)


### PR DESCRIPTION
Comes with a flag to run flyway baseline automatically

@Mazo To set the bind address as an argument you'll now have to use `--bind 1.2.3.4`

Automatic baselining has to be enabled with `--baseline-on-migrate`. Migrations are always being run, but there's a flag to turn that off.