### PR TITLE
Test fixes / tweaks

### DIFF
--- a/src/main/scala/net/psforever/objects/equipment/JammingUnit.scala
+++ b/src/main/scala/net/psforever/objects/equipment/JammingUnit.scala
@@ -152,8 +152,8 @@ trait JammableBehavior {
               case _ =>
                 true
             }) {
-              StartJammeredSound(obj, dur)
               StartJammeredStatus(obj, dur)
+              StartJammeredSound(obj, dur)
             }
           case None =>
         }

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -436,12 +436,16 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
     if (actor == null && guid.Pools.values.foldLeft(0)(_ + _.Count) == 0) {
       import org.fusesource.jansi.Ansi.Color.RED
       import org.fusesource.jansi.Ansi.ansi
-      println(
-        ansi()
-          .fgBright(RED)
-          .a(s"""Caution: replacement of the number pool system for zone $id; function is for testing purposes only""")
-          .reset()
-      )
+
+      // If the number pool has been replaced for a test don't show this warning, if the zone id contains test we'll assume you know what you're doing.
+      if (!id.contains("test")) {
+        println(
+          ansi()
+            .fgBright(RED)
+            .a(s"""Caution: replacement of the number pool system for zone $id; function is for testing purposes only""")
+            .reset()
+        )
+      }
       guid = hub
       true
     } else {

--- a/src/test/scala/objects/DamageableTest.scala
+++ b/src/test/scala/objects/DamageableTest.scala
@@ -932,27 +932,10 @@ class DamageableWeaponTurretJammerTest extends ActorTest {
 
       turret.Actor ! Vitality.Damage(applyDamageTo)
       val msg12 = vehicleProbe.receiveN(2, 500 milliseconds)
-      assert(
-        msg12.head match {
-          case VehicleServiceMessage(
-                "test",
-                VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, PlanetSideGUID(2), 27, 1)
-              ) =>
-            true
-          case _ => false
-        }
-      )
-      assert(
-        msg12(1) match {
-          case VehicleServiceMessage(
-                "test",
-                VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, PlanetSideGUID(5), 27, 1)
-              ) =>
-            true
-          case _ => false
-        }
-      )
-      expectNoMessage(100 milliseconds) // FIXME this is a hack to make it pass
+
+      assert(msg12.contains(VehicleServiceMessage("test", VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, PlanetSideGUID(2), 27, 1))))
+      assert(msg12.contains(VehicleServiceMessage("test", VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, PlanetSideGUID(5), 27, 1))))
+
       assert(turret.Health == turret.Definition.DefaultHealth)
       assert(turret.Jammed)
     }


### PR DESCRIPTION
This should fix some of the flaky tests and speed up some of the water related ones.

There's still a failure with `VehicleControlInteractWithWaterTest` however, and I have no idea why. It runs perfectly fine when ran on it's own, but in a batch of all tests will fail even with greatly exaggerated timeouts for the expected message. Even running it in a smaller batch seems to work

@Fate-JH If you have any ideas on the above let me know.