### PR TITLE
Flaky Facility Faction Fix

### DIFF
--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -355,6 +355,8 @@ class ChatActor(
                           val soi2 = building.Definition.SOIRadius * building.Definition.SOIRadius
                           Vector3.DistanceSquared(building.Position, position) < soi2
                         }
+                    case Some(all) if all.toLowerCase.startsWith("all") =>
+                      session.zone.Buildings.values
                     case Some(x) =>
                       session.zone.Buildings.values.find { _.Name.equalsIgnoreCase(x) }.toList
                     case _ =>

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -6823,7 +6823,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         //silo capacity
         sendResponse(PlanetsideAttributeMessage(amenityId, 45, silo.CapacitorDisplay))
         //warning lights
-        sendResponse(PlanetsideAttributeMessage(silo.Owner.GUID, 47, if (silo.LowNtuWarningOn) 1 else 0))
+        sendResponse(PlanetsideAttributeMessage(silo.Owner.GUID, 47, silo.LowNtuWarningOn))
         if (silo.NtuCapacitor == 0) {
           sendResponse(PlanetsideAttributeMessage(silo.Owner.GUID, 48, 1))
         }

--- a/src/main/scala/net/psforever/objects/serverobject/llu/CaptureFlagSocket.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/llu/CaptureFlagSocket.scala
@@ -1,6 +1,6 @@
 package net.psforever.objects.serverobject.llu
 
-import akka.actor.ActorContext
+import akka.actor.{ActorContext, Props}
 import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.serverobject.structures.Amenity
 import net.psforever.types.Vector3
@@ -24,9 +24,10 @@ object CaptureFlagSocket {
     Constructor(GlobalDefinitions.llm_socket, pos)(id, context)
   }
 
-  def Constructor(tdef: CaptureFlagSocketDefinition, pos: Vector3)(id: Int, context: ActorContext) : CaptureFlagSocket = {
+  def Constructor(tdef: CaptureFlagSocketDefinition, pos: Vector3)(id: Int, context: ActorContext): CaptureFlagSocket = {
     val obj = CaptureFlagSocket(tdef)
     obj.Position = pos
+    obj.Actor = context.actorOf(Props(classOf[CaptureFlagSocketControl], obj), s"${obj.Definition.Name}_$id")
     obj
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/llu/CaptureFlagSocketControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/llu/CaptureFlagSocketControl.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 PSForever
+package net.psforever.objects.serverobject.llu
+
+import akka.actor.Actor
+import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
+
+/**
+  * An `Actor` that handles messages being dispatched to a lattice logic unit (LLU) socket.
+  * Actually does nothing lol
+  * @param socket the socket entity being governed
+  */
+class CaptureFlagSocketControl(socket: CaptureFlagSocket)
+  extends Actor
+  with FactionAffinityBehavior.Check {
+  def FactionObject      = socket
+
+  def receive: Receive = {
+    case _ => ;
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSilo.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSilo.scala
@@ -15,6 +15,7 @@ class ResourceSilo extends Amenity with CommonNtuContainer {
 
   // For the NTU display bar
   private var capacitorDisplay: Long = 0
+  NtuCapacitor = Definition.MaxNtuCapacitor
 
   def MaxNtuCapacitor : Float = Definition.MaxNtuCapacitor
 

--- a/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/resourcesilo/ResourceSiloControl.scala
@@ -32,9 +32,10 @@ class ResourceSiloControl(resourceSilo: ResourceSilo)
   var panelAnimationFunc: (ActorRef, Float) => Unit = PanelAnimation
 
   def receive: Receive = {
-    case "startup" =>
+    case Service.Startup() =>
       resourceSilo.Owner match {
         case building: Building =>
+          UpdateChargeLevel(amount = 0)
           building.Actor ! (if (resourceSilo.NtuCapacitor <= 0f ) {
             BuildingActor.NtuDepleted()
           } else {

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -663,7 +663,7 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
       .flatMap(_.Amenities.filter(_.Definition == GlobalDefinitions.resource_silo))
       .collect {
         case silo: ResourceSilo =>
-          silo.Actor ! "startup"
+          silo.Actor ! Service.Startup()
       }
     //some painfields need to look for their closest door
     buildings.values

--- a/src/main/scala/net/psforever/zones/Zones.scala
+++ b/src/main/scala/net/psforever/zones/Zones.scala
@@ -621,12 +621,13 @@ object Zones {
 
     def initResourceSilos(zone: Zone): Unit = {
       // todo: load silo charge from database
-      zone.Buildings.values.flatMap {
-        _.Amenities.collect {
-          case silo: ResourceSilo =>
-            silo.Actor ! ResourceSilo.UpdateChargeLevel(silo.MaxNtuCapacitor)
-        }
-      }
+      // todo: load silo charge from this function call
+//      zone.Buildings.values.flatMap {
+//        _.Amenities.collect {
+//          case silo: ResourceSilo =>
+//            silo.Actor ! ResourceSilo.UpdateChargeLevel(silo.MaxNtuCapacitor)
+//        }
+//      }
     }
   }
 


### PR DESCRIPTION
Here's the story so far:
When the server starts up, all of the zones start up.  Upon each zone, every building is created.  Buildings also have a separate flag that indicates whether a supply of NTU is available, `true` by default since only major facilities have resource silos to vary the power state (normally).  When a facility's amenities start, a resource silo may get constructed also will also gain a control agency.  That control agency is eventually passed a "start-up" message that initializes the silo to its proper functionality and is supposed to return a message to the building control agency indicating the NTU status upon receipt.  Resource silos start with no NTU in stock.  It's an override and code that runs after normal zone setup that distributes an artificial NTU value (max).  While all this is going on, somewhere else in the code, the last-known faction affiliation of the building is being polled from the database and will be assigned to the building as long as it is powered and believes it has a supply of NTU at the time.  **As long as it believes it has a supply of NTU at the time**.

SO.  The problem we are looking at goes something like this: the facility has completed being set up and the resource silo is sent a "start-up" message; the database is queried about the base's faction affiliation; and, the NTU of the facility is artificially set.  The silo reports to the facility that it has no NTU first, so the facility goes into no NTU mode.  The database reports the facility's faction affiliation second, but it fails to gets applied because the facility has no NTU.  The silo has its NTU artificially set third, so the facility goes into "has NTU" mode.  This is a very specific order of things that should go right going wrong, and that results in a facility previously captured by one faction at the end of one run of the server suddenly being neutral at the start of the next run of the server.

There's a long-winded way to solve it and make certain everything is sequenced properly with the faction of the database call being applied last but I completely eschew that noise and just set the start NTU to silos to max.

It works, doesn't it?