### PR TITLE
_

### DIFF
--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -1152,7 +1152,7 @@ class AvatarActor(
                   tool.GUID = PlanetSideGUID(gen.getAndIncrement)
                 case Some(item: Equipment) =>
                   item.GUID = PlanetSideGUID(gen.getAndIncrement)
-                case None => ;
+                case _ => ;
               }
             )
           player.GUID = PlanetSideGUID(gen.getAndIncrement)
@@ -1193,7 +1193,7 @@ class AvatarActor(
                   item.Invalidate()
                 case Some(item: Equipment) =>
                   item.Invalidate()
-                case None => ;
+                case _ => ;
               }
             )
           player.Invalidate()

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3539,7 +3539,7 @@ class SessionActor extends Actor with MDCContextAware {
           })
           (
             a,
-            (continent.GUID(player.VehicleSeated) match {
+            continent.GUID(player.VehicleSeated) match {
               case Some(vehicle : Vehicle) if vehicle.PassengerInSeat(player).isDefined =>
                 b.partition {
                   _.GUID != vehicle.GUID
@@ -3552,7 +3552,7 @@ class SessionActor extends Actor with MDCContextAware {
                 //throw error since VehicleSeated didn't point to a vehicle?
                 player.VehicleSeated = None
                 (b, List.empty[Vehicle])
-            })
+            }
           )
         }
         val allActiveVehicles = vehicles ++ usedVehicle
@@ -5525,7 +5525,7 @@ class SessionActor extends Actor with MDCContextAware {
                   log.warn(
                     s"DismountVehicleMsg: can not dismount from vehicle as driver while server has asserted control; please wait ..."
                   )
-                case Some(seat_num: Int) =>
+                case Some(seat_num) =>
                   obj.Actor ! Mountable.TryDismount(player, seat_num)
                   if (interstellarFerry.isDefined) {
                     //short-circuit the temporary channel for transferring between zones, the player is no longer doing that
@@ -5564,7 +5564,7 @@ class SessionActor extends Actor with MDCContextAware {
               }) match {
                 case (Some(obj: Mountable), Some(tplayer: Player)) =>
                   obj.PassengerInSeat(tplayer) match {
-                    case Some(seat_num: Int) =>
+                    case Some(seat_num) =>
                       obj.Actor ! Mountable.TryDismount(tplayer, seat_num)
                     case None =>
                       dismountWarning(

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -86,8 +86,8 @@ class BuildingActor(
 
   def postStartBehaviour(): Behavior[Command] = {
     (galaxyService, interstellarCluster) match {
-      case (Some(galaxyService), Some(interstellarCluster)) =>
-        buffer.unstashAll(active(galaxyService, interstellarCluster))
+      case (Some(_galaxyService), Some(_interstellarCluster)) =>
+        buffer.unstashAll(active(_galaxyService, _interstellarCluster))
       case _ =>
         Behaviors.same
     }

--- a/src/main/scala/net/psforever/objects/guid/source/MaxNumberSource.scala
+++ b/src/main/scala/net/psforever/objects/guid/source/MaxNumberSource.scala
@@ -90,7 +90,7 @@ class MaxNumberSource(val max: Int) extends NumberSource {
       case Some(key: Key) if allowRestrictions && key.policy != AvailabilityPolicy.Restricted =>
         key.policy = AvailabilityPolicy.Restricted
         Some(new LoanedKey(number, key))
-      case None =>
+      case _ =>
         None
     }
   }

--- a/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -407,7 +407,7 @@ object ContainableBehavior {
     item match {
       case Some(_) if item.nonEmpty && source.Slot(slot).Equipment.isEmpty =>
         (outSlot, item)
-      case None =>
+      case _ =>
         (None, None)
     }
   }
@@ -560,7 +560,7 @@ object ContainableBehavior {
     (dest match {
       case Some(slot) if ContainableBehavior.TestPutItemInSlot(destination, item, slot).contains(Nil) =>
         ContainableBehavior.TryPutItemInSlot(destination, item, slot)
-      case None => (false, None)
+      case _ => (false, None)
     }) match {
       case (true, swapItem) =>
         (dest, swapItem)

--- a/src/main/scala/net/psforever/services/InterstellarClusterService.scala
+++ b/src/main/scala/net/psforever/services/InterstellarClusterService.scala
@@ -171,7 +171,7 @@ class InterstellarClusterService(context: ActorContext[InterstellarClusterServic
             Random.shuffle(zone.findSpawns(faction, spawnGroups)).headOption match {
               case Some((_, spawnPoints)) if spawnPoints.nonEmpty =>
                 Some((zone, Random.shuffle(spawnPoints.toList).head))
-              case None =>
+              case _ =>
                 None
             }
           case None =>


### PR DESCRIPTION
A `MatchError` is when no patterns included in a `match { ... }` statement would properly parse the input.  Matching patterns can often feature guards, boolean logic that decides whether the given pattern is a closer match to what is wanted than another pattern of similar or same syntax.  Most of those could easily be written into a single case with an `if ... else ... `; but, there is nothing inherently wrong with using guards as long as one is careful not to assume that `None` can be the last ditch pattern in an `Option` match anymore.

The pattern `_` catches everything.