### PR TITLE
Infiltration Suit Stamina Drain

### DIFF
--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -128,7 +128,7 @@ object GlobalDefinitions {
   silent_run.InitializationDuration = 90
   silent_run.StaminaCost = 1
   silent_run.CostIntervalDefault = 333
-  silent_run.CostIntervalByExoSuitHashMap(ExoSuitType.Agile) = 1000
+  silent_run.CostIntervalByExoSuitHashMap(ExoSuitType.Infiltration) = 1000
 
   val surge = new ImplantDefinition(ImplantType.Surge) {
     Name = "surge"


### PR DESCRIPTION
Fixing a type mismatch for the `silent_run` implant and `ExoSuitType.Infiltration` which caused "normal" stamina drain.