### PR TITLE
Middleware

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -93,6 +93,23 @@ anti-cheat {
 }
 
 network {
+  middleware {
+    # How often between executions of the outbound bundling process
+    packet-bundling-delay = 25 milliseconds
+
+    # Pause inbound packet transmission towards the network if the sequence number is out of order
+    # Packets are put aside until the sequence is restored, or this timeout passes
+    in-reorder-timeout = 50 milliseconds
+
+    # Wait on inbound packets if that packet is a SlottedMetaPacket and the next subslot number is greater than expected
+    # Does not stop the transmission of packets to the server
+    # but dictates how long between requests to the network (client) for missing packets with anticipated subslot numbers
+    in-subslot-missing-delay = 50 milliseconds
+
+    # How many attempts at resolving missing packets with anticipated subslot numbers
+    in-subslot-missing-attempts = 10
+  }
+
   session {
     # The maximum amount of time since the last inbound packet from a UDP session
     # before it is dropped.

--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -9,7 +9,7 @@ import akka.io.Udp
 import net.psforever.packet.{CryptoPacketOpcode, PacketCoding, PlanetSideControlPacket, PlanetSideCryptoPacket, PlanetSideGamePacket, PlanetSidePacket}
 import net.psforever.packet.control.{ClientStart, ConnectionClose, ControlSync, ControlSyncResp, HandleGamePacket, MultiPacket, MultiPacketEx, RelatedA, RelatedB, ServerStart, SlottedMetaPacket, TeardownConnection}
 import net.psforever.packet.crypto.{ClientChallengeXchg, ClientFinished, ServerChallengeXchg, ServerFinished}
-import net.psforever.packet.game.{ChangeFireModeMessage, CharacterInfoMessage, KeepAliveMessage, PingMsg}
+import net.psforever.packet.game.{CharacterInfoMessage, KeepAliveMessage, PingMsg}
 import scodec.Attempt.{Failure, Successful}
 import scodec.bits.{BitVector, ByteVector, HexStringSyntax}
 import scodec.interop.akka.EnrichedByteVector
@@ -21,7 +21,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import scodec.Attempt
 
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration._
 
@@ -57,6 +56,9 @@ object MiddlewareActor {
 
   /** Close connection */
   final case class Close() extends Command
+
+  /** Log inbound packets that are yet to be in proper order by sequence number */
+  private case class InReorderEntry(packet: PlanetSidePacket, sequence: Int, time: Long)
 
   /**
     * All packets are bundled by themselves.
@@ -112,13 +114,18 @@ class MiddlewareActor(
     context.spawnAnonymous(next(context.self, sender, connectionId), ActorTags(s"id=$connectionId"))
 
   /** Queue of incoming packets (plus sequence numbers and timestamps) that arrived in the wrong order */
-  val inReorderQueue: ListBuffer[(PlanetSidePacket, Int, Long)] = ListBuffer()
+  private val inReorderQueue: mutable.Queue[InReorderEntry] = mutable.Queue()
 
   /** Latest incoming sequence number */
   var inSequence = 0
 
   /** Latest incoming subslot number */
   var inSubslot = 0
+
+  /** the last confirmed packet `inSubslot` number
+    * @see `RelatedB`
+    */
+  var inSubslotConfirmation: Int = 0
 
   /** List of missing subslot numbers and attempts counter */
   var inSubslotsMissing: mutable.Map[Int, Int] = mutable.Map()
@@ -186,12 +193,16 @@ class MiddlewareActor(
     packet
   }
 
+  /** Delay between runs of the queue processor (ms) */
+  val queueProcessorHz = 10.milliseconds
+
   /** Timer that handles the bundling and throttling of outgoing packets and the reordering of incoming packets */
   val queueProcessor: Cancellable = {
-    context.system.scheduler.scheduleWithFixedDelay(10.milliseconds, 10.milliseconds)(() => {
+    context.system.scheduler.scheduleWithFixedDelay(queueProcessorHz, queueProcessorHz)(() => {
       try {
-
-        if (outQueue.nonEmpty && outQueueBundled.isEmpty) {
+        if (outQueueBundled.nonEmpty) {
+          sendFirstBundle()
+        } else if (outQueue.nonEmpty) {
           val bundle = {
             var length = 0L
             val (_, bundle) = outQueue
@@ -223,61 +234,86 @@ class MiddlewareActor(
           }
 
           if (bundle.length == 1) {
-            outQueueBundled.enqueueAll(splitPacket(bundle.head))
+            splitPacket(bundle.head) match {
+              case Seq() => ;
+                log.warn("")
+                //TODO oversized packet recovery?
+              case data =>
+                outQueueBundled.enqueueAll(data)
+                sendFirstBundle()
+            }
           } else {
             PacketCoding.encodePacket(MultiPacketEx(bundle.toVector.map(_.bytes))) match {
-              case Successful(data) => outQueueBundled.enqueue(smp(0, data.bytes))
-              case Failure(cause)   => log.error(cause.message)
-            }
-          }
-        }
-
-        outQueueBundled.dequeueFirst(_ => true) match {
-          case Some(packet) => send(packet, Some(nextSequence), crypto)
-          case None         => ;
-        }
-
-        if (inReorderQueue.nonEmpty) {
-          var currentSequence = inSequence
-          val currentTime     = System.currentTimeMillis()
-          inReorderQueue
-            .sortBy(_._2)
-            .dropWhile {
-              case (_, sequence, time) =>
-                // Forward packet if next in sequence order or older than 20ms
-                if (sequence == currentSequence + 1 || currentTime - time > 20) {
-                  currentSequence += 1
-                  true
-                } else {
-                  false
+              case Successful(data) =>
+                outQueueBundled.enqueue(smp(slot = 0, data.bytes))
+                sendFirstBundle()
+              case Failure(cause)   =>
+                log.error(cause.message)
+                //to avoid packets being lost, unwrap bundle and attempt to queue the packets individually
+                bundle.foreach { packet =>
+                  outQueueBundled.enqueue(smp(slot = 0, packet.bytes))
                 }
+                sendFirstBundle()
             }
-            .foreach {
-              case (packet, sequence, _) =>
-                if (sequence > inSequence) {
-                  inSequence = sequence
-                }
-                in(packet)
-            }
-        }
-
-        if (inSubslotsMissing.nonEmpty) {
-          inSubslotsMissing.foreach {
-            case (subslot, attempts) =>
-              if (attempts <= 50) {
-                // Slight hack to send RelatedA less frequently, might want to put this on a separate timer
-                if (attempts % 10 == 0) send(RelatedA(0, subslot))
-                inSubslotsMissing(subslot) += 1
-              } else {
-                log.warn(s"Requesting subslot $subslot from client failed")
-                inSubslotsMissing.remove(subslot)
-              }
           }
         }
       } catch {
-        case e: Throwable => log.error(e)("Queue processing error")
+        case e: Throwable =>
+          log.error(s"outbound queue processing error - ${Option(e.getMessage).getOrElse(e.getClass.getSimpleName)}")
+      }
+
+      if (inReorderQueue.nonEmpty) {
+        handleInReorderQueue()
+      }
+
+      inSubslotsMissing.foreach {
+        case (subslot, attempts) =>
+          if (attempts <= 50) {
+            // Slight hack to send RelatedA less frequently, might want to put this on a separate timer
+            if (attempts % 10 == 0) send(RelatedA(0, subslot))
+            inSubslotsMissing(subslot) += 1
+          } else {
+            log.warn(s"requesting subslot $subslot from client failed")
+            inSubslotsMissing.remove(subslot)
+          }
       }
     })
+  }
+
+  /**
+    * Take the first fully-prepared packet from the queue of prepared packets and send it to the client.
+    * Assign the dispatched packet the latest sequence number.
+    * Do not call unless confident the the queue has at least one element.
+    * @throws NoSuchElementException if there is no packet to dequeue
+    * @see `SlottedMetaPacket`
+    */
+  def sendFirstBundle(): Unit = {
+    send(outQueueBundled.dequeue(), Some(nextSequence), crypto)
+  }
+
+  /**
+    * Examine inbound packets that need to be reordered by sequence number and
+    * pass all packets that are now in the correct order and
+    * pass packets that have been kept waiting for too long in the queue.
+    * Set the recorded inbound sequence number to belong to the greatest packet removed from the queue.
+    */
+  def handleInReorderQueue(): Unit = {
+    var currentSequence  = inSequence
+    val currentTime      = System.currentTimeMillis()
+    val take = inReorderQueue
+      .takeWhile { entry =>
+        // Forward packet if next in sequence order or older than 50ms (five update attempts)
+        if (entry.sequence == currentSequence + 1 || currentTime - entry.time > 50) {
+          currentSequence = entry.sequence //already ordered by sequence, stays in order during traversal
+          true
+        } else {
+          false
+        }
+      }
+      .map(_.packet)
+    inReorderQueue.takeRightInPlace(inReorderQueue.length - take.length)
+    inSequence = currentSequence
+    take.foreach { in }
   }
 
 //CryptoSessionActor
@@ -309,9 +345,6 @@ class MiddlewareActor(
                   case ping: PingMsg =>
                     // reflect the packet back to the sender
                     send(ping)
-                    Behaviors.same
-                  case _: ChangeFireModeMessage =>
-                    // ignore
                     Behaviors.same
                   case _ =>
                     log.error(s"Unexpected non-crypto packet type $packet in start")
@@ -447,11 +480,20 @@ class MiddlewareActor(
               if (sequence == inSequence + 1) {
                 inSequence = sequence
                 in(packet)
+              } else if(sequence <= inSequence) { //expedite this packet
+                in(packet)
               } else {
-                inReorderQueue.addOne((packet, sequence, System.currentTimeMillis()))
+                var insertAtIndex = 0
+                val length = inReorderQueue.length
+                while (insertAtIndex < length && sequence >= inReorderQueue(insertAtIndex).sequence) {
+                  insertAtIndex += 1
+                }
+                inReorderQueue.insert(insertAtIndex, InReorderEntry(packet, sequence, System.currentTimeMillis()))
               }
-            case Successful((packet, None)) => in(packet)
-            case Failure(e)                 => log.error(s"Could not decode packet: $e")
+            case Successful((packet, None)) =>
+              in(packet)
+            case Failure(e)                 =>
+              log.error(s"could not decode packet: $e")
           }
           Behaviors.same
 
@@ -467,7 +509,7 @@ class MiddlewareActor(
         case Close() =>
           outQueue
             .dequeueAll(_ => true)
-            .foreach(p => send(smp(0, p._2.bytes), Some(nextSequence), crypto))
+            .foreach(p => send(smp(slot = 0, p._2.bytes), Some(nextSequence), crypto))
           connectionClose()
       }
       .receiveSignal(onSignal)
@@ -512,7 +554,7 @@ class MiddlewareActor(
             Behaviors.same
 
           case RelatedA(slot, subslot) =>
-            log.trace(s"Client indicated a smp of slot $slot is missing prior to subslot $subslot")
+            log.warn(s"Client indicated a smp of slot $slot is missing prior to subslot $subslot")
             val requestedSubslot = subslot - 1
             preparedSlottedMetaPackets.find(_.subslot == requestedSubslot) match {
               case Some(_packet) =>
@@ -624,14 +666,13 @@ class MiddlewareActor(
     if (packet.length > (MTU - 4) * 8) {
       PacketCoding.encodePacket(HandleGamePacket(packet.bytes)) match {
         case Successful(data) =>
-          data.grouped((MTU - 8) * 8).map(vec => smp(4, vec.bytes)).toSeq
+          data.grouped((MTU - 8) * 8).map(vec => smp(slot = 4, vec.bytes)).toSeq
         case Failure(cause) =>
           log.error(cause.message)
           Seq()
       }
     } else {
-      Seq(smp(0, packet.bytes))
+      Seq(smp(slot = 0, packet.bytes))
     }
   }
-
 }

--- a/src/main/scala/net/psforever/packet/PacketCoding.scala
+++ b/src/main/scala/net/psforever/packet/PacketCoding.scala
@@ -16,8 +16,6 @@ import net.psforever.util.Md5Mac
 object PacketCoding {
   Security.addProvider(new BouncyCastleProvider)
 
-  //private val random = new java.security.SecureRandom()
-
   val RC5_BLOCK_SIZE = 8
 
   /** A lower bound on the packet size */

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -114,7 +114,15 @@ case class AntiCheatConfig(
 )
 
 case class NetworkConfig(
-    session: SessionConfig
+    session: SessionConfig,
+    middleware: MiddlewareConfig
+)
+
+case class MiddlewareConfig(
+  packetBundlingDelay: FiniteDuration,
+  inReorderTimeout: FiniteDuration,
+  inSubslotMissingDelay: FiniteDuration,
+  inSubslotMissingAttempts: Int
 )
 
 case class SessionConfig(


### PR DESCRIPTION
___You Should Read This___
I tried to make the `MiddlewareActor` more efficient.  That sentence should strike fear into your heart.

___You Don't Have To Read This___
The scheduled task for `MiddlewareActor` was running once every 10ms, per connected player.  This means it ran one-hundred times every second (twenty-five times every quarter second update from the client) and, in the course of doing that, stepped over itself frequently.  Isolating the encryption cipher in the previous `PacketCoding` changes was designed to mitigate concerns of thread-sharing-issues.  One school of thought is that this update rigor is acceptable since the quarter-second update cycle for all connected players is not synchronized between players; and, all you'd need is twenty-five players in one zone to have one `PlayerStateMessage`, if nothing else, update once every quarter-second; and, that sounds like a quantifiable realistic assessment (even if it is unrealistic from a distribution standpoint).  At the very least, the pace doesn't let up in any significant way.  On the subject of frequency, however, a feature to allocate all players in a zone per sphere of influence (SOI) in the background caused tremendous slowdown because initial design was to update for all buildings in all zones once every second, regardless of the zone's occupancy.  Changing it to limit the number of affected buildings per zone and only affecting zones that players were populating saw immediate improvements.  In the same way, improvements should be able to be seen here.

`MiddlewareActor` undertakes the process of bundling packets which offers a two-fold benefit.  First, it lowers the number of packets being dispatched in the direction of the network (to the clients).  Logging into the server would incur a debt many hundreds of packets without bundling.  With bundling, it became less than a hundred.  Even though the packets that do get dispatched will be bigger, the size will not be as big an issue as it sounds as long as boundaries are respected.  This was my feature.  Secondly, it offers limited TCP benefits to a UDP environment.  This is a significant benefit as that allows the threat of missing or dropped packets to be resolved.  Executing this feature involved wrapping packets and keeping track of previously dispatched packets for when the client requested them.  This feature was realized by a combination of @Mazo and @jgillich.  A third benefit was added by @jgillich recently that staggered packet dispatch such that virtually all packets were bundled (for recovery operations) and artificially paced (to avoid swamping anyone's client). The update was put to the side due to issues involving occasional improper encryption and due to load concerns; but, now, we're moving forward with its deployment.

___You May Want to Read This___
Optimization at this level of code is a half-hearted endeavor no matter what you do but some approaches are always valid.  Making something that runs multiple times per second for all players and must share load with all other events that are occurring in the environment at the same time more efficient is always a valid concern.  But it must actually work.  (List entries below are in order of file changes.)
- In general, reducing the number of branches in the code always helps to make execution as straightforward as possible.  If the first branch taken is the branch that will most likely be taken, that is good.  Not having to branch is still better over time.
- Packet guards make it possible to easily decide which packets should be bundled by themselves rather than having to write a `match` `case` statement for each.  It can even be made dynamic, if the need arises.
- Making `inReorderQueue` - tasked with maintaining packets that do not have sequence numbers in order - an actual `Queue` rather than a `ListBuffer` offers benefits when cleaning up after a proper sequence is realized.  In the past, old data was left around in `inReorderQueue` and was only cleared out because it had gotten too old and this had the potential to have some packets be processed a second time.
- Outbound `SlottedMetaPacket` history is an fixed-size `Array` rather than a resizing `ListBuffer` and is accessed in a circular manner.  Operations elsewhere in the code eliminated packets in the archives as their reception was confirmed by a `RelatedB` packet, and the first 100 entries were disposed to avoid the list becoming too long if the list ever get that long.  Though both of these actions were a waste of time, staying true to the standards they attempted to impose is prudent.
- Exchange of crypto information doesn't take too long.  Regardless, the bundling processor is not necessary until after the cipher is decided upon and that is when it's start has been shifted.
- Out of sequence resolution does not need to occur until the first packet out of sequence has been detected.  It will continue to occur until all out of sequence conditions are resolved.  This is a finite state machine where skipping between the normal case and the resolution case will save time letting the procedure not have to concern itself with features that are not yet relevant.
- A message concerning how much time was wasted in packet resolution for either resolving out of sequence situations or resolving out of subslot order situations has been included to help with future tuning.
- Out of sublot order resolution does not need to occur until the first packet out of subslot order has been detected.  It will continue to occur until all out of subslot order conditions are resolved.  This is a finite state machine where skipping between the normal case and the resolution case will save time letting the procedure not have to concern itself with features that are not yet relevant.  That said, both cases are pretty similar.
- A comment in the original code suggested moving the out of subslot resolution code that dispatched `RelatedA` packets onto a separate timer.  In the original code, this process piggybacked off the primary bundling and sequence scheduled task for the sake of convenience.  The suggestion has been realized and it has been transformed into its own scheduled action.

Specific questions regarding anything in the changes should be lodged.

___Caveats___
1. The primary outbound bundling and inbound out of sequence resolution loop uses self-messaging to queue itself alongside the normal `MiddlewareActor` processing of messages.  The out of subslot order resolution loop synchronizes on the out of subslot order queue only.  Perhaps both of these methods should be standardized to follow one practice?
2. Previous efforts to ensure access protection of the cipher object have not been lifted.  The code is not guaranteed to be as safe as expected without that protection existing.

___Addenda___
1. The `Config` object now has environment variables for the `MiddlewareActor`'s operations, mostly concerning timing.
2. The instance of `ChangeFireModeMessage` reported in the code is the subject of a "what is this" situation.  This packet arrives during cryptographic setup operations and the only reason we analyze it is as a `CFMM` is that, when it fails to unmarshal with the current level of cryptography, we attempt to decode it directly and it comes out looking like `ChangeFireModeMessage(PlanetSideGUID(4), 0)`.  `CFMM` is not one of the non-`ControlPacket`, non-`CryptoPacket` types that are expected at this point.  Furthermore, there's is more to the packet that just the few bytes at the start that look like a `CFMM`.  It often fails to be either sent or to be received.  We don't know what to do with it for the time being but log its existence.
3. The code is longer and a bit harder to follow.  Is it really any more efficient?