### PR TITLE
Better Respawn

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -2594,7 +2594,6 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         sendResponse(PlanetsideAttributeMessage(obj.GUID, 0, obj.Health))
         UpdateWeaponAtSeatPosition(obj, seat_number)
         MountingAction(tplayer, obj, seat_number)
-        keepAliveFunc = KeepAlivePersistence
 
       case Mountable.CanMount(obj: Mountable, _, _) =>
         log.warn(s"MountVehicleMsg: $obj is some mountable object and nothing will happen for ${player.Name}")
@@ -3971,11 +3970,11 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         FindContainedWeapon match {
           case (Some(o), Some(tool)) =>
             (o match {
-              case mount: Mountable => mount.PassengerInSeat(player)
-              case _                => None
+              case mount: Mountable => (o, mount.PassengerInSeat(player))
+              case _                => (None, None)
             }) match {
-              case None | Some(0) => ;
-              case Some(_) =>
+              case (None, None) | (_, None) | (_: Vehicle, Some(0)) => ;
+              case _ =>
                 persist()
                 turnCounterFunc(player.GUID)
             }

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -9169,14 +9169,14 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
   def CountSpawnDelay(toZoneId: String, toSpawnPoint: SpawnPoint, fromZoneId: String): FiniteDuration = {
     val sanctuaryZoneId = Zones.sanctuaryZoneId(player.Faction)
     if (fromZoneId.equals("Nowhere") || sanctuaryZoneId.equals(toZoneId) || !isAcceptableNextSpawnPoint()) {
-      //to sanctuary
+      //first login, to sanctuary, resolution of invalid spawn point
       0 seconds
     } else {
-      //to other zones
-      //biolabs have benefits ...
+      //for other zones ...
+      //biolabs have/grant benefits
       val cryoBenefit: Float = toSpawnPoint.Owner match {
-        case b: Building if b.latticeConnectedFacilityBenefits().contains(GlobalDefinitions.cryo_facility) => 0.5f
-        case _                                                                                             => 1f
+        case b: Building if b.hasLatticeBenefit(GlobalDefinitions.cryo_facility) => 0.5f
+        case _                                                                   => 1f
       }
       //TODO cumulative death penalty
       toSpawnPoint.Definition.Delay.toFloat * cryoBenefit seconds

--- a/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -207,6 +207,27 @@ class Building(
     )
   }
 
+  def hasLatticeBenefit(wantedBenefit: ObjectDefinition): Boolean = {
+    if (Faction == PlanetSideEmpire.NEUTRAL) {
+      false
+    } else {
+      // Check this Building is on the lattice first
+      zone.Lattice find this match {
+        case Some(_) =>
+          val subGraph = Zone.Lattice filter (
+            (b : Building) =>
+              b.Faction == this.Faction &&
+              !b.CaptureTerminalIsHacked &&
+              b.NtuLevel > 0 &&
+              (b.Generator.isEmpty || b.Generator.get.Condition != PlanetSideGeneratorState.Destroyed)
+            )
+          findLatticeBenefit(wantedBenefit, subGraph)
+        case None =>
+          false
+      }
+    }
+  }
+
   private def findLatticeBenefit(
                                   wantedBenefit: ObjectDefinition,
                                   subGraph: Graph[Building, GraphEdge.UnDiEdge]

--- a/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -182,53 +182,6 @@ class Building(
       (o.nonEmpty, false) //TODO poll pain field strength
     }
 
-    val latticeBenefit: Int = {
-      if (Faction == PlanetSideEmpire.NEUTRAL) 0
-      else {
-        def FindLatticeBenefit(
-            wantedBenefit: ObjectDefinition,
-            subGraph: Graph[Building, GraphEdge.UnDiEdge]
-        ): Boolean = {
-          var found = false
-
-          subGraph find this match {
-            case Some(self) =>
-              if (this.Definition == wantedBenefit) found = true
-              else {
-                self pathUntil (_.Definition == wantedBenefit) match {
-                  case Some(_) => found = true
-                  case None    => ;
-                }
-              }
-            case None => ;
-          }
-
-          found
-        }
-
-        // Check this Building is on the lattice first
-        zone.Lattice find this match {
-          case Some(_) =>
-            val subGraph = Zone.Lattice filter ((b: Building) =>
-              b.Faction == this.Faction
-                && !b.CaptureTerminalIsHacked
-                && b.NtuLevel > 0
-                && (b.Generator.isEmpty || b.Generator.get.Condition != PlanetSideGeneratorState.Destroyed)
-            )
-
-            var stackedBenefit = 0
-            if (FindLatticeBenefit(GlobalDefinitions.amp_station, subGraph)) stackedBenefit |= 1
-            if (FindLatticeBenefit(GlobalDefinitions.comm_station_dsp, subGraph)) stackedBenefit |= 2
-            if (FindLatticeBenefit(GlobalDefinitions.cryo_facility, subGraph)) stackedBenefit |= 4
-            if (FindLatticeBenefit(GlobalDefinitions.comm_station, subGraph)) stackedBenefit |= 8
-            if (FindLatticeBenefit(GlobalDefinitions.tech_plant, subGraph)) stackedBenefit |= 16
-
-            stackedBenefit
-          case None => 0;
-        }
-      }
-    }
-
     BuildingInfoUpdateMessage(
       Zone.Number,
       MapId,
@@ -242,7 +195,7 @@ class Building(
       generatorState,
       spawnTubesNormal,
       forceDomeActive,
-      if (generatorState != PlanetSideGeneratorState.Destroyed) latticeBenefit else 0,
+      if (generatorState != PlanetSideGeneratorState.Destroyed) latticeBenefitsValue() else 0,
       if (generatorState != PlanetSideGeneratorState.Destroyed) 48 else 0,    // cavern benefit
       Nil,   // unk4,
       0,     // unk5
@@ -252,6 +205,74 @@ class Building(
       boostSpawnPain,
       boostGeneratorPain
     )
+  }
+
+  private def findLatticeBenefit(
+                                  wantedBenefit: ObjectDefinition,
+                                  subGraph: Graph[Building, GraphEdge.UnDiEdge]
+                                ): Boolean = {
+    var found = false
+    subGraph find this match {
+      case Some(self) =>
+        if (this.Definition == wantedBenefit) {
+          found = true
+        } else {
+          self pathUntil (_.Definition == wantedBenefit) match {
+            case Some(_) => found = true
+            case None    => ;
+          }
+        }
+      case None => ;
+    }
+    found
+  }
+
+  def latticeConnectedFacilityBenefits(): Set[ObjectDefinition] = {
+    if (Faction == PlanetSideEmpire.NEUTRAL) {
+      Set.empty
+    } else {
+      // Check this Building is on the lattice first
+      zone.Lattice find this match {
+        case Some(_) =>
+          val subGraph = Zone.Lattice filter ((b: Building) =>
+            b.Faction == this.Faction
+            && !b.CaptureTerminalIsHacked
+            && b.NtuLevel > 0
+            && (b.Generator.isEmpty || b.Generator.get.Condition != PlanetSideGeneratorState.Destroyed)
+            )
+
+          import scala.collection.mutable
+          var connectedBases: mutable.Set[ObjectDefinition] = mutable.Set()
+          if (findLatticeBenefit(GlobalDefinitions.amp_station, subGraph)) {
+            connectedBases.add(GlobalDefinitions.amp_station)
+          }
+          if (findLatticeBenefit(GlobalDefinitions.comm_station_dsp, subGraph)) {
+            connectedBases.add(GlobalDefinitions.comm_station_dsp)
+          }
+          if (findLatticeBenefit(GlobalDefinitions.cryo_facility, subGraph)) {
+            connectedBases.add(GlobalDefinitions.cryo_facility)
+          }
+          if (findLatticeBenefit(GlobalDefinitions.comm_station, subGraph)) {
+            connectedBases.add(GlobalDefinitions.comm_station)
+          }
+          if (findLatticeBenefit(GlobalDefinitions.tech_plant, subGraph)) {
+            connectedBases.add(GlobalDefinitions.tech_plant)
+          }
+          connectedBases.toSet
+        case None =>
+          Set.empty
+      }
+    }
+  }
+
+  def latticeBenefitsValue(): Int = {
+    latticeConnectedFacilityBenefits().collect {
+      case GlobalDefinitions.amp_station => 1
+      case GlobalDefinitions.comm_station_dsp => 2
+      case GlobalDefinitions.cryo_facility => 4
+      case GlobalDefinitions.comm_station => 8
+      case GlobalDefinitions.tech_plant => 16
+    }.sum
   }
 
   def BuildingType: StructureType = buildingType

--- a/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/WarpGate.scala
@@ -9,6 +9,7 @@ import net.psforever.packet.game.BuildingInfoUpdateMessage
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGeneratorState, Vector3}
 import akka.actor.typed.scaladsl.adapter._
 import net.psforever.actors.zone.BuildingActor
+import net.psforever.objects.definition.ObjectDefinition
 
 import scala.collection.mutable
 
@@ -153,6 +154,10 @@ class WarpGate(name: String, building_guid: Int, map_id: Int, zone: Zone, buildi
   def NtuCapacitor: Float = Definition.MaxNtuCapacitor
 
   def NtuCapacitor_=(value: Float): Float = NtuCapacitor
+
+  override def hasLatticeBenefit(wantedBenefit: ObjectDefinition): Boolean = false
+
+  override def latticeConnectedFacilityBenefits(): Set[ObjectDefinition] = Set.empty
 
   override def Definition: WarpGateDefinition = buildingDefinition
 }


### PR DESCRIPTION
1. Continental possession of a lattice-connected Bio Laboratory facility results in a reduced spawn timer at major facilities.
2. If attempting to spawn on a spawn point that became unavailable during the spawning process, a different spawn point will be selected for no extra time penalty.  The new spawn point should be closest to the lost one, in general.

___Caveat___
1. The alternates for the "lost spawn point" include local friendly AMS's.  This may or may not be accurate behavior.
2. An "available spawn point" only needs to count as available up until the player character is formally created in the game world.  That is also slightly before the that character becomes their avatar, seeing through their eyes and controlling their movements.  In the small window between this and that, the spawn point is allowed to become unavailable through vehicle destruction or facility capture.  At some point, it has to become your own fault that you manifested into an active pain field or your own misfortune to be facing down the barrel of a tank cannon.

___Addenda___
Fix for persistance when in a mountable turret of some kind.