### PR TITLE
Amenity Auto-Repair

### DIFF
--- a/src/main/scala/net/psforever/actors/commands/NtuCommand.scala
+++ b/src/main/scala/net/psforever/actors/commands/NtuCommand.scala
@@ -11,7 +11,7 @@ object NtuCommand {
     *
     * @param source the nanite container recognized as the sender
     */
-  final case class Offer(source: NtuContainer) extends Command
+  final case class Offer(source: NtuContainer, replyTo: ActorRef[Request]) extends Command
 
   /** Message for asking for nanites from the recipient.
     *
@@ -24,6 +24,6 @@ object NtuCommand {
     * @param source the nanite container recognized as the sender
     * @param amount the nanites transferred in this package
     */
-  final case class Grant(source: NtuContainer, amount: Int)
+  final case class Grant(source: NtuContainer, amount: Int) extends Command
 
 }

--- a/src/main/scala/net/psforever/actors/commands/NtuCommand.scala
+++ b/src/main/scala/net/psforever/actors/commands/NtuCommand.scala
@@ -17,13 +17,13 @@ object NtuCommand {
     *
     * @param amount the amount of nanites requested
     */
-  final case class Request(amount: Int, replyTo: ActorRef[Grant]) extends Command
+  final case class Request(amount: Float, replyTo: ActorRef[Grant]) extends Command
 
   /** Response for transferring nanites to a recipient.
     *
     * @param source the nanite container recognized as the sender
     * @param amount the nanites transferred in this package
     */
-  final case class Grant(source: NtuContainer, amount: Int) extends Command
+  final case class Grant(source: NtuContainer, amount: Float) extends Command
 
 }

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -7,7 +7,6 @@ import akka.actor.{Actor, ActorRef, Cancellable, MDCContextAware}
 import akka.pattern.ask
 import akka.util.Timeout
 import java.util.concurrent.TimeUnit
-import MDCContextAware.Implicits._
 import net.psforever.actors.net.MiddlewareActor
 import net.psforever.services.ServiceManager.Lookup
 import net.psforever.objects.locker.LockerContainer

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -156,7 +156,7 @@ class BuildingActor(
   def ntu(msg: NtuCommand.Command): Behavior[Command] = {
     import NtuCommand._
     msg match {
-      case Offer(source, _) =>
+      case Offer(_, _) =>
         Behaviors.same
       case Request(amount, replyTo) =>
         building match {

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -42,6 +42,10 @@ object BuildingActor {
   final case class MapUpdate() extends Command
 
   final case class Ntu(command: NtuCommand.Command) extends Command
+
+  final case class PowerOn() extends Command
+
+  final case class PowerOff() extends Command
 }
 
 class BuildingActor(
@@ -146,6 +150,20 @@ class BuildingActor(
 
       case MapUpdate() =>
         galaxyService ! GalaxyServiceMessage(GalaxyAction.MapUpdate(building.infoUpdateMessage()))
+        Behaviors.same
+
+      case msg @ PowerOff() =>
+        log.trace(s"Facility ${building.Name}, ${building.Zone.id} has lost power.")
+        building.Amenities.foreach { amenity =>
+          amenity.Actor ! msg
+        }
+        Behaviors.same
+
+      case msg @ PowerOn() =>
+        log.trace(s"Power has been restored to facility ${building.Name}, ${building.Zone.id}")
+        building.Amenities.foreach { amenity =>
+          amenity.Actor ! msg
+        }
         Behaviors.same
 
       case Ntu(msg) =>

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -153,14 +153,14 @@ class BuildingActor(
         Behaviors.same
 
       case msg @ PowerOff() =>
-        log.trace(s"Facility ${building.Name}, ${building.Zone.id} has lost power.")
+        log.trace(s"facility ${building.Name} has lost power")
         building.Amenities.foreach { amenity =>
           amenity.Actor ! msg
         }
         Behaviors.same
 
       case msg @ PowerOn() =>
-        log.trace(s"Power has been restored to facility ${building.Name}, ${building.Zone.id}")
+        log.trace(s"power has been restored to facility ${building.Name}")
         building.Amenities.foreach { amenity =>
           amenity.Actor ! msg
         }

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -188,12 +188,15 @@ class BuildingActor(
       case Request(amount, replyTo) =>
         building match {
           case b: WarpGate =>
+            //warp gates are an infiite source of nanites
             replyTo ! Grant(b, if (b.Active) amount else 0)
             Behaviors.same
-          case _ if building.BuildingType == StructureType.Tower =>
+          case _ if building.BuildingType == StructureType.Tower || building.Zone.map.cavern =>
+            //towers and cavern stuff get free repairs
             replyTo ! NtuCommand.Grant(new FakeNtuSource(building), amount)
             Behaviors.same
           case _           =>
+            //all other facilities require a storage silo for ntu
             building.Amenities.find(_.isInstanceOf[NtuContainer]) match {
               case Some(ntuContainer) =>
                 ntuContainer.Actor ! msg //needs to redirect

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -19,7 +19,7 @@ import net.psforever.objects.serverobject.painbox.PainboxDefinition
 import net.psforever.objects.serverobject.terminals._
 import net.psforever.objects.serverobject.tube.SpawnTubeDefinition
 import net.psforever.objects.serverobject.resourcesilo.ResourceSiloDefinition
-import net.psforever.objects.serverobject.structures.{BuildingDefinition, WarpGateDefinition}
+import net.psforever.objects.serverobject.structures.{AutoRepairStats, BuildingDefinition, WarpGateDefinition}
 import net.psforever.objects.serverobject.turret.{FacilityTurretDefinition, TurretUpgrade}
 import net.psforever.objects.vehicles.{DestroyedVehicle, InternalTelepadDefinition, SeatArmorRestriction, UtilityType}
 import net.psforever.objects.vital.damage.{DamageCalculations, DamageModifiers}
@@ -6746,6 +6746,7 @@ object GlobalDefinitions {
     spawn_terminal.Name = "spawn_terminal"
     spawn_terminal.Damageable = false
     spawn_terminal.Repairable = false
+    spawn_terminal.autoRepair = AutoRepairStats(1, 5000, 200, 1) //TODO amount and drain are default? undefined?
 
     order_terminal.Name = "order_terminal"
     order_terminal.Tab += 0 -> OrderTerminalDefinition.EquipmentPage(
@@ -6764,6 +6765,7 @@ object GlobalDefinitions {
     order_terminal.MaxHealth = 500
     order_terminal.Damageable = true
     order_terminal.Repairable = true
+    order_terminal.autoRepair = AutoRepairStats(1, 0, 500, 1f)//AutoRepairStats(1, 5000, 3500, 0.5f)
     order_terminal.RepairIfDestroyed = true
     order_terminal.Subtract.Damage1 = 8
 
@@ -6827,6 +6829,7 @@ object GlobalDefinitions {
     cert_terminal.MaxHealth = 500
     cert_terminal.Damageable = true
     cert_terminal.Repairable = true
+    cert_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     cert_terminal.RepairIfDestroyed = true
     cert_terminal.Subtract.Damage1 = 8
 
@@ -6834,6 +6837,7 @@ object GlobalDefinitions {
     implant_terminal_mech.MaxHealth = 1500 //TODO 1000; right now, 1000 (mech) + 500 (interface)
     implant_terminal_mech.Damageable = true
     implant_terminal_mech.Repairable = true
+    implant_terminal_mech.autoRepair = AutoRepairStats(1, 5000, 2400, 0.5f)
     implant_terminal_mech.RepairIfDestroyed = true
 
     implant_terminal_interface.Name = "implant_terminal_interface"
@@ -6841,6 +6845,7 @@ object GlobalDefinitions {
     implant_terminal_interface.MaxHealth = 500
     implant_terminal_interface.Damageable = false //TODO true
     implant_terminal_interface.Repairable = true
+    implant_terminal_interface.autoRepair = AutoRepairStats(0, 5000, 200, 0) //TODO amount and drain are default? undefined?
     implant_terminal_interface.RepairIfDestroyed = true
 
     ground_vehicle_terminal.Name = "ground_vehicle_terminal"
@@ -6852,6 +6857,7 @@ object GlobalDefinitions {
     ground_vehicle_terminal.MaxHealth = 500
     ground_vehicle_terminal.Damageable = true
     ground_vehicle_terminal.Repairable = true
+    ground_vehicle_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     ground_vehicle_terminal.RepairIfDestroyed = true
     ground_vehicle_terminal.Subtract.Damage1 = 8
 
@@ -6864,6 +6870,7 @@ object GlobalDefinitions {
     air_vehicle_terminal.MaxHealth = 500
     air_vehicle_terminal.Damageable = true
     air_vehicle_terminal.Repairable = true
+    air_vehicle_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     air_vehicle_terminal.RepairIfDestroyed = true
     air_vehicle_terminal.Subtract.Damage1 = 8
 
@@ -6876,6 +6883,7 @@ object GlobalDefinitions {
     dropship_vehicle_terminal.MaxHealth = 500
     dropship_vehicle_terminal.Damageable = true
     dropship_vehicle_terminal.Repairable = true
+    dropship_vehicle_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     dropship_vehicle_terminal.RepairIfDestroyed = true
     dropship_vehicle_terminal.Subtract.Damage1 = 8
 
@@ -6888,6 +6896,7 @@ object GlobalDefinitions {
     vehicle_terminal_combined.MaxHealth = 500
     vehicle_terminal_combined.Damageable = true
     vehicle_terminal_combined.Repairable = true
+    vehicle_terminal_combined.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     vehicle_terminal_combined.RepairIfDestroyed = true
     vehicle_terminal_combined.Subtract.Damage1 = 8
 
@@ -6900,6 +6909,7 @@ object GlobalDefinitions {
     vanu_air_vehicle_term.MaxHealth = 500
     vanu_air_vehicle_term.Damageable = true
     vanu_air_vehicle_term.Repairable = true
+    vanu_air_vehicle_term.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     vanu_air_vehicle_term.RepairIfDestroyed = true
     vanu_air_vehicle_term.Subtract.Damage1 = 8
 
@@ -6912,6 +6922,7 @@ object GlobalDefinitions {
     vanu_vehicle_term.MaxHealth = 500
     vanu_vehicle_term.Damageable = true
     vanu_vehicle_term.Repairable = true
+    vanu_vehicle_term.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     vanu_vehicle_term.RepairIfDestroyed = true
     vanu_vehicle_term.Subtract.Damage1 = 8
 
@@ -6924,6 +6935,7 @@ object GlobalDefinitions {
     bfr_terminal.MaxHealth = 500
     bfr_terminal.Damageable = true
     bfr_terminal.Repairable = true
+    bfr_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     bfr_terminal.RepairIfDestroyed = true
     bfr_terminal.Subtract.Damage1 = 8
 
@@ -6934,6 +6946,7 @@ object GlobalDefinitions {
     respawn_tube.Damageable = true
     respawn_tube.DamageableByFriendlyFire = false
     respawn_tube.Repairable = true
+    respawn_tube.autoRepair = AutoRepairStats(1, 10000, 2400, 1)
     respawn_tube.RepairIfDestroyed = true
     respawn_tube.Subtract.Damage1 = 8
 
@@ -6943,6 +6956,7 @@ object GlobalDefinitions {
     respawn_tube_sanctuary.Damageable = false //true?
     respawn_tube_sanctuary.DamageableByFriendlyFire = false
     respawn_tube_sanctuary.Repairable = true
+    respawn_tube_sanctuary.autoRepair = AutoRepairStats(1, 10000, 2400, 1)
 
     respawn_tube_tower.Name = "respawn_tube_tower"
     respawn_tube_tower.Delay = 10
@@ -6951,6 +6965,7 @@ object GlobalDefinitions {
     respawn_tube_tower.Damageable = true
     respawn_tube_tower.DamageableByFriendlyFire = false
     respawn_tube_tower.Repairable = true
+    respawn_tube_tower.autoRepair = AutoRepairStats(1, 10000, 2400, 1)
     respawn_tube_tower.RepairIfDestroyed = true
     respawn_tube_tower.Subtract.Damage1 = 8
 
@@ -6968,6 +6983,7 @@ object GlobalDefinitions {
     medical_terminal.MaxHealth = 500
     medical_terminal.Damageable = true
     medical_terminal.Repairable = true
+    medical_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     medical_terminal.RepairIfDestroyed = true
 
     adv_med_terminal.Name = "adv_med_terminal"
@@ -6979,6 +6995,7 @@ object GlobalDefinitions {
     adv_med_terminal.MaxHealth = 750
     adv_med_terminal.Damageable = true
     adv_med_terminal.Repairable = true
+    adv_med_terminal.autoRepair = AutoRepairStats(1, 5000, 2400, 0.5f)
     adv_med_terminal.RepairIfDestroyed = true
 
     crystals_health_a.Name = "crystals_health_a"
@@ -7006,6 +7023,7 @@ object GlobalDefinitions {
     portable_med_terminal.MaxHealth = 500
     portable_med_terminal.Damageable = false //TODO actually true
     portable_med_terminal.Repairable = false
+    portable_med_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
 
     pad_landing_frame.Name = "pad_landing_frame"
     pad_landing_frame.Interval = 1000
@@ -7119,6 +7137,7 @@ object GlobalDefinitions {
     manned_turret.Damageable = true
     manned_turret.DamageDisablesAt = 0
     manned_turret.Repairable = true
+    manned_turret.autoRepair = AutoRepairStats(1, 10000, 1600, 0.5f)
     manned_turret.RepairIfDestroyed = true
     manned_turret.Weapons += 1                          -> new mutable.HashMap()
     manned_turret.Weapons(1) += TurretUpgrade.None      -> phalanx_sgl_hevgatcan
@@ -7133,6 +7152,7 @@ object GlobalDefinitions {
     vanu_sentry_turret.Damageable = true
     vanu_sentry_turret.DamageDisablesAt = 0
     vanu_sentry_turret.Repairable = true
+    vanu_sentry_turret.autoRepair = AutoRepairStats(3, 10000, 1000, 0.5f)
     vanu_sentry_turret.RepairIfDestroyed = true
     vanu_sentry_turret.Weapons += 1                     -> new mutable.HashMap()
     vanu_sentry_turret.Weapons(1) += TurretUpgrade.None -> vanu_sentry_turret_weapon
@@ -7174,6 +7194,7 @@ object GlobalDefinitions {
     generator.Damageable = true
     generator.DamageableByFriendlyFire = false
     generator.Repairable = true
+    generator.autoRepair = AutoRepairStats(1, 5000, 875, 1)
     generator.RepairDistance = 13.5f
     generator.RepairIfDestroyed = true
     generator.Subtract.Damage1 = 9

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -6765,7 +6765,7 @@ object GlobalDefinitions {
     order_terminal.MaxHealth = 500
     order_terminal.Damageable = true
     order_terminal.Repairable = true
-    order_terminal.autoRepair = AutoRepairStats(1, 0, 500, 1f)//AutoRepairStats(1, 5000, 3500, 0.5f)
+    order_terminal.autoRepair = AutoRepairStats(1, 5000, 3500, 0.5f)
     order_terminal.RepairIfDestroyed = true
     order_terminal.Subtract.Damage1 = 8
 

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -6845,7 +6845,7 @@ object GlobalDefinitions {
     implant_terminal_interface.MaxHealth = 500
     implant_terminal_interface.Damageable = false //TODO true
     implant_terminal_interface.Repairable = true
-    implant_terminal_interface.autoRepair = AutoRepairStats(0, 5000, 200, 0) //TODO amount and drain are default? undefined?
+    implant_terminal_interface.autoRepair = AutoRepairStats(1, 5000, 200, 1) //TODO amount and drain are default? undefined?
     implant_terminal_interface.RepairIfDestroyed = true
 
     ground_vehicle_terminal.Name = "ground_vehicle_terminal"
@@ -7199,5 +7199,4 @@ object GlobalDefinitions {
     generator.RepairIfDestroyed = true
     generator.Subtract.Damage1 = 9
   }
-
 }

--- a/src/main/scala/net/psforever/objects/Ntu.scala
+++ b/src/main/scala/net/psforever/objects/Ntu.scala
@@ -23,7 +23,7 @@ object Ntu {
     * @param max the amount of nanites required to not make further requests;
     *            if 0, the `sender` is full and the message is for clean up operations
     */
-  final case class Request(min: Int, max: Int)
+  final case class Request(min: Float, max: Float)
 
   /**
     * Message for transferring nanites to a recipient.
@@ -31,23 +31,23 @@ object Ntu {
     * @param src    the nanite container recognized as the sender
     * @param amount the nanites transferred in this package
     */
-  final case class Grant(src: NtuContainer, amount: Int)
+  final case class Grant(src: NtuContainer, amount: Float)
 }
 
 trait NtuContainer extends TransferContainer {
-  def NtuCapacitor: Int
+  def NtuCapacitor: Float
 
-  def NtuCapacitor_=(value: Int): Int
+  def NtuCapacitor_=(value: Float): Float
 
   def Definition: NtuContainerDefinition
 }
 
 trait CommonNtuContainer extends NtuContainer {
-  private var ntuCapacitor: Int = 0
+  private var ntuCapacitor: Float = 0
 
-  def NtuCapacitor: Int = ntuCapacitor
+  def NtuCapacitor: Float = ntuCapacitor
 
-  def NtuCapacitor_=(value: Int): Int = {
+  def NtuCapacitor_=(value: Float): Float = {
     ntuCapacitor = scala.math.max(0, scala.math.min(value, Definition.MaxNtuCapacitor))
     NtuCapacitor
   }
@@ -56,11 +56,11 @@ trait CommonNtuContainer extends NtuContainer {
 }
 
 trait NtuContainerDefinition {
-  private var maxNtuCapacitor: Int = 0
+  private var maxNtuCapacitor: Float = 0
 
-  def MaxNtuCapacitor: Int = maxNtuCapacitor
+  def MaxNtuCapacitor: Float = maxNtuCapacitor
 
-  def MaxNtuCapacitor_=(max: Int): Int = {
+  def MaxNtuCapacitor_=(max: Float): Float = {
     maxNtuCapacitor = max
     MaxNtuCapacitor
   }
@@ -89,7 +89,7 @@ trait NtuStorageBehavior extends Actor {
 
   def StopNtuBehavior(sender: ActorRef): Unit
 
-  def HandleNtuRequest(sender: ActorRef, min: Int, max: Int): Unit
+  def HandleNtuRequest(sender: ActorRef, min: Float, max: Float): Unit
 
-  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Int): Unit
+  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Float): Unit
 }

--- a/src/main/scala/net/psforever/objects/Ntu.scala
+++ b/src/main/scala/net/psforever/objects/Ntu.scala
@@ -76,7 +76,12 @@ trait NtuStorageBehavior extends Actor {
 
     case Ntu.Request(min, max) => HandleNtuRequest(sender(), min, max)
 
+    case NtuCommand.Request(amount, replyTo) =>
+      import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+      HandleNtuRequest(new TypedActorRefOps(replyTo).toClassic, amount, amount+1)
+
     case Ntu.Grant(src, amount)        => HandleNtuGrant(sender(), src, amount)
+
     case NtuCommand.Grant(src, amount) => HandleNtuGrant(sender(), src, amount)
   }
 

--- a/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -231,9 +231,9 @@ object Vehicles {
     // Forcefully dismount any cargo
     target.CargoHolds.values.foreach(cargoHold => {
       cargoHold.Occupant match {
-        case Some(cargo: Vehicle) => {
+        case Some(cargo: Vehicle) =>
           cargo.Seats(0).Occupant match {
-            case Some(cargoDriver: Player) =>
+            case Some(_: Player) =>
               CargoBehavior.HandleVehicleCargoDismount(
                 target.Zone,
                 cargo.GUID,
@@ -243,8 +243,7 @@ object Vehicles {
               )
             case None =>
               log.error("FinishHackingVehicle: vehicle in cargo hold missing driver")
-              CargoBehavior.HandleVehicleCargoDismount(cargo.GUID, cargo, target.GUID, target, false, false, true)
-          }
+              CargoBehavior.HandleVehicleCargoDismount(cargo.GUID, cargo, target.GUID, target, bailed = false, requestedByPassenger = false, kicked = true)
         }
         case None => ;
       }
@@ -326,7 +325,7 @@ object Vehicles {
             Vector3.DistanceSquared(obj.Position.xy, target.Position.xy) < soiRadius * soiRadius
           } =>
         Some(target.asInstanceOf[NtuContainer])
-      case None =>
+      case _ =>
         None
     }).orElse {
       val position = obj.Position.xy

--- a/src/main/scala/net/psforever/objects/serverobject/doors/DoorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/doors/DoorControl.scala
@@ -16,7 +16,6 @@ class DoorControl(door: Door) extends Actor with FactionAffinityBehavior.Check {
       case Door.Use(player, msg) =>
         sender() ! Door.DoorMessage(player, msg, door.Use(player, msg))
 
-      case _ =>
-        sender() ! Door.NoEvent()
+      case _ => ;
     }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
@@ -1,0 +1,91 @@
+//Copyright (c) 2020 PSForever
+package net.psforever.objects.serverobject.repair
+
+import akka.actor.{Actor, Cancellable}
+import akka.actor.typed.{ActorRef => TypedActorRef}
+import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
+import net.psforever.actors.commands.NtuCommand
+import net.psforever.actors.zone.BuildingActor
+import net.psforever.objects.{Default, Ntu}
+import net.psforever.objects.serverobject.damage.Damageable
+import net.psforever.objects.serverobject.structures.{Amenity, AutoRepairStats}
+
+import scala.concurrent.duration._
+
+trait AmenityAutoRepair {
+  _: Damageable with RepairableEntity with Actor =>
+  private lazy val ntuGrantActorRef: TypedActorRef[NtuCommand.Grant] =
+    new ClassicActorRefOps(self).toTyped[NtuCommand.Grant]
+  private var autoRepairStartFunc: ()=>Unit                          = startAutoRepairIfStopped
+  private var autoRepairTimer: Cancellable                           = Default.Cancellable
+
+  def AutoRepairObject: Amenity
+
+  final val autoRepairBehavior: Receive = {
+    case BuildingActor.PowerOn() =>
+      powerOnCallback()
+
+    case BuildingActor.PowerOff() =>
+      powerOffCallback()
+
+    case Ntu.Grant(_, 0) | NtuCommand.Grant(_, 0) =>
+      autoRepairTimer.cancel()
+
+    case Ntu.Grant(_, _) | NtuCommand.Grant(_, _) =>
+      val obj = AutoRepairObject
+      obj.Definition.autoRepair match {
+        case Some(repair : AutoRepairStats) =>
+          PerformRepairs(obj, repair.amount)
+        case _ => ;
+      }
+  }
+
+  def powerOnCallback(): Unit = {
+    startAutoRepairFunctionality()
+  }
+
+  def powerOffCallback(): Unit = {
+    stopAutoRepairFunctionality()
+  }
+
+  final def startAutoRepairFunctionality(): Unit = {
+    retimeAutoRepair()
+    autoRepairStartFunc = startAutoRepairIfStopped
+  }
+
+  final def stopAutoRepairFunctionality(): Unit = {
+    autoRepairTimer.cancel()
+    autoRepairStartFunc = ()=>{}
+  }
+
+  final def startAutoRepairIfStopped(): Unit = {
+    if(autoRepairTimer.isCancelled) {
+      retimeAutoRepair()
+    }
+  }
+
+  final def stopAutoRepair(): Unit = {
+    autoRepairTimer.cancel()
+  }
+
+  final def retimeAutoRepair(): Unit = {
+    val obj = AutoRepairObject
+    obj.Definition.autoRepair match {
+      case Some(AutoRepairStats(_, start, interval, drain))
+        if obj.Definition.Damageable && obj.Health < obj.Definition.MaxHealth =>
+        retimeAutoRepair(start, interval, drain)
+      case _ => ;
+    }
+  }
+
+  final def retimeAutoRepair(initialDelay: Long, delay: Long, drain: Float): Unit = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    autoRepairTimer.cancel()
+    autoRepairTimer = context.system.scheduler.scheduleWithFixedDelay(
+      initialDelay milliseconds,
+      delay milliseconds,
+      AutoRepairObject.Owner.Actor,
+      BuildingActor.Ntu(NtuCommand.Request(drain, ntuGrantActorRef))
+    )
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
@@ -12,12 +12,31 @@ import net.psforever.objects.serverobject.structures.{Amenity, AutoRepairStats}
 
 import scala.concurrent.duration._
 
+/**
+  * A mixin for handling the automatic repair functionality of facility amenities.
+  * Auto-repair is facilitated primarily as a function of nanite transfer unit (NTU) provisions
+  * and is prompted by the amenity itself sustaining damage
+  * and being, at some level, capable of being repaired.
+  * In major facilities - technology plants, bio labs, etc. -
+  * this NTU is obtained from that facility's nanite resource silo.
+  * The amenity that wishes to be repaired asks the facility for nanite.
+  * The reply comes from the NTU source, or from the facility again.
+  * In exchange for the automatic repair, the silo looses some of its NTU stockpile
+  * and that entails all of the consequences of losing all of the NTU for the base.
+  * In smaller field tower bases, the lack of resource silo should not hinder operations
+  * as auto-repair is still carried out nonetheless.
+  * The consequences of losing NTU do not apply in this case;
+  * the field tower is considered to have unlimited, unshared NTU.
+  */
 trait AmenityAutoRepair
   extends NtuStorageBehavior {
   _: Damageable with RepairableEntity with Actor =>
+  /** a dedicated reference to self that facilitates in receiving `NtuCommand.Grant` messages for auto-repair operation */
   private lazy val ntuGrantActorRef: TypedActorRef[NtuCommand.Grant] =
     new ClassicActorRefOps(self).toTyped[NtuCommand.Grant]
+  /** the function that initializes auto-repair operations, if those operations have not yet started */
   private var autoRepairStartFunc: ()=>Unit = startAutoRepairIfStopped
+  /** the timer for requests for auto-repair-actionable resource deposits (NTU) */
   private var autoRepairTimer: Cancellable  = Default.Cancellable
 
   def AutoRepairObject: Amenity
@@ -30,14 +49,26 @@ trait AmenityAutoRepair
       noNtuSupplyCallback()
   }
 
+  //nothing special
   def HandleNtuOffer(sender: ActorRef, src: NtuContainer): Unit = { }
 
+  /**
+    * Stop the auto-repair timer.
+    */
   def StopNtuBehavior(sender : ActorRef) : Unit = {
     autoRepairTimer.cancel()
   }
 
+  //nothing special
   def HandleNtuRequest(sender: ActorRef, min: Float, max: Float): Unit = { }
 
+  /**
+    * When reports of an NTU provision is returned to the requesting amenity,
+    * the amount of repair that can be performed is obtained
+    * and, if the amenity still requires those repairs,
+    * auto-repair executes a single tick.
+    * @see `RepairableAmenity`
+    */
   def HandleNtuGrant(sender : ActorRef, src : NtuContainer, amount : Float) : Unit = {
     val obj = AutoRepairObject
     obj.Definition.autoRepair match {
@@ -47,48 +78,100 @@ trait AmenityAutoRepair
     }
   }
 
+  /**
+    * Confirm that a provision of NTU to the potential requesting amenity is possible.
+    * Attempt to start auto-repair operations.
+    */
   def withNtuSupplyCallback(): Unit = {
     startAutoRepairFunctionality()
   }
 
+  /**
+    * No (further) provisions of NTU to the potential requesting amenity will be forthcoming.
+    * Cancel any attempts at auto-repair.
+    */
   def noNtuSupplyCallback(): Unit = {
     stopAutoRepairFunctionality()
   }
 
+  /**
+    * Attempt to start auto-repair operation if possible,
+    * restarting an existing timed operation if necessary.
+    * Set a function that will attempt auto-repair operations under specific trigger-able conditions (damage).
+    */
   private def startAutoRepairFunctionality(): Unit = {
     retimeAutoRepair()
     autoRepairStartFunc = startAutoRepairIfStopped
   }
 
+  /**
+    * Cancel any attempts at auto-repair
+    * by stopping any currently processing repair timer
+    * and ensuring that otherwise trigger-able conditions (damages) do not instigate auto-repair operations.
+    * @see `stopAutoRepair`
+    */
   private def stopAutoRepairFunctionality(): Unit = {
     autoRepairTimer.cancel()
     autoRepairStartFunc = ()=>{}
   }
 
+  /**
+    * Attempt to start auto-repair operation
+    * only if no operation is currently being processed.
+    */
   private def startAutoRepairIfStopped(): Unit = {
     if(autoRepairTimer.isCancelled) {
       retimeAutoRepair()
     }
   }
 
-  final def tryAutoRepair(): Unit = {
+  /**
+    * Attempt to start auto-repair operation
+    * only if no operation is currently being processed.
+    * @return `true`, if the auto-repair process started specifically due to this call;
+    *        `false`, if it was already started, or did not start
+    */
+  final def tryAutoRepair(): Boolean = {
+    val before = autoRepairTimer.isCancelled
     autoRepairStartFunc()
+    !(before || autoRepairTimer.isCancelled)
   }
 
+/**
+  * Cancel any attempts at auto-repair
+  * by stopping any currently processing repair timer
+  * The operation can be resumed.
+  * @see `stopAutoRepairFunctionality`
+  */
   final def stopAutoRepair(): Unit = {
     autoRepairTimer.cancel()
   }
 
+  /**
+    * As long as setup information regarding the auto-repair process can be discovered in the amenity's definition
+    * and the amenity actually requires to be performed,
+    * perform the setup for the auto-repair operation.
+    */
   private def retimeAutoRepair(): Unit = {
     val obj = AutoRepairObject
     obj.Definition.autoRepair match {
-      case Some(AutoRepairStats(_, start, interval, drain))
-        if obj.Health < obj.Definition.MaxHealth =>
+      case Some(AutoRepairStats(_, start, interval, drain)) if obj.Health < obj.Definition.MaxHealth =>
         retimeAutoRepair(start, interval, drain)
       case _ => ;
     }
   }
 
+  /**
+    * As long as setup information regarding the auto-repair process can be provided,
+    * perform the setup for the auto-repair operation.
+    * @see `BuildingActor.Ntu`
+    * @see `NtuCommand.Request`
+    * @see `scheduleWithFixedDelay`
+    * @param initialDelay the delay before the first message
+    * @param delay the delay between subsequent messages, after the first
+    * @param drain the amount of NTU being levied as a cost for auto-repair operation
+    *              (the responding entity determines how to satisfy the cost)
+    */
   private def retimeAutoRepair(initialDelay: Long, delay: Long, drain: Float): Unit = {
     import scala.concurrent.ExecutionContext.Implicits.global
     autoRepairTimer.cancel()

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSilo.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSilo.scala
@@ -16,7 +16,7 @@ class ResourceSilo extends Amenity with CommonNtuContainer {
   // For the NTU display bar
   private var capacitorDisplay: Long = 0
 
-  def MaxNtuCapacitor : Int = Definition.MaxNtuCapacitor
+  def MaxNtuCapacitor : Float = Definition.MaxNtuCapacitor
 
   def LowNtuWarningOn: Boolean = lowNtuWarningOn
   def LowNtuWarningOn_=(enabled: Boolean): Boolean = {
@@ -24,7 +24,7 @@ class ResourceSilo extends Amenity with CommonNtuContainer {
     LowNtuWarningOn
   }
 
-  def CapacitorDisplay : Long = scala.math.ceil((NtuCapacitor.toFloat / MaxNtuCapacitor.toFloat) * 10).toInt
+  def CapacitorDisplay : Long = scala.math.ceil((NtuCapacitor / MaxNtuCapacitor) * 10).toInt
 
   def Definition: ResourceSiloDefinition = GlobalDefinitions.resource_silo
 
@@ -34,7 +34,7 @@ class ResourceSilo extends Amenity with CommonNtuContainer {
 }
 
 object ResourceSilo {
-  final case class UpdateChargeLevel(amount: Int)
+  final case class UpdateChargeLevel(amount: Float)
   final case class LowNtuWarning(enabled: Boolean)
   sealed trait Exchange
   final case class ChargeEvent() extends Exchange

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
@@ -33,8 +33,12 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
   def receive: Receive = {
     case "startup" =>
       resourceSilo.Owner match {
-        case building: Building if resourceSilo.NtuCapacitor > 0f =>
-          building.Actor ! BuildingActor.PowerOn()
+        case building: Building =>
+          building.Actor ! (if (resourceSilo.NtuCapacitor <= 0f ) {
+            BuildingActor.PowerOff()
+          } else {
+            BuildingActor.PowerOn()
+          })
         case _ => ;
       }
       context.become(Processing)

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
@@ -28,7 +28,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
   def FactionObject: FactionAffinity = resourceSilo
 
   private[this] val log               = org.log4s.getLogger
-  var panelAnimationFunc: Int => Unit = PanelAnimation
+  var panelAnimationFunc: Float => Unit = PanelAnimation
 
   def receive: Receive = {
     case "startup" =>
@@ -59,7 +59,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
         case ResourceSilo.LowNtuWarning(enabled: Boolean) =>
           LowNtuWarning(enabled)
 
-        case ResourceSilo.UpdateChargeLevel(amount: Int) =>
+        case ResourceSilo.UpdateChargeLevel(amount: Float) =>
           UpdateChargeLevel(amount)
 
         case _ => ;
@@ -76,7 +76,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
     )
   }
 
-  def UpdateChargeLevel(amount: Int): Unit = {
+  def UpdateChargeLevel(amount: Float): Unit = {
     val siloChargeBeforeChange  = resourceSilo.NtuCapacitor
     val siloDisplayBeforeChange = resourceSilo.CapacitorDisplay
     val building                = resourceSilo.Owner.asInstanceOf[Building]
@@ -100,7 +100,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
       )
       building.Actor ! BuildingActor.MapUpdate()
     }
-    val ntuIsLow = resourceSilo.NtuCapacitor.toFloat / resourceSilo.Definition.MaxNtuCapacitor.toFloat < 0.2f
+    val ntuIsLow = resourceSilo.NtuCapacitor / resourceSilo.Definition.MaxNtuCapacitor < 0.2f
     if (resourceSilo.LowNtuWarningOn && !ntuIsLow) {
       LowNtuWarning(enabled = false)
     } else if (!resourceSilo.LowNtuWarningOn && ntuIsLow) {
@@ -148,7 +148,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
     * @param min    a minimum amount of nanites requested;
     * @param max    the amount of nanites required to not make further requests;
     */
-  def HandleNtuRequest(sender: ActorRef, min: Int, max: Int): Unit = {
+  def HandleNtuRequest(sender: ActorRef, min: Float, max: Float): Unit = {
     val originalAmount = resourceSilo.NtuCapacitor
     UpdateChargeLevel(-min)
     sender ! Ntu.Grant(resourceSilo, originalAmount - resourceSilo.NtuCapacitor)
@@ -157,7 +157,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
   /**
     * Accept nanites into the silo capacitor and set the animation state.
     */
-  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Int): Unit = {
+  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Float): Unit = {
     if (amount != 0) {
       val originalAmount = resourceSilo.NtuCapacitor
       UpdateChargeLevel(amount)
@@ -174,7 +174,7 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
     * @param trigger if positive, activate the animation;
     *                if negative or zero, disable the animation
     */
-  def PanelAnimation(trigger: Int): Unit = {
+  def PanelAnimation(trigger: Float): Unit = {
     val zone = resourceSilo.Zone
     zone.VehicleEvents ! VehicleServiceMessage(
       zone.id,
@@ -185,5 +185,5 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
   /**
     * Do nothing this turn.
     */
-  def SkipPanelAnimation(trigger: Int): Unit = {}
+  def SkipPanelAnimation(trigger: Float): Unit = {}
 }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/AmenityDefinition.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/AmenityDefinition.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.vital.damage.DamageCalculations
 import net.psforever.objects.vital.{DamageResistanceModel, StandardAmenityResistance, StandardResolutions, VitalityDefinition}
 import net.psforever.objects.vital.resistance.ResistanceProfileMutators
 
-final case class AutoRepair(amount: Int, start: Long, repeat: Long, drain: Float)
+final case class AutoRepairStats(amount: Int, start: Long, repeat: Long, drain: Float)
 
 abstract class AmenityDefinition(objectId: Int)
     extends ObjectDefinition(objectId)
@@ -18,10 +18,12 @@ abstract class AmenityDefinition(objectId: Int)
   ResistUsing = StandardAmenityResistance
   Model = StandardResolutions.Amenities
 
-  var autoRepair: Option[AutoRepair] = None
+  var autoRepair: Option[AutoRepairStats] = None
 
-  def autoRepair_=(auto: AutoRepair): Option[AutoRepair] = {
+  def autoRepair_=(auto: AutoRepairStats): Option[AutoRepairStats] = {
     autoRepair = Some(auto)
     autoRepair
   }
+
+  def hasAutoRepair: Boolean = autoRepair.nonEmpty
 }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/AmenityDefinition.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/AmenityDefinition.scala
@@ -6,6 +6,8 @@ import net.psforever.objects.vital.damage.DamageCalculations
 import net.psforever.objects.vital.{DamageResistanceModel, StandardAmenityResistance, StandardResolutions, VitalityDefinition}
 import net.psforever.objects.vital.resistance.ResistanceProfileMutators
 
+final case class AutoRepair(amount: Int, start: Long, repeat: Long, drain: Float)
+
 abstract class AmenityDefinition(objectId: Int)
     extends ObjectDefinition(objectId)
     with ResistanceProfileMutators
@@ -15,4 +17,11 @@ abstract class AmenityDefinition(objectId: Int)
   DamageUsing = DamageCalculations.AgainstVehicle
   ResistUsing = StandardAmenityResistance
   Model = StandardResolutions.Amenities
+
+  var autoRepair: Option[AutoRepair] = None
+
+  def autoRepair_=(auto: AutoRepair): Option[AutoRepair] = {
+    autoRepair = Some(auto)
+    autoRepair
+  }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -330,9 +330,7 @@ object Building {
   )(name: String, guid: Int, id: Int, zone: Zone, context: ActorContext): Building = {
     val obj = new Building(name, guid, id, zone, buildingType, buildingDefinition)
     obj.Position = location
-    context.spawn(BuildingActor(zone, obj), s"$id-$buildingType-building").toClassic
+    obj.Actor = context.spawn(BuildingActor(zone, obj), s"$id-$buildingType-building").toClassic
     obj
   }
-
-  final case class AmenityStateChange(obj: Amenity)
 }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
@@ -150,9 +150,9 @@ class WarpGate(name: String, building_guid: Int, map_id: Int, zone: Zone, buildi
 
   def Owner: PlanetSideServerObject = this
 
-  def NtuCapacitor: Int = Definition.MaxNtuCapacitor
+  def NtuCapacitor: Float = Definition.MaxNtuCapacitor
 
-  def NtuCapacitor_=(value: Int): Int = NtuCapacitor
+  def NtuCapacitor_=(value: Float): Float = NtuCapacitor
 
   override def Definition: WarpGateDefinition = buildingDefinition
 }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
@@ -96,8 +96,7 @@ class ProximityTerminalControl(term: Terminal with ProximityUnit)
         case ProximityUnit.Action(_, _) =>
         //reserved
 
-        case msg =>
-          log.warn(s"unexpected message $msg")
+        case _ =>
       }
 
   def Use(target: PlanetSideGameObject, zone: String, callback: ActorRef): Unit = {

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.damage.Damageable.Target
-import net.psforever.objects.serverobject.damage.DamageableAmenity
+import net.psforever.objects.serverobject.damage.{Damageable, DamageableAmenity}
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
 import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, RepairableAmenity}
 import net.psforever.objects.serverobject.structures.Building
@@ -56,8 +56,13 @@ class TerminalControl(term: Terminal)
       }
 
   override protected def DamageAwareness(target : Target, cause : ResolvedProjectile, amount : Any) : Unit = {
-    startAutoRepairIfStopped()
+    tryAutoRepair()
     super.DamageAwareness(target, cause, amount)
+  }
+
+  override protected def DestructionAwareness(target: Damageable.Target, cause: ResolvedProjectile) : Unit = {
+    tryAutoRepair()
+    super.DestructionAwareness(target, cause)
   }
 
   override def PerformRepairs(target : Target, amount : Int) : Int = {

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -1,22 +1,16 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals
 
-import akka.actor.typed.{ActorRef => TypedActorRef}
-import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
-import akka.actor.{Actor, ActorRef, Cancellable}
-import net.psforever.actors.commands.NtuCommand
-import net.psforever.actors.zone.BuildingActor
+import akka.actor.{Actor, ActorRef}
 import net.psforever.objects.ballistics.ResolvedProjectile
-import net.psforever.objects.{Default, GlobalDefinitions, SimpleItem}
+import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.DamageableAmenity
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
-import net.psforever.objects.serverobject.repair.RepairableAmenity
-import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building}
-
-import scala.concurrent.duration._
+import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, RepairableAmenity}
+import net.psforever.objects.serverobject.structures.Building
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `Terminal`.
@@ -27,22 +21,20 @@ class TerminalControl(term: Terminal)
     with FactionAffinityBehavior.Check
     with HackableBehavior.GenericHackable
     with DamageableAmenity
-    with RepairableAmenity {
+    with RepairableAmenity
+    with AmenityAutoRepair {
   def FactionObject    = term
   def HackableObject   = term
   def DamageableObject = term
   def RepairableObject = term
-
-  private lazy val ntuGrantActorRef: TypedActorRef[NtuCommand.Grant] =
-    new ClassicActorRefOps(self).toTyped[NtuCommand.Grant]
-  private var periodicRepairFunc: ()=>Unit                           = startAutoRepair
-  private var periodicRepairTimer: Cancellable                       = Default.Cancellable
+  def AutoRepairObject = term
 
   def receive: Receive =
     checkBehavior
       .orElse(hackableBehavior)
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
+      .orElse(autoRepairBehavior)
       .orElse {
         case Terminal.Request(player, msg) =>
           TerminalControl.Dispatch(sender(), term, Terminal.TerminalMessage(player, msg, term.Request(player, msg)))
@@ -60,62 +52,18 @@ class TerminalControl(term: Terminal)
             case _ => ;
           }
 
-        case BuildingActor.PowerOff() =>
-          periodicRepairTimer.cancel()
-          periodicRepairFunc = ()=>{}
-
-        case BuildingActor.PowerOn() =>
-          retimeAutoRepair()
-          periodicRepairFunc = startAutoRepair
-
-        case NtuCommand.Grant(_, 0) =>
-          periodicRepairTimer.cancel()
-
-        case NtuCommand.Grant(_, _) =>
-          term.Definition.autoRepair match {
-            case Some(repair : AutoRepairStats) =>
-              PerformRepairs(term, repair.amount)
-            case _ => ;
-          }
-
         case _ => ;
       }
 
   override protected def DamageAwareness(target : Target, cause : ResolvedProjectile, amount : Any) : Unit = {
-    periodicRepairFunc()
+    startAutoRepairIfStopped()
     super.DamageAwareness(target, cause, amount)
-  }
-
-  def startAutoRepair(): Unit = {
-    if(periodicRepairTimer.isCancelled) {
-      retimeAutoRepair()
-    }
-  }
-
-  def retimeAutoRepair(): Unit = {
-    term.Definition.autoRepair match {
-      case Some(AutoRepairStats(_, start, interval, drain))
-        if term.Definition.Damageable && term.Health < term.Definition.MaxHealth =>
-        retimeAutoRepair(start, interval, drain)
-      case _ => ;
-    }
-  }
-
-  def retimeAutoRepair(initialDelay: Long, delay: Long, drain: Float): Unit = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-    periodicRepairTimer.cancel()
-    periodicRepairTimer = context.system.scheduler.scheduleWithFixedDelay(
-      initialDelay milliseconds,
-      delay milliseconds,
-      term.Owner.Actor,
-      BuildingActor.Ntu(NtuCommand.Request(drain, ntuGrantActorRef))
-    )
   }
 
   override def PerformRepairs(target : Target, amount : Int) : Int = {
     val newHealth = super.PerformRepairs(target, amount)
     if(newHealth == target.Definition.MaxHealth) {
-      periodicRepairTimer.cancel()
+      stopAutoRepair()
     }
     newHealth
   }
@@ -124,8 +72,6 @@ class TerminalControl(term: Terminal)
 }
 
 object TerminalControl {
-  private case class PeriodicRepair()
-
   def Dispatch(sender: ActorRef, terminal: Terminal, msg: Terminal.TerminalMessage): Unit = {
     msg.response match {
       case Terminal.NoDeal() => sender ! msg

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -2,9 +2,13 @@
 package net.psforever.objects.serverobject.terminals
 
 import akka.actor.{Actor, ActorRef}
+import net.psforever.actors.commands.NtuCommand
+import net.psforever.actors.zone.BuildingActor
+import net.psforever.objects.ballistics.ResolvedProjectile
 import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
+import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.DamageableAmenity
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
 import net.psforever.objects.serverobject.repair.RepairableAmenity
@@ -46,8 +50,18 @@ class TerminalControl(term: Terminal)
               )
             case _ => ;
           }
+
+        case NtuCommand.Grant(_, _) =>
+          PerformRepairs(term, amount = 5)
+
         case _ => ;
       }
+
+  override protected def DamageAwareness(target : Target, cause : ResolvedProjectile, amount : Any) : Unit = {
+    import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
+    term.Owner.Actor ! BuildingActor.Ntu(NtuCommand.Request(100, new ClassicActorRefOps(self).toTyped[NtuCommand.Grant]))
+    super.DamageAwareness(target, cause, amount)
+  }
 
   override def toString: String = term.Definition.Name
 }

--- a/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
@@ -2,11 +2,12 @@
 package net.psforever.objects.serverobject.tube
 
 import akka.actor.Actor
+import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.ballistics.ResolvedProjectile
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.DamageableAmenity
-import net.psforever.objects.serverobject.repair.{Repairable, RepairableAmenity}
+import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, Repairable, RepairableAmenity}
 import net.psforever.objects.serverobject.structures.Building
 
 /**
@@ -17,25 +18,42 @@ class SpawnTubeControl(tube: SpawnTube)
     extends Actor
     with FactionAffinityBehavior.Check
     with DamageableAmenity
-    with RepairableAmenity {
+    with RepairableAmenity
+    with AmenityAutoRepair {
   def FactionObject    = tube
   def DamageableObject = tube
   def RepairableObject = tube
+  def AutoRepairObject = tube
 
   def receive: Receive =
     checkBehavior
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
+      .orElse(autoRepairBehavior)
       .orElse {
         case _ => ;
       }
 
+  override protected def DamageAwareness(target : Target, cause : ResolvedProjectile, amount : Any) : Unit = {
+    tryAutoRepair()
+    super.DamageAwareness(target, cause, amount)
+  }
+
   override protected def DestructionAwareness(target: Target, cause: ResolvedProjectile): Unit = {
+    tryAutoRepair()
     super.DestructionAwareness(target, cause)
     tube.Owner match {
-      case b: Building => b.Actor ! Building.AmenityStateChange(tube)
+      case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
       case _           => ;
     }
+  }
+
+  override def PerformRepairs(target : Target, amount : Int) : Int = {
+    val newHealth = super.PerformRepairs(target, amount)
+    if(newHealth == target.Definition.MaxHealth) {
+      stopAutoRepair()
+    }
+    newHealth
   }
 
   override def Restoration(obj: Repairable.Target): Unit = {

--- a/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
@@ -59,7 +59,7 @@ class SpawnTubeControl(tube: SpawnTube)
   override def Restoration(obj: Repairable.Target): Unit = {
     super.Restoration(obj)
     tube.Owner match {
-      case b: Building => b.Actor ! Building.AmenityStateChange(tube)
+      case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
       case _           => ;
     }
   }

--- a/src/main/scala/net/psforever/objects/vehicles/AntTransferBehavior.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/AntTransferBehavior.scala
@@ -68,7 +68,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
           //ANTs would charge from 0-100% in roughly 75s on live (https://www.youtube.com/watch?v=veOWToR2nSk&feature=youtu.be&t=1194)
           val max = obj.Definition.MaxNtuCapacitor - obj.NtuCapacitor
           target.Actor ! BuildingActor.Ntu(
-            NtuCommand.Request(scala.math.min(obj.Definition.MaxNtuCapacitor / 75, max), context.self)
+            NtuCommand.Request(scala.math.min(obj.Definition.MaxNtuCapacitor / 75f, max), context.self)
           )
         case _ =>
       }
@@ -86,7 +86,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
     }
   }
 
-  def ReceiveAndDepositUntilFull(vehicle: Vehicle, amount: Int): Boolean = {
+  def ReceiveAndDepositUntilFull(vehicle: Vehicle, amount: Float): Boolean = {
     val isNotFull = (vehicle.NtuCapacitor += amount) < vehicle.Definition.MaxNtuCapacitor
     UpdateNtuUI(vehicle)
     isNotFull
@@ -128,7 +128,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
     ActivatePanelsForChargingEvent(ChargeTransferObject)
   }
 
-  def WithdrawAndTransmit(vehicle: Vehicle, maxRequested: Int): Any = {
+  def WithdrawAndTransmit(vehicle: Vehicle, maxRequested: Float): Any = {
     val chargeable      = ChargeTransferObject
     var chargeToDeposit = Math.min(Math.min(chargeable.NtuCapacitor, 100), maxRequested)
     chargeable.NtuCapacitor -= chargeToDeposit
@@ -176,7 +176,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
 
   def HandleNtuOffer(sender: ActorRef, src: NtuContainer): Unit = {}
 
-  def HandleNtuRequest(sender: ActorRef, min: Int, max: Int): Unit = {
+  def HandleNtuRequest(sender: ActorRef, min: Float, max: Float): Unit = {
     if (transferEvent == TransferBehavior.Event.Discharging) {
       val chargeable = ChargeTransferObject
       val chargeToDeposit = if (min == 0) {
@@ -197,7 +197,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
     }
   }
 
-  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Int): Unit = {
+  def HandleNtuGrant(sender: ActorRef, src: NtuContainer, amount: Float): Unit = {
     if (transferEvent == TransferBehavior.Event.Charging) {
       val obj = ChargeTransferObject
       if (ReceiveAndDepositUntilFull(obj, amount)) {

--- a/src/test/scala/objects/AutoRepairIntegrationTest.scala
+++ b/src/test/scala/objects/AutoRepairIntegrationTest.scala
@@ -7,7 +7,7 @@ import base.FreedContextActorTest
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.ballistics.{Projectile, ProjectileResolution, ResolvedProjectile, SourceEntry}
 import net.psforever.objects.guid.NumberPoolHub
-import net.psforever.objects.guid.source.LimitedNumberSource
+import net.psforever.objects.guid.source.MaxNumberSource
 import net.psforever.objects.serverobject.resourcesilo.{ResourceSilo, ResourceSiloControl}
 import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{OrderTerminalDefinition, Terminal, TerminalControl}
@@ -32,7 +32,7 @@ class AutoRepairFacilityIntegrationTest extends FreedContextActorTest {
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairIntegrationTest.terminal_definition)
   val silo = new ResourceSilo()
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -101,7 +101,7 @@ class AutoRepairTowerIntegrationTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairIntegrationTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)

--- a/src/test/scala/objects/AutoRepairIntegrationTest.scala
+++ b/src/test/scala/objects/AutoRepairIntegrationTest.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2020 PSForever
+package objects
+
+import akka.actor.Props
+import akka.testkit.TestProbe
+import base.FreedContextActorTest
+import net.psforever.objects.avatar.Avatar
+import net.psforever.objects.ballistics.{Projectile, ProjectileResolution, ResolvedProjectile, SourceEntry}
+import net.psforever.objects.guid.NumberPoolHub
+import net.psforever.objects.guid.source.LimitedNumberSource
+import net.psforever.objects.serverobject.resourcesilo.{ResourceSilo, ResourceSiloControl}
+import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building, StructureType}
+import net.psforever.objects.serverobject.terminals.{OrderTerminalDefinition, Terminal, TerminalControl}
+import net.psforever.objects.vital.Vitality
+import net.psforever.objects.vital.damage.DamageProfile
+import net.psforever.objects.zones.{Zone, ZoneMap}
+import net.psforever.objects.{GlobalDefinitions, Player, Tool}
+import net.psforever.services.galaxy.GalaxyService
+import net.psforever.services.{InterstellarClusterService, ServiceManager}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+
+import scala.concurrent.duration._
+
+class AutoRepairFacilityIntegrationTest extends FreedContextActorTest {
+  import akka.actor.typed.scaladsl.adapter._
+  system.spawn(InterstellarClusterService(Nil), InterstellarClusterService.InterstellarClusterServiceKey.id)
+  ServiceManager.boot(system) ! ServiceManager.Register(Props[GalaxyService](), "galaxy")
+  expectNoMessage(200 milliseconds)
+
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairIntegrationTest.terminal_definition)
+  val silo = new ResourceSilo()
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+  guid.register(silo, number = 5)
+
+  val building = Building.Structure(StructureType.Facility)(name = "test-building", guid = 6, map_id = 0, zone, context)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  building.Amenities = silo
+  building.Amenities = terminal
+
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+
+  silo.NtuCapacitor = 1000
+  silo.Actor = system.actorOf(Props(classOf[ResourceSiloControl], silo), "test-silo")
+  silo.Actor ! "startup"
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "should activate on damage and trade NTU from the facility's resource silo for repairs" in {
+      assert(silo.NtuCapacitor == silo.MaxNtuCapacitor)
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      var i = 0 //safety counter
+      while(terminal.Health < terminal.MaxHealth && i < 100) {
+        i += 1
+        avatarProbe.receiveOne(max = 1000 milliseconds) //health update event
+      }
+      assert(silo.NtuCapacitor < silo.MaxNtuCapacitor)
+      assert(terminal.Health == terminal.MaxHealth)
+    }
+  }
+}
+
+class AutoRepairTowerIntegrationTest extends FreedContextActorTest {
+  import akka.actor.typed.scaladsl.adapter._
+  system.spawn(InterstellarClusterService(Nil), InterstellarClusterService.InterstellarClusterServiceKey.id)
+  ServiceManager.boot(system) ! ServiceManager.Register(Props[GalaxyService](), "galaxy")
+  expectNoMessage(200 milliseconds)
+
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairIntegrationTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building.Structure(StructureType.Tower)(name = "test-building", guid = 6, map_id = 0, zone, context)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  building.Amenities = terminal
+
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "should activate on damage and trade NTU from the tower for repairs" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      var i = 0 //safety counter
+      while(terminal.Health < terminal.MaxHealth && i < 100) {
+        i += 1
+        avatarProbe.receiveOne(max = 1000 milliseconds) //health update event
+      }
+      assert(terminal.Health == terminal.MaxHealth)
+    }
+  }
+}
+
+object AutoRepairIntegrationTest {
+  val terminal_definition = new OrderTerminalDefinition(objId = 612) {
+    Name = "order_terminal"
+    MaxHealth = 500
+    Damageable = true
+    Repairable = true
+    autoRepair = AutoRepairStats(1, 500, 500, 1)
+    RepairIfDestroyed = true
+  }
+}

--- a/src/test/scala/objects/AutoRepairTest.scala
+++ b/src/test/scala/objects/AutoRepairTest.scala
@@ -1,0 +1,390 @@
+// Copyright (c) 2020 PSForever
+package objects
+
+import akka.actor.Props
+import akka.testkit.TestProbe
+import base.FreedContextActorTest
+import net.psforever.actors.commands.NtuCommand
+import net.psforever.actors.zone.BuildingActor
+import net.psforever.objects.avatar.Avatar
+import net.psforever.objects.ballistics.{Projectile, ProjectileResolution, ResolvedProjectile, SourceEntry}
+import net.psforever.objects.guid.NumberPoolHub
+import net.psforever.objects.guid.source.LimitedNumberSource
+import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building, StructureType}
+import net.psforever.objects.serverobject.terminals.{OrderTerminalDefinition, Terminal, TerminalControl}
+import net.psforever.objects.vital.Vitality
+import net.psforever.objects.vital.damage.DamageProfile
+import net.psforever.objects.zones.{Zone, ZoneMap}
+import net.psforever.objects.{GlobalDefinitions, Player, Tool}
+import net.psforever.types.{CharacterGender, CharacterVoice, PlanetSideEmpire, Vector3}
+
+import scala.concurrent.duration._
+
+class AutoRepairRequestNtuTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "asks owning building for NTU after damage" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      val buildingMsg = buildingProbe.receiveOne(max = 600 milliseconds)
+      assert(buildingMsg match {
+        case BuildingActor.Ntu(NtuCommand.Request(drain, _)) =>
+          drain == terminal.Definition.autoRepair.get.drain
+        case _ =>
+          false
+      })
+    }
+  }
+}
+
+class AutoRepairRequestNtuRepeatTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "repeatedly asks owning building for NTU after damage" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      (0 to 3).foreach { _ =>
+        val buildingMsg = buildingProbe.receiveOne(max = 1000 milliseconds)
+        assert(buildingMsg match {
+          case BuildingActor.Ntu(NtuCommand.Request(drain, _)) =>
+            drain == terminal.Definition.autoRepair.get.drain
+          case _ =>
+            false
+        })
+      }
+    }
+  }
+}
+
+class AutoRepairNoRequestNtuTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "not ask for NTU after damage if it expects no NTU" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! BuildingActor.NtuDepleted()
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      buildingProbe.expectNoMessage(max = 2000 milliseconds)
+    }
+  }
+}
+
+class AutoRepairRestoreRequestNtuTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "ask for NTU after damage if its expectation of NTU is restored" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! BuildingActor.NtuDepleted()
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      buildingProbe.expectNoMessage(max = 2000 milliseconds)
+
+      terminal.Actor ! BuildingActor.SuppliedWithNtu()
+      val buildingMsg = buildingProbe.receiveOne(max = 600 milliseconds)
+      assert(buildingMsg match {
+        case BuildingActor.Ntu(NtuCommand.Request(drain, _)) =>
+          drain == terminal.Definition.autoRepair.get.drain
+        case _ =>
+          false
+      })
+    }
+  }
+}
+
+class AutoRepairRepairWithNtuTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "repair some of the damage when it receives NTU" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! BuildingActor.NtuDepleted() //don't worry about requests
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      val reducedHealth = terminal.Health
+      buildingProbe.expectNoMessage(max = 2000 milliseconds)
+      terminal.Actor ! NtuCommand.Grant(null, 1)
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health > reducedHealth)
+    }
+  }
+}
+
+class AutoRepairRepairWithNtuUntilDoneTest extends FreedContextActorTest {
+  val player = Player(Avatar(0, "TestCharacter", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
+  player.Spawn()
+  val weapon = new Tool(GlobalDefinitions.suppressor)
+  val terminal = new Terminal(AutoRepairTest.terminal_definition)
+  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val zone = new Zone("test", new ZoneMap("test"), 0) {
+    override def SetupNumberPools() = {}
+    GUID(guid)
+  }
+  val avatarProbe = new TestProbe(system)
+  zone.AvatarEvents = avatarProbe.ref
+
+  guid.register(player, number = 1)
+  guid.register(weapon, number = 2)
+  guid.register(weapon.AmmoSlot.Box, number = 3)
+  guid.register(terminal, number = 4)
+
+  val building = Building("test-building", 1, 1, zone, StructureType.Facility)
+  building.Invalidate()
+  guid.register(building, number = 6)
+  val buildingProbe = new TestProbe(system)
+  building.Actor = buildingProbe.ref
+  building.Zone = zone
+  terminal.Actor = context.actorOf(Props(classOf[TerminalControl], terminal), name = "test-terminal")
+  terminal.Owner = building
+
+  val wep_fmode  = weapon.FireMode
+  val wep_prof   = wep_fmode.Add
+  val proj       = weapon.Projectile
+  val proj_prof  = proj.asInstanceOf[DamageProfile]
+  val projectile = Projectile(proj, weapon.Definition, wep_fmode, player, Vector3(2, 0, 0), Vector3.Zero)
+  val resolved = ResolvedProjectile(
+    ProjectileResolution.Hit,
+    projectile,
+    SourceEntry(terminal),
+    terminal.DamageModel,
+    Vector3(1, 0, 0)
+  )
+  val applyDamageTo = resolved.damage_model.Calculate(resolved)
+
+  "AutoRepair" should {
+    "ask for NTU after damage and repair some of the damage when it receives NTU, until fully-repaired" in {
+      assert(terminal.Health == terminal.MaxHealth)
+      terminal.Actor ! Vitality.Damage(applyDamageTo)
+
+      avatarProbe.receiveOne(max = 200 milliseconds) //health update event
+      assert(terminal.Health < terminal.MaxHealth)
+      var i = 0
+      while(terminal.Health < terminal.MaxHealth && i < 100) {
+        i += 1 //safety counter
+        val buildingMsg = buildingProbe.receiveOne(max = 1000 milliseconds)
+        buildingMsg match {
+          case BuildingActor.Ntu(NtuCommand.Request(_, _)) =>
+            terminal.Actor ! NtuCommand.Grant(null, 1)
+          case _ => ;
+        }
+      }
+      assert(terminal.Health == terminal.MaxHealth)
+    }
+  }
+}
+
+object AutoRepairTest {
+  val terminal_definition = new OrderTerminalDefinition(objId = 612) {
+    Name = "order_terminal"
+    MaxHealth = 500
+    Damageable = true
+    Repairable = true
+    autoRepair = AutoRepairStats(1, 500, 500, 1)
+    RepairIfDestroyed = true
+  }
+}

--- a/src/test/scala/objects/AutoRepairTest.scala
+++ b/src/test/scala/objects/AutoRepairTest.scala
@@ -9,7 +9,7 @@ import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.ballistics.{Projectile, ProjectileResolution, ResolvedProjectile, SourceEntry}
 import net.psforever.objects.guid.NumberPoolHub
-import net.psforever.objects.guid.source.LimitedNumberSource
+import net.psforever.objects.guid.source.MaxNumberSource
 import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{OrderTerminalDefinition, Terminal, TerminalControl}
 import net.psforever.objects.vital.Vitality
@@ -25,7 +25,7 @@ class AutoRepairRequestNtuTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -84,7 +84,7 @@ class AutoRepairRequestNtuRepeatTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -145,7 +145,7 @@ class AutoRepairNoRequestNtuTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -199,7 +199,7 @@ class AutoRepairRestoreRequestNtuTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -262,7 +262,7 @@ class AutoRepairRepairWithNtuTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)
@@ -320,7 +320,7 @@ class AutoRepairRepairWithNtuUntilDoneTest extends FreedContextActorTest {
   player.Spawn()
   val weapon = new Tool(GlobalDefinitions.suppressor)
   val terminal = new Terminal(AutoRepairTest.terminal_definition)
-  val guid = new NumberPoolHub(new LimitedNumberSource(max = 10))
+  val guid = new NumberPoolHub(new MaxNumberSource(max = 10))
   val zone = new Zone("test", new ZoneMap("test"), 0) {
     override def SetupNumberPools() = {}
     GUID(guid)

--- a/src/test/scala/objects/DoorTest.scala
+++ b/src/test/scala/objects/DoorTest.scala
@@ -25,22 +25,22 @@ class DoorTest extends Specification {
 
     "starts as closed (false)" in {
       val door = Door(GlobalDefinitions.door)
-      door.Open mustEqual None
+      door.Open.isEmpty mustEqual true
       door.isOpen mustEqual false
     }
 
     "be opened and closed (1; manual)" in {
       val door = Door(GlobalDefinitions.door)
       door.isOpen mustEqual false
-      door.Open mustEqual None
+      door.Open.isEmpty mustEqual true
 
       door.Open = Some(player)
       door.isOpen mustEqual true
-      door.Open mustEqual Some(player)
+      door.Open.contains(player) mustEqual true
 
       door.Open = None
       door.isOpen mustEqual false
-      door.Open mustEqual None
+      door.Open.isEmpty mustEqual true
     }
 
     "be opened and closed (2; toggle)" in {
@@ -58,11 +58,11 @@ class DoorTest extends Specification {
         364
       )
       val door = Door(GlobalDefinitions.door)
-      door.Open mustEqual None
+      door.Open.isEmpty mustEqual true
       door.Use(player, msg)
-      door.Open mustEqual Some(player)
+      door.Open.contains(player) mustEqual true
       door.Use(player, msg)
-      door.Open mustEqual None
+      door.Open.isEmpty mustEqual true
     }
   }
 }
@@ -115,8 +115,7 @@ class DoorControl3Test extends ActorTest {
       assert(door.Open.isEmpty)
 
       door.Actor ! "trash"
-      val reply = receiveOne(Duration.create(500, "ms"))
-      assert(reply.isInstanceOf[Door.NoEvent])
+      expectNoMessage(Duration.create(500, "ms"))
       assert(door.Open.isEmpty)
     }
   }

--- a/src/test/scala/objects/GeneratorTest.scala
+++ b/src/test/scala/objects/GeneratorTest.scala
@@ -4,6 +4,7 @@ package objects
 import akka.actor.{ActorRef, Props}
 import akka.testkit.TestProbe
 import base.ActorTest
+import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.ballistics._
 import net.psforever.objects.{GlobalDefinitions, Player, Tool}
@@ -206,7 +207,7 @@ class GeneratorControlCriticalTest extends ActorTest {
       )
       assert(
         msg_building match {
-          case Building.AmenityStateChange(o) => o eq gen
+          case BuildingActor.AmenityStateChange(o) => o eq gen
           case _                              => false
         }
       )
@@ -268,6 +269,7 @@ class GeneratorControlDestroyedTest extends ActorTest {
     Vector3(1, 0, 0)
   )
   val applyDamageTo = resolved.damage_model.Calculate(resolved)
+  gen.Actor ! BuildingActor.NtuDepleted() //no auto-repair
   expectNoMessage(200 milliseconds)
   //we're not testing that the math is correct
 
@@ -293,12 +295,11 @@ class GeneratorControlDestroyedTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal)
 
       avatarProbe.expectNoMessage(9 seconds)
-      buildingProbe.expectNoMessage(50 milliseconds) //no prior messages
       val msg_avatar2  = avatarProbe.receiveN(3, 1000 milliseconds) //see DamageableEntity test file
       val msg_building = buildingProbe.receiveOne(200 milliseconds)
       assert(
         msg_building match {
-          case Building.AmenityStateChange(o) => o eq gen
+          case BuildingActor.AmenityStateChange(o) => o eq gen
           case _                              => false
         }
       )
@@ -399,6 +400,7 @@ class GeneratorControlKillsTest extends ActorTest {
     Vector3(1, 0, 0)
   )
   val applyDamageTo = resolved.damage_model.Calculate(resolved)
+  gen.Actor ! BuildingActor.NtuDepleted() //no auto-repair
   expectNoMessage(200 milliseconds)
   //we're not testing that the math is correct
 
@@ -438,7 +440,7 @@ class GeneratorControlKillsTest extends ActorTest {
       player2Probe.expectNoMessage(200 milliseconds)
       assert(
         msg_building match {
-          case Building.AmenityStateChange(o) => o eq gen
+          case BuildingActor.AmenityStateChange(o) => o eq gen
           case _                              => false
         }
       )
@@ -840,7 +842,7 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
       )
       assert(
         msg_building match {
-          case Building.AmenityStateChange(o) => o eq gen
+          case BuildingActor.AmenityStateChange(o) => o eq gen
           case _                              => false
         }
       )

--- a/tools/client/src/main/scala/net/psforever/tools/client/Client.scala
+++ b/tools/client/src/main/scala/net/psforever/tools/client/Client.scala
@@ -23,7 +23,6 @@ import scodec.Attempt.{Failure, Successful}
 import scodec.bits._
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.util.control.Breaks._
 
 object Client {
   Security.addProvider(new BouncyCastleProvider)
@@ -153,6 +152,7 @@ class Client(username: String, password: String) {
         socket.send(new DatagramPacket(payload, payload.length, host))
       case (None, Some(ref)) =>
       // ref ! Udp.Received(ByteString(payload), new InetSocketAddress(socket.getInetAddress, socket.getPort))
+      case _ => ;
     }
   }
 

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -14,7 +14,6 @@ import scala.collection.parallel.CollectionConverters._
 import scala.io.{Codec, Source}
 import scala.sys.process._
 import scala.util.Using
-import scala.util.control.Breaks._
 
 case class Config(
     outDir: String = System.getProperty("user.dir"),


### PR DESCRIPTION

A friendly reminder for those who have long forgotten that, for most bases, things that can be broken can also repair themselves over time.  The nano-dispenser (gluegun) is no longer an absolute necessity but will expedite the process.  The resource of change in terms of repair is the nanite transfer unit (NTU, or Ntu).  In major facilities, this resource is housed in the NTU silo and is exchanged as a part of the facility's energy plan.  When the silo is drained of all of its NTU, all repairs within the facility will be put on hold until NTU supply is restored as a function of the advanced nanite transport vehicle (ANT).  In lesser facilities, this resource is considered infinite and just gets exchanged.  Doesn't that sound quite unfair?

___Features___
__`AutoRepairStats`__
All important information about how an amenity's auto-repair cycle occurs, located on the `AmenityDefintion`.

__`ResourceSilo`__
NTU is now reported as a decimal rather than an integer.  This is entirely in aid of auto-repair drain values, a common one being 0.5.  This change actually involves all NTU-related features, behaviors, and objects.

__`ResourceSiloControl`__
When the silo starts up it will emit a message that reports to its owner whether or not it has NTU to share or whether its NTU sources are depleted.

__`BuildingActor`__
More facilities than just `Warpgate` buildings deal in the exchange of NTU.  Field tower buildings will always provide NTU for their own amenity, if it requests.  All other building types will check for an `NtuContainer` amongst their amenities and pass the message on to that.

__`AmenityAutoRepair`__
A behavior for `Amenity` entities that are `Damageable` and are `Repairable` (`RepairableEntity`) and have a `AutoRepairStats` field indicated in their definition.  Upon taking damage, the amenity will start a timer to the first request for an NTU exchange.  After this timer fires, the first request is sent and the event is timed for a different period of each subsequent request.  When NTU grant is received, the amount to be repaired is determined and that must health is given back to the amenity.  This will repeat until the amenity is fully repaired or NTU has been exhausted.  A report of no NTU being available (`NtuDepleted`) will cause auto-repair to not issue further requests.  A report of NTU being available (`SuppliedWithNtu`) will cause auto-repair to resume, if it is necessary.

___Caveats___
1.  The damageable status of nothing has been adjusted in this update.  In particular, the `ImplantTerminalMech` and the `ImplantTerminalInterface` have not been changed since when they were introduced.  With this update, they can become an invisible drain on facility resources, though a small one.  Remember: one hitbox above (stand straight in front and aim up at the hood), one hitbox behind (stand on the side of the unit and aim at the body).
2.  ~~The amenities of any building that is not a major continental facility or a field tower are currently not subject to auto-repair.  This includes anything that is owned by its own platform structure and anything in the caverns.  These refinements will be introduced later.~~

___Addenda___
1.  Even though it affects a facility's `Generator`, this update has nothing to do with the "power" coming from that generator for the rest of the facility or its other amenities.  That is independent from the NTU exchange used to fuel the auto-repair system (even a destroyed generator will auto-repair) and will be handled later.
2.  Tests are divided into parallel and serial categories by module.  The more common parallel tests run in groups while the less common serialized tests should only be run one and a time.  This latter category, however, is not being run at the moment as a part of `sbt test` protocol.  Perhaps, it has been like this for some time.  Due to a Java-call incompatibility in some packet, some efforts to manually run tests are stymied.  This is not a terribly serious issue unless the vehicle spawn pad is changed, whereupon those tests will need to be run to confirm consistent operation.