### PR TITLE
DO NOT MERGE - Slightly-Fresh Corpses

### DIFF
--- a/common/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
@@ -42,7 +42,7 @@ class CharacterSelectConverter extends AvatarConverter {
       CommonFieldData(
         obj.Faction,
         bops = false,
-        false,
+        alternate = false,
         false,
         None,
         false,
@@ -71,7 +71,7 @@ class CharacterSelectConverter extends AvatarConverter {
       facingYawUpper = 0,
       lfs = false,
       GrenadeState.None,
-      obj.Cloaked,
+      is_cloaking = false,
       false,
       false,
       charging_pose = false,

--- a/common/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
+++ b/common/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
@@ -2,11 +2,9 @@
 package net.psforever.objects.definition.converter
 
 import net.psforever.objects.Player
-import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
 import net.psforever.packet.game.objectcreate._
 import net.psforever.types.{PlanetSideGUID, _}
 
-import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 class CorpseConverter extends AvatarConverter {
@@ -19,7 +17,7 @@ class CorpseConverter extends AvatarConverter {
         PlacementData(obj.Position, Vector3(0, 0, obj.Orientation.z)),
         MakeAppearanceData(obj),
         MakeDetailedCharacterData(obj),
-        InventoryData((MakeHolsters(obj) ++ MakeInventory(obj)).sortBy(_.parentSlot)),
+        InventoryData(),
         DrawnSlot.None
       )
     )
@@ -32,11 +30,11 @@ class CorpseConverter extends AvatarConverter {
     */
   private def MakeAppearanceData(obj: Player): Int => CharacterAppearanceData = {
     val aa: Int => CharacterAppearanceA = CharacterAppearanceA(
-      BasicCharacterData(obj.Name, obj.Faction, CharacterGender.Male, 0, CharacterVoice.Mute),
+      BasicCharacterData(obj.Name, obj.Faction, obj.Sex, 0, CharacterVoice.Mute),
       CommonFieldData(
         obj.Faction,
         bops = false,
-        alternate = true,
+        alternate = false,
         false,
         None,
         false,
@@ -57,7 +55,7 @@ class CorpseConverter extends AvatarConverter {
       outfit_name = "",
       outfit_logo = 0,
       false,
-      backpack = true,
+      backpack = false,
       false,
       false,
       false,
@@ -116,78 +114,7 @@ class CorpseConverter extends AvatarConverter {
       false,
       cosmetics = None
     )
-    (pad_length: Option[Int]) => DetailedCharacterData(ba, bb(0, pad_length))(pad_length)
-  }
-
-  /**
-    * Given a player with an inventory, convert the contents of that inventory into converted-decoded packet data.
-    * The inventory is not represented in a `0x17` `Player`, so the conversion is only valid for `0x18` avatars.
-    * It will always be "`Detailed`".
-    * @param obj the `Player` game object
-    * @return a list of all items that were in the inventory in decoded packet form
-    */
-  private def MakeInventory(obj: Player): List[InternalSlot] = {
-    obj.Inventory.Items
-      .map(item => {
-        val equip: Equipment = item.obj
-        BuildEquipment(item.start, equip)
-      })
-  }
-
-  /**
-    * Given a player with equipment holsters, convert the contents of those holsters into converted-decoded packet data.
-    * The decoded packet form is determined by the function in the parameters as both `0x17` and `0x18` conversions are available,
-    * with exception to the contents of the fifth slot.
-    * The fifth slot is only represented if the `Player` is an `0x18` type.
-    * @param obj the `Player` game object
-    * @return a list of all items that were in the holsters in decoded packet form
-    */
-  private def MakeHolsters(obj: Player): List[InternalSlot] = {
-    recursiveMakeHolsters(obj.Holsters().iterator)
-  }
-
-  /**
-    * Given some equipment holsters, convert the contents of those holsters into converted-decoded packet data.
-    * @param iter an `Iterator` of `EquipmentSlot` objects that are a part of the player's holsters
-    * @param list the current `List` of transformed data
-    * @param index which holster is currently being explored
-    * @return the `List` of inventory data created from the holsters
-    */
-  @tailrec private def recursiveMakeHolsters(
-      iter: Iterator[EquipmentSlot],
-      list: List[InternalSlot] = Nil,
-      index: Int = 0
-  ): List[InternalSlot] = {
-    if (!iter.hasNext) {
-      list
-    } else {
-      val slot: EquipmentSlot = iter.next
-      if (slot.Equipment.isDefined) {
-        val equip: Equipment = slot.Equipment.get
-        recursiveMakeHolsters(
-          iter,
-          list :+ BuildEquipment(index, equip),
-          index + 1
-        )
-      } else {
-        recursiveMakeHolsters(iter, list, index + 1)
-      }
-    }
-  }
-
-  /**
-    * A builder method for turning an object into `0x17` decoded packet form.
-    * @param index the position of the object
-    * @param equip the game object
-    * @return the game object in decoded packet form
-    */
-  private def BuildEquipment(index: Int, equip: Equipment): InternalSlot = {
-    InternalSlot(
-      equip.Definition.ObjectId,
-      equip.GUID,
-      index,
-      equip.Definition.Packet.DetailedConstructorData(equip).get
-    )
+    pad_length: Option[Int] => DetailedCharacterData(ba, bb(0, pad_length))(pad_length)
   }
 }
 


### PR DESCRIPTION
Warm up a test server (?) where player corpses are spawned in a different fashion for the purpose of crash to desktop fault isolation.

This eliminates looting but should allow all other faculties. The player still actually has its equipment but the PAM6 (PlanetsideAttributeMessage, attribute 6) packet makes the client forget them. Do not focus on the need to fix that; it will be handled if this test proves successful.

This PR is not for merging.
If this PR ends up being merged,
I will find you.

A new PR for #521, "DO NOT MERGE - Fresh Corpses".