### PR TITLE
No Second-class Facilities

### DIFF
--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -162,6 +162,9 @@ class HackCaptureActor(val taskResolver: ActorRef) extends Actor {
             false
         }
 
+      case _: Building =>
+        false //building does not possess an LLU socket
+
       case thing =>
         log.error(s"Capture terminal has unexpected owner - $thing - that is not a facility")
         false


### PR DESCRIPTION
Except for bunkers.

Minor over-logging where a facility without an LLU socket was described as "not a facility".