### PR TITLE
Fix forwarding message to use IP instead of host name

### DIFF
--- a/pslogin/src/main/scala/LoginSessionActor.scala
+++ b/pslogin/src/main/scala/LoginSessionActor.scala
@@ -128,7 +128,7 @@ class LoginSessionActor extends Actor with MDCContextAware {
 
       case ConnectToWorldRequestMessage(name, _, _, _, _, _, _) =>
         log.info(s"Connect to world request for '$name'")
-        val response = ConnectToWorldMessage(serverName, publicAddress.getHostString, publicAddress.getPort)
+        val response = ConnectToWorldMessage(serverName, publicAddress.getAddress.getHostAddress, publicAddress.getPort)
         sendResponse(PacketCoding.CreateGamePacket(0, response))
         sendResponse(DropSession(sessionId, "user transferring to world"))
 


### PR DESCRIPTION
INetAddress#getHostString can return both an IP address
and a host name depending on how thclass is initialized.