### PR TITLE
ResetSequence 2

### DIFF
--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -417,7 +417,7 @@ class MiddlewareActor(
             case Successful((packet, None)) =>
               in(packet)
             case Failure(e)                 =>
-              log.error(s"Could not decode packet: $e")
+              log.error(s"Could not decode $connectionId's packet: $e")
           }
           Behaviors.same
 

--- a/src/main/scala/net/psforever/packet/PSPacket.scala
+++ b/src/main/scala/net/psforever/packet/PSPacket.scala
@@ -39,6 +39,9 @@ trait PlanetSideCryptoPacket extends PlanetSidePacket {
   def opcode: CryptoPacketOpcode.Type
 }
 
+/** PlanetSide ResetSequence packets: self-contained? */
+trait PlanetSideResetSequencePacket extends PlanetSidePacket { }
+
 /** PlanetSide packet type. Used in more complicated packet headers
   *
   * ResetSequence - Not sure what this is used for or if the name matches what it actually does

--- a/src/main/scala/net/psforever/packet/PacketCoding.scala
+++ b/src/main/scala/net/psforever/packet/PacketCoding.scala
@@ -174,10 +174,12 @@ object PacketCoding {
         }
       case PacketType.Crypto =>
         if (flags.secured && crypto.isEmpty) {
-          return Failure(Err("Unsupported packet type: crypto packets must be unencrypted"))
+          return Failure(Err("Unsupported packet type: secured crypto packets must be unencrypted"))
         }
       case PacketType.ResetSequence =>
-        return Failure(Err(s"Caught a wild ResetSequence when cryptoState is ${crypto.nonEmpty}: $msg -> $flags and $remainder"))
+        if (!flags.secured || crypto.isEmpty) {
+          return Failure(Err("Unsupported packet type: reset sequence packets must be encrypted"))
+        }
       case _ =>
         return Failure(Err(s"Unsupported packet type: ${flags.packetType.toString}"))
     }
@@ -187,7 +189,7 @@ object PacketCoding {
       case Successful(DecodeResult(value, _remainder)) =>
         (value, _remainder.toByteVector)
       case Failure(e) =>
-        return Failure(Err(s"Failed to parse packet sequence number: ${e.message}"))
+        return Failure(Err(s"Failed to parse ${flags.packetType} packet sequence number: ${e.message}"))
     }
 
     (flags.packetType, crypto) match {
@@ -201,9 +203,13 @@ object PacketCoding {
       case (PacketType.Normal, None) if !flags.secured =>
         decodePacket(payload).map(p => (p, sequence))
       case (PacketType.Normal, None) =>
-        Failure(Err(s"Cannot unmarshal encrypted packet without CryptoCoding"))
+        Failure(Err("Cannot unmarshal encrypted packet without a cipher"))
+      case (PacketType.ResetSequence, Some(_crypto)) =>
+        val test = _crypto.decrypt(payload.drop(1))
+        Failure(Err(s"ResetSequence not completely supported, but: $flags, $sequence, and $payload; decrypt: $test"))
+      case (ptype, _) =>
+        Failure(Err(s"Cannot unmarshal $ptype packet at all"))
     }
-
   }
 
   /**


### PR DESCRIPTION
Refer to the comments from the first ResetSequence PR #729 .

In this original analysis, after removing the packet flags, 216 bits remained in the data.  The first 16 of those bits are comfortably the packet sequence number.  I am comfortable removing that standard packet sequence number field now and testing a form of decryption based on the standard crytographic cipher used by "normal" packets.  Attached is the `connectionId` information from the `MiddlewareActor` processing the message that should give more insight on which and how many different accounts are logging this packet.

There are 200bits of data to figure out and I'm hoping our RC5 decryption works.  If it works and we're really lucky, 128 of those bits belong to the MAC and a padding value for the MAC leaves no remainder behind.  In other words, `ResetSequence` will have just been a packet that exists without need for actual decoding to determine its packet structure.  If not, the answer is still just to stuff whatever is left over in a placeholder packet and ship it back to `MiddlewareActor`.