### PR TITLE
Finally fix list_players command

### DIFF
--- a/src/main/scala/net/psforever/login/psadmin/CmdListPlayers.scala
+++ b/src/main/scala/net/psforever/login/psadmin/CmdListPlayers.scala
@@ -6,6 +6,8 @@ import net.psforever.services.{InterstellarClusterService, ServiceManager}
 import scala.collection.mutable.Map
 import akka.actor.typed.scaladsl.adapter._
 
+private case class Player(name: String, faction_id: Int)
+
 class CmdListPlayers(args: Array[String], services: Map[String, ActorRef]) extends Actor {
   private[this] val log = org.log4s.getLogger(self.path.name)
 
@@ -22,19 +24,13 @@ class CmdListPlayers(args: Array[String], services: Map[String, ActorRef]) exten
 
     case InterstellarClusterService.PlayersResponse(players) =>
       val data = Map[String, Any]()
-      data {
-        "player_count"
-      } = players.size
-      data {
-        "player_list"
-      } = Array[String]()
+      data("player_count") = players.size
+      data("player_list") = Array[Player]()
 
       if (players.isEmpty) {
         context.parent ! CommandGoodResponse("No players currently online!", data)
       } else {
-        data {
-          "player_list"
-        } = players.map(_.name)
+        data("player_list") = players.map(a => Player(a.name, a.faction.id))
         context.parent ! CommandGoodResponse(s"${players.length} players online\n", data)
       }
     case default => log.error(s"Unexpected message $default")

--- a/src/main/scala/net/psforever/services/InterstellarClusterService.scala
+++ b/src/main/scala/net/psforever/services/InterstellarClusterService.scala
@@ -93,7 +93,6 @@ class InterstellarClusterService(context: ActorContext[InterstellarClusterServic
   }
 
   override def onMessage(msg: Command): Behavior[Command] = {
-    log.info(s"$msg")
     msg match {
       case GetPlayers(replyTo) =>
         replyTo ! PlayersResponse(zones.flatMap(_.Players).toSeq)


### PR DESCRIPTION
Originally I made list_players return the full avatar
object rather than just the name string. Which was kind of
a bad idea because certain contents were unserializable
which caused the command to break (sometimes).

Weeks later, I attempted to fix it by returning to the
original behaviour of only returning names. By that point
I had forgotten that PSFPortal was changed to expect an
object.

So here's the final fix. player_list now returns a very
simple object made up of the name and faction id.