### PR TITLE
Middleware: Add MTU rather than setting length to max

### DIFF
--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -604,7 +604,7 @@ class MiddlewareActor(
 
               if (packetsBundledByThemselves.exists { _(packet) }) {
                 if (length == packetLength) {
-                  length = Long.MaxValue
+                  length += MTU * 8
                   true // dequeue only packet
                 } else {
                   false // dequeue later


### PR DESCRIPTION
Don't want overflow errors here since the next iteration will still
add their packet length.