### PR TITLE
Powered

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3646,12 +3646,6 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         if (isMovingPlus) {
           CancelZoningProcessWithDescriptiveReason("cancel_motion")
         }
-        if (!player.Crouching && is_crouching) {
-          continent.Buildings.values.find { b => Vector3.Distance(player.Position, b.Position) <= b.Definition.SOIRadius} match {
-            case Some(b) => ;
-            case _ => ;
-          }
-        }
         player.Position = pos
         player.Velocity = vel
         player.Orientation = Vector3(player.Orientation.x, pitch, yaw)

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -6558,9 +6558,9 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       sendResponse(SetEmpireMessage(guid, building.Faction))
       // power
       building.Generator match {
-        case Some(obj) if obj.Condition != PlanetSideGeneratorState.Normal =>
-          sendResponse(PlanetsideAttributeMessage(guid, 48, 1))
-          sendResponse(PlanetsideAttributeMessage(guid, 38, 0))
+        case Some(obj) if obj.Condition == PlanetSideGeneratorState.Destroyed || building.NtuLevel == 0 =>
+          sendResponse(PlanetsideAttributeMessage(guid, 48, 1)) //amenities disabled; red warning lights
+          sendResponse(PlanetsideAttributeMessage(guid, 38, 0)) //disable spawn target on deployment map
         case _ => ;
       }
       // capitol force dome state

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -7,6 +7,7 @@ import akka.{actor => classic}
 import net.psforever.actors.commands.NtuCommand
 import net.psforever.objects.{CommonNtuContainer, NtuContainer}
 import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.generator.Generator
 import net.psforever.objects.serverobject.structures.{Amenity, Building, StructureType, WarpGate}
 import net.psforever.objects.zones.Zone
 import net.psforever.persistence
@@ -49,6 +50,10 @@ object BuildingActor {
   final case class SuppliedWithNtu() extends Command
 
   final case class NtuDepleted() extends Command
+
+  final case class PowerOn() extends Command
+
+  final case class PowerOff() extends Command
 }
 
 class BuildingActor(
@@ -152,6 +157,14 @@ class BuildingActor(
         Behaviors.same
 
       case MapUpdate() =>
+        galaxyService ! GalaxyServiceMessage(GalaxyAction.MapUpdate(building.infoUpdateMessage()))
+        Behaviors.same
+
+      case AmenityStateChange(obj: Generator) =>
+        //TODO when parameter object is finally immutable, perform analysis on it to determine specific actions
+        val msg = if(obj.Destroyed) BuildingActor.PowerOff() else BuildingActor.PowerOn()
+        building.Amenities.foreach { _.Actor ! msg }
+        //update the map
         galaxyService ! GalaxyServiceMessage(GalaxyAction.MapUpdate(building.infoUpdateMessage()))
         Behaviors.same
 

--- a/src/main/scala/net/psforever/actors/zone/ZoneActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/ZoneActor.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
 import net.psforever.objects.ballistics.SourceEntry
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.equipment.Equipment
-import net.psforever.objects.serverobject.structures.StructureType
+import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.zones.Zone
 import net.psforever.objects.{ConstructionItem, PlanetSideGameObject, Player, Vehicle}
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
@@ -76,12 +76,21 @@ class ZoneActor(context: ActorContext[ZoneActor.Command], zone: Zone)
 
   ctx.run(query[persistence.Building].filter(_.zoneId == lift(zone.Number))).onComplete {
     case Success(buildings) =>
+      var capitol: Option[Building] = None
       buildings.foreach { building =>
         zone.BuildingByMapId(building.localId) match {
-          case Some(b) => b.Faction = PlanetSideEmpire(building.factionId)
-          case None    => // TODO this happens during testing, need a way to not always persist during tests
+          case Some(b) =>
+            b.Faction = PlanetSideEmpire(building.factionId)
+            if(b.IsCapitol) {
+              capitol = Some(b)
+            }
+          case None    =>
+          // TODO this happens during testing, need a way to not always persist during tests
         }
-
+      }
+      capitol match {
+        case Some(b) => b.ForceDomeActive = BuildingActor.checkForceDomeStatus(b).getOrElse(false)
+        case None    => ;
       }
     case Failure(e) => log.error(e.getMessage)
   }

--- a/src/main/scala/net/psforever/objects/SpawnPoint.scala
+++ b/src/main/scala/net/psforever/objects/SpawnPoint.scala
@@ -50,7 +50,7 @@ trait SpawnPoint {
     */
   def Definition: ObjectDefinition with SpawnPointDefinition
 
-  def Offline: Boolean = psso.Destroyed
+  def isOffline: Boolean = psso.Destroyed
 
   /**
     * Determine a specific position and orientation in which to spawn the target.

--- a/src/main/scala/net/psforever/objects/serverobject/doors/Door.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/doors/Door.scala
@@ -25,16 +25,6 @@ class Door(private val ddef: DoorDefinition) extends Amenity {
     Open
   }
 
-  def Use(player: Player, msg: UseItemMessage): Door.Exchange = {
-    if (openState.isEmpty) {
-      openState = Some(player)
-      Door.OpenEvent()
-    } else {
-      openState = None
-      Door.CloseEvent()
-    }
-  }
-
   def Definition: DoorDefinition = ddef
 }
 

--- a/src/main/scala/net/psforever/objects/serverobject/doors/DoorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/doors/DoorControl.scala
@@ -1,21 +1,90 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.doors
 
-import akka.actor.Actor
+import net.psforever.objects.Player
+import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.locks.IFFLock
+import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
+import net.psforever.services.Service
+import net.psforever.services.local.{LocalAction, LocalResponse, LocalServiceMessage, LocalServiceResponse}
+import net.psforever.types.{PlanetSideEmpire, Vector3}
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `Door`.
   * @param door the `Door` object being governed
   */
-class DoorControl(door: Door) extends Actor with FactionAffinityBehavior.Check {
+class DoorControl(door: Door)
+  extends PoweredAmenityControl
+  with FactionAffinityBehavior.Check {
   def FactionObject: FactionAffinity = door
 
-  def receive: Receive =
-    checkBehavior.orElse {
-      case Door.Use(player, msg) =>
-        sender() ! Door.DoorMessage(player, msg, door.Use(player, msg))
+  val commonBehavior: Receive = checkBehavior
 
-      case _ => ;
+  def poweredStateLogic: Receive =
+    commonBehavior
+      .orElse {
+        case CommonMessages.Use(player, _) =>
+          val zone = door.Zone
+          val doorGUID = door.GUID
+          if (
+                player.Faction == door.Faction || (zone.GUID(zone.map.doorToLock.getOrElse(doorGUID.guid, 0)) match {
+                  case Some(lock: IFFLock) =>
+                    val owner            = lock.Owner.asInstanceOf[Building]
+                    val playerIsOnInside = Vector3.ScalarProjection(lock.Outwards, player.Position - door.Position) < 0f
+                    /*
+                    If an IFF lock exists and
+                    the IFF lock faction doesn't match the current player and
+                    one of the following conditions are met:
+                    1. player is on the inside of the door (determined by the lock orientation)
+                    2. lock is hacked
+                    3. facility capture terminal has been hacked
+                    4. base is neutral
+                    ... open the door.
+                     */
+                    playerIsOnInside || lock.HackedBy.isDefined || owner.CaptureTerminalIsHacked || lock.Faction == PlanetSideEmpire.NEUTRAL
+                  case _ => true // no linked IFF lock, just try open the door
+                })
+              ) {
+            openDoor(player)
+          }
+
+        case _ => ;
+      }
+
+  def unpoweredStateLogic: Receive = {
+    commonBehavior
+      .orElse {
+        case CommonMessages.Use(player, _) =>
+          //without power, the door opens freely
+          openDoor(player)
+
+        case _ => ;
+      }
+  }
+
+  def openDoor(player: Player): Unit = {
+    val zone = door.Zone
+    val doorGUID = door.GUID
+    if (!door.isOpen) {
+      //global open
+      door.Open = player
+      zone.LocalEvents ! LocalServiceMessage(
+        zone.id,
+        LocalAction.DoorOpens(Service.defaultPlayerGUID, zone, door)
+      )
     }
+    else {
+      //the door should already open, but the requesting player does not see it as open
+      sender() ! LocalServiceResponse(
+        player.Name,
+        Service.defaultPlayerGUID,
+        LocalResponse.DoorOpens(doorGUID)
+      )
+    }
+  }
+
+  override def powerTurnOffCallback() : Unit = { }
+
+  override def powerTurnOnCallback() : Unit = { }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/generator/Generator.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/generator/Generator.scala
@@ -24,6 +24,16 @@ class Generator(private val gdef: GeneratorDefinition) extends Amenity {
     Condition
   }
 
+  override def Destroyed_=(state : Boolean) : Boolean = {
+    val isDestroyed = super.Destroyed_=(state)
+    condition = if (isDestroyed) {
+      PlanetSideGeneratorState.Destroyed
+    } else {
+      PlanetSideGeneratorState.Normal
+    }
+    isDestroyed
+  }
+
   def Definition: GeneratorDefinition = gdef
 }
 

--- a/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
@@ -80,6 +80,8 @@ class GeneratorControl(gen: Generator)
       .orElse {
         case GeneratorControl.Destabilized() =>
           imminentExplosion = true
+          //the generator's condition is technically destroyed, but avoid official reporting until the explosion
+          gen.Condition = PlanetSideGeneratorState.Destroyed
           GeneratorControl.UpdateOwner(gen, Some(GeneratorControl.Event.Destabilized))
           queuedExplosion.cancel()
           queuedExplosion = context.system.scheduler.scheduleOnce(10 seconds, self, GeneratorControl.GeneratorExplodes())
@@ -89,7 +91,6 @@ class GeneratorControl(gen: Generator)
           val zone = gen.Zone
           gen.Health = 0
           super.DestructionAwareness(gen, gen.LastShot.get)
-          gen.Condition = PlanetSideGeneratorState.Destroyed
           GeneratorControl.UpdateOwner(gen, Some(GeneratorControl.Event.Destroyed))
           //kaboom
           zone.AvatarEvents ! AvatarServiceMessage(

--- a/src/main/scala/net/psforever/objects/serverobject/implantmech/ImplantTerminalMechControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/implantmech/ImplantTerminalMechControl.scala
@@ -1,7 +1,6 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.implantmech
 
-import akka.actor.Actor
 import net.psforever.objects.ballistics.ResolvedProjectile
 import net.psforever.objects.{GlobalDefinitions, Player, SimpleItem}
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
@@ -11,14 +10,15 @@ import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.{Damageable, DamageableEntity, DamageableMountable}
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
 import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, RepairableEntity}
-import net.psforever.objects.serverobject.structures.Building
+import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
+import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `ImplantTerminalMech`.
   * @param mech the "mech" object being governed
   */
 class ImplantTerminalMechControl(mech: ImplantTerminalMech)
-    extends Actor
+    extends PoweredAmenityControl
     with FactionAffinityBehavior.Check
     with MountableBehavior.Mount
     with MountableBehavior.Dismount
@@ -33,17 +33,19 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
   def RepairableObject = mech
   def AutoRepairObject = mech
 
-  def receive: Receive =
+  def commonBehavior: Receive =
     checkBehavior
-      .orElse(mountBehavior)
       .orElse(dismountBehavior)
-      .orElse(hackableBehavior)
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
       .orElse(autoRepairBehavior)
+
+  def poweredStateLogic : Receive =
+    commonBehavior
+      .orElse(mountBehavior)
       .orElse {
         case CommonMessages.Use(player, Some(item: SimpleItem))
-            if item.Definition == GlobalDefinitions.remote_electronics_kit =>
+          if item.Definition == GlobalDefinitions.remote_electronics_kit =>
           //TODO setup certifications check
           mech.Owner match {
             case b: Building if (b.Faction != player.Faction || b.CaptureTerminalIsHacked) && mech.HackedBy.isEmpty =>
@@ -54,6 +56,12 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
               )
             case _ => ;
           }
+        case _ => ;
+      }
+
+  def unpoweredStateLogic: Receive =
+    commonBehavior
+      .orElse {
         case _ => ;
       }
 
@@ -98,4 +106,25 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     }
     newHealth
   }
+
+  def powerTurnOffCallback(): Unit = {
+    //kick all occupants
+    val guid = mech.GUID
+    val zone = mech.Zone
+    val zoneId = zone.id
+    val events = zone.VehicleEvents
+    mech.Seats.values.foreach(seat =>
+      seat.Occupant match {
+        case Some(player) =>
+          seat.Occupant = None
+          player.VehicleSeated = None
+          if (player.HasGUID) {
+            events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, 4, false, guid))
+          }
+        case None => ;
+      }
+    )
+  }
+
+  def powerTurnOnCallback(): Unit = { }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/implantmech/ImplantTerminalMechControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/implantmech/ImplantTerminalMechControl.scala
@@ -107,7 +107,12 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     newHealth
   }
 
+  override def tryAutoRepair() : Boolean = {
+    isPowered && super.tryAutoRepair()
+  }
+
   def powerTurnOffCallback(): Unit = {
+    stopAutoRepair()
     //kick all occupants
     val guid = mech.GUID
     val zone = mech.Zone
@@ -126,5 +131,7 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     )
   }
 
-  def powerTurnOnCallback(): Unit = { }
+  def powerTurnOnCallback(): Unit = {
+    tryAutoRepair()
+  }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
@@ -21,7 +21,7 @@ class PainboxControl(painbox: Painbox) extends PoweredAmenityControl {
 
   var disabled = false // Temporary to disable cavern non-radius fields
 
-  val initialStartup: Unit = {
+  def initialStartup(): Unit = {
     if (painbox.Definition.HasNearestDoorDependency) {
       (painbox.Owner match {
         case obj : Building =>

--- a/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/painbox/PainboxControl.scala
@@ -1,8 +1,9 @@
 package net.psforever.objects.serverobject.painbox
 
-import akka.actor.{Actor, Cancellable}
+import akka.actor.Cancellable
+import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.serverobject.doors.Door
-import net.psforever.objects.serverobject.structures.Building
+import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
 import net.psforever.objects.{Default, GlobalDefinitions}
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
@@ -10,7 +11,7 @@ import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class PainboxControl(painbox: Painbox) extends Actor {
+class PainboxControl(painbox: Painbox) extends PoweredAmenityControl {
   private[this] val log         = org.log4s.getLogger(s"Painbox")
   var painboxTick: Cancellable  = Default.Cancellable
   var nearestDoor: Option[Door] = None
@@ -20,149 +21,167 @@ class PainboxControl(painbox: Painbox) extends Actor {
 
   var disabled = false // Temporary to disable cavern non-radius fields
 
-  def receive: Receive = {
-    case "startup" =>
-      if (painbox.Definition.HasNearestDoorDependency) {
-        (painbox.Owner match {
-          case obj: Building =>
-            obj.Amenities
-              .collect { case door: Door => door }
-              .sortBy(door => Vector3.DistanceSquared(painbox.Position, door.Position))
-              .headOption
-          case _ =>
-            None
-        }) match {
-          case door @ Some(_) =>
-            nearestDoor = door
-          case _ =>
-            log.error(
-              s"Painbox ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position} can not find a door that it is dependent on"
-            )
+  val initialStartup: Unit = {
+    if (painbox.Definition.HasNearestDoorDependency) {
+      (painbox.Owner match {
+        case obj : Building =>
+          obj.Amenities
+            .collect { case door : Door => door }
+            .sortBy(door => Vector3.DistanceSquared(painbox.Position, door.Position))
+            .headOption
+        case _ =>
+          None
+      }) match {
+        case door@Some(_) =>
+          nearestDoor = door
+        case _ =>
+          log.error(
+            s"Painbox ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position} can not find a door that it is dependent on"
+          )
+      }
+    }
+    else {
+      if (painbox.Definition.Radius == 0f) {
+        if (painbox.Owner.Continent.matches("c[0-9]")) {
+          // todo: handle non-radius painboxes in caverns properly
+          log.warn(s"Skipping initialization of ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position}")
+          disabled = true
         }
-      } else {
-        if (painbox.Definition.Radius == 0f) {
-          if (painbox.Owner.Continent.matches("c[0-9]")) {
-            // todo: handle non-radius painboxes in caverns properly
-            log.warn(s"Skipping initialization of ${painbox.GUID} on ${painbox.Owner.Continent} - ${painbox.Position}")
-            disabled = true
-          } else {
-            painbox.Owner match {
-              case obj: Building =>
-                val planarRange = 16.5f
-                val aboveRange  = 5
-                val belowRange  = 5
+        else {
+          painbox.Owner match {
+            case obj : Building =>
+              val planarRange = 16.5f
+              val aboveRange = 5
+              val belowRange = 5
+              // Find amenities within the specified range
+              val nearbyAmenities = obj.Amenities
+                .filter(amenity =>
+                  amenity.Position != Vector3.Zero
+                  && (amenity.Definition == GlobalDefinitions.mb_locker
+                      || amenity.Definition == GlobalDefinitions.respawn_tube
+                      || amenity.Definition == GlobalDefinitions.spawn_terminal
+                      || amenity.Definition == GlobalDefinitions.order_terminal
+                      || amenity.Definition == GlobalDefinitions.door)
+                  && amenity.Position.x > painbox.Position.x - planarRange && amenity.Position.x < painbox.Position.x + planarRange
+                  && amenity.Position.y > painbox.Position.y - planarRange && amenity.Position.y < painbox.Position.y + planarRange
+                  && amenity.Position.z > painbox.Position.z - belowRange && amenity.Position.z < painbox.Position.z + aboveRange
+                )
 
-                // Find amenities within the specified range
-                val nearbyAmenities = obj.Amenities
-                  .filter(amenity =>
-                    amenity.Position != Vector3.Zero
-                      && (amenity.Definition == GlobalDefinitions.mb_locker
-                        || amenity.Definition == GlobalDefinitions.respawn_tube
-                        || amenity.Definition == GlobalDefinitions.spawn_terminal
-                        || amenity.Definition == GlobalDefinitions.order_terminal
-                        || amenity.Definition == GlobalDefinitions.door)
-                      && amenity.Position.x > painbox.Position.x - planarRange && amenity.Position.x < painbox.Position.x + planarRange
-                      && amenity.Position.y > painbox.Position.y - planarRange && amenity.Position.y < painbox.Position.y + planarRange
-                      && amenity.Position.z > painbox.Position.z - belowRange && amenity.Position.z < painbox.Position.z + aboveRange
-                  )
-
-                // Calculate bounding box of amenities
-                bBoxMinCorner = Vector3(
-                  nearbyAmenities.minBy(amenity => amenity.Position.x).Position.x,
-                  nearbyAmenities.minBy(amenity => amenity.Position.y).Position.y,
-                  nearbyAmenities.minBy(x => x.Position.z).Position.z
-                )
-                bBoxMaxCorner = Vector3(
-                  nearbyAmenities.maxBy(amenity => amenity.Position.x).Position.x,
-                  nearbyAmenities.maxBy(amenity => amenity.Position.y).Position.y,
-                  painbox.Position.z
-                )
-                bBoxMidPoint = Vector3(
-                  (bBoxMinCorner.x + bBoxMaxCorner.x) / 2,
-                  (bBoxMinCorner.y + bBoxMaxCorner.y) / 2,
-                  (bBoxMinCorner.z + bBoxMaxCorner.z) / 2
-                )
-              case _ => None
-            }
+              // Calculate bounding box of amenities
+              bBoxMinCorner = Vector3(
+                nearbyAmenities.minBy(amenity => amenity.Position.x).Position.x,
+                nearbyAmenities.minBy(amenity => amenity.Position.y).Position.y,
+                nearbyAmenities.minBy(x => x.Position.z).Position.z
+              )
+              bBoxMaxCorner = Vector3(
+                nearbyAmenities.maxBy(amenity => amenity.Position.x).Position.x,
+                nearbyAmenities.maxBy(amenity => amenity.Position.y).Position.y,
+                painbox.Position.z
+              )
+              bBoxMidPoint = Vector3(
+                (bBoxMinCorner.x + bBoxMaxCorner.x) / 2,
+                (bBoxMinCorner.y + bBoxMaxCorner.y) / 2,
+                (bBoxMinCorner.z + bBoxMaxCorner.z) / 2
+              )
+            case _ => None
           }
         }
       }
-
-      if (!disabled) {
-        context.become(Stopped)
-      }
-
-    case _ => ;
+    }
+    if (!disabled) {
+      self ! BuildingActor.PowerOff()
+    }
   }
 
-  def Running: Receive = {
+  var commonBehavior: Receive = {
+    case "startup" =>
+      if (bBoxMidPoint == Vector3.Zero) {
+        initialStartup()
+      }
+
     case Painbox.Stop() =>
-      context.become(Stopped)
       painboxTick.cancel()
       painboxTick = Default.Cancellable
-
-    case Painbox.Tick() =>
-      //todo: Account for overlapping pain fields
-      //todo: Pain module
-      //todo: REK boosting
-      val guid    = painbox.GUID
-      val owner   = painbox.Owner.asInstanceOf[Building]
-      val faction = owner.Faction
-      if (
-        faction != PlanetSideEmpire.NEUTRAL && (nearestDoor match {
-          case Some(door) => door.Open.nonEmpty;
-          case _          => true
-        })
-      ) {
-        val events   = painbox.Zone.AvatarEvents
-        val damage   = painbox.Definition.Damage
-        val radius   = painbox.Definition.Radius * painbox.Definition.Radius
-        val position = painbox.Position
-
-        if (painbox.Definition.Radius != 0f) {
-          // Spherical pain field
-          owner.PlayersInSOI
-            .collect {
-              case p
-                  if p.Faction != faction
-                    && p.Health > 0
-                    && Vector3.DistanceSquared(p.Position, position) < radius =>
-                events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
-            }
-        } else {
-          // Bounding box pain field
-          owner.PlayersInSOI
-            .collect {
-              case p
-                  if p.Faction != faction
-                    && p.Health > 0 =>
-                /*
-                 This may be cpu intensive with a large number of players in SOI. Further performance tweaking may be required
-                 The bounding box is calculated aligned to the world XY axis, instead of rotating the painbox corners to match the base rotation
-                 we instead rotate the player's current coordinates to match the base rotation, which allows for much simplified checking of if the player is
-                 within the bounding box
-                 */
-                val playerRot =
-                  Vector3.PlanarRotateAroundPoint(p.Position, bBoxMidPoint, painbox.Owner.Orientation.z.toRadians)
-                if (
-                  bBoxMinCorner.x <= playerRot.x && playerRot.x <= bBoxMaxCorner.x && bBoxMinCorner.y <= playerRot.y && playerRot.y <= bBoxMaxCorner.y
-                  && playerRot.z >= bBoxMinCorner.z && playerRot.z <= bBoxMaxCorner.z
-                ) {
-                  events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
-                }
-            }
-        }
-      }
-
-    case _ => ;
   }
 
-  def Stopped: Receive = {
-    case Painbox.Start() =>
-      context.become(Running)
-      painboxTick.cancel()
-      painboxTick = context.system.scheduler.scheduleWithFixedDelay(0 seconds, 1 second, self, Painbox.Tick())
+  def poweredStateLogic: Receive =
+    commonBehavior
+      .orElse {
+        case Painbox.Start() if isPowered =>
+          painboxTick.cancel()
+          painboxTick = context.system.scheduler.scheduleWithFixedDelay(0 seconds, 1 second, self, Painbox.Tick())
 
-    case _ => ;
+        case Painbox.Tick() =>
+          //todo: Account for overlapping pain fields
+          //todo: Pain module
+          //todo: REK boosting
+          val guid    = painbox.GUID
+          val owner   = painbox.Owner.asInstanceOf[Building]
+          val faction = owner.Faction
+          if (
+            isPowered && faction != PlanetSideEmpire.NEUTRAL && (nearestDoor match {
+              case Some(door) => door.Open.nonEmpty;
+              case _          => true
+            })
+          ) {
+            val events   = painbox.Zone.AvatarEvents
+            val damage   = painbox.Definition.Damage
+            val radius   = painbox.Definition.Radius * painbox.Definition.Radius
+            val position = painbox.Position
+
+            if (painbox.Definition.Radius != 0f) {
+              // Spherical pain field
+              owner.PlayersInSOI
+                .collect {
+                  case p
+                    if p.Faction != faction
+                       && p.Health > 0
+                       && Vector3.DistanceSquared(p.Position, position) < radius =>
+                    events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
+                }
+            } else {
+              // Bounding box pain field
+              owner.PlayersInSOI
+                .collect {
+                  case p
+                    if p.Faction != faction
+                       && p.Health > 0 =>
+                    /*
+                     This may be cpu intensive with a large number of players in SOI. Further performance tweaking may be required
+                     The bounding box is calculated aligned to the world XY axis, instead of rotating the painbox corners to match the base rotation
+                     we instead rotate the player's current coordinates to match the base rotation, which allows for much simplified checking of if the player is
+                     within the bounding box
+                     */
+                    val playerRot =
+                      Vector3.PlanarRotateAroundPoint(p.Position, bBoxMidPoint, painbox.Owner.Orientation.z.toRadians)
+                    if (
+                      bBoxMinCorner.x <= playerRot.x && playerRot.x <= bBoxMaxCorner.x && bBoxMinCorner.y <= playerRot.y && playerRot.y <= bBoxMaxCorner.y
+                      && playerRot.z >= bBoxMinCorner.z && playerRot.z <= bBoxMaxCorner.z
+                    ) {
+                      events ! AvatarServiceMessage(p.Name, AvatarAction.EnvironmentalDamage(p.GUID, guid, damage))
+                    }
+                }
+            }
+          }
+
+        case _ => ;
+      }
+
+  def unpoweredStateLogic: Receive =
+    commonBehavior
+      .orElse {
+        case _ => ;
+      }
+
+  def powerTurnOffCallback(): Unit = {
+    self ! Painbox.Stop()
+  }
+
+  def powerTurnOnCallback(): Unit = {
+    painbox.Owner match {
+      case b: Building if b.PlayersInSOI.nonEmpty =>
+        self ! Painbox.Start()
+      case _ => ;
+    }
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/repair/AmenityAutoRepair.scala
@@ -129,10 +129,25 @@ trait AmenityAutoRepair
   /**
     * Attempt to start auto-repair operation
     * only if no operation is currently being processed.
+    * @see `actuallyTryAutoRepair`
     * @return `true`, if the auto-repair process started specifically due to this call;
     *        `false`, if it was already started, or did not start
     */
-  final def tryAutoRepair(): Boolean = {
+  def tryAutoRepair(): Boolean = {
+    actuallyTryAutoRepair()
+  }
+
+  /**
+    * Attempt to start auto-repair operation
+    * only if no operation is currently being processed.
+    * In case that an override to the normals operations of `tryAutoRepair` is necessary,
+    * but the superclass can not be invoked,
+    * this method is the backup of those operations to initiate auto-repair.
+    * @see `tryAutoRepair`
+    * @return `true`, if the auto-repair process started specifically due to this call;
+    *        `false`, if it was already started, or did not start
+    */
+  final def actuallyTryAutoRepair(): Boolean = {
     val before = autoRepairTimer.isCancelled
     autoRepairStartFunc()
     !(before || autoRepairTimer.isCancelled)

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
@@ -113,18 +113,9 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
       LowNtuWarning(enabled = true)
     }
     if (resourceSilo.NtuCapacitor == 0 && siloChargeBeforeChange > 0) {
-      // Oops, someone let the base run out of power. Shut it all down.
-      zone.AvatarEvents ! AvatarServiceMessage(zone.id, AvatarAction.PlanetsideAttribute(building.GUID, 48, 1))
       building.Actor ! BuildingActor.NtuDepleted()
       building.Actor ! BuildingActor.AmenityStateChange(resourceSilo)
-      building.Actor ! BuildingActor.SetFaction(PlanetSideEmpire.NEUTRAL)
     } else if (siloChargeBeforeChange == 0 && resourceSilo.NtuCapacitor > 0) {
-      // Power restored. Reactor Online. Sensors Online. Weapons Online. All systems nominal.
-      //todo: Check generator is online before starting up
-      zone.AvatarEvents ! AvatarServiceMessage(
-        zone.id,
-        AvatarAction.PlanetsideAttribute(building.GUID, 48, 0)
-      )
       building.Actor ! BuildingActor.SuppliedWithNtu()
       building.Actor ! BuildingActor.AmenityStateChange(resourceSilo)
     }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -114,6 +114,13 @@ class Building(
     }
   }
 
+  def Generator: Option[Generator] = {
+    Amenities.find(_.isInstanceOf[Generator]) match {
+      case Some(obj: Generator) => Some(obj)
+      case _                    => None
+    }
+  }
+
   def CaptureTerminal: Option[CaptureTerminal] = {
     Amenities.find(_.isInstanceOf[CaptureTerminal]) match {
       case Some(term) => Some(term.asInstanceOf[CaptureTerminal])
@@ -187,8 +194,8 @@ class Building(
         (false, PlanetSideEmpire.NEUTRAL, 0L)
     }
     //if we have no generator, assume the state is "Normal"
-    val (generatorState, boostGeneratorPain) = Amenities.find(x => x.isInstanceOf[Generator]) match {
-      case Some(obj: Generator) =>
+    val (generatorState, boostGeneratorPain) = Generator match {
+      case Some(obj) =>
         (obj.Condition, false) // todo: poll pain field strength
       case _ =>
         (PlanetSideGeneratorState.Normal, false)

--- a/src/main/scala/net/psforever/objects/serverobject/structures/PoweredAmenityControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/PoweredAmenityControl.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects.serverobject.structures
+
+import akka.actor.Actor
+import net.psforever.actors.zone.BuildingActor
+
+trait PoweredAmenityControl extends Actor {
+  private var powered: Boolean = true
+
+  final def receive: Receive = powerOnCondition
+
+  final def powerOnCondition: Receive = {
+    case BuildingActor.PowerOff() =>
+      powered = false
+      context.become(powerOffCondition)
+      powerTurnOffCallback()
+    case msg =>
+      poweredStateLogic.apply(msg)
+  }
+
+  final def powerOffCondition: Receive = {
+    case BuildingActor.PowerOn() =>
+      powered = true
+      context.become(powerOnCondition)
+      powerTurnOnCallback()
+    case msg =>
+      unpoweredStateLogic.apply(msg)
+  }
+
+  def isPowered: Boolean = powered
+
+  def poweredStateLogic: Receive
+
+  def unpoweredStateLogic: Receive
+
+  def powerTurnOnCallback(): Unit
+
+  def powerTurnOffCallback(): Unit
+}

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -89,7 +89,12 @@ class TerminalControl(term: Terminal)
     newHealth
   }
 
+  override def tryAutoRepair() : Boolean = {
+    isPowered && super.tryAutoRepair()
+  }
+
   def powerTurnOffCallback() : Unit = {
+    stopAutoRepair()
     //clear hack state
     if (term.HackedBy.nonEmpty) {
       val zone = term.Zone
@@ -97,7 +102,9 @@ class TerminalControl(term: Terminal)
     }
   }
 
-  def powerTurnOnCallback() : Unit = { }
+  def powerTurnOnCallback() : Unit = {
+    tryAutoRepair()
+  }
 
   override def toString: String = term.Definition.Name
 }

--- a/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTube.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTube.scala
@@ -10,6 +10,10 @@ import net.psforever.objects.serverobject.structures.Amenity
   * @param tDef the `ObjectDefinition` that constructs this object and maintains some of its immutable fields
   */
 class SpawnTube(tDef: SpawnTubeDefinition) extends Amenity with SpawnPoint {
+  var offline: Boolean = false
+
+  override def isOffline: Boolean = offline || super.isOffline
+
   def Definition: SpawnTubeDefinition = tDef
 }
 

--- a/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
@@ -71,8 +71,13 @@ class SpawnTubeControl(tube: SpawnTube)
     }
   }
 
+  override def tryAutoRepair() : Boolean = {
+    isPowered && super.tryAutoRepair()
+  }
+
   def powerTurnOffCallback(): Unit = {
     tube.offline = false
+    stopAutoRepair()
     tube.Owner match {
       case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
       case _           => ;
@@ -81,6 +86,7 @@ class SpawnTubeControl(tube: SpawnTube)
 
   def powerTurnOnCallback(): Unit = {
     tube.offline = true
+    tryAutoRepair()
     tube.Owner match {
       case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
       case _           => ;

--- a/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/tube/SpawnTubeControl.scala
@@ -1,21 +1,20 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.tube
 
-import akka.actor.Actor
 import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.ballistics.ResolvedProjectile
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.DamageableAmenity
 import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, Repairable, RepairableAmenity}
-import net.psforever.objects.serverobject.structures.Building
+import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `SpawnTube`.
   * @param tube the `SpawnTube` object being governed
   */
 class SpawnTubeControl(tube: SpawnTube)
-    extends Actor
+    extends PoweredAmenityControl
     with FactionAffinityBehavior.Check
     with DamageableAmenity
     with RepairableAmenity
@@ -25,11 +24,19 @@ class SpawnTubeControl(tube: SpawnTube)
   def RepairableObject = tube
   def AutoRepairObject = tube
 
-  def receive: Receive =
-    checkBehavior
-      .orElse(takesDamage)
-      .orElse(canBeRepairedByNanoDispenser)
-      .orElse(autoRepairBehavior)
+  val commonBehavior: Receive = checkBehavior
+    .orElse(takesDamage)
+    .orElse(canBeRepairedByNanoDispenser)
+    .orElse(autoRepairBehavior)
+
+  def poweredStateLogic: Receive =
+    commonBehavior
+      .orElse {
+        case _ => ;
+      }
+
+  def unpoweredStateLogic: Receive =
+    commonBehavior
       .orElse {
         case _ => ;
       }
@@ -58,6 +65,22 @@ class SpawnTubeControl(tube: SpawnTube)
 
   override def Restoration(obj: Repairable.Target): Unit = {
     super.Restoration(obj)
+    tube.Owner match {
+      case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
+      case _           => ;
+    }
+  }
+
+  def powerTurnOffCallback(): Unit = {
+    tube.offline = false
+    tube.Owner match {
+      case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
+      case _           => ;
+    }
+  }
+
+  def powerTurnOnCallback(): Unit = {
+    tube.offline = true
     tube.Owner match {
       case b: Building => b.Actor ! BuildingActor.AmenityStateChange(tube)
       case _           => ;

--- a/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
@@ -58,11 +58,11 @@ class FacilityTurretControl(turret: FacilityTurret)
       .orElse(dismountBehavior)
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
-      .orElse(autoRepairBehavior)
 
   def poweredStateLogic: Receive =
     commonBehavior
       .orElse(mountBehavior)
+      .orElse(autoRepairBehavior)
       .orElse {
         case CommonMessages.Use(player, Some((item: Tool, upgradeValue: Int)))
             if player.Faction == turret.Faction &&
@@ -157,7 +157,12 @@ class FacilityTurretControl(turret: FacilityTurret)
     events ! AvatarServiceMessage(zoneId, AvatarAction.PlanetsideAttributeToAll(tguid, 51, 0))
   }
 
+  override def tryAutoRepair() : Boolean = {
+    isPowered && super.tryAutoRepair()
+  }
+
   def powerTurnOffCallback(): Unit = {
+    stopAutoRepair()
     //kick all occupants
     val guid = turret.GUID
     val zone = turret.Zone
@@ -176,5 +181,7 @@ class FacilityTurretControl(turret: FacilityTurret)
     )
   }
 
-  def powerTurnOnCallback(): Unit = { }
+  def powerTurnOnCallback(): Unit = {
+    tryAutoRepair()
+  }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
@@ -58,11 +58,11 @@ class FacilityTurretControl(turret: FacilityTurret)
       .orElse(dismountBehavior)
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
+      .orElse(autoRepairBehavior)
 
   def poweredStateLogic: Receive =
     commonBehavior
       .orElse(mountBehavior)
-      .orElse(autoRepairBehavior)
       .orElse {
         case CommonMessages.Use(player, Some((item: Tool, upgradeValue: Int)))
             if player.Faction == turret.Faction &&

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -354,8 +354,8 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
       .filter {
         case (building, spawns) =>
           spawns.nonEmpty &&
-            spawns.exists(_.Offline == false) &&
-            structures.contains(building.BuildingType)
+          spawns.exists(_.isOffline == false) &&
+          structures.contains(building.BuildingType)
       }
       .filter {
         case (building, _) =>
@@ -368,7 +368,7 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
       }
       .map {
         case (building, spawns: List[SpawnPoint]) =>
-          (building, spawns.filter(!_.Offline))
+          (building, spawns.filter(!_.isOffline))
       }
       .concat(
         (if (ams) Vehicles else List())

--- a/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -144,7 +144,7 @@ import scodec.codecs._
   * `45 - NTU charge bar 0-10, 5 = 50% full. Seems to apply to both ANT and NTU Silo (possibly siphons?)`<br>
   * `46 - Sends "Generator damage is at a critical level!" message`
   * `47 - Sets base NTU level to CRITICAL. MUST use base MapId not base GUID`<br>
-  * `48 - Set to 1 to send base power loss message & turns on red warning lights throughout base. MUST use base MapId not base GUID`<br>
+  * `48 - Set to 1 to send base power loss message & turns on red warning lights throughout base. MUST use base MapId not base GUID`?<br>
   * `49 - Vehicle texture effects state? (>0 turns on ANT panel glow or ntu silo panel glow + orbs) (bit?)`<br>
   * `52 - Vehicle particle effects? (>0 turns on orbs going towards ANT. Doesn't affect silo) (bit?)`<br>
   * `53 - LFS. Value is 1 to flag LFS`<br>

--- a/src/test/scala/objects/AutoRepairIntegrationTest.scala
+++ b/src/test/scala/objects/AutoRepairIntegrationTest.scala
@@ -160,7 +160,7 @@ object AutoRepairIntegrationTest {
     MaxHealth = 500
     Damageable = true
     Repairable = true
-    autoRepair = AutoRepairStats(1, 500, 500, 1)
+    autoRepair = AutoRepairStats(200, 500, 500, 1)
     RepairIfDestroyed = true
   }
 }

--- a/src/test/scala/objects/AutoRepairIntegrationTest.scala
+++ b/src/test/scala/objects/AutoRepairIntegrationTest.scala
@@ -4,6 +4,7 @@ package objects
 import akka.actor.Props
 import akka.testkit.TestProbe
 import base.FreedContextActorTest
+import net.psforever.actors.zone.BuildingActor
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.ballistics.{Projectile, ProjectileResolution, ResolvedProjectile, SourceEntry}
 import net.psforever.objects.guid.NumberPoolHub
@@ -57,6 +58,7 @@ class AutoRepairFacilityIntegrationTest extends FreedContextActorTest {
   silo.NtuCapacitor = 1000
   silo.Actor = system.actorOf(Props(classOf[ResourceSiloControl], silo), "test-silo")
   silo.Actor ! "startup"
+  building.Actor ! BuildingActor.PowerOn() //artificial
 
   val wep_fmode  = weapon.FireMode
   val wep_prof   = wep_fmode.Add

--- a/src/test/scala/objects/DoorTest.scala
+++ b/src/test/scala/objects/DoorTest.scala
@@ -59,10 +59,12 @@ class DoorTest extends Specification {
       )
       val door = Door(GlobalDefinitions.door)
       door.Open.isEmpty mustEqual true
-      door.Use(player, msg)
+      door.Open = player
+      door.isOpen mustEqual true
       door.Open.contains(player) mustEqual true
-      door.Use(player, msg)
+      door.Open = None
       door.Open.isEmpty mustEqual true
+      door.isOpen mustEqual false
     }
   }
 }

--- a/src/test/scala/objects/DoorTest.scala
+++ b/src/test/scala/objects/DoorTest.scala
@@ -2,17 +2,22 @@
 package objects
 
 import akka.actor.{ActorSystem, Props}
+import akka.testkit.TestProbe
 import base.ActorTest
 import net.psforever.objects.avatar.Avatar
+import net.psforever.objects.guid.NumberPoolHub
+import net.psforever.objects.guid.source.MaxNumberSource
+import net.psforever.objects.serverobject.CommonMessages
 import net.psforever.objects.{Default, GlobalDefinitions, Player}
 import net.psforever.objects.serverobject.doors.{Door, DoorControl}
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
-import net.psforever.objects.zones.Zone
+import net.psforever.objects.zones.{Zone, ZoneMap}
 import net.psforever.packet.game.UseItemMessage
+import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.types._
 import org.specs2.mutable.Specification
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 class DoorTest extends Specification {
   val player = Player(Avatar(0, "test", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute))
@@ -83,6 +88,8 @@ class DoorControl2Test extends ActorTest {
   "DoorControl" should {
     "open on use" in {
       val (player, door) = DoorControlTest.SetUpAgents(PlanetSideEmpire.TR)
+      val probe = new TestProbe(system)
+      door.Zone.LocalEvents = probe.ref
       val msg = UseItemMessage(
         PlanetSideGUID(1),
         PlanetSideGUID(0),
@@ -98,13 +105,12 @@ class DoorControl2Test extends ActorTest {
       ) //faked
       assert(door.Open.isEmpty)
 
-      door.Actor ! Door.Use(player, msg)
-      val reply = receiveOne(Duration.create(500, "ms"))
-      assert(reply.isInstanceOf[Door.DoorMessage])
-      val reply2 = reply.asInstanceOf[Door.DoorMessage]
-      assert(reply2.player == player)
-      assert(reply2.msg == msg)
-      assert(reply2.response == Door.OpenEvent())
+      door.Actor ! CommonMessages.Use(player, Some(msg))
+      val reply = probe.receiveOne(1000 milliseconds)
+      assert(reply match {
+        case LocalServiceMessage("test", LocalAction.DoorOpens(PlanetSideGUID(0), _, d)) => d eq door
+        case _ => false
+      })
       assert(door.Open.isDefined)
     }
   }
@@ -126,16 +132,24 @@ class DoorControl3Test extends ActorTest {
 object DoorControlTest {
   def SetUpAgents(faction: PlanetSideEmpire.Value)(implicit system: ActorSystem): (Player, Door) = {
     val door = Door(GlobalDefinitions.door)
+    val guid = new NumberPoolHub(new MaxNumberSource(5))
+    val zone = new Zone("test", new ZoneMap("test"), 0) {
+      override def SetupNumberPools() = {}
+      GUID(guid)
+    }
+    guid.register(door, 1)
     door.Actor = system.actorOf(Props(classOf[DoorControl], door), "door")
     door.Owner = new Building(
       "Building",
       building_guid = 0,
       map_id = 0,
-      Zone.Nowhere,
+      zone,
       StructureType.Building,
       GlobalDefinitions.building
     )
     door.Owner.Faction = faction
-    (Player(Avatar(0, "test", faction, CharacterGender.Male, 0, CharacterVoice.Mute)), door)
+    val player = Player(Avatar(0, "test", faction, CharacterGender.Male, 0, CharacterVoice.Mute))
+    guid.register(player, 2)
+    (player, door)
   }
 }

--- a/src/test/scala/objects/GeneratorTest.scala
+++ b/src/test/scala/objects/GeneratorTest.scala
@@ -11,7 +11,7 @@ import net.psforever.objects.{GlobalDefinitions, Player, Tool}
 import net.psforever.objects.guid.NumberPoolHub
 import net.psforever.objects.guid.source.MaxNumberSource
 import net.psforever.objects.serverobject.CommonMessages
-import net.psforever.objects.serverobject.generator.{Generator, GeneratorControl}
+import net.psforever.objects.serverobject.generator.{Generator, GeneratorControl, GeneratorDefinition}
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.zones.{Zone, ZoneMap}
@@ -25,12 +25,12 @@ import scala.concurrent.duration._
 class GeneratorTest extends Specification {
   "Generator" should {
     "construct" in {
-      Generator(GlobalDefinitions.generator)
+      Generator(GeneratorTest.generator_definition)
       ok
     }
 
     "start in 'Normal' condition" in {
-      val obj = Generator(GlobalDefinitions.generator)
+      val obj = Generator(GeneratorTest.generator_definition)
       obj.Condition mustEqual PlanetSideGeneratorState.Normal
     }
   }
@@ -39,7 +39,7 @@ class GeneratorTest extends Specification {
 class GeneratorControlConstructTest extends ActorTest {
   "GeneratorControl" should {
     "construct" in {
-      val gen = Generator(GlobalDefinitions.generator)
+      val gen = Generator(GeneratorTest.generator_definition)
       gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "gen-control")
       assert(gen.Actor != ActorRef.noSender)
     }
@@ -57,7 +57,7 @@ class GeneratorControlDamageTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -106,19 +106,18 @@ class GeneratorControlDamageTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal)
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar = avatarProbe.receiveN(2, 500 milliseconds)
-      buildingProbe.expectNoMessage(200 milliseconds)
+      val msg_avatar = avatarProbe.receiveOne(500 milliseconds)
+      val msg_building = buildingProbe.receiveOne(500 milliseconds)
       assert(
-        msg_avatar.head match {
+        msg_avatar match {
           case AvatarServiceMessage("test", AvatarAction.PlanetsideAttributeToAll(PlanetSideGUID(2), 0, _)) => true
           case _                                                                                            => false
         }
       )
       assert(
-        msg_avatar(1) match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 15)) =>
-            true
-          case _ => false
+        msg_building match {
+          case BuildingActor.AmenityStateChange(_, Some(GeneratorControl.Event.UnderAttack)) => true
+          case _                                                                             => false
         }
       )
       assert(gen.Health < gen.Definition.MaxHealth)
@@ -139,7 +138,7 @@ class GeneratorControlCriticalTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -190,25 +189,18 @@ class GeneratorControlCriticalTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal)
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar   = avatarProbe.receiveN(2, 500 milliseconds)
+      val msg_avatar   = avatarProbe.receiveOne(500 milliseconds)
       val msg_building = buildingProbe.receiveOne(500 milliseconds)
       assert(
-        msg_avatar.head match {
+        msg_avatar match {
           case AvatarServiceMessage("test", AvatarAction.PlanetsideAttributeToAll(PlanetSideGUID(2), 0, _)) => true
           case _                                                                                            => false
         }
       )
       assert(
-        msg_avatar(1) match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 15)) =>
-            true
-          case _ => false
-        }
-      )
-      assert(
         msg_building match {
-          case BuildingActor.AmenityStateChange(o) => o eq gen
-          case _                              => false
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Critical)) => o eq gen
+          case _                                                                          => false
         }
       )
       assert(gen.Health < halfHealth)
@@ -229,7 +221,7 @@ class GeneratorControlDestroyedTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -269,7 +261,6 @@ class GeneratorControlDestroyedTest extends ActorTest {
     Vector3(1, 0, 0)
   )
   val applyDamageTo = resolved.damage_model.Calculate(resolved)
-  gen.Actor ! BuildingActor.NtuDepleted() //no auto-repair
   expectNoMessage(200 milliseconds)
   //we're not testing that the math is correct
 
@@ -281,12 +272,16 @@ class GeneratorControlDestroyedTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal) //skipped critical state because didn't transition ~50%
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar1 = avatarProbe.receiveOne(500 milliseconds)
-      buildingProbe.expectNoMessage(200 milliseconds)
+      val msg_building12 = buildingProbe.receiveN(2,500 milliseconds)
       assert(
-        msg_avatar1 match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 16)) =>
-            true
+        msg_building12.head match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Offline)) => o eq gen
+          case _ => false
+        }
+      )
+      assert(
+        msg_building12(1) match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destabilized)) => o eq gen
           case _ => false
         }
       )
@@ -294,13 +289,13 @@ class GeneratorControlDestroyedTest extends ActorTest {
       assert(!gen.Destroyed)
       assert(gen.Condition == PlanetSideGeneratorState.Normal)
 
-      avatarProbe.expectNoMessage(9 seconds)
+      avatarProbe.expectNoMessage(9500 milliseconds)
       val msg_avatar2  = avatarProbe.receiveN(3, 1000 milliseconds) //see DamageableEntity test file
       val msg_building = buildingProbe.receiveOne(200 milliseconds)
       assert(
         msg_building match {
-          case BuildingActor.AmenityStateChange(o) => o eq gen
-          case _                              => false
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destroyed)) => o eq gen
+          case _                                                                           => false
         }
       )
       assert(
@@ -352,7 +347,7 @@ class GeneratorControlKillsTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -400,7 +395,6 @@ class GeneratorControlKillsTest extends ActorTest {
     Vector3(1, 0, 0)
   )
   val applyDamageTo = resolved.damage_model.Calculate(resolved)
-  gen.Actor ! BuildingActor.NtuDepleted() //no auto-repair
   expectNoMessage(200 milliseconds)
   //we're not testing that the math is correct
 
@@ -412,21 +406,16 @@ class GeneratorControlKillsTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal) //skipped critical state because didn't transition ~50%
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar1 = avatarProbe.receiveN(2, 500 milliseconds)
-      buildingProbe.expectNoMessage(200 milliseconds)
-      player1Probe.expectNoMessage(200 milliseconds)
-      player2Probe.expectNoMessage(200 milliseconds)
+      val msg_building12 = buildingProbe.receiveN(2,500 milliseconds)
       assert(
-        msg_avatar1.head match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 16)) =>
-            true
+        msg_building12.head match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Offline)) => o eq gen
           case _ => false
         }
       )
       assert(
-        msg_avatar1(1) match {
-          case AvatarServiceMessage("TestCharacter2", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 16)) =>
-            true
+        msg_building12(1) match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destabilized)) => o eq gen
           case _ => false
         }
       )
@@ -434,14 +423,13 @@ class GeneratorControlKillsTest extends ActorTest {
       assert(!gen.Destroyed)
       assert(gen.Condition == PlanetSideGeneratorState.Normal)
 
-      val msg_building = buildingProbe.receiveOne(10500 milliseconds)
-      val msg_avatar2  = avatarProbe.receiveN(3, 200 milliseconds)
-      val msg_player1  = player1Probe.receiveOne(100 milliseconds)
-      player2Probe.expectNoMessage(200 milliseconds)
+      avatarProbe.expectNoMessage(9500 milliseconds)
+      val msg_avatar2  = avatarProbe.receiveN(3, 1000 milliseconds) //see DamageableEntity test file
+      val msg_building = buildingProbe.receiveOne(200 milliseconds)
       assert(
         msg_building match {
-          case BuildingActor.AmenityStateChange(o) => o eq gen
-          case _                              => false
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destroyed)) => o eq gen
+          case _                                                                           => false
         }
       )
       assert(
@@ -459,22 +447,25 @@ class GeneratorControlKillsTest extends ActorTest {
       assert(
         msg_avatar2(2) match {
           case AvatarServiceMessage(
-                "test",
-                AvatarAction.SendResponse(_, TriggerEffectMessage(PlanetSideGUID(2), "explosion_generator", None, None))
-              ) =>
+          "test",
+          AvatarAction.SendResponse(_, TriggerEffectMessage(PlanetSideGUID(2), "explosion_generator", None, None))
+          ) =>
             true
           case _ => false
         }
       )
+      assert(gen.Health == 0)
+      assert(gen.Destroyed)
+      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
+
+      val msg_player1  = player1Probe.receiveOne(100 milliseconds)
+      player2Probe.expectNoMessage(200 milliseconds)
       assert(
         msg_player1 match {
           case _ @Player.Die() => true
           case _               => false
         }
       )
-      assert(gen.Health == 0)
-      assert(gen.Destroyed)
-      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
     }
   }
 }
@@ -487,7 +478,7 @@ class GeneratorControlNotDestroyTwice extends ActorTest {
     GUID(guid)
   }
   val building = Building("test-building", 1, 1, zone, StructureType.Facility) //guid=1
-  val gen      = Generator(GlobalDefinitions.generator)                        //guid=2
+  val gen      = Generator(GeneratorTest.generator_definition)                        //guid=2
   val player1 =
     Player(Avatar(0, "TestCharacter1", PlanetSideEmpire.TR, CharacterGender.Male, 0, CharacterVoice.Mute)) //guid=3
   player1.Spawn()
@@ -573,7 +564,7 @@ class GeneratorControlNotDamageIfExplodingTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -625,13 +616,16 @@ class GeneratorControlNotDamageIfExplodingTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal) //skipped critical state because didn't transition ~50%
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar = avatarProbe.receiveOne(500 milliseconds)
-      buildingProbe.expectNoMessage(200 milliseconds)
-      player1Probe.expectNoMessage(200 milliseconds)
+      val msg_building12 = buildingProbe.receiveN(2,500 milliseconds)
       assert(
-        msg_avatar match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 16)) =>
-            true
+        msg_building12.head match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Offline)) => o eq gen
+          case _ => false
+        }
+      )
+      assert(
+        msg_building12(1) match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destabilized)) => o eq gen
           case _ => false
         }
       )
@@ -667,7 +661,7 @@ class GeneratorControlNotRepairIfExplodingTest extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -723,13 +717,16 @@ class GeneratorControlNotRepairIfExplodingTest extends ActorTest {
       assert(gen.Condition == PlanetSideGeneratorState.Normal) //skipped critical state because didn't transition ~50%
 
       gen.Actor ! Vitality.Damage(applyDamageTo)
-      val msg_avatar1 = avatarProbe.receiveOne(500 milliseconds)
-      buildingProbe.expectNoMessage(200 milliseconds)
-      player1Probe.expectNoMessage(200 milliseconds)
+      val msg_building12 = buildingProbe.receiveN(2,500 milliseconds)
       assert(
-        msg_avatar1 match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 16)) =>
-            true
+        msg_building12.head match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Offline)) => o eq gen
+          case _ => false
+        }
+      )
+      assert(
+        msg_building12(1) match {
+          case BuildingActor.AmenityStateChange(o, Some(GeneratorControl.Event.Destabilized)) => o eq gen
           case _ => false
         }
       )
@@ -765,7 +762,7 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
   val activityProbe = TestProbe()
   zone.Activity = activityProbe.ref
 
-  val gen = Generator(GlobalDefinitions.generator) //guid=2
+  val gen = Generator(GeneratorTest.generator_definition) //guid=2
   gen.Position = Vector3(1, 0, 0)
   gen.Actor = system.actorOf(Props(classOf[GeneratorControl], gen), "generator-control")
 
@@ -804,7 +801,7 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
       assert(gen.Destroyed)
 
       gen.Actor ! CommonMessages.Use(player1, Some(tool)) //repair
-      val msg_avatar   = avatarProbe.receiveN(4, 500 milliseconds) //expected
+      val msg_avatar   = avatarProbe.receiveN(3, 500 milliseconds) //expected
       val msg_building = buildingProbe.receiveOne(200 milliseconds)
       assert(
         msg_avatar.head match {
@@ -825,13 +822,6 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
       )
       assert(
         msg_avatar(2) match {
-          case AvatarServiceMessage("TestCharacter1", AvatarAction.GenericObjectAction(_, PlanetSideGUID(1), 17)) =>
-            true
-          case _ => false
-        }
-      )
-      assert(
-        msg_avatar(3) match {
           case AvatarServiceMessage(
                 "TestCharacter1",
                 AvatarAction.SendResponse(_, RepairMessage(ValidPlanetSideGUID(2), _))
@@ -842,7 +832,7 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
       )
       assert(
         msg_building match {
-          case BuildingActor.AmenityStateChange(o) => o eq gen
+          case BuildingActor.AmenityStateChange(o, _) => o eq gen
           case _                              => false
         }
       )
@@ -850,5 +840,17 @@ class GeneratorControlRepairPastRestorePoint extends ActorTest {
       assert(gen.Health > gen.Definition.RepairRestoresAt)
       assert(!gen.Destroyed)
     }
+  }
+}
+
+object GeneratorTest {
+  final val generator_definition = new GeneratorDefinition(352) {
+    MaxHealth = 4000
+    Damageable = true
+    DamageableByFriendlyFire = false
+    Repairable = true
+    RepairDistance = 13.5f
+    RepairIfDestroyed = true
+    //note: no auto-repair
   }
 }

--- a/src/test/scala/objects/GeneratorTest.scala
+++ b/src/test/scala/objects/GeneratorTest.scala
@@ -287,7 +287,7 @@ class GeneratorControlDestroyedTest extends ActorTest {
       )
       assert(gen.Health == 1)
       assert(!gen.Destroyed)
-      assert(gen.Condition == PlanetSideGeneratorState.Normal)
+      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
 
       avatarProbe.expectNoMessage(9500 milliseconds)
       val msg_avatar2  = avatarProbe.receiveN(3, 1000 milliseconds) //see DamageableEntity test file
@@ -421,7 +421,7 @@ class GeneratorControlKillsTest extends ActorTest {
       )
       assert(gen.Health == 1)
       assert(!gen.Destroyed)
-      assert(gen.Condition == PlanetSideGeneratorState.Normal)
+      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
 
       avatarProbe.expectNoMessage(9500 milliseconds)
       val msg_avatar2  = avatarProbe.receiveN(3, 1000 milliseconds) //see DamageableEntity test file
@@ -631,7 +631,7 @@ class GeneratorControlNotDamageIfExplodingTest extends ActorTest {
       )
       assert(gen.Health == 1)
       assert(!gen.Destroyed)
-      assert(gen.Condition == PlanetSideGeneratorState.Normal)
+      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
       //going to explode state
 
       //once
@@ -732,7 +732,7 @@ class GeneratorControlNotRepairIfExplodingTest extends ActorTest {
       )
       assert(gen.Health == 1)
       assert(!gen.Destroyed)
-      assert(gen.Condition == PlanetSideGeneratorState.Normal)
+      assert(gen.Condition == PlanetSideGeneratorState.Destroyed)
       //going to explode state
 
       //once

--- a/src/test/scala/objects/ResourceSiloTest.scala
+++ b/src/test/scala/objects/ResourceSiloTest.scala
@@ -289,12 +289,6 @@ class ResourceSiloControlUpdate1Test extends ActorTest {
         case AvatarServiceMessage("nowhere", AvatarAction.PlanetsideAttribute(PlanetSideGUID(6), 47, 0)) => true
         case _                                                                                           => false
       })
-
-      val reply4 = zoneEvents.receiveOne(500 milliseconds)
-      assert(reply4 match {
-        case AvatarServiceMessage("nowhere", AvatarAction.PlanetsideAttribute(PlanetSideGUID(6), 48, 0)) => true
-        case _                                                                                           => false
-      })
     }
   }
 }


### PR DESCRIPTION
For major facilities, power originates from a generator receiving nanites from the NTU resource silo.  Amenities belonging to a facility that receive power behave differently than when without power.  The facility itself is different when with power than when without power.  For facilities without generators or NTU resource silos, power and nanites manifest from thin air.

There's basically a lot of testing that needs being done but the limit of characters I may simultaneously have in one private instance at a time and not have that instance degenerate is three.  Four is like a PowerPoint presentation.

___`Features`___
__`PoweredAmenityControl`__
A new superclass for `Amenity` control agenices that exhibit different operation depending on whether they had been informed they are receiving power.  The control agencies that inherit this class have their `receive` functionality finalized by it and must append their operations onto either of two paths - `poweredStateLogic` and `unpoweredStateLogic`.  Additionally, callbacks for the transition between powered states may be invoked.

__`BuildingActor`__
"Power" is an abstract concept that derives almost entirely from the application of the message `BuildingActor.PowerOn()` and `BuildingActor.PowerOff()` and an independent variable that keeps track of which state the facility is in.  Although any given entity can be assigned a power state, the facility is the only object through which power is naturally transmitted.  Messages about power states changing will occasionally be sent back from an amenity and administered by an amenity's owning facility, e.g., what a facility does for its generator.  Right now, only the generator has given this responsibility back to its facility; but, the generator is the only one that seems to require this responsibility in any major way at the moment.  (Projection: this will change when the main terminal and viruses are implemented.)

__`GeneratorControl`__
The generator is a unique entity that serves as a confused junction between the instigation of power and the supply of NTU.  In terms of NTU, the generator needs NTU for its auto-repair operations and that is also what determines its "powered" status.  For that reason, it is not a `PoweredAmenityControl`-type agency, though it accommodates the same sort of state logic.  It must also accommodate the state logic for NTU provision (`SuppliedWithNtu` and `NtuDepleted`) without negatively affecting existing auto-repair implementation.  Whether or not the generator is "not destroyed" also plays a part in the decision.  The generator is a lifecycle-heavy component that has a variety of changes it can undergo - online, offline, normal, critical, destroyed, etc. - and those states affect other aspects of the facility in which it is installed.  Notably, whether any other amenity in the facility is accessible or whether the facility is spawnable even if the spawn tubes are operational otherwise.  For these, it sends status reports back to its owning facility and lets the facility dispatch messages.  Previously, before "power", it handled all of the message dispatch by itself.

__`DoorControl`__
The relationship between opening doors and checking against IFF locks has been moved from a more external site (`SessionActor`) to an internal location (this class, obviously).  Moving the door opening logic like so allows it to be under the auspicies of whether or not the door is powered.  If not powered, the door will just open freely.  If the door is powered, the existence of an IFF lock will be probed, same as before.  In the end, the door should behave the same way as before, and should also behave correctly if the facility has lost power.  Additionally, it is no longer necessary to call back to the player who wanted to open the door to open the door, if it ever was.  (It never was.  The original purpose for doing this was to give the person who wanted to open the door an "initiative bonus" that allowed the door to open before anyone else who subscribed for the event.  Implementation is moving away from the "initiative bonus" angle.)

__`TerminalControl` and `ProximityTerminalControl`__
When power is lost, no transactions with the terminals occur.  Standard terminals do not resolve their submitted requests and terminals that operate based on proximity do not affect local targets.  It should still be possible to open terminals, if the "use" prompt for a visual terminal UI becomes available, but nothing can be done from it.  Opening terminals is still overtly controlled from the client-facing session actor rather than through terminal control agency so the only thing that deters the UI are messages dispatched about the status of the owning facility in general.

__`SpawnTubeControl`__
Spawn tubes are considered offline when they are unpowered, but that does not grant them any other specific benefits or penalties.  They behave mostly the same.  The owning facility for a spawn tube will send a message that disables or enables the spawnability of that facility regardless of the state of its installed tubes on power change.

__`PainboxControl`__
The painbox will not cause damage if the power is off.  It will only reactivate if the SOI has players.  (A generator can auto-repair itself as long as there is NTU available from the silo.)  Subsequent startup messages will never cause the painbox boundaries to be re-defined subsequent times.

__`ImplantTerminalMechControl`__
When power is lost, any mounted player is forcibly dismounted and can not re-mount.

__`FacilityTurretControl`__
When power is lost, any mounted player is forcibly dismounted and can not re-mount.

___`Caveats`___
1.  When the generator is destroyed while being supplied with NTU, it will explode in 10s and kill everyone within 14m.  It will not actually report being "destroyed" until such a time when it explodes.  If the generator is destroyed while under the assumption that NTU is unavailable, it will not explode.  Likewise, if the generator is queued to explode but NTU becomes scarce during the prep time, it will not explode.  In these cases, it will switch quickly to characteristics of being destroyed without any further fanfare.  This may not be Gemini Live behavior.
2.  ~~The capitol force dome and~~ linked benefits are not currently influenced by facility power state.  Capture mechanics and power are untuned and may interfere with each other.

___`Addenda`___
1.  The NTU command (`!ntu`) has been enhanced this was necessary for testing purposes and the change is useful enough to leave.  Originally just a means of jump-starting a zone's facilities with a range of NTU, the command can now target specific facilities by name, and can set an exact amount of NTU.  The syntax is `!ntu [facility] [value]` where value can either call out a facility by name ("dagon") or refer to the current facility ("curr[ent]"), if any and if that facility has a silo.  Additionally, the NTU value can be set from empty to full in intervals of 10% (0-10) or to an exact number (>10).  The original functionality of setting NTU within a certain range of values can still be employed by not listing a value; and, same as before, designating no target facility sets all facilities in the zone to a new NTU value.  Though setting facility NTU to a value between 0 and 10 is impossible, it's not really a problem?
2.  In the future, the opening door should try `ask`ing its corresponding IFF lock whether or not that door may open for someone.
3.  For some reason, `/zone` and `/warp` commands cause players that release after dying to be ejected from the world.  These ejection messages can stack up to three times per login.  This is a dire but preexisting issue?
4.  Maybe we can fix Gemini Live.  Have we tried turning it off and on again?