### PR TITLE
Minor Squad Refactor

### DIFF
--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -521,6 +521,10 @@ class MiddlewareActor(
       case packet: PlanetSideCryptoPacket =>
         log.error(s"Unexpected crypto packet '$packet'")
         Behaviors.same
+
+      case packet =>
+        log.error(s"Unexpected type of packet '$packet'")
+        Behaviors.same
     }
   }
 

--- a/src/main/scala/net/psforever/packet/PacketCoding.scala
+++ b/src/main/scala/net/psforever/packet/PacketCoding.scala
@@ -106,7 +106,8 @@ object PacketCoding {
     packet.encode match {
       case Successful(payload) =>
         packet match {
-          case _: PlanetSideCryptoPacket => Successful(payload)
+          case _: PlanetSideCryptoPacket =>
+            Successful(payload)
           case packet: PlanetSideControlPacket =>
             ControlPacketOpcode.codec.encode(packet.opcode) match {
               case Successful(opcode) => Successful(hex"00".bits ++ opcode ++ payload)
@@ -117,6 +118,8 @@ object PacketCoding {
               case Successful(opcode) => Successful(opcode ++ payload)
               case f @ Failure(_)     => f
             }
+          case _ =>
+            Failure(Err("packet not supported"))
         }
       case f @ Failure(_) => f
     }

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -306,7 +306,7 @@ class SquadService extends Actor {
     to match {
       case str if "TRNCVS".indexOf(str) > -1 || str.matches("(TR|NC|VS)-Squad\\d+") =>
         SquadEvents.publish(SquadServiceResponse(s"/$str/Squad", excluded, msg))
-      case str if str.matches("//d+") =>
+      case str if str.matches("\\d+") =>
         Publish(to.toLong, msg, excluded)
       case _ =>
         log.warn(s"Publish(String): subscriber information is an unhandled format - $to")

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -3402,7 +3402,6 @@ class SquadService extends Actor {
             Publish(faction, SquadResponse.InitList(PublishedLists(factionListings)))
         }
       case None =>
-      case None =>
         //first time being published
         factionListings += guid
         Publish(faction, SquadResponse.InitList(PublishedLists(factionListings)))


### PR DESCRIPTION
I really did create a quagmire for myself with this code.  Each part is so finely interwoven that I can't see where it could be cleanly separated into pieces, for example, invitation activity from squad support activity.  Additionally, no matter what theory I use, I can't see anything but a waste of more time than is beneficial coming back to the main `SquadService` file to do proper updating calls after each squad update boils down to one or two lines.  At the least, I've cleaned up the `receive` method call by moving all of the cases into their own functions.