### PR TITLE
Load Vehicle

### DIFF
--- a/server/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
+++ b/server/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
@@ -36,7 +36,7 @@ class VehicleSpawnControl2Test extends ActorTest {
       pad.Actor ! VehicleSpawnPad.VehicleOrder(player, vehicle) //order
 
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.ConcealPlayer])
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.LoadVehicle])
+      probe.expectMsgClass(1 minute, classOf[VehicleServiceMessage])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.AttachToRails])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.StartPlayerSeatedInVehicle])
       vehicle.Seats(0).mount(player)
@@ -72,7 +72,7 @@ class VehicleSpawnControl3Test extends ActorTest {
         case _                                                                       => false
       })
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.ConcealPlayer])
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.LoadVehicle])
+      probe.expectMsgClass(1 minute, classOf[VehicleServiceMessage])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.AttachToRails])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.StartPlayerSeatedInVehicle])
       vehicle.Seats(0).mount(player)
@@ -132,7 +132,7 @@ class VehicleSpawnControl5Test extends ActorTest() {
       pad.Actor ! VehicleSpawnPad.VehicleOrder(player, vehicle) //order
 
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.ConcealPlayer])
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.LoadVehicle])
+      probe.expectMsgClass(1 minute, classOf[VehicleServiceMessage])
       vehicle.Health = 0 //problem
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.AttachToRails])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.DetachFromRails])
@@ -159,7 +159,7 @@ class VehicleSpawnControl6Test extends ActorTest() {
       pad.Actor ! VehicleSpawnPad.VehicleOrder(player, vehicle) //order
 
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.ConcealPlayer])
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.LoadVehicle])
+      probe.expectMsgClass(1 minute, classOf[VehicleServiceMessage])
       player.Die
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.AttachToRails])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.DetachFromRails])
@@ -187,7 +187,7 @@ class VehicleSpawnControl7Test extends ActorTest {
       pad.Actor ! VehicleSpawnPad.VehicleOrder(player, vehicle) //order
 
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.ConcealPlayer])
-      probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.LoadVehicle])
+      probe.expectMsgClass(1 minute, classOf[VehicleServiceMessage])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.AttachToRails])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.StartPlayerSeatedInVehicle])
       probe.expectMsgClass(1 minute, classOf[VehicleSpawnPad.DetachFromRails])

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -6793,6 +6793,7 @@ object GlobalDefinitions {
     dropship.Seats += 5 -> bailableSeat
     dropship.Seats += 6 -> bailableSeat
     dropship.Seats += 7 -> bailableSeat
+    dropship.Seats += 8 -> bailableSeat
     dropship.Seats += 9 -> new SeatDefinition() {
       bailable = true
       restriction = MaxOnly

--- a/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
@@ -45,12 +45,6 @@ object VehicleSpawnPad {
   final case class RevealPlayer(player_guid: PlanetSideGUID)
 
   /**
-    * Message to properly introduce the vehicle into the zone.
-    * @param vehicle the vehicle being spawned
-    */
-  final case class LoadVehicle(vehicle: Vehicle)
-
-  /**
     * Message to attach the vehicle to the spawn pad's lifting platform ("put on rails").
     * The attachment process (to the third slot) itself begins autonomous operation of the lifting platform.
     * @see `ObjectAttachMessage`

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -73,7 +73,7 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       }
 
-    case Zone.Vehicle.CanNotSpawn(zone, vehicle, reason) =>
+    case Zone.Vehicle.CanNotSpawn(_, _, reason) =>
       trace(s"vehicle $reason; abort order fulfillment")
       temp.cancel()
       context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -1,9 +1,12 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.pad.process
 
-import akka.actor.Props
-import net.psforever.objects.GlobalDefinitions
+import akka.actor.{Cancellable, Props}
+import net.psforever.objects.{Default, GlobalDefinitions}
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
+import net.psforever.objects.zones.Zone
+import net.psforever.services.Service
+import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 import net.psforever.types.Vector3
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -25,6 +28,13 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
 
   val railJack = context.actorOf(Props(classOf[VehicleSpawnControlRailJack], pad), s"${context.parent.path.name}-rails")
 
+  var temp: Cancellable = Default.Cancellable
+
+  override def postStop() : Unit = {
+    temp.cancel()
+    super.postStop()
+  }
+
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
       if (driver.Continent == pad.Continent && vehicle.Health > 0 && driver.isAlive) {
@@ -33,17 +43,48 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
           if (GlobalDefinitions.isFlightVehicle(vehicle.Definition)) 9 else 5
         ) //appear below the trench and doors
         vehicle.Cloaked = vehicle.Definition.CanCloak && driver.Cloaked
-        pad.Zone.VehicleEvents ! VehicleSpawnPad.LoadVehicle(vehicle)
-        context.system.scheduler.scheduleOnce(100 milliseconds, railJack, order)
+        pad.Zone.Transport.tell(Zone.Vehicle.Spawn(vehicle), self)
+        temp = context.system.scheduler.scheduleOnce(
+          delay = 100 milliseconds,
+          self,
+          VehicleSpawnControlLoadVehicle.WaitOnSpawn(order)
+        )
       } else {
         trace("owner lost or vehicle in poor condition; abort order fulfillment")
         VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       }
 
+    case Zone.Vehicle.HasSpawned(zone, vehicle) =>
+      val definition = vehicle.Definition
+      val vtype      = definition.ObjectId
+      val vguid      = vehicle.GUID
+      val vdata      = definition.Packet.ConstructorData(vehicle).get
+      zone.VehicleEvents ! VehicleServiceMessage(
+        zone.id,
+        VehicleAction.LoadVehicle(Service.defaultPlayerGUID, vehicle, vtype, vguid, vdata)
+      )
+
+    case VehicleSpawnControlLoadVehicle.WaitOnSpawn(order) =>
+      if (pad.Zone.Vehicles.contains(order.vehicle)) {
+        railJack ! order
+      } else {
+        VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
+        context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+      }
+
+    case Zone.Vehicle.CanNotSpawn(zone, vehicle, reason) =>
+      trace(s"vehicle $reason; abort order fulfillment")
+      temp.cancel()
+      context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+
     case msg @ (VehicleSpawnControl.ProcessControl.Reminder | VehicleSpawnControl.ProcessControl.GetNewOrder) =>
       context.parent ! msg
 
     case _ => ;
   }
+}
+
+object VehicleSpawnControlLoadVehicle {
+  private case class WaitOnSpawn(order: VehicleSpawnControl.Order)
 }

--- a/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
@@ -338,20 +338,6 @@ class VehicleService(zone: Zone) extends Actor {
         )
       )
 
-    case VehicleSpawnPad.LoadVehicle(vehicle) =>
-      val definition = vehicle.Definition
-      val vtype      = definition.ObjectId
-      val vguid      = vehicle.GUID
-      val vdata      = definition.Packet.ConstructorData(vehicle).get
-      zone.Transport ! Zone.Vehicle.Spawn(vehicle)
-      VehicleEvents.publish(
-        VehicleServiceResponse(
-          s"/${zone.id}/Vehicle",
-          Service.defaultPlayerGUID,
-          VehicleResponse.LoadVehicle(vehicle, vtype, vguid, vdata)
-        )
-      )
-
     //correspondence from WorldSessionActor
     case VehicleServiceMessage.AMSDeploymentChange(_) =>
       VehicleEvents.publish(


### PR DESCRIPTION
Originally, the purpose was to diagnose a chat message that indicated vehicles failing to be added to the same zone multiple times, indicating overactivity.  The solution for that was rather simple, though at first I pursued it in the course of vehicle loading messages between the client-facing session and the zone vehicle service.  In the course of those changes, the `VehicleSpawnPad` construction process now deals in introducing the vehicle into the zone's vehicle management queue directly and uses the responses from that process to determine when to issue client loading packets.  The real solution to the original problem was merely not re-submitting the vehicle to the zone management queue during avatar re-loads.

Included is some logging changes, including a case that doesn't complain about writing over unresolved projectiles if the overwrite happens beyond that old projectile's normal lifespan.  This case may need mild expansion in the future.