### PR TITLE
Forget How to Wear Clothes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -82,6 +82,9 @@ game {
   # Modify the amount of NTU drain per autorepair tick for facility amenities
   amenity-autorepair-drain-rate = 0.5
 
+  # Purchases timers for the mechanized assault exo-suits all update at the same time when any of them would update
+  shared-max-cooldown = no
+
   # HART system, shuttles and facilities
   hart {
     # How long the shuttle is not boarding passengers (going through the motions)

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -488,16 +488,18 @@ class AvatarActor(
                   sessionActor ! SessionActor.SendResponse(
                     ItemTransactionResultMessage(terminalGuid, TransactionType.Sell, success = true)
                   )
-                  //wearing invalid armor
-                  if ((certification == Certification.ReinforcedExoSuit && player.ExoSuit == ExoSuitType.Reinforced) ||
-                      (certification == Certification.InfiltrationSuit && player.ExoSuit == ExoSuitType.Infiltration) ||
-                      (player.ExoSuit == ExoSuitType.MAX && {
-                        val wep = player.Slot(slot = 0).Equipment
-                        certification == Certification.UniMAX ||
-                        (certification == Certification.AAMAX && InfantryLoadout.DetermineSubtypeA(ExoSuitType.MAX, wep) == 1) ||
-                        (certification == Certification.AIMAX && InfantryLoadout.DetermineSubtypeA(ExoSuitType.MAX, wep) == 2) ||
-                        (certification == Certification.AVMAX && InfantryLoadout.DetermineSubtypeA(ExoSuitType.MAX, wep) == 3)
-                      })
+                  //wearing invalid armor?
+                  if (
+                    if (certification == Certification.ReinforcedExoSuit) player.ExoSuit == ExoSuitType.Reinforced
+                    else if (certification == Certification.InfiltrationSuit) player.ExoSuit == ExoSuitType.Infiltration
+                    else if (player.ExoSuit == ExoSuitType.MAX) {
+                      lazy val subtype = InfantryLoadout.DetermineSubtypeA(ExoSuitType.MAX, player.Slot(slot = 0).Equipment)
+                      if (certification == Certification.UniMAX) true
+                      else if (certification == Certification.AAMAX) subtype == 1
+                      else if (certification == Certification.AIMAX) subtype == 2
+                      else if (certification == Certification.AVMAX) subtype == 3
+                      else false
+                    } else false
                   ) {
                     player.Actor ! PlayerControl.SetExoSuit(ExoSuitType.Standard, 0)
                   }

--- a/src/main/scala/net/psforever/objects/loadouts/InfantryLoadout.scala
+++ b/src/main/scala/net/psforever/objects/loadouts/InfantryLoadout.scala
@@ -88,8 +88,7 @@ object InfantryLoadout {
   /**
     * The sub-type of the player's uniform, as used in `FavoritesMessage`.<br>
     * <br>
-    * The values for `Standard`, `Infiltration`, and the generic `MAX` are not perfectly known.
-    * The latter-most exo-suit option is presumed.
+    * The values for a specific `MAX` type is only known by knowing the subtype.
     * @param suit the player's uniform
     * @param subtype the mechanized assault exo-suit subtype as determined by their arm weapons
     * @return the numeric subtype

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -137,7 +137,8 @@ case class GameConfig(
     bepRate: Double,
     cepRate: Double,
     newAvatar: NewAvatar,
-    hart: HartConfig
+    hart: HartConfig,
+    sharedMaxCooldown: Boolean
 )
 
 case class NewAvatar(


### PR DESCRIPTION
When a player unlearns an exo-suit certification, if that player is currently outfitted in the very exo-suit that would be granted by that certification, the model will switch over to pajamas.  As with normal protocol, all items that do not fit into the resized inventory are dropped underfoot.

Also resolved a curious issue with purchase cooldowns, and moved the ability to toggle the shared MAX cooldowns into the configuration files.