### PR TITLE
Persistent Vehicle Loadouts

### DIFF
--- a/server/src/main/resources/db/migration/V004__VehicleLoadout.sql
+++ b/server/src/main/resources/db/migration/V004__VehicleLoadout.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "vehicleloadout" (
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "loadout_number" INT NOT NULL,
+  "name" VARCHAR(36) NOT NULL,
+  "vehicle" SMALLINT NOT NULL,
+  "items" TEXT NOT NULL
+);

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -332,8 +332,8 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       }
     }
     // when going from classic -> typed this seems necessary
-    akka.actor.TypedActor(context.system).poisonPill(avatarActor)
-    akka.actor.TypedActor(context.system).poisonPill(chatActor)
+    context.stop(avatarActor)
+    context.stop(chatActor)
   }
 
   def ValidObject(id: Int): Option[PlanetSideGameObject] = ValidObject(Some(PlanetSideGUID(id)))
@@ -3078,7 +3078,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     sendResponse(CreateShortcutMessage(guid, 1, 0, true, Shortcut.Medkit))
     sendResponse(ChangeShortcutBankMessage(guid, 0))
     //Favorites lists
-    avatarActor ! AvatarActor.RefreshLoadouts()
+    avatarActor ! AvatarActor.InitialRefreshLoadouts()
 
     sendResponse(
       SetChatFilterMessage(ChatChannel.Platoon, false, ChatChannel.values.toList)

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -5105,7 +5105,6 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
 
       case msg @ FavoritesRequest(player_guid, loadoutType, action, line, label) =>
         CancelZoningProcessWithDescriptiveReason("cancel_use")
-        log.info(s"${player.Name} wishes to load a saved favorite loadout")
         action match {
           case FavoritesAction.Save   => avatarActor ! AvatarActor.SaveLoadout(player, loadoutType, label, line)
           case FavoritesAction.Delete => avatarActor ! AvatarActor.DeleteLoadout(player, loadoutType, line)

--- a/src/main/scala/net/psforever/persistence/Vehicleloadout.scala
+++ b/src/main/scala/net/psforever/persistence/Vehicleloadout.scala
@@ -1,0 +1,4 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.persistence
+
+case class Vehicleloadout(id: Int, avatarId: Int, loadoutNumber: Int, name: String, vehicle: Int, items: String)

--- a/src/main/scala/net/psforever/util/DefinitionUtil.scala
+++ b/src/main/scala/net/psforever/util/DefinitionUtil.scala
@@ -218,7 +218,50 @@ object DefinitionUtil {
       case 39  => advanced_ace
       case 148 => boomer
       case 149 => boomer_trigger
-      case _   => frag_grenade
+      //vehicles
+      case 67  => apc_tr
+      case 66  => apc_nc
+      case 68  => apc_vs
+      case 46  => ams
+      case 60  => ant
+      //case 83  => aphelion_flight
+      //case 84  => aphelion_gunner
+      case 118 => aurora
+      case 135 => battlewagon
+      //case 199 => colossus_flight
+      //case 200 => colossus_gunner
+      case 258 => droppod
+      case 259 => dropship
+      case 294 => flail
+      case 335 => fury
+      case 338 => galaxy_gunship
+      case 432 => liberator
+      case 441 => lightgunship
+      case 446 => lightning
+      case 459 => lodestar
+      case 470 => magrider
+      case 572 => mosquito
+      case 532 => mediumtransport
+      case 608 => orbital_shuttle
+      //case 642 => peregrine_flight
+      //case 643 => peregrine_gunner
+      case 671 => phantasm
+      case 697 => prowler
+      case 707 => quadassault
+      case 710 => quadstealth
+      case 741 => router
+      case 784 => skyguard
+      case 847 => switchblade
+      case 862 => threemanheavybuggy
+      case 865 => thunderer
+      case 896 => two_man_assault_buggy
+      case 898 => twomanheavybuggy
+      case 900 => twomanhoverbuggy
+      case 923 => vanguard
+      case 986 => vulture
+      case 997 => wasp
+      //default
+      case _  => throw new IllegalArgumentException(s"you can not build $id")
     }
   }
 


### PR DESCRIPTION
**DATABASED!**

___Caveats___
1. If the new table is migrated incorrectly: the server will not start up correctly; or, the server wil start correctly but the character will not load.  Check warnings in (local) logs.  What it is looking for is the proper grant of permissions and/or the proper owner to be set.  This may just be an issue that only I encounter because of the complicated history I have with my local build.  On top of that, migrations with just a table defined didn't negatively impact anyone (least of all the CI) when supporting buildings.  Perhaps it really is just me?
2. Vehicle inventory loading works the same as it did before persistence was applied.  Nothing has changed.  If there are any issues. that'll be another PR.
3. I neglected to check that all of the appropriate vehicle weapon definitions are available through the lookup resource `DefinitionUtil`.  That's something I will fix in this PR if need be.