### PR TITLE
Flak Burst

### DIFF
--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2356,7 +2356,11 @@ object GlobalDefinitions {
     burster_projectile.InitialVelocity = 125
     burster_projectile.Lifespan = 4f
     ProjectileDefinition.CalculateDerivedFields(burster_projectile)
-    //TODO burster_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    burster_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     chainblade_projectile.Name = "chainblade_projectile"
     // TODO for later, maybe : set_resource_parent chainblade_projectile game_objects melee_ammo_projectile
@@ -2396,7 +2400,11 @@ object GlobalDefinitions {
     colossus_burster_projectile.InitialVelocity = 175
     colossus_burster_projectile.Lifespan = 2.5f
     ProjectileDefinition.CalculateDerivedFields(colossus_burster_projectile)
-    //TODO colossus_burster_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    colossus_burster_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     colossus_chaingun_projectile.Name = "colossus_chaingun_projectile"
     // TODO for later, maybe : set_resource_parent colossus_chaingun_projectile game_objects 35mmbullet_projectile
@@ -3448,7 +3456,11 @@ object GlobalDefinitions {
     phalanx_flak_projectile.InitialVelocity = 100
     phalanx_flak_projectile.Lifespan = 5f
     ProjectileDefinition.CalculateDerivedFields(phalanx_flak_projectile)
-    //TODO phalanx_flak_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    phalanx_flak_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     phalanx_projectile.Name = "phalanx_projectile"
     phalanx_projectile.Damage0 = 20
@@ -3747,7 +3759,11 @@ object GlobalDefinitions {
     rocklet_flak_projectile.InitialVelocity = 60
     rocklet_flak_projectile.Lifespan = 3.2f
     ProjectileDefinition.CalculateDerivedFields(rocklet_flak_projectile)
-    //TODO rocklet_flak_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    rocklet_flak_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     rocklet_jammer_projectile.Name = "rocklet_jammer_projectile"
     rocklet_jammer_projectile.Damage0 = 0
@@ -3826,7 +3842,11 @@ object GlobalDefinitions {
     skyguard_flak_cannon_projectile.InitialVelocity = 100
     skyguard_flak_cannon_projectile.Lifespan = 5f
     ProjectileDefinition.CalculateDerivedFields(skyguard_flak_cannon_projectile)
-    //TODO skyguard_flak_cannon_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    skyguard_flak_cannon_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     sparrow_projectile.Name = "sparrow_projectile"
     sparrow_projectile.Damage0 = 35
@@ -3894,7 +3914,11 @@ object GlobalDefinitions {
     spitfire_aa_ammo_projectile.InitialVelocity = 100
     spitfire_aa_ammo_projectile.Lifespan = 5f
     ProjectileDefinition.CalculateDerivedFields(spitfire_aa_ammo_projectile)
-    //TODO spitfire_aa_ammo_projectile.Modifiers = DamageModifiers.RadialDegrade?
+    spitfire_aa_ammo_projectile.Modifiers = List(
+      //DamageModifiers.FlakHit,
+      DamageModifiers.FlakBurst,
+      DamageModifiers.MaxDistanceCutoff
+    )
 
     spitfire_ammo_projectile.Name = "spitfire_ammo_projectile"
     spitfire_ammo_projectile.Damage0 = 15

--- a/src/main/scala/net/psforever/objects/vital/damage/DamageModifiers.scala
+++ b/src/main/scala/net/psforever/objects/vital/damage/DamageModifiers.scala
@@ -47,6 +47,7 @@ object DamageModifiers {
     private def function(damage: Int, data: ResolvedProjectile): Int = damage
   }
 
+  /** If the calculated distance is greater than the maximum distance of the projectile, damage is zero'd. */
   case object MaxDistanceCutoff extends Mod {
     def Calculate: DamageModifiers.Format = function
 
@@ -62,6 +63,21 @@ object DamageModifiers {
     }
   }
 
+  /** If the calculated distance is greater than a custom distance, damage is zero'd. */
+  case class CustomDistanceCutoff(cutoff: Float) extends Mod {
+    def Calculate: DamageModifiers.Format = function
+
+    private def function(damage: Int, data: ResolvedProjectile): Int = {
+      val projectile = data.projectile
+      val distance   = Vector3.Distance(data.hit_pos, projectile.shot_origin)
+      if (distance <= cutoff) {
+        damage
+      } else {
+        0
+      }
+    }
+  }
+
   /**
     * The input value degrades (lessens)
     * the further the distance between the point of origin (`shot_origin`)
@@ -70,22 +86,7 @@ object DamageModifiers {
     * If the value is encountered beyond its maximum distance, the value is zero'd.
     */
   case object DistanceDegrade extends Mod {
-    def Calculate: DamageModifiers.Format = function
-
-    private def function(damage: Int, data: ResolvedProjectile): Int = {
-      val projectile = data.projectile
-      val profile    = projectile.profile
-      val distance   = Vector3.Distance(data.hit_pos, projectile.shot_origin)
-      if (distance <= profile.DistanceMax) {
-        if (profile.DistanceNoDegrade == profile.DistanceMax || distance <= profile.DistanceNoDegrade) {
-          damage
-        } else {
-          damage - ((damage - profile.DegradeMultiplier * damage) * ((distance - profile.DistanceNoDegrade) / (profile.DistanceMax - profile.DistanceNoDegrade))).toInt
-        }
-      } else {
-        0
-      }
-    }
+    def Calculate: DamageModifiers.Format = distanceDegradeFunction
   }
 
   /**
@@ -95,24 +96,7 @@ object DamageModifiers {
     * If the value is encountered beyond its maximum radial distance, the value is zero'd.
     */
   case object RadialDegrade extends Mod {
-    def Calculate: DamageModifiers.Format = function
-
-    private def function(damage: Int, data: ResolvedProjectile): Int = {
-      val profile   = data.projectile.profile
-      val distance  = Vector3.Distance(data.hit_pos, data.target.Position)
-      val radius    = profile.DamageRadius
-      val radiusMin = profile.DamageRadiusMin
-      if (distance <= radiusMin) {
-        damage
-      } else if (distance <= radius) {
-        //damage - (damage * profile.DamageAtEdge * (distance - radiusMin) / (radius - radiusMin)).toInt
-        val base = profile.DamageAtEdge
-        val radi = radius - radiusMin
-        (damage * ((1 - base) * ((radi - (distance - radiusMin)) / radi) + base)).toInt
-      } else {
-        0
-      }
-    }
+    def Calculate: DamageModifiers.Format = radialDegradeFunction
   }
 
   /**
@@ -139,7 +123,7 @@ object DamageModifiers {
   }
 
   /*
-  Below this point are the calculations for sources of aggravated damage.
+  Aggravated damage.
   For the most part, these calculations are individualistic and arbitrary.
   They exist in their current form to satisfy observed shots to kill (STK) of specific weapon systems
   according to 2012 standards of the Youtube video series by TheLegendaryNarwhal.
@@ -150,7 +134,7 @@ object DamageModifiers {
     */
   case object InfantryAggravatedDirect extends Mod {
     def Calculate: DamageModifiers.Format =
-      BaseAggravatedFormula(ProjectileResolution.AggravatedDirect, DamageType.Direct)
+      baseAggravatedFormula(ProjectileResolution.AggravatedDirect, DamageType.Direct)
   }
 
   /**
@@ -159,7 +143,7 @@ object DamageModifiers {
     */
   case object InfantryAggravatedSplash extends Mod {
     def Calculate: DamageModifiers.Format =
-      BaseAggravatedFormula(ProjectileResolution.AggravatedSplash, DamageType.Splash)
+      baseAggravatedFormula(ProjectileResolution.AggravatedSplash, DamageType.Splash)
   }
 
   /**
@@ -169,7 +153,7 @@ object DamageModifiers {
     */
   case object InfantryAggravatedDirectBurn extends Mod {
     def Calculate: DamageModifiers.Format =
-      BaseAggravatedBurnFormula(ProjectileResolution.AggravatedDirectBurn, DamageType.Direct)
+      baseAggravatedBurnFormula(ProjectileResolution.AggravatedDirectBurn, DamageType.Direct)
   }
 
   /**
@@ -179,110 +163,7 @@ object DamageModifiers {
     */
   case object InfantryAggravatedSplashBurn extends Mod {
     def Calculate: DamageModifiers.Format =
-      BaseAggravatedBurnFormula(ProjectileResolution.AggravatedSplashBurn, DamageType.Splash)
-  }
-
-  /**
-    * For damage application that involves aggravation of a particular damage type,
-    * calculate that initial damage application for infantry targets
-    * and produce the modified damage value.
-    * Infantry wearing mechanized assault exo-suits (MAX) incorporate an additional modifier.
-    * @see `AggravatedDamage`
-    * @see `ExoSuitType`
-    * @see `InfantryAggravatedDirect`
-    * @see `InfantryAggravatedSplash`
-    * @see `PlayerSource`
-    * @see `ProjectileTarget.AggravatesTarget`
-    * @see `ResolvedProjectile`
-    * @param resolution the projectile resolution to match against
-    * @param damageType the damage type to find in as a component of aggravated information
-    * @param damage the base damage value
-    * @param data historical information related to the damage interaction
-    * @return the modified damage
-    */
-  private def BaseAggravatedFormula(
-                                     resolution: ProjectileResolution.Value,
-                                     damageType : DamageType.Value
-                                   )
-                                   (
-                                     damage: Int,
-                                     data: ResolvedProjectile
-                                   ): Int = {
-    if (data.resolution == resolution &&
-      data.projectile.quality == ProjectileQuality.AggravatesTarget) {
-      (data.projectile.profile.Aggravated, data.target) match {
-        case (Some(aggravation), p: PlayerSource) =>
-          val aggravatedDamage = aggravation.info.find(_.damage_type == damageType) match {
-            case Some(infos) =>
-              damage * infos.degradation_percentage + damage
-            case _ =>
-              damage toFloat
-          }
-          if(p.ExoSuit == ExoSuitType.MAX) {
-            (aggravatedDamage * aggravation.max_factor) toInt
-          } else {
-            aggravatedDamage toInt
-          }
-        case _ =>
-          damage
-      }
-    } else {
-      damage
-    }
-  }
-
-  /**
-    * For damage application that involves aggravation of a particular damage type,
-    * calculate that damage application burn for each tick for infantry targets
-    * and produce the modified damage value.
-    * Infantry wearing mechanized assault exo-suits (MAX) incorporate an additional modifier.
-    * Vanilla infantry incorporate their resistance value into a slightly different calculation than usual.
-    * @see `AggravatedDamage`
-    * @see `ExoSuitType`
-    * @see `InfantryAggravatedDirectBurn`
-    * @see `InfantryAggravatedSplashBurn`
-    * @see `PlayerSource`
-    * @see `ResolvedProjectile`
-    * @param resolution the projectile resolution to match against
-    * @param damageType the damage type to find in as a component of aggravated information
-    * @param damage the base damage value
-    * @param data historical information related to the damage interaction
-    * @return the modified damage
-    */
-  private def BaseAggravatedBurnFormula(
-                                         resolution: ProjectileResolution.Value,
-                                         damageType : DamageType.Value
-                                       )
-                                       (
-                                         damage: Int,
-                                         data: ResolvedProjectile
-                                       ): Int = {
-    if (data.resolution == resolution) {
-      (data.projectile.profile.Aggravated, data.target) match {
-        case (Some(aggravation), p: PlayerSource) =>
-          val degradation = aggravation.info.find(_.damage_type == damageType) match {
-            case Some(info) =>
-              info.degradation_percentage
-            case _ =>
-              1f
-          }
-          if (p.exosuit == ExoSuitType.MAX) {
-            (damage * degradation * aggravation.max_factor) toInt
-          } else {
-            val resist = data.damage_model.ResistUsing(data)(data)
-            //add resist to offset resist subtraction later
-            if (damage > resist) {
-              ((damage - resist) * degradation).toInt + resist
-            } else {
-              (damage * degradation).toInt + resist
-            }
-          }
-        case _ =>
-          0
-      }
-    } else {
-      damage
-    }
+      baseAggravatedBurnFormula(ProjectileResolution.AggravatedSplashBurn, DamageType.Splash)
   }
 
   /**
@@ -295,8 +176,8 @@ object DamageModifiers {
 
     private def formula(damage: Int, data: ResolvedProjectile): Int = {
       if (damage > 0 &&
-          data.resolution == ProjectileResolution.AggravatedDirectBurn ||
-          data.resolution == ProjectileResolution.AggravatedSplashBurn) {
+          (data.resolution == ProjectileResolution.AggravatedDirectBurn ||
+           data.resolution == ProjectileResolution.AggravatedSplashBurn)) {
         //add resist to offset resist subtraction later
         1 + data.damage_model.ResistUsing(data)(data)
       } else {
@@ -425,6 +306,17 @@ object DamageModifiers {
     }
   }
 
+  /**
+    * If the projectile has charging properties,
+    * and the weapon that produced the projectile has charging mechanics,
+    * calculate the current value of the damage as a sum
+    * of some minimum damage and scaled normal damage.
+    * The projectile quality has information about the "factor" of damage scaling.
+    * @see `ChargeDamage`
+    * @see `ChargeFireModeDefinition`
+    * @see `ProjectileQuality`
+    * @see `ResolvedProjectile`
+    */
   case object SpikerChargeDamage extends Mod {
     def Calculate: DamageModifiers.Format = formula
 
@@ -437,6 +329,195 @@ object DamageModifiers {
         case _ =>
           damage
       }
+    }
+  }
+
+  /**
+    * If the damage is resolved through a `HitDamage` packet,
+    * calculate the damage as a function of its degrading value over distance traveled by its carrier projectile.
+    * @see `distanceDegradeFunction`
+    * @see `ProjectileQuality`
+    * @see `ResolvedProjectile`
+    */
+  case object FlakHit extends Mod {
+    def Calculate: DamageModifiers.Format = formula
+
+    private def formula(damage: Int, data: ResolvedProjectile): Int = {
+      if(data.resolution == ProjectileResolution.Hit) {
+        distanceDegradeFunction(damage, data)
+      } else {
+        damage
+      }
+    }
+  }
+
+  /**
+    * If the damage is resolved through a `SplashHitDamage` packet,
+    * calculate the damage as a function of its degrading value over distance
+    * between the hit position of the projectile and the position of the target.
+    * @see `radialDegradeFunction`
+    * @see `ProjectileQuality`
+    * @see `ResolvedProjectile`
+    */
+  case object FlakBurst extends Mod {
+    def Calculate: DamageModifiers.Format = formula
+
+    private def formula(damage: Int, data: ResolvedProjectile): Int = {
+      if(data.resolution == ProjectileResolution.Splash) {
+        radialDegradeFunction(damage, data)
+      } else {
+        damage
+      }
+    }
+  }
+
+  /* Functions */
+
+  /**
+    * The input value degrades (lessens)
+    * the further the distance between the point of origin (`shot_origin`)
+    * and the point of encounter (`hit_pos`) of its vector (projectile).
+    * If the value is not set to degrade over any distance within its maximum distance, the value goes unmodified.
+    * If the value is encountered beyond its maximum distance, the value is zero'd.
+    */
+  private def distanceDegradeFunction(damage: Int, data: ResolvedProjectile): Int = {
+    val projectile = data.projectile
+    val profile    = projectile.profile
+    val distance   = Vector3.Distance(data.hit_pos, projectile.shot_origin)
+    if (distance <= profile.DistanceMax) {
+      if (profile.DistanceNoDegrade == profile.DistanceMax || distance <= profile.DistanceNoDegrade) {
+        damage
+      } else {
+        damage - ((damage - profile.DegradeMultiplier * damage) * ((distance - profile.DistanceNoDegrade) / (profile.DistanceMax - profile.DistanceNoDegrade))).toInt
+      }
+    } else {
+      0
+    }
+  }
+
+  /**
+    * The input value degrades (lessens)
+    * the further the distance between the point of origin (target position)
+    * and the point of encounter (`hit_pos`) of its vector (projectile).
+    * If the value is encountered beyond its maximum radial distance, the value is zero'd.
+    */
+  private def radialDegradeFunction(damage: Int, data: ResolvedProjectile): Int = {
+    val profile   = data.projectile.profile
+    val distance  = Vector3.Distance(data.hit_pos, data.target.Position)
+    val radius    = profile.DamageRadius
+    val radiusMin = profile.DamageRadiusMin
+    if (distance <= radiusMin) {
+      damage
+    } else if (distance <= radius) {
+      //damage - (damage * profile.DamageAtEdge * (distance - radiusMin) / (radius - radiusMin)).toInt
+      val base = profile.DamageAtEdge
+      val radi = radius - radiusMin
+      (damage * ((1 - base) * ((radi - (distance - radiusMin)) / radi) + base)).toInt
+    } else {
+      0
+    }
+  }
+
+  /**
+    * For damage application that involves aggravation of a particular damage type,
+    * calculate that initial damage application for infantry targets
+    * and produce the modified damage value.
+    * Infantry wearing mechanized assault exo-suits (MAX) incorporate an additional modifier.
+    * @see `AggravatedDamage`
+    * @see `ExoSuitType`
+    * @see `InfantryAggravatedDirect`
+    * @see `InfantryAggravatedSplash`
+    * @see `PlayerSource`
+    * @see `ProjectileTarget.AggravatesTarget`
+    * @see `ResolvedProjectile`
+    * @param resolution the projectile resolution to match against
+    * @param damageType the damage type to find in as a component of aggravated information
+    * @param damage the base damage value
+    * @param data historical information related to the damage interaction
+    * @return the modified damage
+    */
+  private def baseAggravatedFormula(
+                                     resolution: ProjectileResolution.Value,
+                                     damageType : DamageType.Value
+                                   )
+                                   (
+                                     damage: Int,
+                                     data: ResolvedProjectile
+                                   ): Int = {
+    if (data.resolution == resolution &&
+        data.projectile.quality == ProjectileQuality.AggravatesTarget) {
+      (data.projectile.profile.Aggravated, data.target) match {
+        case (Some(aggravation), p: PlayerSource) =>
+          val aggravatedDamage = aggravation.info.find(_.damage_type == damageType) match {
+            case Some(infos) =>
+              damage * infos.degradation_percentage + damage
+            case _ =>
+              damage toFloat
+          }
+          if(p.ExoSuit == ExoSuitType.MAX) {
+            (aggravatedDamage * aggravation.max_factor) toInt
+          } else {
+            aggravatedDamage toInt
+          }
+        case _ =>
+          damage
+      }
+    } else {
+      damage
+    }
+  }
+
+  /**
+    * For damage application that involves aggravation of a particular damage type,
+    * calculate that damage application burn for each tick for infantry targets
+    * and produce the modified damage value.
+    * Infantry wearing mechanized assault exo-suits (MAX) incorporate an additional modifier.
+    * Vanilla infantry incorporate their resistance value into a slightly different calculation than usual.
+    * @see `AggravatedDamage`
+    * @see `ExoSuitType`
+    * @see `InfantryAggravatedDirectBurn`
+    * @see `InfantryAggravatedSplashBurn`
+    * @see `PlayerSource`
+    * @see `ResolvedProjectile`
+    * @param resolution the projectile resolution to match against
+    * @param damageType the damage type to find in as a component of aggravated information
+    * @param damage the base damage value
+    * @param data historical information related to the damage interaction
+    * @return the modified damage
+    */
+  private def baseAggravatedBurnFormula(
+                                         resolution: ProjectileResolution.Value,
+                                         damageType : DamageType.Value
+                                       )
+                                       (
+                                         damage: Int,
+                                         data: ResolvedProjectile
+                                       ): Int = {
+    if (data.resolution == resolution) {
+      (data.projectile.profile.Aggravated, data.target) match {
+        case (Some(aggravation), p: PlayerSource) =>
+          val degradation = aggravation.info.find(_.damage_type == damageType) match {
+            case Some(info) =>
+              info.degradation_percentage
+            case _ =>
+              1f
+          }
+          if (p.exosuit == ExoSuitType.MAX) {
+            (damage * degradation * aggravation.max_factor) toInt
+          } else {
+            val resist = data.damage_model.ResistUsing(data)(data)
+            //add resist to offset resist subtraction later
+            if (damage > resist) {
+              ((damage - resist) * degradation).toInt + resist
+            } else {
+              (damage * degradation).toInt + resist
+            }
+          }
+        case _ =>
+          0
+      }
+    } else {
+      damage
     }
   }
 }


### PR DESCRIPTION
Flak is a contraction of the German word _**Fl**ug**a**bwehr**k**anone_ (or _Fliegerabwehrkanone_) meaning "aircraft-defense cannon".  Aren't you happy we don't call it "Fluga"?

Part of solving the flak question at one point meant unravelling the question regard why we have projectiles that possess primary damage attributes and secondary damage attributes.  The technical answer was actually already known and very simple.  When the projectile reaches a target for which it would turn into a burst of flak, it gets reported with a `SplashHitDamage` packet and is treated as `DamageType.Splash`; and, when the projectile reaches for a target for which it would not be turned into a burst of flak, the projectile directly strikes the target and is reported with a `HitDamage` message and its thus treated as being `DamageType.Hit`.  Knowing that, however, the practical answer is that the question was pointless in the first place because we don't use those values in any meaningful way on the server.  

The only thing the projectile needs to do is check which packet resolved it and, if it's the `SplashHitDamage` one, consider the possibility of radial degrade against the target.  Anything else it does it already did.

___Features___
__`DamageModifiers.FlakBurst`__
Not much to say.  The modifier applies a radial degrade value to indirectly splashed targets.

___Caveats___
This is one of those times where I am not trying to imitate the TheLegendaryNarwhal video that corresponds to the weapons of test in terms of shots to kill.  Only the Burster and the Rocket Rifle (flak) are available for test in an adversarial virtual reality range.  The presentations of both weapons are too messy to get incontestible answers, though close enough to the chosen results that it may not matter.  Anyway, the damage calculations are straight - get numbers, use maths.

___Addenda___
1.  I had originally thought the direct hit damage of the flak projectile would be subject to damage degrade over travel distance but, as it turns out, the properties aren't set up for that.  The only way it could be true and we'd never know would be a default property value we don't know being a non-zero.  At the very least, the projectile needs to declare a non-zero degrade rate.
2.  I actually haven't done much to directly correct flak damage in any capacity.  Nick complained that it seemed really weak a long time ago - eventually clarified to meaning that it did a third of the damage that it probably should - but whatever behavior he observed was not evident when I began testing.  I feel the biggest change that probably made it work better was setting the hit position of the flak to the same position of the primary direct damage target and that the low damage was actually due to the natural degradation of a projectile that detonates so many meters from the center of the target.
3.  Fluga.