### PR TITLE
Allow a small change in coverage (0.25%) without flagging check as a failure

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,13 @@
 # Too spammy for us
 comment: off
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.25%
+
 ignore:
   - "src/main/scala/net/psforever/objects/ObjectType.scala"
   - "src/main/scala/net/psforever/objects/avatar/Avatars.scala"


### PR DESCRIPTION
Hopefully this will allow the renovate PRs to be automerged as the checks should succeed instead of being marked as failure due to minor fluctuations (Not sure why that's happening though...)

See: https://docs.codecov.io/docs/commit-status