### PR TITLE
Leave Squad Service by Character Id

### DIFF
--- a/server/src/main/java/net/psforever/filters/ApplyCooldownToDuplicateLoggingFilter.java
+++ b/server/src/main/java/net/psforever/filters/ApplyCooldownToDuplicateLoggingFilter.java
@@ -43,8 +43,8 @@ public class ApplyCooldownToDuplicateLoggingFilter extends Filter<ILoggingEvent>
     }
 
     public void setCleaning(Long duration) {
+        housecleaningTime = housecleaningTime - cleaning + duration;
         cleaning = duration;
-        housecleaningTime = System.currentTimeMillis() + cleaning;
     }
 
     private void runCleaning() {
@@ -55,6 +55,14 @@ public class ApplyCooldownToDuplicateLoggingFilter extends Filter<ILoggingEvent>
                     .map( Map.Entry::getKey )
                     .iterator();
             oldLogMessages.forEachRemaining(key -> messageMap.remove(key));
+        }
+    }
+
+    @Override
+    public void start() {
+        if (this.cooldown != 0L) {
+            messageMap = new ConcurrentHashMap<>(1000);
+            super.start();
         }
     }
 


### PR DESCRIPTION
The original error message indicated a failure due to a character id that could easily be resolved into a `Long` value, and that would have become a `ClassCastException` anyway (`String` to `Long`).  My guess is that the exception might have been raised by a bad value lookup and, therefore, I have expanded a number of those lookups along the paths that would have lead to the exception message into `get`/`match` statements, for safety.  Logging of the stack trace for such an error was also included, as only the console would have known what went wrong before.  Debug-level logging has actually been raised to debug-level logging.