### PR TITLE
Inside the Generator Room

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -5356,7 +5356,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         HandleWeaponFire(weapon_guid, projectile_guid, shot_origin)
 
       case msg @ WeaponLazeTargetPositionMessage(_, _, pos2) =>
-        log.debug(s"${player.Name} is lazing the position $pos2; to what ends?")
+        log.info(s"${player.Name} is lazing the position ${continent.id}@(${pos2.x},${pos2.y},${pos2.z})")
 
       case msg @ ObjectDetectedMessage(guid1, guid2, unk, targets) =>
         FindWeapon match {

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -7915,11 +7915,11 @@ object GlobalDefinitions {
     generator.innateDamage = new DamageWithPosition {
       CausesDamageType = DamageType.One
       Damage0 = 99999
-      DamageRadiusMin = 14
-      DamageRadius = 14.5f
-      DamageAtEdge = 0.00002f
+      DamageRadiusMin = 11
+      DamageRadius = 11.1f
+      DamageAtEdge = 0.000011f
       Modifiers = ExplodingRadialDegrade
-      //damage is 99999 at 14m, dropping rapidly to ~1 at 14.5m
+      //damage is 99999 at 11m, dropping rapidly to ~1 at 11.1m
     }
     generator.Geometry = GeometryForm.representByCylinder(radius = 1.2617f, height = 9.14063f)
 

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -7915,11 +7915,11 @@ object GlobalDefinitions {
     generator.innateDamage = new DamageWithPosition {
       CausesDamageType = DamageType.One
       Damage0 = 99999
-      DamageRadiusMin = 11
-      DamageRadius = 11.1f
+      DamageRadiusMin = 15
+      DamageRadius = 15.1f
       DamageAtEdge = 0.000011f
       Modifiers = ExplodingRadialDegrade
-      //damage is 99999 at 11m, dropping rapidly to ~1 at 11.1m
+      //damage is 99999 at 15m, dropping rapidly to ~1 at 15.1m
     }
     generator.Geometry = GeometryForm.representByCylinder(radius = 1.2617f, height = 9.14063f)
 

--- a/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
@@ -381,7 +381,7 @@ object GeneratorControl {
     /* withinSideToSide; squaring negates the "which side" concern */
     MagnitudeSquared(VectorProjection(dir, uside)) < 121 &&
     ( /* withinFrontBack */
-      if (VectorProjection(udir, ufront) == ufront) {
+      if (DotProduct(udir, ufront) > 0) {
         MagnitudeSquared(VectorProjection(dir, ufront)) < 210 //front, towards entry door
       } else {
         MagnitudeSquared(VectorProjection(dir, neg(ufront))) < 72 //back, towards back of room


### PR DESCRIPTION
Complaint came back that the generator explosion was too big and its damage was affecting potential targets outside of the room, including whatever room would be above it.  The following calculations should produce a more realistic immediate death region.