### PR TITLE
Vehicle Spawn Pad QoL

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -438,6 +438,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       session.player.spectator = spectator
 
     case Recall() =>
+      player.ZoningRequest = Zoning.Method.Recall
       zoningType = Zoning.Method.Recall
       zoningChatMessageType = ChatMessageType.CMT_RECALL
       zoningStatus = Zoning.Status.Request
@@ -451,6 +452,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       })
 
     case InstantAction() =>
+      player.ZoningRequest = Zoning.Method.InstantAction
       zoningType = Zoning.Method.InstantAction
       zoningChatMessageType = ChatMessageType.CMT_INSTANTACTION
       zoningStatus = Zoning.Status.Request
@@ -477,10 +479,11 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       cluster ! ICS.GetInstantActionSpawnPoint(player.Faction, context.self)
 
     case Quit() =>
-      //priority to quitting is given to quit over other zoning methods
+      //priority is given to quit over other zoning methods
       if (session.zoningType == Zoning.Method.InstantAction || session.zoningType == Zoning.Method.Recall) {
         CancelZoningProcessWithDescriptiveReason("cancel")
       }
+      player.ZoningRequest = Zoning.Method.Quit
       zoningType = Zoning.Method.Quit
       zoningChatMessageType = ChatMessageType.CMT_QUIT
       zoningStatus = Zoning.Status.Request
@@ -1721,6 +1724,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     */
   def CancelZoningProcess(): Unit = {
     zoningTimer.cancel()
+    player.ZoningRequest = Zoning.Method.None
     zoningType = Zoning.Method.None
     zoningStatus = Zoning.Status.None
     zoningCounter = 0

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -1876,7 +1876,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
 
         continent.GUID(mount) match {
           case Some(obj: Vehicle) =>
-            TotalDriverVehicleControl(obj)
+            ConditionalDriverVehicleControl(obj)
             UnaccessContainer(obj)
           case _ => ;
         }
@@ -2634,7 +2634,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         val player_guid: PlanetSideGUID = tplayer.GUID
         if (player_guid == player.GUID) {
           //disembarking self
-          TotalDriverVehicleControl(obj)
+          ConditionalDriverVehicleControl(obj)
           UnaccessContainer(obj)
           DismountAction(tplayer, obj, seat_num)
         } else {
@@ -2976,6 +2976,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       case VehicleResponse.StartPlayerSeatedInVehicle(vehicle, pad) =>
         val vehicle_guid = vehicle.GUID
         PlayerActionsToCancel()
+        serverVehicleControlVelocity = Some(0)
         CancelAllProximityUnits()
         if (player.VisibleSlots.contains(player.DrawnSlot)) {
           player.DrawnSlot = Player.HandsDownSlot
@@ -4894,6 +4895,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
                     }
                   case _ => log.warn("Item in specialItemSlotGuid is not registered with continent or is not a LLU")
                 }
+              case _ => ;
             }
 
           case Some(obj: FacilityTurret) =>
@@ -7057,10 +7059,10 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     progressBarUpdate.cancel()
     progressBarValue = None
     lastTerminalOrderFulfillment = true
-    serverVehicleControlVelocity = None
     accessedContainer match {
       case Some(v: Vehicle) =>
         val vguid = v.GUID
+        ConditionalDriverVehicleControl(v)
         if (v.AccessingTrunk.contains(player.GUID)) {
           if (player.VehicleSeated.contains(vguid)) {
             v.AccessingTrunk = None //player is seated; just stop accessing trunk
@@ -7779,7 +7781,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     * Set the vehicle to move in reverse
     */
   def ServerVehicleLockReverse(): Unit = {
-    serverVehicleControlVelocity = Some(0)
+    serverVehicleControlVelocity = Some(-1)
     sendResponse(
       ServerVehicleOverrideMsg(
         lock_accelerator = true,
@@ -7800,7 +7802,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     * Set the vehicle to strafe right
     */
   def ServerVehicleLockStrafeRight(): Unit = {
-    serverVehicleControlVelocity = Some(0)
+    serverVehicleControlVelocity = Some(-1)
     sendResponse(
       ServerVehicleOverrideMsg(
         lock_accelerator = true,
@@ -7821,7 +7823,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     * Set the vehicle to strafe left
     */
   def ServerVehicleLockStrafeLeft(): Unit = {
-    serverVehicleControlVelocity = Some(0)
+    serverVehicleControlVelocity = Some(-1)
     sendResponse(
       ServerVehicleOverrideMsg(
         lock_accelerator = true,
@@ -7842,7 +7844,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     * @param vehicle the vehicle being controlled
     */
   def ServerVehicleLock(vehicle: Vehicle): Unit = {
-    serverVehicleControlVelocity = Some(0)
+    serverVehicleControlVelocity = Some(-1)
     sendResponse(ServerVehicleOverrideMsg(true, true, false, false, 0, 1, 0, Some(0)))
   }
 
@@ -7877,11 +7879,15 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     * Stop all movement entirely.
     * @param vehicle the vehicle
     */
-  def TotalDriverVehicleControl(vehicle: Vehicle): Unit = {
-    if (serverVehicleControlVelocity.nonEmpty) {
-      serverVehicleControlVelocity = None
-      sendResponse(ServerVehicleOverrideMsg(false, false, false, false, 0, 0, 0, None))
+  def ConditionalDriverVehicleControl(vehicle: Vehicle): Unit = {
+    if (serverVehicleControlVelocity.nonEmpty && !serverVehicleControlVelocity.contains(0)) {
+      TotalDriverVehicleControl(vehicle)
     }
+  }
+
+  def TotalDriverVehicleControl(vehicle: Vehicle): Unit = {
+    serverVehicleControlVelocity = None
+    sendResponse(ServerVehicleOverrideMsg(false, false, false, false, 0, 0, 0, None))
   }
 
   /**
@@ -8913,6 +8919,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     if (player.avatar.vehicle.nonEmpty && player.VehicleSeated != player.avatar.vehicle) {
       continent.GUID(player.avatar.vehicle) match {
         case Some(vehicle: Vehicle) if vehicle.Actor != Default.Actor =>
+          TotalDriverVehicleControl(vehicle)
           vehicle.Actor ! Vehicle.Ownership(None)
         case _ => ;
       }

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -5530,11 +5530,14 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
               projectile.profile.JammerProjectile ||
               projectile.profile.SympatheticExplosion
             ) {
-              Zone.causeSpecialEmp(
+              //can also substitute 'projectile.profile' for 'SpecialEmp.emp'
+              Zone.serverSideDamage(
                 continent,
                 player,
-                explosion_pos,
-                GlobalDefinitions.special_emp.innateDamage.get
+                SpecialEmp.emp,
+                SpecialEmp.createEmpInteraction(SpecialEmp.emp, explosion_pos),
+                SpecialEmp.prepareDistanceCheck(player, explosion_pos, player.Faction),
+                SpecialEmp.findAllBoomers
               )
             }
             if (profile.ExistsOnRemoteClients && projectile.HasGUID) {

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -2811,7 +2811,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
           ObjectDetachMessage(
             pad_guid,
             vehicle_guid,
-            pad_position + Vector3(0, 0, pad.VehicleCreationZOffset),
+            pad_position + Vector3.z(pad.VehicleCreationZOffset),
             pad_orientation_z + pad.VehicleCreationZOrientOffset
           )
         )

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -44,6 +44,7 @@ import net.psforever.objects.vehicles.Utility.InternalTelepad
 import net.psforever.objects.vehicles._
 import net.psforever.objects.vital._
 import net.psforever.objects.vital.base._
+import net.psforever.objects.vital.etc.ExplodingEntityReason
 import net.psforever.objects.vital.interaction.DamageInteraction
 import net.psforever.objects.vital.projectile.ProjectileReason
 import net.psforever.objects.zones.{Zone, ZoneHotSpotProjector, Zoning}
@@ -1858,6 +1859,16 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
 
         DropSpecialSlotItem()
         ToggleMaxSpecialState(enable = false)
+        if (player.LastDamage match {
+          case Some(damage) => damage.interaction.cause match {
+            case cause: ExplodingEntityReason => cause.entity.isInstanceOf[VehicleSpawnPad]
+            case _ => false
+          }
+          case None => false
+        }) {
+          //also, @SVCP_Killed_TooCloseToPadOnCreate^n~ or "... within n meters of pad ..."
+          sendResponse(ChatMsg(ChatMessageType.UNK_227, false, "", "@SVCP_Killed_OnPadOnCreate", None))
+        }
 
         keepAliveFunc = NormalKeepAlive
         zoningStatus = Zoning.Status.None

--- a/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
+++ b/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
@@ -170,7 +170,12 @@ object ExplosiveDeployableControl {
     val zone = target.Zone
     zone.Activity ! Zone.HotSpot.Activity(cause)
     zone.LocalEvents ! LocalServiceMessage(zone.id, LocalAction.Detonate(target.GUID, target))
-    Zone.causeExplosion(zone, target, Some(cause), ExplosiveDeployableControl.detectionForExplosiveSource(target))
+    Zone.serverSideDamage(
+      zone,
+      target,
+      Zone.explosionDamage(Some(cause)),
+      ExplosiveDeployableControl.detectionForExplosiveSource(target)
+    )
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -6788,9 +6788,7 @@ object GlobalDefinitions {
     dropship.MaxShields = 1000
     dropship.CanFly = true
     dropship.Seats += 0 -> new SeatDefinition()
-    dropship.Seats += 1 -> new SeatDefinition() {
-      bailable = true
-    }
+    dropship.Seats += 1 -> bailableSeat
     dropship.Seats += 2 -> bailableSeat
     dropship.Seats += 3 -> bailableSeat
     dropship.Seats += 4 -> bailableSeat

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -7711,6 +7711,15 @@ object GlobalDefinitions {
     mb_pad_creation.Name = "mb_pad_creation"
     mb_pad_creation.Damageable = false
     mb_pad_creation.Repairable = false
+    mb_pad_creation.explodes = true
+    mb_pad_creation.innateDamage = new DamageWithPosition {
+      CausesDamageType = DamageType.One
+      Damage0 = 99999
+      DamageRadiusMin = 14
+      DamageRadius = 14.5f
+      DamageAtEdge = 0.00002f
+      //damage is 99999 at 14m, dropping rapidly to ~1 at 14.5m
+    }
 
     dropship_pad_doors.Name = "dropship_pad_doors"
     dropship_pad_doors.Damageable = false

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -20,12 +20,7 @@ import net.psforever.objects.serverobject.painbox.PainboxDefinition
 import net.psforever.objects.serverobject.terminals._
 import net.psforever.objects.serverobject.tube.SpawnTubeDefinition
 import net.psforever.objects.serverobject.resourcesilo.ResourceSiloDefinition
-import net.psforever.objects.serverobject.structures.{
-  AmenityDefinition,
-  AutoRepairStats,
-  BuildingDefinition,
-  WarpGateDefinition
-}
+import net.psforever.objects.serverobject.structures.{AmenityDefinition, AutoRepairStats, BuildingDefinition, WarpGateDefinition}
 import net.psforever.objects.serverobject.terminals.capture.CaptureTerminalDefinition
 import net.psforever.objects.serverobject.terminals.implant.{ImplantTerminalDefinition, ImplantTerminalMechDefinition}
 import net.psforever.objects.serverobject.turret.{FacilityTurretDefinition, TurretUpgrade}
@@ -7677,7 +7672,12 @@ object GlobalDefinitions {
     mb_pad_creation.Name = "mb_pad_creation"
     mb_pad_creation.Damageable = false
     mb_pad_creation.Repairable = false
-    mb_pad_creation.explodes = true
+    mb_pad_creation.killBox = VehicleSpawnPadDefinition.prepareKillBox(
+      forwardLimit = 14,
+      backLimit = 10,
+      sideLimit = 7.5f,
+      aboveLimit = 5 //double to 10 when spawning a flying vehicle
+    )
     mb_pad_creation.innateDamage = new DamageWithPosition {
       CausesDamageType = DamageType.One
       Damage0 = 99999
@@ -7690,10 +7690,36 @@ object GlobalDefinitions {
     dropship_pad_doors.Name = "dropship_pad_doors"
     dropship_pad_doors.Damageable = false
     dropship_pad_doors.Repairable = false
+    dropship_pad_doors.killBox = VehicleSpawnPadDefinition.prepareKillBox(
+      forwardLimit = 14,
+      backLimit = 14,
+      sideLimit = 13.5f,
+      aboveLimit = 5 //doubles to 10
+    )
+    dropship_pad_doors.innateDamage = new DamageWithPosition {
+      CausesDamageType = DamageType.One
+      Damage0 = 99999
+      DamageRadiusMin = 14
+      DamageRadius = 14.5f
+      DamageAtEdge = 0.00002f
+      //damage is 99999 at 14m, dropping rapidly to ~1 at 14.5m
+    }
 
     vanu_vehicle_creation_pad.Name = "vanu_vehicle_creation_pad"
     vanu_vehicle_creation_pad.Damageable = false
     vanu_vehicle_creation_pad.Repairable = false
+    vanu_vehicle_creation_pad.killBox = VehicleSpawnPadDefinition.prepareVanuKillBox(
+      radius = 8.5f,
+      aboveLimit = 5
+    )
+    vanu_vehicle_creation_pad.innateDamage = new DamageWithPosition {
+      CausesDamageType = DamageType.One
+      Damage0 = 99999
+      DamageRadiusMin = 14
+      DamageRadius = 14.5f
+      DamageAtEdge = 0.00002f
+      //damage is 99999 at 14m, dropping rapidly to ~1 at 14.5m
+    }
 
     mb_locker.Name = "mb_locker"
     mb_locker.Damageable = false

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -982,8 +982,6 @@ object GlobalDefinitions {
 
   val router_telepad_deployable = SimpleDeployableDefinition(DeployedItem.router_telepad_deployable)
 
-  val special_emp = ExplosiveDeployableDefinition(DeployedItem.jammer_mine)
-
   //this is only treated like a deployable
   val internal_router_telepad_deployable = InternalTelepadDefinition() //objectId: 744
   init_deployables()
@@ -7037,11 +7035,10 @@ object GlobalDefinitions {
     * Initialize `Deployable` globals.
     */
   private def init_deployables(): Unit = {
-    val mine        = GeometryForm.representByCylinder(radius = 0.1914f, height = 0.0957f) _
+    val mine = GeometryForm.representByCylinder(radius = 0.1914f, height = 0.0957f) _
     val smallTurret = GeometryForm.representByCylinder(radius = 0.48435f, height = 1.23438f) _
-    val sensor      = GeometryForm.representByCylinder(radius = 0.1914f, height = 1.21875f) _
+    val sensor = GeometryForm.representByCylinder(radius = 0.1914f, height = 1.21875f) _
     val largeTurret = GeometryForm.representByCylinder(radius = 0.8437f, height = 2.29687f) _
-
     boomer.Name = "boomer"
     boomer.Descriptor = "Boomers"
     boomer.MaxHealth = 100
@@ -7064,7 +7061,6 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     boomer.Geometry = mine
-
     he_mine.Name = "he_mine"
     he_mine.Descriptor = "Mines"
     he_mine.MaxHealth = 100
@@ -7086,7 +7082,6 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     he_mine.Geometry = mine
-
     jammer_mine.Name = "jammer_mine"
     jammer_mine.Descriptor = "JammerMines"
     jammer_mine.MaxHealth = 100
@@ -7096,14 +7091,13 @@ object GlobalDefinitions {
     jammer_mine.DeployTime = Duration.create(1000, "ms")
     jammer_mine.DetonateOnJamming = false
     jammer_mine.Geometry = mine
-
     spitfire_turret.Name = "spitfire_turret"
     spitfire_turret.Descriptor = "Spitfires"
     spitfire_turret.MaxHealth = 100
     spitfire_turret.Damageable = true
     spitfire_turret.Repairable = true
     spitfire_turret.RepairIfDestroyed = false
-    spitfire_turret.WeaponPaths += 1                     -> new mutable.HashMap()
+    spitfire_turret.WeaponPaths += 1 -> new mutable.HashMap()
     spitfire_turret.WeaponPaths(1) += TurretUpgrade.None -> spitfire_weapon
     spitfire_turret.ReserveAmmunition = false
     spitfire_turret.DeployCategory = DeployableCategory.SmallTurrets
@@ -7120,14 +7114,13 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     spitfire_turret.Geometry = smallTurret
-
     spitfire_cloaked.Name = "spitfire_cloaked"
     spitfire_cloaked.Descriptor = "CloakingSpitfires"
     spitfire_cloaked.MaxHealth = 100
     spitfire_cloaked.Damageable = true
     spitfire_cloaked.Repairable = true
     spitfire_cloaked.RepairIfDestroyed = false
-    spitfire_cloaked.WeaponPaths += 1                     -> new mutable.HashMap()
+    spitfire_cloaked.WeaponPaths += 1 -> new mutable.HashMap()
     spitfire_cloaked.WeaponPaths(1) += TurretUpgrade.None -> spitfire_weapon
     spitfire_cloaked.ReserveAmmunition = false
     spitfire_cloaked.DeployCategory = DeployableCategory.SmallTurrets
@@ -7143,14 +7136,13 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     spitfire_cloaked.Geometry = smallTurret
-
     spitfire_aa.Name = "spitfire_aa"
     spitfire_aa.Descriptor = "FlakSpitfires"
     spitfire_aa.MaxHealth = 100
     spitfire_aa.Damageable = true
     spitfire_aa.Repairable = true
     spitfire_aa.RepairIfDestroyed = false
-    spitfire_aa.WeaponPaths += 1                     -> new mutable.HashMap()
+    spitfire_aa.WeaponPaths += 1 -> new mutable.HashMap()
     spitfire_aa.WeaponPaths(1) += TurretUpgrade.None -> spitfire_aa_weapon
     spitfire_aa.ReserveAmmunition = false
     spitfire_aa.DeployCategory = DeployableCategory.SmallTurrets
@@ -7166,7 +7158,6 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     spitfire_aa.Geometry = smallTurret
-
     motionalarmsensor.Name = "motionalarmsensor"
     motionalarmsensor.Descriptor = "MotionSensors"
     motionalarmsensor.MaxHealth = 100
@@ -7175,7 +7166,6 @@ object GlobalDefinitions {
     motionalarmsensor.RepairIfDestroyed = false
     motionalarmsensor.DeployTime = Duration.create(1000, "ms")
     motionalarmsensor.Geometry = sensor
-
     sensor_shield.Name = "sensor_shield"
     sensor_shield.Descriptor = "SensorShields"
     sensor_shield.MaxHealth = 100
@@ -7184,7 +7174,6 @@ object GlobalDefinitions {
     sensor_shield.RepairIfDestroyed = false
     sensor_shield.DeployTime = Duration.create(5000, "ms")
     sensor_shield.Geometry = sensor
-
     tank_traps.Name = "tank_traps"
     tank_traps.Descriptor = "TankTraps"
     tank_traps.MaxHealth = 5000
@@ -7203,7 +7192,6 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     tank_traps.Geometry = GeometryForm.representByCylinder(radius = 2.89680997f, height = 3.57812f)
-
     val fieldTurretConverter = new FieldTurretConverter
     portable_manned_turret.Name = "portable_manned_turret"
     portable_manned_turret.Descriptor = "FieldTurrets"
@@ -7211,11 +7199,11 @@ object GlobalDefinitions {
     portable_manned_turret.Damageable = true
     portable_manned_turret.Repairable = true
     portable_manned_turret.RepairIfDestroyed = false
-    portable_manned_turret.controlledWeapons += 0               -> 1
-    portable_manned_turret.WeaponPaths += 1                     -> new mutable.HashMap()
+    portable_manned_turret.controlledWeapons += 0 -> 1
+    portable_manned_turret.WeaponPaths += 1 -> new mutable.HashMap()
     portable_manned_turret.WeaponPaths(1) += TurretUpgrade.None -> energy_gun
-    portable_manned_turret.MountPoints += 1                     -> MountInfo(0)
-    portable_manned_turret.MountPoints += 2                     -> MountInfo(0)
+    portable_manned_turret.MountPoints += 1 -> MountInfo(0)
+    portable_manned_turret.MountPoints += 2 -> MountInfo(0)
     portable_manned_turret.ReserveAmmunition = true
     portable_manned_turret.FactionLocked = true
     portable_manned_turret.Packet = fieldTurretConverter
@@ -7232,18 +7220,17 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     portable_manned_turret.Geometry = largeTurret
-
     portable_manned_turret_nc.Name = "portable_manned_turret_nc"
     portable_manned_turret_nc.Descriptor = "FieldTurrets"
     portable_manned_turret_nc.MaxHealth = 1000
     portable_manned_turret_nc.Damageable = true
     portable_manned_turret_nc.Repairable = true
     portable_manned_turret_nc.RepairIfDestroyed = false
-    portable_manned_turret_nc.WeaponPaths += 1                     -> new mutable.HashMap()
+    portable_manned_turret_nc.WeaponPaths += 1 -> new mutable.HashMap()
     portable_manned_turret_nc.WeaponPaths(1) += TurretUpgrade.None -> energy_gun_nc
-    portable_manned_turret_nc.controlledWeapons += 0               -> 1
-    portable_manned_turret_nc.MountPoints += 1                     -> MountInfo(0)
-    portable_manned_turret_nc.MountPoints += 2                     -> MountInfo(0)
+    portable_manned_turret_nc.controlledWeapons += 0 -> 1
+    portable_manned_turret_nc.MountPoints += 1 -> MountInfo(0)
+    portable_manned_turret_nc.MountPoints += 2 -> MountInfo(0)
     portable_manned_turret_nc.ReserveAmmunition = true
     portable_manned_turret_nc.FactionLocked = true
     portable_manned_turret_nc.Packet = fieldTurretConverter
@@ -7260,18 +7247,17 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     portable_manned_turret_nc.Geometry = largeTurret
-
     portable_manned_turret_tr.Name = "portable_manned_turret_tr"
     portable_manned_turret_tr.Descriptor = "FieldTurrets"
     portable_manned_turret_tr.MaxHealth = 1000
     portable_manned_turret_tr.Damageable = true
     portable_manned_turret_tr.Repairable = true
     portable_manned_turret_tr.RepairIfDestroyed = false
-    portable_manned_turret_tr.WeaponPaths += 1                     -> new mutable.HashMap()
+    portable_manned_turret_tr.WeaponPaths += 1 -> new mutable.HashMap()
     portable_manned_turret_tr.WeaponPaths(1) += TurretUpgrade.None -> energy_gun_tr
-    portable_manned_turret_tr.controlledWeapons += 0               -> 1
-    portable_manned_turret_tr.MountPoints += 1                     -> MountInfo(0)
-    portable_manned_turret_tr.MountPoints += 2                     -> MountInfo(0)
+    portable_manned_turret_tr.controlledWeapons += 0 -> 1
+    portable_manned_turret_tr.MountPoints += 1 -> MountInfo(0)
+    portable_manned_turret_tr.MountPoints += 2 -> MountInfo(0)
     portable_manned_turret_tr.ReserveAmmunition = true
     portable_manned_turret_tr.FactionLocked = true
     portable_manned_turret_tr.Packet = fieldTurretConverter
@@ -7288,18 +7274,17 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     portable_manned_turret_tr.Geometry = largeTurret
-
     portable_manned_turret_vs.Name = "portable_manned_turret_vs"
     portable_manned_turret_vs.Descriptor = "FieldTurrets"
     portable_manned_turret_vs.MaxHealth = 1000
     portable_manned_turret_vs.Damageable = true
     portable_manned_turret_vs.Repairable = true
     portable_manned_turret_vs.RepairIfDestroyed = false
-    portable_manned_turret_vs.WeaponPaths += 1                     -> new mutable.HashMap()
+    portable_manned_turret_vs.WeaponPaths += 1 -> new mutable.HashMap()
     portable_manned_turret_vs.WeaponPaths(1) += TurretUpgrade.None -> energy_gun_vs
-    portable_manned_turret_vs.controlledWeapons += 0               -> 1
-    portable_manned_turret_vs.MountPoints += 1                     -> MountInfo(0)
-    portable_manned_turret_vs.MountPoints += 2                     -> MountInfo(0)
+    portable_manned_turret_vs.controlledWeapons += 0 -> 1
+    portable_manned_turret_vs.MountPoints += 1 -> MountInfo(0)
+    portable_manned_turret_vs.MountPoints += 2 -> MountInfo(0)
     portable_manned_turret_vs.ReserveAmmunition = true
     portable_manned_turret_vs.FactionLocked = true
     portable_manned_turret_vs.Packet = fieldTurretConverter
@@ -7316,7 +7301,6 @@ object GlobalDefinitions {
       Modifiers = ExplodingRadialDegrade
     }
     portable_manned_turret_vs.Geometry = largeTurret
-
     deployable_shield_generator.Name = "deployable_shield_generator"
     deployable_shield_generator.Descriptor = "ShieldGenerators"
     deployable_shield_generator.MaxHealth = 1700
@@ -7326,7 +7310,6 @@ object GlobalDefinitions {
     deployable_shield_generator.DeployTime = Duration.create(6000, "ms")
     deployable_shield_generator.Model = ComplexDeployableResolutions.calculate
     deployable_shield_generator.Geometry = GeometryForm.representByCylinder(radius = 0.6562f, height = 2.17188f)
-
     router_telepad_deployable.Name = "router_telepad_deployable"
     router_telepad_deployable.MaxHealth = 100
     router_telepad_deployable.Damageable = true
@@ -7336,7 +7319,6 @@ object GlobalDefinitions {
     router_telepad_deployable.Packet = new TelepadDeployableConverter
     router_telepad_deployable.Model = SimpleResolutions.calculate
     router_telepad_deployable.Geometry = GeometryForm.representByRaisedSphere(radius = 1.2344f)
-
     internal_router_telepad_deployable.Name = "router_telepad_deployable"
     internal_router_telepad_deployable.MaxHealth = 1
     internal_router_telepad_deployable.Damageable = false
@@ -7344,22 +7326,6 @@ object GlobalDefinitions {
     internal_router_telepad_deployable.DeployTime = Duration.create(1, "ms")
     internal_router_telepad_deployable.DeployCategory = DeployableCategory.Telepads
     internal_router_telepad_deployable.Packet = new InternalTelepadDeployableConverter
-
-    special_emp.Name = "emp"
-    special_emp.MaxHealth = 1
-    special_emp.Damageable = false
-    special_emp.Repairable = false
-    special_emp.DeployCategory = DeployableCategory.Mines
-    special_emp.explodes = true
-    special_emp.innateDamage = new DamageWithPosition {
-      CausesDamageType = DamageType.Splash
-      SympatheticExplosion = true
-      Damage0 = 0
-      DamageAtEdge = 1.0f
-      DamageRadius = 5f
-      AdditionalEffect = true
-      Modifiers = MaxDistanceCutoff
-    }
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects
 
-import net.psforever.objects.avatar.{Avatar, LoadoutManager}
+import net.psforever.objects.avatar.{Avatar, LoadoutManager, SpecialCarry}
 import net.psforever.objects.definition.{AvatarDefinition, ExoSuitDefinition, SpecialExoSuitDefinition}
 import net.psforever.objects.equipment.{Equipment, EquipmentSize, EquipmentSlot, JammableUnit}
 import net.psforever.objects.inventory.{Container, GridInventory, InventoryItem}
@@ -44,6 +44,7 @@ class Player(var avatar: Avatar)
   private var drawnSlot: Int                         = Player.HandsDownSlot
   private var lastDrawnSlot: Int                     = Player.HandsDownSlot
   private var backpackAccess: Option[PlanetSideGUID] = None
+  private var carrying: Option[SpecialCarry]         = None
 
   private var facingYawUpper: Float = 0f
   private var crouching: Boolean    = false
@@ -496,6 +497,16 @@ class Player(var avatar: Avatar)
   def VehicleSeated_=(guid: Option[PlanetSideGUID]): Option[PlanetSideGUID] = {
     vehicleSeated = guid
     VehicleSeated
+  }
+
+  def Carrying: Option[SpecialCarry] = carrying
+
+  def Carrying_=(item: SpecialCarry): Option[SpecialCarry] = {
+    Carrying
+  }
+
+  def Carrying_=(item: Option[SpecialCarry]): Option[SpecialCarry] = {
+    Carrying
   }
 
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -13,7 +13,7 @@ import net.psforever.objects.vital.resistance.ResistanceProfile
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.vital.interaction.DamageInteraction
 import net.psforever.objects.vital.resolution.DamageResistanceModel
-import net.psforever.objects.zones.ZoneAware
+import net.psforever.objects.zones.{ZoneAware, Zoning}
 import net.psforever.types.{PlanetSideGUID, _}
 
 import scala.annotation.tailrec
@@ -30,6 +30,7 @@ class Player(var avatar: Avatar)
     with ZoneAware
     with AuraContainer {
   private var backpack: Boolean = false
+  private var released: Boolean = false
   private var armor: Int        = 0
 
   private var capacitor: Float                         = 0f
@@ -46,11 +47,12 @@ class Player(var avatar: Avatar)
   private var backpackAccess: Option[PlanetSideGUID] = None
   private var carrying: Option[SpecialCarry]         = None
 
-  private var facingYawUpper: Float = 0f
-  private var crouching: Boolean    = false
-  private var jumping: Boolean      = false
-  private var cloaked: Boolean      = false
-  private var afk: Boolean          = false
+  private var facingYawUpper: Float       = 0f
+  private var crouching: Boolean          = false
+  private var jumping: Boolean            = false
+  private var cloaked: Boolean            = false
+  private var afk: Boolean                = false
+  private var zoning: Zoning.Method.Value = Zoning.Method.None
 
   private var vehicleSeated: Option[PlanetSideGUID] = None
 
@@ -96,6 +98,7 @@ class Player(var avatar: Avatar)
       Health = Definition.DefaultHealth
       Armor = MaxArmor
       Capacitor = 0
+      released = false
     }
     isAlive
   }
@@ -109,17 +112,17 @@ class Player(var avatar: Avatar)
   def Revive: Boolean = {
     Destroyed = false
     Health = Definition.DefaultHealth
+    released = false
     true
   }
 
   def Release: Boolean = {
-    if (!isAlive) {
-      backpack = true
-      true
-    } else {
-      false
-    }
+    released = true
+    backpack = !isAlive
+    true
   }
+
+  def isReleased: Boolean = released
 
   def Armor: Int = armor
 
@@ -507,6 +510,13 @@ class Player(var avatar: Avatar)
 
   def Carrying_=(item: Option[SpecialCarry]): Option[SpecialCarry] = {
     Carrying
+  }
+
+  def ZoningRequest: Zoning.Method.Value = zoning
+
+  def ZoningRequest_=(request: Zoning.Method.Value): Zoning.Method.Value = {
+    zoning = request
+    ZoningRequest
   }
 
   def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]

--- a/src/main/scala/net/psforever/objects/SpecialEmp.scala
+++ b/src/main/scala/net/psforever/objects/SpecialEmp.scala
@@ -1,0 +1,144 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects
+
+import net.psforever.objects.ballistics.SourceEntry
+import net.psforever.objects.definition.ObjectDefinition
+import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.affinity.FactionAffinity
+import net.psforever.objects.vital.{Vitality, VitalityDefinition}
+import net.psforever.objects.vital.base.DamageType
+import net.psforever.objects.vital.etc.EmpReason
+import net.psforever.objects.vital.interaction.DamageInteraction
+import net.psforever.objects.vital.projectile.MaxDistanceCutoff
+import net.psforever.objects.vital.prop.DamageWithPosition
+import net.psforever.objects.zones.Zone
+import net.psforever.types.{PlanetSideEmpire, Vector3}
+
+/**
+  * Information and functions useful for the construction of a server-side electromagnetic pulse
+  * (not intigated by any specific thing the client does).
+  */
+object SpecialEmp {
+  /** A defaulted emp definition.
+    * Any projectile definition can be used. */
+  final val emp = new DamageWithPosition {
+    CausesDamageType = DamageType.Splash
+    SympatheticExplosion = true
+    Damage0 = 0
+    DamageAtEdge = 1.0f
+    DamageRadius = 5f
+    AdditionalEffect = true
+    Modifiers = MaxDistanceCutoff
+  }
+
+  /** The definition for a proxy object that represents a physical component of the source of the electromagnetic pulse. */
+  private val proxy_definition = new ObjectDefinition(objectId = 420) with VitalityDefinition {
+    Name = "emp"
+    MaxHealth = 1
+    Damageable = false
+    Repairable = false
+    explodes = true
+    innateDamage = emp
+  }
+
+  /**
+    * The damage interaction for an electromagnetic pulse effect.
+    * @param empEffect information about the effect
+    * @param position where the effect occurs
+    * @param source a game object that represents the source of the EMP
+    * @param target a game object that is affected by the EMP
+    * @return a `DamageInteraction` object
+    */
+  def createEmpInteraction(
+                            empEffect: DamageWithPosition,
+                            position: Vector3
+                          )
+                          (
+                            source: PlanetSideGameObject with FactionAffinity with Vitality,
+                            target: PlanetSideGameObject with FactionAffinity with Vitality
+                          ): DamageInteraction = {
+    DamageInteraction(
+      SourceEntry(target),
+      EmpReason(source, empEffect, target),
+      position
+    )
+  }
+
+  /**
+    * The "within affected distance" test for special electromagnetic pulses
+    * is not necessarily centered around a game object as the source of that EMP.
+    * A proxy entity is generated to perform the measurements and
+    * is given token information that connects it with another object for the proper attribution.
+    * @see `OwnableByPlayer`
+    * @see `PlanetSideServerObject`
+    * @see `SpecialEmp.distanceCheck`
+    * @param owner the formal entity to which the EMP is attributed
+    * @param position the coordinate location of the EMP
+    * @param faction the affinity of the EMP
+    * @return a function that determines if two game entities are near enough to each other
+    */
+  def prepareDistanceCheck(
+                     owner: PlanetSideGameObject,
+                     position: Vector3,
+                     faction: PlanetSideEmpire.Value
+                   ): (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean = {
+    distanceCheck(new PlanetSideServerObject with OwnableByPlayer {
+      Owner = Some(owner.GUID)
+      OwnerName = owner match {
+        case p: Player          => p.Name
+        case o: OwnableByPlayer => o.OwnerName.getOrElse("")
+        case _                  => ""
+      }
+      Position = position
+      def Faction = faction
+      def Definition = proxy_definition
+    })
+  }
+
+  /**
+    * The "within affected distance" test for special electromagnetic pulses
+    * is not necessarily centered around a game object as the source of that EMP.
+    * A proxy entity is provided to perform the measurements and
+    * is given token information that connects it with another object for the proper attribution.
+    * @see `Zone.distanceCheck`
+    * @param obj1 a game entity, should be the source of the damage
+    * @param obj2 a game entity, should be the target of the damage
+    * @param maxDistance the square of the maximum distance permissible between game entities
+    *                    before they are no longer considered "near"
+    * @return `true`, if the two entities are near enough to each other;
+    *        `false`, otherwise
+    */
+  def distanceCheck(
+                     proxy: PlanetSideGameObject
+                   )
+                   (
+                     obj1: PlanetSideGameObject,
+                     obj2: PlanetSideGameObject,
+                     maxDistance: Float
+                   ): Boolean = {
+    Zone.distanceCheck(proxy, obj2, maxDistance)
+  }
+
+  /**
+    * A sort of `SpecialEmp` that only affects deployed boomer explosives
+    * must find affected deployed boomer explosive entities.
+    * @see `BoomerDeployable`
+    * @param zone the zone in which to search
+    * @param obj a game entity that is excluded from results
+    * @param properties information about the effect/damage
+    * @return two lists of objects with different characteristics;
+    *         the first list is `PlanetSideServerObject` entities with `Vitality`;
+    *         since only boomer explosives are returned, this second list can be ignored
+    */
+  def findAllBoomers(
+                      zone: Zone,
+                      obj: PlanetSideGameObject with FactionAffinity with Vitality,
+                      properties: DamageWithPosition
+                    ): (List[PlanetSideServerObject with Vitality], List[PlanetSideGameObject with FactionAffinity with Vitality]) = {
+    (
+      zone.DeployableList
+        .collect { case o: BoomerDeployable if !o.Destroyed && (o ne obj) => o },
+      Nil
+    )
+  }
+}

--- a/src/main/scala/net/psforever/objects/TrapDeployable.scala
+++ b/src/main/scala/net/psforever/objects/TrapDeployable.scala
@@ -47,6 +47,6 @@ class TrapDeployableControl(trap: TrapDeployable) extends Actor with DamageableE
   override protected def DestructionAwareness(target: Damageable.Target, cause: DamageResult): Unit = {
     super.DestructionAwareness(target, cause)
     Deployables.AnnounceDestroyDeployable(trap, None)
-    Zone.causeExplosion(target.Zone, target, Some(cause))
+    Zone.serverSideDamage(target.Zone, target, Zone.explosionDamage(Some(cause)))
   }
 }

--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -711,6 +711,9 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
     //uninitialize implants
     avatarActor ! AvatarActor.DeinitializeImplants()
 
+    //log historical event
+    target.History(cause)
+    //log message
     cause.adversarial match {
       case Some(a) =>
         damageLog.info(s"DisplayDestroy: ${a.defender} was killed by ${a.attacker}")

--- a/src/main/scala/net/psforever/objects/avatar/SpecialCarry.scala
+++ b/src/main/scala/net/psforever/objects/avatar/SpecialCarry.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.avatar
+
+import enumeratum.values.{StringEnum, StringEnumEntry}
+
+sealed abstract class SpecialCarry(override val value: String) extends StringEnumEntry
+
+object SpecialCarry extends StringEnum[SpecialCarry] {
+  val values = findValues
+
+  case object CaptureFlag extends SpecialCarry(value = "CaptureFlag")
+  case object VanuModule extends SpecialCarry(value = "VanuModule")
+  case object MonolithUnit extends SpecialCarry(value = "MonolithUnit")
+  case object RabbitBall extends SpecialCarry(value = "RabbitBall")
+}

--- a/src/main/scala/net/psforever/objects/avatar/SpecialCarry.scala
+++ b/src/main/scala/net/psforever/objects/avatar/SpecialCarry.scala
@@ -5,11 +5,18 @@ import enumeratum.values.{StringEnum, StringEnumEntry}
 
 sealed abstract class SpecialCarry(override val value: String) extends StringEnumEntry
 
+/**
+  * Things that the player can carry that are not stored in the inventory or in holsters.
+  */
 object SpecialCarry extends StringEnum[SpecialCarry] {
   val values = findValues
 
+  /** The lattice logic unit (LLU).  Not actually a flag. */
   case object CaptureFlag extends SpecialCarry(value = "CaptureFlag")
+  /** Special enhancement modules generated in cavern facilities to be installed into above ground facilities. */
   case object VanuModule extends SpecialCarry(value = "VanuModule")
+  /** Mysterious MacGuffins tied to the Bending. */
   case object MonolithUnit extends SpecialCarry(value = "MonolithUnit")
+  /** Pyon~~ */
   case object RabbitBall extends SpecialCarry(value = "RabbitBall")
 }

--- a/src/main/scala/net/psforever/objects/geometry/PrimitiveShape.scala
+++ b/src/main/scala/net/psforever/objects/geometry/PrimitiveShape.scala
@@ -431,3 +431,73 @@ object Cylinder {
     */
   def apply(p: Vector3, v: Vector3, radius: Float, height: Float): Cylinder = Cylinder(Point3D(p), v, radius, height)
 }
+
+/**
+  * Untested geometry.
+  * @param p na
+  * @param relativeForward na
+  * @param relativeUp na
+  * @param length na
+  * @param width na
+  * @param height na
+  */
+final case class Cuboid(
+                         p: Point3D,
+                         relativeForward: Vector3,
+                         relativeUp: Vector3,
+                         length: Float,
+                         width: Float,
+                         height: Float,
+                       ) extends Geometry3D {
+  def center: Point3D = Point3D(p.asVector3 + relativeUp * height * 0.5f)
+
+  override def pointOnOutside(v: Vector3): Point3D = {
+    import net.psforever.types.Vector3.{CrossProduct, DotProduct, neg}
+    val height2 = height * 0.5f
+    val relativeSide = CrossProduct(relativeForward, relativeUp)
+    //val forwardVector = relativeForward * length
+    //val sideVector = relativeSide * width
+    //val upVector = relativeUp * height2
+    val closestVector: Vector3 = Seq(
+      relativeForward, relativeSide, relativeUp,
+      neg(relativeForward), neg(relativeSide), neg(relativeUp)
+    ).maxBy { dir => DotProduct(dir, v) }
+    def dz(): Float = {
+      if (Geometry.closeToInsignificance(v.z) != 0) {
+        closestVector.z / v.z
+      } else {
+        0f
+      }
+    }
+    def dy(): Float = {
+      if (Geometry.closeToInsignificance(v.y) != 0) {
+        val fyfactor = closestVector.y / v.y
+        if (v.z * fyfactor <= height2) {
+          fyfactor
+        } else {
+          dz()
+        }
+      } else {
+        dz()
+      }
+    }
+
+    val scaleFactor: Float = {
+      if (Geometry.closeToInsignificance(v.x) != 0) {
+        val fxfactor = closestVector.x / v.x
+        if (v.y * fxfactor <= length) {
+          if (v.z * fxfactor <= height2) {
+            fxfactor
+          } else {
+            dy()
+          }
+        } else {
+          dy()
+        }
+      } else {
+        dy()
+      }
+    }
+    Point3D(center.asVector3 + (v * scaleFactor))
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/damage/DamageableVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/damage/DamageableVehicle.scala
@@ -205,7 +205,7 @@ trait DamageableVehicle
       }
     })
     //things positioned around us can get hurt from us
-    Zone.causeExplosion(obj.Zone, obj, Some(cause))
+    Zone.serverSideDamage(obj.Zone, target, Zone.explosionDamage(Some(cause)))
     //special considerations for certain vehicles
     Vehicles.BeforeUnloadVehicle(obj, zone)
     //shields

--- a/src/main/scala/net/psforever/objects/serverobject/damage/DamageableWeaponTurret.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/damage/DamageableWeaponTurret.scala
@@ -93,7 +93,7 @@ trait DamageableWeaponTurret
     EndAllAggravation()
     DamageableWeaponTurret.DestructionAwareness(obj, cause)
     DamageableMountable.DestructionAwareness(obj, cause)
-    Zone.causeExplosion(target.Zone, target, Some(cause))
+    Zone.serverSideDamage(target.Zone, target, Zone.explosionDamage(Some(cause)))
   }
 }
 

--- a/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
@@ -122,7 +122,7 @@ class GeneratorControl(gen: Generator)
           queuedExplosion = Default.Cancellable
           imminentExplosion = false
           //hate on everything nearby
-          Zone.causeExplosion(gen.Zone, gen, gen.LastDamage, explosionFunc)
+          Zone.serverSideDamage(gen.Zone, gen, Zone.explosionDamage(gen.LastDamage), explosionFunc)
           gen.ClearHistory()
 
         case GeneratorControl.Restored() =>
@@ -338,8 +338,8 @@ object GeneratorControl {
     * As a consequence, different measurements must be performed to determine that the target is "within" and
     * that the target is not "outside" of the detection radius of the room.
     * Magic numbers for the room dimensions are employed.
-    * @see `Zone.causeExplosion`
     * @see `Zone.distanceCheck`
+    * @see `Zone.serverSideDamage`
     * @param g1ctrXY the center of the generator on the xy-axis
     * @param ufront a `Vector3` entity that points to the "front" direction of the generator;
     *               the `u` prefix indicates a "unit vector"

--- a/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnControl.scala
@@ -499,7 +499,7 @@ object VehicleSpawnControl {
     */
   def DisposeVehicle(vehicle: Vehicle, zone: Zone): Unit = {
     if (zone.Vehicles.exists(_.GUID == vehicle.GUID)) { //already added to zone
-      vehicle.Actor ! Vehicle.Deconstruct()
+      vehicle.Actor ! Vehicle.Deconstruct(Some(0.seconds))
     } else { //just registered to zone
       zone.tasks ! UnregisterVehicle(vehicle)(zone.GUID)
     }

--- a/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPad.scala
@@ -3,6 +3,7 @@ package net.psforever.objects.serverobject.pad
 
 import net.psforever.objects.{Player, Vehicle}
 import net.psforever.objects.serverobject.structures.Amenity
+import net.psforever.objects.serverobject.terminals.Terminal
 import net.psforever.types.PlanetSideGUID
 
 /**
@@ -28,7 +29,7 @@ object VehicleSpawnPad {
     * @param player the player who submitted the order (the "owner")
     * @param vehicle the vehicle produced from the order
     */
-  final case class VehicleOrder(player: Player, vehicle: Vehicle)
+  final case class VehicleOrder(player: Player, vehicle: Vehicle, terminal: Terminal)
 
   /**
     * Message to indicate that a certain player should be made transparent.
@@ -130,9 +131,11 @@ object VehicleSpawnPad {
     * An `Enumeration` of reasons for sending a periodic reminder to the user.
     */
   object Reminders extends Enumeration {
-    val Queue, //optional data is the numeric position in the queue
-    Blocked,   //optional data is a message regarding the blockage
-    Cancelled = Value
+    val
+    Queue, //optional data is the numeric position in the queue
+    Blocked, //optional data is a message regarding the blockage
+    Cancelled //optional data is the message
+    = Value
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPadDefinition.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/VehicleSpawnPadDefinition.scala
@@ -1,7 +1,9 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.pad
 
+import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.serverobject.structures.AmenityDefinition
+import net.psforever.types.Vector3
 
 /**
   * The definition for any `VehicleSpawnPad`.
@@ -38,5 +40,167 @@ class VehicleSpawnPadDefinition(objectId: Int) extends AmenityDefinition(objectI
     case 816 => Name = "spawnpoint_vehicle"
     case 947 => Name = "vanu_vehicle_creation_pad"
     case _   => throw new IllegalArgumentException("Not a valid object id with the type vehicle_creation_pad")
+  }
+
+  /** The region surrounding a vehicle spawn pad that is cleared of damageable targets prior to a vehicle being spawned.
+    * I mean to say that, if it can die, that target will die.
+    * @see `net.psforever.objects.serverobject.pad.process.VehicleSpawnControlRailJack` */
+  var killBox: (VehicleSpawnPad, Boolean)=>(PlanetSideGameObject, PlanetSideGameObject, Float)=> Boolean =
+    VehicleSpawnPadDefinition.prepareKillBox(forwardLimit = 0, backLimit = 0, sideLimit = 0, aboveLimit = 0)
+}
+
+object VehicleSpawnPadDefinition {
+  /**
+    * A function that sets up the region around a vehicle spawn pad
+    * to be cleared of damageable targets upon spawning of a vehicle.
+    * All measurements are provided in terms of distance from the center of the pad.
+    * These generic pads are rectangular in bounds and the kill box is cuboid in shape.
+    * @param forwardLimit how far in front of the spawn pad is to be cleared
+    * @param backLimit how far behind the spawn pad to be cleared;
+    *                  "back" is a squared direction usually in that direction of the corresponding terminal
+    * @param sideLimit how far to either side of the spawn pad is to be cleared
+    * @param aboveLimit how far above the spawn pad is to be cleared
+    * @param pad the vehicle spawn pad in question
+    * @param flightVehicle whether the current vehicle being ordered is a flying craft
+    * @return a function that describes a region around the vehicle spawn pad
+    */
+  def prepareKillBox(
+                      forwardLimit: Float,
+                      backLimit: Float,
+                      sideLimit: Float,
+                      aboveLimit: Float
+                    )
+                    (
+                      pad: VehicleSpawnPad,
+                      flightVehicle: Boolean
+                    ): (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean = {
+    val forward = Vector3(0,1,0).Rz(pad.Orientation.z + pad.Definition.VehicleCreationZOrientOffset)
+    val side = Vector3.CrossProduct(forward, Vector3(0,0,1))
+    vehicleSpawnKillBox(
+      forward,
+      side,
+      pad.Position,
+      if (flightVehicle) backLimit else forwardLimit,
+      backLimit,
+      sideLimit,
+      if (flightVehicle) aboveLimit * 2 else aboveLimit,
+    )
+  }
+
+  /**
+    * A function that finalizes the detection for the region around a vehicle spawn pad
+    * to be cleared of damageable targets upon spawning of a vehicle.
+    * All measurements are provided in terms of distance from the center of the pad.
+    * These generic pads are rectangular in bounds and the kill box is cuboid in shape.
+    * @param forward a direction in a "forwards" direction relative to the orientation of the spawn pad
+    * @param side a direction in a "side-wards" direction relative to the orientation of the spawn pad
+    * @param origin the center of the spawn pad
+    * @param forwardLimit how far in front of the spawn pad is to be cleared
+    * @param backLimit how far behind the spawn pad to be cleared
+    * @param sideLimit how far to either side of the spawn pad is to be cleared
+    * @param aboveLimit how far above the spawn pad is to be cleared
+    * @param obj1 a game entity, should be the source
+    * @param obj2 a game entity, should be the target
+    * @param maxDistance the square of the maximum distance permissible between game entities
+    *                    before they are no longer considered "near"
+    * @return `true`, if the two entities are near enough to each other;
+    *        `false`, otherwise
+    */
+  protected def vehicleSpawnKillBox(
+                                     forward: Vector3,
+                                     side: Vector3,
+                                     origin: Vector3,
+                                     forwardLimit: Float,
+                                     backLimit: Float,
+                                     sideLimit: Float,
+                                     aboveLimit: Float
+                                   )
+                                   (
+                                     obj1: PlanetSideGameObject,
+                                     obj2: PlanetSideGameObject,
+                                     maxDistance: Float
+                                   ): Boolean = {
+    val dir: Vector3 = {
+      val g2 = obj2.Definition.Geometry(obj2)
+      val cdir = Vector3.Unit(origin - g2.center.asVector3)
+      val point = g2.pointOnOutside(cdir).asVector3
+      point - origin
+    }
+    val originZ = origin.z
+    val obj2Z = obj2.Position.z
+    originZ - 1 <= obj2Z && originZ + aboveLimit > obj2Z &&
+    {
+      val calculatedForwardDistance = Vector3.ScalarProjection(dir, forward)
+      if (calculatedForwardDistance >= 0) {
+        calculatedForwardDistance < forwardLimit
+      }
+      else {
+        -calculatedForwardDistance < backLimit
+      }
+    } &&
+    math.abs(Vector3.ScalarProjection(dir, side)) < sideLimit
+  }
+
+  /**
+    * A function that sets up the region around a vehicle spawn pad
+    * to be cleared of damageable targets upon spawning of a vehicle.
+    * All measurements are provided in terms of distance from the center of the pad.
+    * These pads are only found in the cavern zones and are cylindrical in shape.
+    * @param radius the distance from the middle of the spawn pad
+    * @param aboveLimit how far above the spawn pad is to be cleared
+    * @param pad he vehicle spawn pad in question
+    * @param flightVehicle whether the current vehicle being ordered is a flying craft
+    * @return a function that describes a region around the vehicle spawn pad
+    */
+  def prepareVanuKillBox(
+                          radius: Float,
+                          aboveLimit: Float
+                        )
+                        (
+                          pad: VehicleSpawnPad,
+                          flightVehicle: Boolean
+                        ): (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean = {
+    if (flightVehicle) {
+      vanuKillBox(pad.Position, radius, aboveLimit * 2)
+    } else {
+      vanuKillBox(pad.Position, radius * 1.2f, aboveLimit)
+    }
+  }
+
+  /**
+    * A function that finalizes the detection for the region around a vehicle spawn pad
+    * to be cleared of damageable targets upon spawning of a vehicle.
+    * All measurements are provided in terms of distance from the center of the pad.
+    * These pads are only found in the cavern zones and are cylindrical in shape.
+    * @param origin the center of the spawn pad
+    * @param radius the distance from the middle of the spawn pad
+    * @param aboveLimit how far above the spawn pad is to be cleared
+    * @param obj1 a game entity, should be the source
+    * @param obj2 a game entity, should be the target
+    * @param maxDistance the square of the maximum distance permissible between game entities
+    *                    before they are no longer considered "near"
+    * @return `true`, if the two entities are near enough to each other;
+    *        `false`, otherwise
+    */
+  def vanuKillBox(
+                   origin: Vector3,
+                   radius: Float,
+                   aboveLimit: Float
+                 )
+                 (
+                   obj1: PlanetSideGameObject,
+                   obj2: PlanetSideGameObject,
+                   maxDistance: Float
+                 ): Boolean = {
+    val dir: Vector3 = {
+      val g2 = obj2.Definition.Geometry(obj2)
+      val cdir = Vector3.Unit(origin - g2.center.asVector3)
+      val point = g2.pointOnOutside(cdir).asVector3
+      point - origin
+    }
+    val originZ = origin.z
+    val obj2Z = obj2.Position.z
+    originZ - 1 <= obj2Z && originZ + aboveLimit > obj2Z &&
+    Vector3.MagnitudeSquared(dir.xy) < radius * radius
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
@@ -32,11 +32,12 @@ class VehicleSpawnControlConcealPlayer(pad: VehicleSpawnPad) extends VehicleSpaw
         context.system.scheduler.scheduleOnce(2000 milliseconds, loadVehicle, order)
       } else {
         trace(s"integral component lost; abort order fulfillment")
-        VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
-        context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+        context.parent ! VehicleSpawnControl.ProcessControl.OrderCancelled
       }
 
-    case msg @ (VehicleSpawnControl.ProcessControl.Reminder | VehicleSpawnControl.ProcessControl.GetNewOrder) =>
+    case msg @ (VehicleSpawnControl.ProcessControl.Reminder |
+                VehicleSpawnControl.ProcessControl.GetNewOrder |
+                VehicleSpawnControl.ProcessControl.OrderCancelled) =>
       context.parent ! msg
 
     case _ => ;

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlConcealPlayer.scala
@@ -25,9 +25,8 @@ class VehicleSpawnControlConcealPlayer(pad: VehicleSpawnPad) extends VehicleSpaw
     context.actorOf(Props(classOf[VehicleSpawnControlLoadVehicle], pad), s"${context.parent.path.name}-load")
 
   def receive: Receive = {
-    case order @ VehicleSpawnControl.Order(driver, _) =>
-      //TODO how far can the driver stray from the Terminal before his order is cancelled?
-      if (driver.Continent == pad.Continent && driver.VehicleSeated.isEmpty && driver.isAlive) {
+    case order @ VehicleSpawnControl.Order(driver, vehicle) =>
+      if (VehicleSpawnControl.validateOrderCredentials(pad, driver, vehicle).isEmpty) {
         trace(s"hiding ${driver.Name}")
         pad.Zone.VehicleEvents ! VehicleSpawnPad.ConcealPlayer(driver.GUID)
         context.system.scheduler.scheduleOnce(2000 milliseconds, loadVehicle, order)

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
@@ -22,12 +22,8 @@ class VehicleSpawnControlDriverControl(pad: VehicleSpawnPad) extends VehicleSpaw
 
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      if (vehicle.Health > 0 && vehicle.PassengerInSeat(driver).contains(0)) {
-        trace(s"returning control of ${vehicle.Definition.Name} to ${driver.Name}")
-        pad.Zone.VehicleEvents ! VehicleSpawnPad.ServerVehicleOverrideEnd(driver.Name, vehicle, pad)
-      } else {
-        trace(s"${driver.Name} is not seated in ${vehicle.Definition.Name}; vehicle controls might have been locked")
-      }
+      trace(s"returning control of ${vehicle.Definition.Name} to ${driver.Name}")
+      pad.Zone.VehicleEvents ! VehicleSpawnPad.ServerVehicleOverrideEnd(driver.Name, vehicle, pad)
       vehicle.MountedIn = None
       finalClear ! order
 

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlDriverControl.scala
@@ -22,9 +22,10 @@ class VehicleSpawnControlDriverControl(pad: VehicleSpawnPad) extends VehicleSpaw
 
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      trace(s"returning control of ${vehicle.Definition.Name} to ${driver.Name}")
-      pad.Zone.VehicleEvents ! VehicleSpawnPad.ServerVehicleOverrideEnd(driver.Name, vehicle, pad)
-      vehicle.MountedIn = None
+      trace(s"returning control of ${vehicle.Definition.Name} to its current driver")
+      if (vehicle.PassengerInSeat(driver).nonEmpty) {
+        pad.Zone.VehicleEvents ! VehicleSpawnPad.ServerVehicleOverrideEnd(driver.Name, vehicle, pad)
+      }
       finalClear ! order
 
     case msg @ (VehicleSpawnControl.ProcessControl.Reminder | VehicleSpawnControl.ProcessControl.GetNewOrder) =>

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
@@ -1,6 +1,8 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.pad.process
 
+import akka.actor.Cancellable
+import net.psforever.objects.Default
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
 import net.psforever.types.{PlanetSideGUID, Vector3}
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
@@ -13,8 +15,7 @@ import scala.concurrent.duration._
   * The basic `VehicleSpawnControl` is the root of a simple tree of "spawn control" objects that chain to each other.
   * Each object performs on (or more than one related) actions upon the vehicle order that was submitted.<br>
   * <br>
-  * There is nothing left to do
-  * except make certain that the vehicle has moved far enough away from the spawn pad
+  * There is nothing left to do except make certain that the vehicle has moved far enough away from the spawn pad
   * to not block the next order that may  be queued.
   * A long call is made to the root of this `Actor` object chain to start work on any subsequent vehicle order.
   * @param pad the `VehicleSpawnPad` object being governed
@@ -22,9 +23,15 @@ import scala.concurrent.duration._
 class VehicleSpawnControlFinalClearance(pad: VehicleSpawnPad) extends VehicleSpawnControlBase(pad) {
   def LogId = "-clearer"
 
+  var temp: Cancellable = Default.Cancellable
+
+  override def postStop() : Unit = {
+    temp.cancel()
+  }
+
   def receive: Receive = {
-    case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      if (vehicle.PassengerInSeat(driver).isEmpty) {
+    case order @ VehicleSpawnControl.Order(_, vehicle) =>
+      if (!vehicle.Seats(0).isOccupied) {
         //ensure the vacant vehicle is above the trench and the doors
         vehicle.Position = pad.Position + Vector3.z(pad.Definition.VehicleCreationZOffset)
         val definition = vehicle.Definition
@@ -43,12 +50,20 @@ class VehicleSpawnControlFinalClearance(pad: VehicleSpawnPad) extends VehicleSpa
       self ! VehicleSpawnControlFinalClearance.Test(order)
 
     case test @ VehicleSpawnControlFinalClearance.Test(entry) =>
-      if (Vector3.DistanceSquared(entry.vehicle.Position, pad.Position) > 100.0f) { //10m away from pad
+      //the vehicle has an initial decay of 30s in which time it needs to be mounted
+      //once mounted, it will complain to the current driver that it is blocking the spawn pad
+      //no time limit exists for that state
+      val vehicle = entry.vehicle
+      if (Vector3.DistanceSquared(vehicle.Position, pad.Position) > 144) { //12m away from pad
         trace("pad cleared")
         pad.Zone.VehicleEvents ! VehicleSpawnPad.ResetSpawnPad(pad)
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+      } else if (vehicle.Destroyed) {
+        trace("clearing the pad of vehicle wreckage")
+        VehicleSpawnControl.DisposeVehicle(vehicle, pad.Zone)
+        context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       } else {
-        context.system.scheduler.scheduleOnce(2000 milliseconds, self, test)
+        temp = context.system.scheduler.scheduleOnce(2000 milliseconds, self, test)
       }
 
     case _ => ;

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlFinalClearance.scala
@@ -25,7 +25,7 @@ class VehicleSpawnControlFinalClearance(pad: VehicleSpawnPad) extends VehicleSpa
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
       if (vehicle.PassengerInSeat(driver).isEmpty) {
-        //ensure the vacant vehicle is above the trench and doors
+        //ensure the vacant vehicle is above the trench and the doors
         vehicle.Position = pad.Position + Vector3.z(pad.Definition.VehicleCreationZOffset)
         val definition = vehicle.Definition
         pad.Zone.VehicleEvents ! VehicleServiceMessage(

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -1,8 +1,10 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.pad.process
 
-import akka.actor.{Cancellable, Props}
-import net.psforever.objects.{Default, GlobalDefinitions}
+import akka.actor.Props
+import akka.pattern.ask
+import akka.util.Timeout
+import net.psforever.objects.GlobalDefinitions
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
 import net.psforever.objects.zones.Zone
 import net.psforever.services.Service
@@ -11,6 +13,7 @@ import net.psforever.types.Vector3
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.util.Success
 
 /**
   * An `Actor` that handles vehicle spawning orders for a `VehicleSpawnPad`.
@@ -28,12 +31,9 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
 
   val railJack = context.actorOf(Props(classOf[VehicleSpawnControlRailJack], pad), s"${context.parent.path.name}-rails")
 
-  var temp: Cancellable = Default.Cancellable
+  var temp: Option[VehicleSpawnControl.Order] = None
 
-  override def postStop() : Unit = {
-    temp.cancel()
-    super.postStop()
-  }
+  implicit val timeout = Timeout(3.seconds)
 
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
@@ -43,48 +43,59 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
           if (GlobalDefinitions.isFlightVehicle(vehicle.Definition)) 9 else 5
         ) //appear below the trench and doors
         vehicle.Cloaked = vehicle.Definition.CanCloak && driver.Cloaked
-        pad.Zone.Transport.tell(Zone.Vehicle.Spawn(vehicle), self)
-        temp = context.system.scheduler.scheduleOnce(
-          delay = 100 milliseconds,
-          self,
-          VehicleSpawnControlLoadVehicle.WaitOnSpawn(order)
-        )
+
+        temp = Some(order)
+        val result = ask(pad.Zone.Transport, Zone.Vehicle.Spawn(vehicle))
+        //if too long, or something goes wrong
+        result.recover {
+          case _ =>
+            temp match {
+              case Some(_order) => railJack ! VehicleSpawnControl.DisposeVehicle(_order.vehicle, pad.Zone)
+              case None => ; //should we have gotten this message?
+            }
+            temp = None
+            context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+        }
+        //resolution
+        result.onComplete {
+          case Success(Zone.Vehicle.HasSpawned(zone, v))
+          if (temp match { case Some(_order) => _order.vehicle eq v; case _ => false }) =>
+            val definition = v.Definition
+            val vtype      = definition.ObjectId
+            val vguid      = v.GUID
+            val vdata      = definition.Packet.ConstructorData(v).get
+            zone.VehicleEvents ! VehicleServiceMessage(
+              zone.id,
+              VehicleAction.LoadVehicle(Service.defaultPlayerGUID, v, vtype, vguid, vdata)
+            )
+            railJack ! temp.get
+            temp = None
+
+          case Success(Zone.Vehicle.CanNotSpawn(z, v, reason)) =>
+            trace(s"vehicle can not spawn - $reason; abort order fulfillment")
+            VehicleSpawnControl.DisposeVehicle(v, z)
+            temp = None
+            context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+
+          case _ =>
+            temp match {
+              case Some(_order) =>
+                trace(s"abort order fulfillment")
+                VehicleSpawnControl.DisposeVehicle(_order.vehicle, pad.Zone)
+                context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
+              case None => ; //should we have gotten this message?
+            }
+            temp = None
+        }
       } else {
         trace("owner lost or vehicle in poor condition; abort order fulfillment")
         VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
         context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
       }
 
-    case Zone.Vehicle.HasSpawned(zone, vehicle) =>
-      val definition = vehicle.Definition
-      val vtype      = definition.ObjectId
-      val vguid      = vehicle.GUID
-      val vdata      = definition.Packet.ConstructorData(vehicle).get
-      zone.VehicleEvents ! VehicleServiceMessage(
-        zone.id,
-        VehicleAction.LoadVehicle(Service.defaultPlayerGUID, vehicle, vtype, vguid, vdata)
-      )
-
-    case VehicleSpawnControlLoadVehicle.WaitOnSpawn(order) =>
-      if (pad.Zone.Vehicles.contains(order.vehicle)) {
-        railJack ! order
-      } else {
-        VehicleSpawnControl.DisposeVehicle(order.vehicle, pad.Zone)
-        context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
-      }
-
-    case Zone.Vehicle.CanNotSpawn(_, _, reason) =>
-      trace(s"vehicle $reason; abort order fulfillment")
-      temp.cancel()
-      context.parent ! VehicleSpawnControl.ProcessControl.GetNewOrder
-
     case msg @ (VehicleSpawnControl.ProcessControl.Reminder | VehicleSpawnControl.ProcessControl.GetNewOrder) =>
       context.parent ! msg
 
     case _ => ;
   }
-}
-
-object VehicleSpawnControlLoadVehicle {
-  private case class WaitOnSpawn(order: VehicleSpawnControl.Order)
 }

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -37,7 +37,7 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
 
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
-      if (driver.Continent == pad.Continent && vehicle.Health > 0 && driver.isAlive) {
+      if (VehicleSpawnControl.validateOrderCredentials(pad, driver, vehicle).isEmpty) {
         trace(s"loading the ${vehicle.Definition.Name}")
         vehicle.Position = vehicle.Position - Vector3.z(
           if (GlobalDefinitions.isFlightVehicle(vehicle.Definition)) 9 else 5

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
@@ -2,7 +2,14 @@
 package net.psforever.objects.serverobject.pad.process
 
 import akka.actor.Props
+import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.ballistics.SourceEntry
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
+import net.psforever.objects.vital.base.DamageType
+import net.psforever.objects.vital.etc.VehicleSpawnReason
+import net.psforever.objects.vital.interaction.DamageInteraction
+import net.psforever.objects.zones.Zone
+import net.psforever.types.Vector3
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -13,10 +20,7 @@ import scala.concurrent.duration._
   * Each object performs on (or more than one related) actions upon the vehicle order that was submitted.<br>
   * <br>
   * When the vehicle is added into the environment, it is attached to the spawn pad platform.
-  * On cue, the trapdoor of the platform will open, and the vehicle will be raised up into plain sight on a group of rails.
-  * These actions are actually integrated into previous stages and into later stages of the process.
-  * The primary objective to be completed is a specific place to start a frequent message to the other customers.
-  * It has failure cases should the driver be in an incorrect state.
+  * On cue, the trapdoor of the platform will open, and the vehicle will be raised on a railed platform.
   * @param pad the `VehicleSpawnPad` object being governed
   */
 class VehicleSpawnControlRailJack(pad: VehicleSpawnPad) extends VehicleSpawnControlBase(pad) {
@@ -25,9 +29,22 @@ class VehicleSpawnControlRailJack(pad: VehicleSpawnPad) extends VehicleSpawnCont
   val seatDriver =
     context.actorOf(Props(classOf[VehicleSpawnControlSeatDriver], pad), s"${context.parent.path.name}-mount")
 
+  val killBoxFunc: (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean =
+    VehicleSpawnControlRailJack.prepareKillBox(pad)
+
   def receive: Receive = {
-    case order @ VehicleSpawnControl.Order(_, vehicle) =>
+    case order @ VehicleSpawnControl.Order(driver, vehicle) =>
       vehicle.MountedIn = pad.GUID
+      Zone.causeExplosion(
+        pad.Zone,
+        pad,
+        Some(DamageInteraction(
+          SourceEntry(pad),
+          VehicleSpawnReason(SourceEntry(driver), SourceEntry(vehicle)),
+          pad.Position
+        ).calculate(DamageType.None)(pad)),
+        killBoxFunc
+      )
       pad.Zone.VehicleEvents ! VehicleSpawnPad.AttachToRails(vehicle, pad)
       context.system.scheduler.scheduleOnce(10 milliseconds, seatDriver, order)
 
@@ -35,5 +52,55 @@ class VehicleSpawnControlRailJack(pad: VehicleSpawnPad) extends VehicleSpawnCont
       context.parent ! msg
 
     case _ => ;
+  }
+}
+
+object VehicleSpawnControlRailJack {
+  def prepareKillBox(pad: VehicleSpawnPad): (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean = {
+    val forward = Vector3(0,1,0).Rz(pad.Orientation.z + pad.Definition.VehicleCreationZOrientOffset)
+    vehicleSpawnKillBox(
+      forward,
+      Vector3.CrossProduct(forward, Vector3(0,0,1)),
+      pad.Position,
+      forwardLimit = 14,
+      backLimit = 10,
+      sideLimit = 7.5f,
+      aboveLimit = 5
+    )
+  }
+
+  protected def vehicleSpawnKillBox(
+                                     forward: Vector3,
+                                     side: Vector3,
+                                     origin: Vector3,
+                                     forwardLimit: Float,
+                                     backLimit: Float,
+                                     sideLimit: Float,
+                                     aboveLimit: Float
+                                   )
+                                   (
+                                     obj1: PlanetSideGameObject,
+                                     obj2: PlanetSideGameObject,
+                                     maxDistance: Float
+                                   ): Boolean = {
+    val dir: Vector3 = {
+      val g2 = obj2.Definition.Geometry(obj2)
+      val cdir = Vector3.Unit(origin - g2.center.asVector3)
+      val point = g2.pointOnOutside(cdir).asVector3
+      point - origin
+    }
+    val originZ = origin.z
+    val obj2Z = obj2.Position.z
+    originZ - 1 <= obj2Z && originZ + aboveLimit > obj2Z &&
+    {
+      val calculatedForwardDistance = Vector3.ScalarProjection(dir, forward)
+      if (calculatedForwardDistance >= 0) {
+        calculatedForwardDistance < forwardLimit
+      }
+      else {
+        -calculatedForwardDistance < backLimit
+      }
+    } &&
+    math.abs(Vector3.ScalarProjection(dir, side)) < sideLimit
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlRailJack.scala
@@ -11,7 +11,6 @@ import net.psforever.objects.vital.etc.{ExplodingEntityReason, VehicleSpawnReaso
 import net.psforever.objects.vital.interaction.{DamageInteraction, DamageResult}
 import net.psforever.objects.vital.prop.DamageProperties
 import net.psforever.objects.zones.Zone
-import net.psforever.types.Vector3
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -31,9 +30,6 @@ class VehicleSpawnControlRailJack(pad: VehicleSpawnPad) extends VehicleSpawnCont
   val seatDriver =
     context.actorOf(Props(classOf[VehicleSpawnControlSeatDriver], pad), s"${context.parent.path.name}-mount")
 
-  val killBoxFunc: (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean =
-    VehicleSpawnControlRailJack.prepareKillBox(pad)
-
   def receive: Receive = {
     case order @ VehicleSpawnControl.Order(driver, vehicle) =>
       vehicle.MountedIn = pad.GUID
@@ -41,7 +37,7 @@ class VehicleSpawnControlRailJack(pad: VehicleSpawnPad) extends VehicleSpawnCont
         pad.Zone,
         pad,
         VehicleSpawnControlRailJack.prepareSpawnExplosion(pad, SourceEntry(driver), SourceEntry(vehicle)),
-        killBoxFunc
+        pad.Definition.killBox(pad, vehicle.Definition.CanFly)
       )
       pad.Zone.VehicleEvents ! VehicleSpawnPad.AttachToRails(vehicle, pad)
       context.system.scheduler.scheduleOnce(10 milliseconds, seatDriver, order)
@@ -93,53 +89,5 @@ object VehicleSpawnControlRailJack {
       ),
       target.Position
     )
-  }
-
-  def prepareKillBox(pad: VehicleSpawnPad): (PlanetSideGameObject, PlanetSideGameObject, Float) => Boolean = {
-    val forward = Vector3(0,1,0).Rz(pad.Orientation.z + pad.Definition.VehicleCreationZOrientOffset)
-    vehicleSpawnKillBox(
-      forward,
-      Vector3.CrossProduct(forward, Vector3(0,0,1)),
-      pad.Position,
-      forwardLimit = 14,
-      backLimit = 10,
-      sideLimit = 7.5f,
-      aboveLimit = 5
-    )
-  }
-
-  protected def vehicleSpawnKillBox(
-                                     forward: Vector3,
-                                     side: Vector3,
-                                     origin: Vector3,
-                                     forwardLimit: Float,
-                                     backLimit: Float,
-                                     sideLimit: Float,
-                                     aboveLimit: Float
-                                   )
-                                   (
-                                     obj1: PlanetSideGameObject,
-                                     obj2: PlanetSideGameObject,
-                                     maxDistance: Float
-                                   ): Boolean = {
-    val dir: Vector3 = {
-      val g2 = obj2.Definition.Geometry(obj2)
-      val cdir = Vector3.Unit(origin - g2.center.asVector3)
-      val point = g2.pointOnOutside(cdir).asVector3
-      point - origin
-    }
-    val originZ = origin.z
-    val obj2Z = obj2.Position.z
-    originZ - 1 <= obj2Z && originZ + aboveLimit > obj2Z &&
-    {
-      val calculatedForwardDistance = Vector3.ScalarProjection(dir, forward)
-      if (calculatedForwardDistance >= 0) {
-        calculatedForwardDistance < forwardLimit
-      }
-      else {
-        -calculatedForwardDistance < backLimit
-      }
-    } &&
-    math.abs(Vector3.ScalarProjection(dir, side)) < sideLimit
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlServerVehicleOverride.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlServerVehicleOverride.scala
@@ -30,6 +30,7 @@ class VehicleSpawnControlServerVehicleOverride(pad: VehicleSpawnPad) extends Veh
       val vehicleFailState = vehicle.Health == 0 || vehicle.Position == Vector3.Zero
       val driverFailState =
         !driver.isAlive || driver.Continent != pad.Continent || !vehicle.PassengerInSeat(driver).contains(0)
+      vehicle.MountedIn = None
       pad.Zone.VehicleEvents ! VehicleSpawnPad.DetachFromRails(vehicle, pad)
       if (vehicleFailState || driverFailState) {
         if (vehicleFailState) {

--- a/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/VehicleControl.scala
@@ -698,7 +698,10 @@ class VehicleControl(vehicle: Vehicle)
         percentage,
         body,
         vehicle.Seats.values
-          .flatMap { case seat if seat.isOccupied => seat.occupants }
+          .flatMap {
+            case seat if seat.isOccupied => seat.occupants
+            case _ => Nil
+          }
           .filter { p => p.isAlive && (p.Zone eq vehicle.Zone) }
       )
     }

--- a/src/main/scala/net/psforever/objects/vital/etc/EmpReason.scala
+++ b/src/main/scala/net/psforever/objects/vital/etc/EmpReason.scala
@@ -3,7 +3,6 @@ package net.psforever.objects.vital.etc
 
 import net.psforever.objects.PlanetSideGameObject
 import net.psforever.objects.ballistics.SourceEntry
-import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.vital.base.{DamageReason, DamageResolution}
@@ -13,9 +12,8 @@ import net.psforever.objects.vital.resolution.DamageAndResistance
 /**
   * A wrapper for a "damage source" in damage calculations
   * that parameterizes information necessary to explain a server-driven electromagnetic pulse occurring.
-  * @see `VitalityDefinition.explodes`
+  * @see `SpecialEmp.createEmpInteraction`
   * @see `VitalityDefinition.innateDamage`
-  * @see `Zone.causesSpecialEmp`
   * @param entity the source of the explosive yield
   * @param damageModel the model to be utilized in these calculations;
   *                    typically, but not always, defined by the target
@@ -41,7 +39,7 @@ object EmpReason {
   def apply(
              owner: PlanetSideGameObject with FactionAffinity,
              source: DamageWithPosition,
-             target: PlanetSideServerObject with Vitality
+             target: PlanetSideGameObject with Vitality
            ): EmpReason = {
     EmpReason(SourceEntry(owner), source, target.DamageModel, owner.Definition.ObjectId)
   }

--- a/src/main/scala/net/psforever/objects/vital/etc/VehicleSpawnReason.scala
+++ b/src/main/scala/net/psforever/objects/vital/etc/VehicleSpawnReason.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vital.etc
+
+import net.psforever.objects.ballistics.SourceEntry
+import net.psforever.objects.vital.{NoResistanceSelection, SimpleResolutions}
+import net.psforever.objects.vital.base.{DamageReason, DamageResolution}
+import net.psforever.objects.vital.damage.DamageCalculations.AgainstNothing
+import net.psforever.objects.vital.prop.DamageProperties
+import net.psforever.objects.vital.resolution.{DamageAndResistance, DamageResistanceModel}
+
+/**
+  * The instigating cause of dying on an operational vehicle spawn pad.
+  * @param driver the driver whose vehicle was being created
+  * @param vehicle the vehicle being created
+  */
+final case class VehicleSpawnReason(driver: SourceEntry, vehicle: SourceEntry)
+  extends DamageReason {
+  def resolution: DamageResolution.Value = DamageResolution.Resolved
+
+  def same(test: DamageReason): Boolean = test match {
+    case cause: VehicleSpawnReason =>
+      driver.Name.equals(cause.driver.Name) &&
+      (vehicle.Definition eq cause.vehicle.Definition)
+    case _ =>
+      false
+  }
+
+  def source: DamageProperties = VehicleSpawnReason.source
+
+  def damageModel: DamageAndResistance = VehicleSpawnReason.drm
+
+  override def adversary : Option[SourceEntry] = Some(driver)
+
+  override def attribution : Int = vehicle.Definition.ObjectId
+}
+
+object VehicleSpawnReason {
+  private val source = new DamageProperties { /*intentional blank*/ }
+
+  /** basic damage, no resisting, quick and simple */
+  private val drm = new DamageResistanceModel {
+    DamageUsing = AgainstNothing
+    ResistUsing = NoResistanceSelection
+    Model = SimpleResolutions.calculate
+  }
+}

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -1226,7 +1226,7 @@ object Zone {
   }
 
   /**
-    *
+    * na
     * @param instigation what previous event happened, if any, that caused this explosion
     * @param source a game object that represents the source of the explosion
     * @param target a game object that is affected by the explosion

--- a/src/main/scala/net/psforever/objects/zones/Zoning.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zoning.scala
@@ -7,7 +7,7 @@ object Zoning {
   object Method extends Enumeration {
     type Type = Value
 
-    val None, InstantAction, Recall, Quit = Value
+    val None, InstantAction, OutfitRecall, Recall, Quit = Value
   }
 
   object Status extends Enumeration {


### PR DESCRIPTION
The vehicle spawn pad had been, for some time, missing some minor features, mainly proper messages and events.  For example, the maximum distance the would-be-driver can flee from the side of the vehicle spawn terminal was never being enforced.  As long as sufficient delay existed in between the current order being fulfilled and one's own order, a player could go all the way across the continent and be brought back to the spawn pad by the will of the nanites when their time comes.  Now the distance is only about 35m.  If the player should stray onto the spawn pad during a vehicle's creation, where they should have died and an informative message be displayed, no death would occur.  Now, near instant death.  Player conditions such as what key items they are carrying and whether they are in transit, things that previously were localized to the server-facing session, now travel with the player's server-side entity.

Ordering a vehicle proceeds much like normal, with the exception of the messaging that is caused by the process, and the inclusion of the ability to exchange vehicles orders so long as the player are already in the vehicle order queue.  The second order overwrites the first and the player does not lose their place in the queue.

Ways to test this PR involve ordering vehicles and everyone but the person whose order is currently being handled doing something that would sabotage the order - fly away, try to zone away, succumb, change armors, mount the seat of a different vehicle, destroy the vehicle order terminal, etc..  Consequently, some people must also tread onto the spawn pad itself during vehicle creation to die a few times.  (Ritual sacrifice will help this PR succeed.)

___Features___
__`SpecialCarry`__
All of those special key items that will never be able to grace an inventory icon.  Only the lattice logic unit is the only holdable thing at the moment but messages exist for the monolith units and the vanu modules.  No word on the rabbit ball.

__`VehicleSpawnReason`__
For when you die for being on the vehicle spawn pad.

__`SpecialEmp`__
Previously, the generation of a server-side electromagnetic pulse was confined to speial functions and definitions on the `Zone` object.  Now, they are mostly located here.  Remember that this currently exists to allow projectiles with jammering properties to affect boomer explosives through walls, to balance out the fact that boomer explosives can inadvertantly bleed damage through nearby perpendicular walls.

Additionally:
__`VehicleSpawnControlRailJack`__
The kill box of the vehicle spawn pad is executed as if it were a "server-side explosion", but using `VehicleSpawnReason` as a justification.  The region of explosion is a cuboid 1m into the trench and at least as wide and long enough to cover the entirety of the pad, and as high as to clear a few meters above it.  As with other explosions, all damageable targets that find their way into the blast region are affected.

__`Zone`__
"causeEmp" and "cause Explosion" have been replaced with a generic "serverSideDamage" function that accepts a wider variety of  customization in order to deal a valid form of damage to (specific) targets.

___Caveats___
1. `Cuboid` was an attempt at resolving the polyhedron shape of the vehicle spawn pad for use in reconstructing the profile for the server-side damage.  It eventually was proven unnecessary when an easier solution existed and its functionality is currently untested.  In the future, with refinement, it may be useful for representing damage profiles of more boxy features, ones not as suitable for the cylinders that are currently utilized by most entities, the `apc` vehicles for example.  It will not be leveraged for now.
2. Players will die from being on the spawn pad during vehicle creation even when in Sanctuary, even when a Spectator or a GM.
3. Although almost all messages are now based on the client's string literals (`@`), the message that informs that one's vehicle is blocking the spawn pad from starting its next order is still custom.

___Addenda___
1. A fix for a significant stickiness side-effect of a previous "players can not exit or bail just-spawned vehicle too early" fix that caused unrelated players to get stuck inside everything.
2. A fix for a minor issue with vehicles drowning with weird seating arrangements.
3. A fix for a minor issue with the system for interacting with capture consoles that would fail to reach a default case.