### PR TITLE
ResetSequence 1

### DIFF
--- a/src/main/scala/net/psforever/packet/PacketCoding.scala
+++ b/src/main/scala/net/psforever/packet/PacketCoding.scala
@@ -176,6 +176,8 @@ object PacketCoding {
         if (flags.secured && crypto.isEmpty) {
           return Failure(Err("Unsupported packet type: crypto packets must be unencrypted"))
         }
+      case PacketType.ResetSequence =>
+        return Failure(Err(s"Caught a wild ResetSequence when cryptoState is ${crypto.nonEmpty}: $msg -> $flags and $remainder"))
       case _ =>
         return Failure(Err(s"Unsupported packet type: ${flags.packetType.toString}"))
     }


### PR DESCRIPTION
I need to figure out what `ResetSequence` is doing.  It drowns out the log at the end of the server's lives and at the end of very many sessions's lives.  This will not solve the problem, but will allow me to get a sample about what the packet type is doing in our logs by showing me what it looks like.  I need to understand what it looks like to transform it into some kind of packet container that can move past the remainder of the checks, gettting it out of our basic unmarshalling functions and into the server's operations.  As the packet is difficult to trigger and even waiting around for hours in the game is not perfectly reliable, pushing it to Live will most certainly reward some entries in the log.

The working theory is that `ResetSequence` merely resets the packet sequence number - the number that accompanies all packets - back to 0, or maybe to something specific.  Probably 0, probably.  As soon as analysis bears fruit, this solution can enter the experimentation phase.

@jgillich suggested modifying our packet capture parsers but I would only advise doing that for a local transformation of packets and not making it a permanent change to the parsers.  I believe the data we would get would only be very specific to this problem and create much more clutter that would bog down our decoded transcripts exists than necessary otherwise.