### PR TITLE
Quick Fixes

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -2851,7 +2851,10 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         }
         sendResponse(PlanetsideAttributeMessage(vehicle_guid, 22, 1L))          //mount points off
         sendResponse(PlanetsideAttributeMessage(player.GUID, 21, vehicle_guid)) //ownership
-        vehicle.Actor ! Mountable.TryMount(player, 0)
+        vehicle.MountPoints.find { case (_, mp) => mp.seatIndex == 0 } match {
+          case Some((mountPoint, _)) => vehicle.Actor ! Mountable.TryMount(player, mountPoint)
+          case _ => ;
+        }
 
       case VehicleResponse.PlayerSeatedInVehicle(vehicle, pad) =>
         val vehicle_guid = vehicle.GUID
@@ -9154,9 +9157,9 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       .flatMap {
         case Some(obj: Vehicle) if !obj.Cloaked =>
           //TODO hint: vehicleService ! VehicleServiceMessage(s"${obj.Actor}", VehicleAction.ProjectileAutoLockAwareness(mode))
-          obj.Seats.values.flatMap { case seat if seat.isOccupied => seat.occupants.map(_.Name) }
+          obj.Seats.values.flatMap { case seat => seat.occupants.map(_.Name) }
         case Some(obj: Mountable) =>
-          obj.Seats.values.flatMap { case seat if seat.isOccupied => seat.occupants.map(_.Name) }
+          obj.Seats.values.flatMap { case seat => seat.occupants.map(_.Name) }
         case Some(obj: Player) if obj.ExoSuit == ExoSuitType.MAX =>
           Seq(obj.Name)
         case _ =>
@@ -9263,7 +9266,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     */
   def TurnCounterDuringInterim(guid: PlanetSideGUID): Unit = {
     upstreamMessageCount = 0
-    if (player.GUID == guid && player.Zone == continent) {
+    if (player != null && player.GUID == guid && player.Zone == continent) {
       turnCounterFunc = NormalTurnCounter
     }
   }

--- a/src/main/scala/net/psforever/objects/zones/MapInfo.scala
+++ b/src/main/scala/net/psforever/objects/zones/MapInfo.scala
@@ -64,7 +64,7 @@ case object MapInfo extends StringEnum[MapInfo] {
         checksum = 1624200906L,
         scale = MapScale.Dim8192,
         environment = List(
-          SeaLevel(EnvironmentAttribute.Water, 35),
+          SeaLevel(EnvironmentAttribute.Water, 29.5f),
           Pool(EnvironmentAttribute.Water, 67.3125f, 3449.586f, 5870.383f, 3313.75f, 5715.3203f), //east of itan, south of kaang
           Pool(EnvironmentAttribute.Water, 53.71875f, 6013.0625f, 1861.7969f, 5947.1406f, 1634.7734f), //E6
           Pool(EnvironmentAttribute.Water, 49.625f, 7181.6953f, 1496.3828f, 6972.992f, 1340.1328f), //east of wele


### PR DESCRIPTION
- Cyssor sea level was 5.5m too high resulting in premature drowning
- Vehicle spawn pad auto-mount attempt to mount to seat index rather than mount point index, thus failing to mount the driver upon spawn