### PR TITLE
Separate Vehicle Controls

### DIFF
--- a/server/src/test/scala/actor/objects/AutoRepairIntegrationTest.scala
+++ b/server/src/test/scala/actor/objects/AutoRepairIntegrationTest.scala
@@ -14,7 +14,6 @@ import net.psforever.objects.serverobject.deploy.Deployment
 import net.psforever.objects.serverobject.resourcesilo.{ResourceSilo, ResourceSiloControl}
 import net.psforever.objects.serverobject.structures.{AutoRepairStats, Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{OrderTerminalDefinition, Terminal, TerminalControl}
-import net.psforever.objects.vehicles.VehicleControl
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.vital.base.DamageResolution
 import net.psforever.objects.vital.damage.DamageProfile
@@ -201,7 +200,7 @@ class AutoRepairFacilityIntegrationAntGiveNtuTest extends FreedContextActorTest 
   val maxNtuCap = ant.Definition.MaxNtuCapacitor
   player.Spawn()
   ant.NtuCapacitor = maxNtuCap
-  ant.Actor = context.actorOf(Props(classOf[VehicleControl], ant), name = "test-ant")
+  ant.Definition.Initialize(ant, context)
   ant.Zone = zone
   ant.Seats(0).mount(player)
   ant.DeploymentState = DriveState.Deployed
@@ -295,7 +294,7 @@ class AutoRepairFacilityIntegrationTerminalDestroyedTerminalAntTest extends Free
   val maxNtuCap = ant.Definition.MaxNtuCapacitor
   player.Spawn()
   ant.NtuCapacitor = maxNtuCap
-  ant.Actor = context.actorOf(Props(classOf[VehicleControl], ant), name = "test-ant")
+  ant.Definition.Initialize(ant, context)
   ant.Zone = zone
   ant.Seats(0).mount(player)
   ant.DeploymentState = DriveState.Deployed
@@ -397,7 +396,7 @@ class AutoRepairFacilityIntegrationTerminalIncompleteRepairTest extends FreedCon
   val maxNtuCap = ant.Definition.MaxNtuCapacitor
   player.Spawn()
   ant.NtuCapacitor = maxNtuCap
-  ant.Actor = context.actorOf(Props(classOf[VehicleControl], ant), name = "test-ant")
+  ant.Definition.Initialize(ant, context)
   ant.Zone = zone
   ant.Seats(0).mount(player)
   ant.DeploymentState = DriveState.Deployed

--- a/server/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
+++ b/server/src/test/scala/actor/objects/VehicleSpawnPadTest.scala
@@ -215,7 +215,7 @@ object VehicleSpawnPadControlTest {
     import net.psforever.objects.guid.NumberPoolHub
     import net.psforever.objects.guid.source.MaxNumberSource
     import net.psforever.objects.serverobject.structures.Building
-    import net.psforever.objects.vehicles.VehicleControl
+    import net.psforever.objects.vehicles.control.VehicleControl
     import net.psforever.objects.Tool
     import net.psforever.types.CharacterSex
 

--- a/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
+++ b/src/main/scala/net/psforever/objects/ExplosiveDeployable.scala
@@ -244,7 +244,7 @@ object ExplosiveDeployableControl {
     //val scalar = Vector3.ScalarProjection(dir, up)
     val point1 = g1.pointOnOutside(dir).asVector3
     val point2 = g2.pointOnOutside(Vector3.neg(dir)).asVector3
-    val scalar = Vector3.ScalarProjection(point2 - point1, up)
+    val scalar = Vector3.ScalarProjection(point2 - obj1.Position, up)
     (scalar >= 0 || Vector3.MagnitudeSquared(up * scalar) < 0.35f) &&
     math.min(
       Vector3.DistanceSquared(g1.center.asVector3, g2.center.asVector3),

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -911,15 +911,15 @@ object GlobalDefinitions {
 
   val magrider = VehicleDefinition(ObjectClass.magrider)
 
-  val ant = VehicleDefinition(ObjectClass.ant)
+  val ant = VehicleDefinition.Ant(ObjectClass.ant)
 
-  val ams = VehicleDefinition(ObjectClass.ams)
+  val ams = VehicleDefinition.Ams(ObjectClass.ams)
 
-  val router = VehicleDefinition(ObjectClass.router)
+  val router = VehicleDefinition.Router(ObjectClass.router)
 
-  val switchblade = VehicleDefinition(ObjectClass.switchblade)
+  val switchblade = VehicleDefinition.Deployer(ObjectClass.switchblade)
 
-  val flail = VehicleDefinition(ObjectClass.flail)
+  val flail = VehicleDefinition.Deployer(ObjectClass.flail)
 
   val mosquito = VehicleDefinition(ObjectClass.mosquito)
 
@@ -931,11 +931,11 @@ object GlobalDefinitions {
 
   val vulture = VehicleDefinition(ObjectClass.vulture)
 
-  val dropship = VehicleDefinition(ObjectClass.dropship)
+  val dropship = VehicleDefinition.Carrier(ObjectClass.dropship)
 
   val galaxy_gunship = VehicleDefinition(ObjectClass.galaxy_gunship)
 
-  val lodestar = VehicleDefinition(ObjectClass.lodestar)
+  val lodestar = VehicleDefinition.Carrier(ObjectClass.lodestar)
 
   val phantasm = VehicleDefinition(ObjectClass.phantasm)
 

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -897,11 +897,11 @@ object GlobalDefinitions {
 
   val aurora = VehicleDefinition(ObjectClass.aurora)
 
-  val apc_tr = VehicleDefinition(ObjectClass.apc_tr)
+  val apc_tr = VehicleDefinition.Apc(ObjectClass.apc_tr)
 
-  val apc_nc = VehicleDefinition(ObjectClass.apc_nc)
+  val apc_nc = VehicleDefinition.Apc(ObjectClass.apc_nc)
 
-  val apc_vs = VehicleDefinition(ObjectClass.apc_vs)
+  val apc_vs = VehicleDefinition.Apc(ObjectClass.apc_vs)
 
   val lightning = VehicleDefinition(ObjectClass.lightning)
 
@@ -917,9 +917,9 @@ object GlobalDefinitions {
 
   val router = VehicleDefinition.Router(ObjectClass.router)
 
-  val switchblade = VehicleDefinition.Deployer(ObjectClass.switchblade)
+  val switchblade = VehicleDefinition.Deploying(ObjectClass.switchblade)
 
-  val flail = VehicleDefinition.Deployer(ObjectClass.flail)
+  val flail = VehicleDefinition.Deploying(ObjectClass.flail)
 
   val mosquito = VehicleDefinition(ObjectClass.mosquito)
 
@@ -6146,6 +6146,7 @@ object GlobalDefinitions {
     apc_tr.MaxDepth = 3
     apc_tr.UnderwaterLifespan(suffocation = 15000L, recovery = 7500L)
     apc_tr.Geometry = apcForm
+    apc_tr.MaxCapacitor = 300
 
     apc_nc.Name = "apc_nc" // Vindicator
     apc_nc.MaxHealth = 6000
@@ -6208,6 +6209,7 @@ object GlobalDefinitions {
     apc_nc.MaxDepth = 3
     apc_nc.UnderwaterLifespan(suffocation = 15000L, recovery = 7500L)
     apc_nc.Geometry = apcForm
+    apc_nc.MaxCapacitor = 300
 
     apc_vs.Name = "apc_vs" // Leviathan
     apc_vs.MaxHealth = 6000
@@ -6270,6 +6272,7 @@ object GlobalDefinitions {
     apc_vs.MaxDepth = 3
     apc_vs.UnderwaterLifespan(suffocation = 15000L, recovery = 7500L)
     apc_vs.Geometry = apcForm
+    apc_vs.MaxCapacitor = 300
 
     lightning.Name = "lightning"
     lightning.MaxHealth = 2000

--- a/src/main/scala/net/psforever/objects/SpecialEmp.scala
+++ b/src/main/scala/net/psforever/objects/SpecialEmp.scala
@@ -42,6 +42,11 @@ object SpecialEmp {
   }
 
   /**
+    * Trigger an electromagnetic pulse.
+    */
+  final case class Burst()
+
+  /**
     * The damage interaction for an electromagnetic pulse effect.
     * @param empEffect information about the effect
     * @param position where the effect occurs

--- a/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
+++ b/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
@@ -227,6 +227,17 @@ object VehicleDefinition {
   }
   def Ant(objectId: Int): VehicleDefinition = new AntDefinition(objectId)
 
+  protected class ApcDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.ApcControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[ApcControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Apc(objectId: Int): VehicleDefinition = new ApcDefinition(objectId)
+
   protected class CarrierDefinition(objectId: Int) extends VehicleDefinition(objectId) {
     import net.psforever.objects.vehicles.control.CargoCarrierControl
     override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
@@ -238,16 +249,16 @@ object VehicleDefinition {
   }
   def Carrier(objectId: Int): VehicleDefinition = new CarrierDefinition(objectId)
 
-  protected class DeployerDefinition(objectId: Int) extends VehicleDefinition(objectId) {
-    import net.psforever.objects.vehicles.control.DeployableVehicleControl
+  protected class DeployingDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.DeployingVehicleControl
     override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
       obj.Actor = context.actorOf(
-        Props(classOf[DeployableVehicleControl], obj),
+        Props(classOf[DeployingVehicleControl], obj),
         PlanetSideServerObject.UniqueActorName(obj)
       )
     }
   }
-  def Deployer(objectId: Int): VehicleDefinition = new DeployerDefinition(objectId)
+  def Deploying(objectId: Int): VehicleDefinition = new DeployingDefinition(objectId)
 
   protected class RouterDefinition(objectId: Int) extends VehicleDefinition(objectId) {
     import net.psforever.objects.vehicles.control.RouterControl

--- a/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
+++ b/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
@@ -214,6 +214,10 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition for the advanced mobile spawn (AMS) vehicle.
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Ams(objectId: Int): VehicleDefinition = new AmsDefinition(objectId)
 
   protected class AntDefinition(objectId: Int) extends VehicleDefinition(objectId) {
@@ -225,6 +229,10 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition for the advanced nanite transport (ANT) vehicle.
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Ant(objectId: Int): VehicleDefinition = new AntDefinition(objectId)
 
   protected class ApcDefinition(objectId: Int) extends VehicleDefinition(objectId) {
@@ -236,6 +244,10 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition(s) for the armored personnel carrier (`apc*`) vehicles.
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Apc(objectId: Int): VehicleDefinition = new ApcDefinition(objectId)
 
   protected class CarrierDefinition(objectId: Int) extends VehicleDefinition(objectId) {
@@ -247,6 +259,10 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition(s) for the vehicles (carriers) that are used to transport other vehicles (cargo).
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Carrier(objectId: Int): VehicleDefinition = new CarrierDefinition(objectId)
 
   protected class DeployingDefinition(objectId: Int) extends VehicleDefinition(objectId) {
@@ -258,6 +274,10 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition(s) for the vehicles that perform significant mode state transitions.
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Deploying(objectId: Int): VehicleDefinition = new DeployingDefinition(objectId)
 
   protected class RouterDefinition(objectId: Int) extends VehicleDefinition(objectId) {
@@ -269,5 +289,9 @@ object VehicleDefinition {
       )
     }
   }
+  /**
+    * Vehicle definition for the Router.
+    * @param objectId the object id that is associated with this sort of `Vehicle`
+    */
   def Router(objectId: Int): VehicleDefinition = new RouterDefinition(objectId)
 }

--- a/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
+++ b/src/main/scala/net/psforever/objects/definition/VehicleDefinition.scala
@@ -1,9 +1,11 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.definition
 
-import net.psforever.objects.NtuContainerDefinition
+import akka.actor.{ActorContext, Props}
+import net.psforever.objects.{Default, NtuContainerDefinition, Vehicle}
 import net.psforever.objects.definition.converter.VehicleConverter
 import net.psforever.objects.inventory.InventoryTile
+import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.vehicles.{DestroyedVehicle, MountableWeaponsDefinition, UtilityType}
 import net.psforever.objects.vital._
 import net.psforever.objects.vital.damage.DamageCalculations
@@ -181,6 +183,19 @@ class VehicleDefinition(objectId: Int)
     destroyedModel = model
     DestroyedModel
   }
+
+  def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+    import net.psforever.objects.vehicles.control.VehicleControl
+    obj.Actor = context.actorOf(
+      Props(classOf[VehicleControl], obj),
+      PlanetSideServerObject.UniqueActorName(obj)
+    )
+  }
+
+  def Uninitialize(obj: Vehicle, context: ActorContext): Unit = {
+    obj.Actor ! akka.actor.PoisonPill
+    obj.Actor = Default.Actor
+  }
 }
 
 object VehicleDefinition {
@@ -189,4 +204,59 @@ object VehicleDefinition {
   def apply(objectId: Int): VehicleDefinition = {
     new VehicleDefinition(objectId)
   }
+
+  protected class AmsDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.AmsControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[AmsControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Ams(objectId: Int): VehicleDefinition = new AmsDefinition(objectId)
+
+  protected class AntDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.AntControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[AntControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Ant(objectId: Int): VehicleDefinition = new AntDefinition(objectId)
+
+  protected class CarrierDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.CargoCarrierControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[CargoCarrierControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Carrier(objectId: Int): VehicleDefinition = new CarrierDefinition(objectId)
+
+  protected class DeployerDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.DeployableVehicleControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[DeployableVehicleControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Deployer(objectId: Int): VehicleDefinition = new DeployerDefinition(objectId)
+
+  protected class RouterDefinition(objectId: Int) extends VehicleDefinition(objectId) {
+    import net.psforever.objects.vehicles.control.RouterControl
+    override def Initialize(obj: Vehicle, context: ActorContext): Unit = {
+      obj.Actor = context.actorOf(
+        Props(classOf[RouterControl], obj),
+        PlanetSideServerObject.UniqueActorName(obj)
+      )
+    }
+  }
+  def Router(objectId: Int): VehicleDefinition = new RouterDefinition(objectId)
 }

--- a/src/main/scala/net/psforever/objects/serverobject/deploy/Deployment.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/deploy/Deployment.scala
@@ -110,4 +110,8 @@ object Deployment {
     */
   def CheckForUndeployState(state: DriveState.Value): Boolean =
     state == DriveState.Undeploying || state == DriveState.Mobile || state == DriveState.State7
+
+  def AngleCheck(obj: Deployment.DeploymentObject): Boolean = {
+    obj.Orientation.x <= 30 || obj.Orientation.x >= 330
+  }
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
@@ -6,10 +6,20 @@ import net.psforever.services.Service
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 import net.psforever.types.DriveState
 
-//ams
+/**
+  * A vehicle control agency exclusive to the advanced mobile spawn (AMS).
+  * When deployed, infantry troops may manifest nearby the vehicle
+  * as they switch from being deconstructed (or dead) to being alive.
+  * @param vehicle the AMS
+  */
 class AmsControl(vehicle: Vehicle)
   extends DeployingVehicleControl(vehicle) {
 
+  /**
+    * React to a deployment state change.
+    * Announce that this AMS is ready to accept troop deployment.
+    * @param state the deployment state
+    */
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Deployed =>
@@ -25,6 +35,11 @@ class AmsControl(vehicle: Vehicle)
     }
   }
 
+  /**
+    * React to an undeployment state change.
+    * This AMS is now off the grid.
+    * @param state the deployment state
+    */
   override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Undeploying =>

--- a/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
@@ -8,7 +8,7 @@ import net.psforever.types.DriveState
 
 //ams
 class AmsControl(vehicle: Vehicle)
-  extends DeployableVehicleControl(vehicle) {
+  extends DeployingVehicleControl(vehicle) {
 
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {

--- a/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AmsControl.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.services.Service
+import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
+import net.psforever.types.DriveState
+
+//ams
+class AmsControl(vehicle: Vehicle)
+  extends DeployableVehicleControl(vehicle) {
+
+  override def specificResponseToDeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Deployed =>
+        val zone  = vehicle.Zone
+        val driverChannel = vehicle.Seats(0).occupant match {
+          case Some(tplayer) => tplayer.Name
+          case None          => ""
+        }
+        val events = zone.VehicleEvents
+        events ! VehicleServiceMessage.AMSDeploymentChange(zone)
+        events ! VehicleServiceMessage(driverChannel, VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, vehicle.GUID, 81, 1))
+      case _ => ;
+    }
+  }
+
+  override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Undeploying =>
+        val zone  = vehicle.Zone
+        val driverChannel = vehicle.Seats(0).occupant match {
+          case Some(tplayer) => tplayer.Name
+          case None          => ""
+        }
+        val events = zone.VehicleEvents
+        events ! VehicleServiceMessage.AMSDeploymentChange(zone)
+        events ! VehicleServiceMessage(driverChannel, VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, vehicle.GUID, 81, 0))
+      case _ => ;
+    }
+  }
+}
+

--- a/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.objects.serverobject.transfer.TransferBehavior
+import net.psforever.objects.vehicles._
+import net.psforever.types.DriveState
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+//ant
+class AntControl(vehicle: Vehicle)
+  extends DeployableVehicleControl(vehicle)
+    with AntTransferBehavior {
+  def ChargeTransferObject = vehicle
+
+  findChargeTargetFunc = Vehicles.FindANTChargingSource
+  findDischargeTargetFunc = Vehicles.FindANTDischargingTarget
+
+  override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(antBehavior)
+
+  override def specificResponseToDeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Deployed =>
+        // Start ntu regeneration
+        // If vehicle sends UseItemMessage with silo as target NTU regeneration will be disabled and orb particles will be disabled
+        context.system.scheduler.scheduleOnce(
+          delay = 1000 milliseconds,
+          vehicle.Actor,
+          TransferBehavior.Charging(Ntu.Nanites)
+        )
+      case _ => ;
+    }
+  }
+
+  override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Undeploying =>
+        TryStopChargingEvent(vehicle)
+      case _ => ;
+    }
+  }
+}

--- a/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 //ant
 class AntControl(vehicle: Vehicle)
-  extends DeployableVehicleControl(vehicle)
+  extends DeployingVehicleControl(vehicle)
     with AntTransferBehavior {
   def ChargeTransferObject = vehicle
 

--- a/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
@@ -9,7 +9,13 @@ import net.psforever.types.DriveState
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-//ant
+/**
+  * A vehicle control agency exclusive to the advanced nanite transport (ANT).
+  * When deployed, nanites in the package of nanite transfer units (NTU) are moved around
+  * and may be may be acquired from a Warp Gate structure
+  * or supplied to a nanite resource silo belonging to a mjaor facility.
+  * @param vehicle the ANT
+  */
 class AntControl(vehicle: Vehicle)
   extends DeployingVehicleControl(vehicle)
     with AntTransferBehavior {
@@ -20,6 +26,11 @@ class AntControl(vehicle: Vehicle)
 
   override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(antBehavior)
 
+  /**
+    * React to a deployment state change.
+    * Make ourselves available to nanite charging or discharging.
+    * @param state the deployment state
+    */
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Deployed =>
@@ -34,6 +45,11 @@ class AntControl(vehicle: Vehicle)
     }
   }
 
+  /**
+    * React to an undeployment state change.
+    * Stop charging or discharging and tell the partner entity that it is no longer interacting with this vehicle.
+    * @param state the undeployment state
+    */
   override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Undeploying =>

--- a/src/main/scala/net/psforever/objects/vehicles/control/ApcControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/ApcControl.scala
@@ -78,7 +78,7 @@ class ApcControl(vehicle: Vehicle)
               vehicle,
               emp,
               SpecialEmp.createEmpInteraction(emp, pos),
-              Zone.distanceCheck, //TODO ExplosiveDeployableControl.detectionForExplosiveSource(vehicle),
+              ExplosiveDeployableControl.detectionForExplosiveSource(vehicle),
               Zone.findAllTargets
             )
             //start charging again

--- a/src/main/scala/net/psforever/objects/vehicles/control/ApcControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/ApcControl.scala
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.objects.serverobject.damage.Damageable.Target
+import net.psforever.objects.vital.interaction.DamageResult
+import net.psforever.objects.zones.Zone
+import net.psforever.packet.game.{TriggerEffectMessage, TriggeredEffectLocation}
+import net.psforever.services.Service
+import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+//apc, apc_nc, apc_tr, apc_vs
+class ApcControl(vehicle: Vehicle)
+  extends VehicleControl(vehicle) {
+  protected var capacitor = Default.Cancellable
+
+  startCapacitorTimer()
+
+  override def postStop() : Unit = {
+    super.postStop()
+    capacitor.cancel()
+  }
+
+  override def commonEnabledBehavior : Receive =
+    super.commonEnabledBehavior
+      .orElse {
+        case ApcControl.CapacitorCharge(amount) =>
+          if (vehicle.Capacitor < vehicle.Definition.MaxCapacitor) {
+            val capacitance = vehicle.Capacitor += amount
+            vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
+              self.toString(),
+              VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, vehicle.GUID, 113, capacitance)
+            )
+            startCapacitorTimer()
+          } else {
+            capacitor = Default.Cancellable
+          }
+
+        case SpecialEmp.Burst() =>
+          if (vehicle.Capacitor == vehicle.Definition.MaxCapacitor) { //only if the capacitor is full
+            val zone = vehicle.Zone
+            val events = zone.VehicleEvents
+            val pos = vehicle.Position
+            val GUID0 = Service.defaultPlayerGUID
+            val emp = SpecialEmp.emp
+            vehicle.Capacitor = 0
+            events ! VehicleServiceMessage(
+              self.toString(),
+              VehicleAction.PlanetsideAttribute(GUID0, vehicle.GUID, 113, 0)
+            )
+            events ! VehicleServiceMessage(
+              zone.id,
+              VehicleAction.SendResponse(
+                GUID0,
+                TriggerEffectMessage(
+                  GUID0,
+                  s"apc_explosion_emp_${vehicle.Faction}",
+                  None,
+                  Some(TriggeredEffectLocation(pos, vehicle.Orientation))
+                )
+              )
+            )
+            Zone.serverSideDamage(
+              zone,
+              vehicle,
+              emp,
+              SpecialEmp.createEmpInteraction(emp, pos),
+              Zone.distanceCheck,
+              Zone.findAllTargets
+            )
+          }
+          startCapacitorTimer()
+      }
+
+  override protected def DestructionAwareness(target: Target, cause: DamageResult): Unit = {
+    super.DestructionAwareness(target, cause)
+    capacitor.cancel()
+    vehicle.Capacitor = 0
+  }
+
+  private def startCapacitorTimer(): Unit = {
+    capacitor = context.system.scheduler.scheduleOnce(
+      delay = 1000 millisecond,
+      self,
+      ApcControl.CapacitorCharge(10)
+    )
+  }
+}
+
+object ApcControl {
+  private case class CapacitorCharge(amount: Int)
+}

--- a/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.objects.vehicles.CargoBehavior
+
+//dropship (galaxy)
+//lodestar
+class CargoCarrierControl(vehicle: Vehicle)
+  extends VehicleControl(vehicle)
+    with CargoBehavior {
+  def CargoObject = vehicle
+
+  override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(cargoBehavior)
+
+  override def PrepareForDisabled(kickPassengers : Boolean) : Unit = {
+    //abandon all cargo
+    vehicle.CargoHolds.values
+      .collect {
+        case hold if hold.isOccupied =>
+          val cargo = hold.occupant.get
+          CargoBehavior.HandleVehicleCargoDismount(
+            cargo.GUID,
+            cargo,
+            vehicle.GUID,
+            vehicle,
+            bailed = false,
+            requestedByPassenger = false,
+            kicked = false
+          )
+      }
+    super.PrepareForDisabled(kickPassengers)
+  }
+}

--- a/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
@@ -2,7 +2,9 @@
 package net.psforever.objects.vehicles.control
 
 import net.psforever.objects._
+import net.psforever.objects.serverobject.damage.Damageable
 import net.psforever.objects.vehicles.CargoBehavior
+import net.psforever.objects.vital.interaction.DamageResult
 
 //dropship (galaxy)
 //lodestar
@@ -11,7 +13,22 @@ class CargoCarrierControl(vehicle: Vehicle)
     with CargoBehavior {
   def CargoObject = vehicle
 
-  override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(cargoBehavior)
+  override def commonEnabledBehavior: Receive =
+    super.commonEnabledBehavior
+      .orElse(cargoBehavior)
+      .orElse {
+        case CargoCarrierControl.Damage(cause, damage) =>
+          //cargo vehicles inherit feedback from carrier
+          reportDamageToVehicle = damage > 0
+          DamageAwareness(DamageableObject, cause, amount = 0)
+
+        case CargoCarrierControl.Destruction(cause) =>
+          //cargo vehicles are destroyed when carrier is destroyed
+          val obj = DamageableObject
+          obj.Health = 0
+          obj.History(cause)
+          DestructionAwareness(obj, cause)
+      }
 
   override def PrepareForDisabled(kickPassengers : Boolean) : Unit = {
     //abandon all cargo
@@ -31,4 +48,67 @@ class CargoCarrierControl(vehicle: Vehicle)
       }
     super.PrepareForDisabled(kickPassengers)
   }
+
+  /**
+    * A damaged carrier alerts its cargo vehicles of the source of the damage,
+    * but that cargo will not be affected by either damage directly or by other effects applied to the carrier.
+    * @param target the entity being destroyed
+    * @param cause historical information about the damage
+    * @param amount how much damage was performed
+    */
+  override protected def DamageAwareness(target: Damageable.Target, cause: DamageResult, amount: Any): Unit = {
+    val totalDamage = amount match {
+      case (a: Int, b: Int) => a + b
+      case a: Int => a
+      case _ => 0
+    }
+    val announceConfrontation: Boolean = reportDamageToVehicle || totalDamage > 0
+    super.DamageAwareness(target, cause, amount)
+    if (announceConfrontation) {
+      //alert cargo occupants to damage source
+      vehicle.CargoHolds.values.foreach(hold => {
+        hold.occupant match {
+          case Some(cargo) =>
+            cargo.Actor ! CargoCarrierControl.Damage(cause, totalDamage)
+          case None => ;
+        }
+      })
+    }
+  }
+
+  /**
+    * A destroyed carrier informs its cargo vehicles that they should also be destroyed
+    * for reasons of the same cause being inherited as the source of damage.
+    * Regardless of the amount of damage they carrier takes or some other target would take,
+    * its cargo vehicles die immediately.
+    * @param target the entity being destroyed
+    * @param cause historical information about the damage
+    */
+  override protected def DestructionAwareness(target: Damageable.Target, cause: DamageResult): Unit = {
+    super.DestructionAwareness(target, cause)
+    //cargo vehicles die with us
+    vehicle.CargoHolds.values.foreach { hold =>
+      hold.occupant match {
+        case Some(cargo) =>
+          cargo.Actor ! CargoCarrierControl.Destruction(cause)
+        case None => ;
+      }
+    }
+    super.DestructionAwareness(target, cause)
+  }
+}
+
+object CargoCarrierControl {
+  /**
+    * Message for instructing the target's cargo vehicles about a damage source affecting their carrier.
+    * @param cause historical information about damage
+    */
+  private case class Damage(cause: DamageResult, amount: Int)
+
+  /**
+    * Message for instructing the target's cargo vehicles that their carrier is destroyed,
+    * and they should be destroyed too.
+    * @param cause historical information about damage
+    */
+  private case class Destruction(cause: DamageResult)
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/CargoCarrierControl.scala
@@ -2,35 +2,27 @@
 package net.psforever.objects.vehicles.control
 
 import net.psforever.objects._
-import net.psforever.objects.serverobject.damage.Damageable
+import net.psforever.objects.serverobject.damage.{Damageable, DamageableVehicle}
 import net.psforever.objects.vehicles.CargoBehavior
 import net.psforever.objects.vital.interaction.DamageResult
 
-//dropship (galaxy)
-//lodestar
+/**
+  * A vehicle control agency exclusive to vehicles that can physically transport other vehicles.
+  * This includes the Galaxy (`dropship`) and the Lodestar.
+  * @param vehicle the vehicle
+  */
 class CargoCarrierControl(vehicle: Vehicle)
   extends VehicleControl(vehicle)
     with CargoBehavior {
   def CargoObject = vehicle
 
-  override def commonEnabledBehavior: Receive =
-    super.commonEnabledBehavior
-      .orElse(cargoBehavior)
-      .orElse {
-        case CargoCarrierControl.Damage(cause, damage) =>
-          //cargo vehicles inherit feedback from carrier
-          reportDamageToVehicle = damage > 0
-          DamageAwareness(DamageableObject, cause, amount = 0)
+  override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(cargoBehavior)
 
-        case CargoCarrierControl.Destruction(cause) =>
-          //cargo vehicles are destroyed when carrier is destroyed
-          val obj = DamageableObject
-          obj.Health = 0
-          obj.History(cause)
-          DestructionAwareness(obj, cause)
-      }
-
-  override def PrepareForDisabled(kickPassengers : Boolean) : Unit = {
+  /**
+    * If the vehicle becomes disabled, the safety and autonomy of the cargo should be prioritized.
+    * @param kickPassengers passengers need to be ejected "by force"
+    */
+  override def PrepareForDisabled(kickPassengers: Boolean) : Unit = {
     //abandon all cargo
     vehicle.CargoHolds.values
       .collect {
@@ -57,19 +49,18 @@ class CargoCarrierControl(vehicle: Vehicle)
     * @param amount how much damage was performed
     */
   override protected def DamageAwareness(target: Damageable.Target, cause: DamageResult, amount: Any): Unit = {
-    val totalDamage = amount match {
+    val report = amount match {
       case (a: Int, b: Int) => a + b
       case a: Int => a
       case _ => 0
     }
-    val announceConfrontation: Boolean = reportDamageToVehicle || totalDamage > 0
+    val announceConfrontation: Boolean = reportDamageToVehicle || report > 0
     super.DamageAwareness(target, cause, amount)
     if (announceConfrontation) {
       //alert cargo occupants to damage source
       vehicle.CargoHolds.values.foreach(hold => {
         hold.occupant match {
-          case Some(cargo) =>
-            cargo.Actor ! CargoCarrierControl.Damage(cause, totalDamage)
+          case Some(cargo) => cargo.Actor ! DamageableVehicle.Damage(cause, report)
           case None => ;
         }
       })
@@ -89,26 +80,9 @@ class CargoCarrierControl(vehicle: Vehicle)
     //cargo vehicles die with us
     vehicle.CargoHolds.values.foreach { hold =>
       hold.occupant match {
-        case Some(cargo) =>
-          cargo.Actor ! CargoCarrierControl.Destruction(cause)
+        case Some(cargo) => cargo.Actor ! DamageableVehicle.Destruction(cause)
         case None => ;
       }
     }
-    super.DestructionAwareness(target, cause)
   }
-}
-
-object CargoCarrierControl {
-  /**
-    * Message for instructing the target's cargo vehicles about a damage source affecting their carrier.
-    * @param cause historical information about damage
-    */
-  private case class Damage(cause: DamageResult, amount: Int)
-
-  /**
-    * Message for instructing the target's cargo vehicles that their carrier is destroyed,
-    * and they should be destroyed too.
-    * @param cause historical information about damage
-    */
-  private case class Destruction(cause: DamageResult)
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/DeployableVehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/DeployableVehicleControl.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.objects.serverobject.deploy.Deployment.DeploymentObject
+import net.psforever.objects.serverobject.deploy.{Deployment, DeploymentBehavior}
+import net.psforever.objects.serverobject.mount.Mountable
+import net.psforever.types._
+
+//switchblade
+//flail
+class DeployableVehicleControl(vehicle: Vehicle)
+  extends VehicleControl(vehicle)
+    with DeploymentBehavior {
+  def DeploymentObject = vehicle
+
+  override def commonEnabledBehavior : Receive = super.commonEnabledBehavior.orElse(deployBehavior)
+
+  override def commonDisabledBehavior : Receive =
+    super.commonDisabledBehavior
+      .orElse {
+        case msg : Deployment.TryUndeploy =>
+          deployBehavior.apply(msg)
+
+        case msg @ Mountable.TryDismount(_, seat_num) =>
+          dismountBehavior.apply(msg)
+          dismountCleanup(seat_num)
+      }
+
+  override def commonDeleteBehavior : Receive =
+    super.commonDeleteBehavior
+      .orElse {
+        case msg : Deployment.TryUndeploy =>
+          deployBehavior.apply(msg)
+      }
+
+  override def PrepareForDisabled(kickPassengers: Boolean) : Unit = {
+    vehicle.Actor ! Deployment.TryUndeploy(DriveState.Undeploying)
+    super.PrepareForDisabled(kickPassengers)
+  }
+
+  override def PrepareForDeletion() : Unit = {
+    vehicle.Actor ! Deployment.TryUndeploy(DriveState.Undeploying)
+    super.PrepareForDeletion()
+  }
+
+  override def TryDeploymentChange(obj: Deployment.DeploymentObject, state: DriveState.Value): Boolean = {
+    DeployableVehicleControl.DeploymentAngleCheck(obj) && super.TryDeploymentChange(obj, state)
+  }
+
+  override def DeploymentAction(
+                                 obj: DeploymentObject,
+                                 state: DriveState.Value,
+                                 prevState: DriveState.Value
+                               ): DriveState.Value = {
+    val out = super.DeploymentAction(obj, state, prevState)
+    Vehicles.ReloadAccessPermissions(vehicle, vehicle.Faction.toString)
+    specificResponseToDeployment(state)
+    out
+  }
+
+  def specificResponseToDeployment(state: DriveState.Value): Unit = { }
+
+  override def UndeploymentAction(
+                                   obj: DeploymentObject,
+                                   state: DriveState.Value,
+                                   prevState: DriveState.Value
+                                 ): DriveState.Value = {
+    val out = if (decaying) state else super.UndeploymentAction(obj, state, prevState)
+    Vehicles.ReloadAccessPermissions(vehicle, vehicle.Faction.toString)
+    specificResponseToUndeployment(state)
+    out
+  }
+
+  def specificResponseToUndeployment(state: DriveState.Value): Unit = { }
+}
+
+object DeployableVehicleControl {
+  def DeploymentAngleCheck(obj: Deployment.DeploymentObject): Boolean = {
+    obj.Orientation.x <= 30 || obj.Orientation.x >= 330
+  }
+}

--- a/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
@@ -7,8 +7,16 @@ import net.psforever.objects.serverobject.deploy.{Deployment, DeploymentBehavior
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.types._
 
-//switchblade
-//flail
+/**
+  * A vehicle control agency exclusive to vehicles that can switch out a navigation mode
+  * and convert to a sessile mode that affords additional functionality.
+  * This includes only the Switchblade and the Flail.
+  * Other vehicles that deploy are handled by specific instances of this control agency.
+  * @see `AmsControl`
+  * @see `AntControl`
+  * @see `RouterControl`
+  * @param vehicle the vehicle
+  */
 class DeployingVehicleControl(vehicle: Vehicle)
   extends VehicleControl(vehicle)
     with DeploymentBehavior {
@@ -16,6 +24,10 @@ class DeployingVehicleControl(vehicle: Vehicle)
 
   override def commonEnabledBehavior : Receive = super.commonEnabledBehavior.orElse(deployBehavior)
 
+  /**
+    * Even when disabled, the vehicle can be made to undeploy.
+    * Even when disabled, passengers can formally dismount from the vehicle.
+    */
   override def commonDisabledBehavior : Receive =
     super.commonDisabledBehavior
       .orElse {
@@ -27,6 +39,9 @@ class DeployingVehicleControl(vehicle: Vehicle)
           dismountCleanup(seat_num)
       }
 
+  /**
+    * Even when on the verge of deletion, the vehicle can be made to undeploy.
+    */
   override def commonDeleteBehavior : Receive =
     super.commonDeleteBehavior
       .orElse {
@@ -34,11 +49,17 @@ class DeployingVehicleControl(vehicle: Vehicle)
           deployBehavior.apply(msg)
       }
 
+  /**
+    * Even when disabled, the vehicle can be made to undeploy.
+    */
   override def PrepareForDisabled(kickPassengers: Boolean) : Unit = {
     vehicle.Actor ! Deployment.TryUndeploy(DriveState.Undeploying)
     super.PrepareForDisabled(kickPassengers)
   }
 
+  /**
+    * Even when on the verge of deletion, the vehicle can be made to undeploy.
+    */
   override def PrepareForDeletion() : Unit = {
     vehicle.Actor ! Deployment.TryUndeploy(DriveState.Undeploying)
     super.PrepareForDeletion()

--- a/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
@@ -9,7 +9,7 @@ import net.psforever.types._
 
 //switchblade
 //flail
-class DeployableVehicleControl(vehicle: Vehicle)
+class DeployingVehicleControl(vehicle: Vehicle)
   extends VehicleControl(vehicle)
     with DeploymentBehavior {
   def DeploymentObject = vehicle
@@ -45,7 +45,7 @@ class DeployableVehicleControl(vehicle: Vehicle)
   }
 
   override def TryDeploymentChange(obj: Deployment.DeploymentObject, state: DriveState.Value): Boolean = {
-    DeployableVehicleControl.DeploymentAngleCheck(obj) && super.TryDeploymentChange(obj, state)
+    Deployment.AngleCheck(obj) && super.TryDeploymentChange(obj, state)
   }
 
   override def DeploymentAction(
@@ -73,10 +73,4 @@ class DeployableVehicleControl(vehicle: Vehicle)
   }
 
   def specificResponseToUndeployment(state: DriveState.Value): Unit = { }
-}
-
-object DeployableVehicleControl {
-  def DeploymentAngleCheck(obj: Deployment.DeploymentObject): Boolean = {
-    obj.Orientation.x <= 30 || obj.Orientation.x >= 330
-  }
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.objects.vehicles.control
+
+import net.psforever.objects._
+import net.psforever.objects.ce.TelepadLike
+import net.psforever.objects.vehicles.{Utility, UtilityType}
+import net.psforever.types.DriveState
+
+//router
+class RouterControl(vehicle: Vehicle)
+  extends DeployableVehicleControl(vehicle) {
+
+  override def specificResponseToDeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Deployed =>
+        vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
+          case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Activate(util)
+          case _ => ;
+        }
+      case _ => ;
+    }
+  }
+
+  override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
+    state match {
+      case DriveState.Undeploying =>
+        vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
+          case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Deactivate(util)
+          case _ => ;
+        }
+      case _ => ;
+    }
+  }
+}

--- a/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
@@ -6,10 +6,21 @@ import net.psforever.objects.ce.TelepadLike
 import net.psforever.objects.vehicles.{Utility, UtilityType}
 import net.psforever.types.DriveState
 
-//router
+/**
+  * A vehicle control agency exclusive to the router.
+  * When deployed, any router telepad that was acquired from this particular router
+  * and then constructed into a router telepad somewhere in the world
+  * may synchronize with the vehicle to establish a short to medium range infantry teleportation system.
+  * @param vehicle the router
+  */
 class RouterControl(vehicle: Vehicle)
   extends DeployingVehicleControl(vehicle) {
 
+  /**
+    * React to a deployment state change.
+    * Activate the internal telepad mechanism.
+    * @param state the deployment state
+    */
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Deployed =>
@@ -21,6 +32,11 @@ class RouterControl(vehicle: Vehicle)
     }
   }
 
+  /**
+    * React to an undeployment state change.
+    * Deactivate the internal telepad mechanism.
+    * @param state the deployment state
+    */
   override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Undeploying =>

--- a/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
@@ -8,7 +8,7 @@ import net.psforever.types.DriveState
 
 //router
 class RouterControl(vehicle: Vehicle)
-  extends DeployableVehicleControl(vehicle) {
+  extends DeployingVehicleControl(vehicle) {
 
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -37,9 +37,9 @@ import scala.concurrent.duration._
 /**
   * An `Actor` that handles messages being dispatched to a specific `Vehicle`.<br>
   * <br>
-  * Vehicle-controlling actors have two behavioral states - responsive and "`Disabled`."
+  * Vehicle-controlling actors have two important behavioral states - responsive and "`Disabled`."
   * The latter is applicable only when the specific vehicle is being deconstructed.
-  *
+  * Furthermore, being "ready to delete" is also a behavoral state for the end of life operations of the vehicle.
   * @param vehicle the `Vehicle` object being governed
   */
 class VehicleControl(vehicle: Vehicle)

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 PSForever
+// Copyright (c) 2017-2021 PSForever
 package net.psforever.objects.vehicles.control
 
 import akka.actor.{Actor, Cancellable}
@@ -119,7 +119,7 @@ class VehicleControl(vehicle: Vehicle)
 
       case Vehicle.ChargeShields(amount) =>
         val now : Long = System.currentTimeMillis()
-        //make certain vehicle doesn't charge shields too quickly
+        //make certain vehicles don't charge shields too quickly
         if (
           vehicle.Health > 0 && vehicle.Shields < vehicle.MaxShields &&
           !vehicle.History.exists(VehicleControl.LastShieldChargeOrDamage(now))

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -1,11 +1,10 @@
 // Copyright (c) 2017-2020 PSForever
-package net.psforever.objects.vehicles
+package net.psforever.objects.vehicles.control
 
 import akka.actor.{Actor, Cancellable}
 import net.psforever.actors.zone.ZoneActor
 import net.psforever.objects._
 import net.psforever.objects.ballistics.VehicleSource
-import net.psforever.objects.ce.TelepadLike
 import net.psforever.objects.entity.WorldEntity
 import net.psforever.objects.equipment.{Equipment, EquipmentSlot, JammableMountedWeapons}
 import net.psforever.objects.guid.GUIDTask
@@ -14,14 +13,12 @@ import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObjec
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
 import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
 import net.psforever.objects.serverobject.damage.{AggravatedBehavior, DamageableVehicle}
-import net.psforever.objects.serverobject.deploy.Deployment.DeploymentObject
-import net.psforever.objects.serverobject.deploy.{Deployment, DeploymentBehavior}
 import net.psforever.objects.serverobject.environment._
 import net.psforever.objects.serverobject.hackable.GenericHackables
 import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
 import net.psforever.objects.serverobject.repair.RepairableVehicle
 import net.psforever.objects.serverobject.terminals.Terminal
-import net.psforever.objects.serverobject.transfer.TransferBehavior
+import net.psforever.objects.vehicles.{AccessPermissionGroup, CargoBehavior, Utility, VehicleLockState}
 import net.psforever.objects.vital.interaction.{DamageInteraction, DamageResult}
 import net.psforever.objects.vital.VehicleShieldCharge
 import net.psforever.objects.vital.environment.EnvironmentReason
@@ -46,38 +43,29 @@ import scala.concurrent.duration._
   * @param vehicle the `Vehicle` object being governed
   */
 class VehicleControl(vehicle: Vehicle)
-    extends Actor
+  extends Actor
     with FactionAffinityBehavior.Check
-    with DeploymentBehavior
     with MountableBehavior
-    with CargoBehavior
     with DamageableVehicle
     with RepairableVehicle
     with JammableMountedWeapons
     with ContainableBehavior
-    with AntTransferBehavior
     with AggravatedBehavior
     with RespondsToZoneEnvironment {
   //make control actors belonging to utilities when making control actor belonging to vehicle
-  vehicle.Utilities.foreach({ case (_, util) => util.Setup })
+  vehicle.Utilities.foreach { case (_, util) => util.Setup }
 
   def MountableObject = vehicle
-
-  def CargoObject = vehicle
 
   def JammableObject = vehicle
 
   def FactionObject = vehicle
-
-  def DeploymentObject = vehicle
 
   def DamageableObject = vehicle
 
   def RepairableObject = vehicle
 
   def ContainerObject = vehicle
-
-  def ChargeTransferObject = vehicle
 
   def InteractiveObject = vehicle
   SetInteraction(EnvironmentAttribute.Water, doInteractingWithWater)
@@ -87,10 +75,6 @@ class VehicleControl(vehicle: Vehicle)
     SetInteractionStop(EnvironmentAttribute.Water, stopInteractingWithWater)
   }
 
-  if (vehicle.Definition == GlobalDefinitions.ant) {
-    findChargeTargetFunc = Vehicles.FindANTChargingSource
-    findDischargeTargetFunc = Vehicles.FindANTDischargingTarget
-  }
   /** cheap flag for whether the vehicle is decaying */
   var decaying : Boolean = false
   /** primary vehicle decay timer */
@@ -112,199 +96,197 @@ class VehicleControl(vehicle: Vehicle)
     recoverFromEnvironmentInteracting()
   }
 
-  def Enabled : Receive =
-    checkBehavior
-      .orElse(deployBehavior)
-      .orElse(cargoBehavior)
-      .orElse(jammableBehavior)
-      .orElse(takesDamage)
-      .orElse(canBeRepairedByNanoDispenser)
-      .orElse(containerBehavior)
-      .orElse(antBehavior)
-      .orElse(environmentBehavior)
-      .orElse {
-        case Vehicle.Ownership(None) =>
-          LoseOwnership()
+  def commonEnabledBehavior: Receive = checkBehavior
+    .orElse(jammableBehavior)
+    .orElse(takesDamage)
+    .orElse(canBeRepairedByNanoDispenser)
+    .orElse(containerBehavior)
+    .orElse(environmentBehavior)
+    .orElse {
+      case Vehicle.Ownership(None) =>
+        LoseOwnership()
 
-        case Vehicle.Ownership(Some(player)) =>
-          GainOwnership(player)
+      case Vehicle.Ownership(Some(player)) =>
+        GainOwnership(player)
 
-        case msg @ Mountable.TryMount(player, mount_point) =>
-          mountBehavior.apply(msg)
-          mountCleanup(mount_point, player)
+      case msg @ Mountable.TryMount(player, mount_point) =>
+        mountBehavior.apply(msg)
+        mountCleanup(mount_point, player)
 
-        case msg @ Mountable.TryDismount(_, seat_num) =>
-          dismountBehavior.apply(msg)
-          dismountCleanup(seat_num)
+      case msg @ Mountable.TryDismount(_, seat_num) =>
+        dismountBehavior.apply(msg)
+        dismountCleanup(seat_num)
 
-        case Vehicle.ChargeShields(amount) =>
-          val now : Long = System.currentTimeMillis()
-          //make certain vehicle doesn't charge shields too quickly
-          if (
-            vehicle.Health > 0 && vehicle.Shields < vehicle.MaxShields &&
-            !vehicle.History.exists(VehicleControl.LastShieldChargeOrDamage(now))
-          ) {
-            vehicle.History(VehicleShieldCharge(VehicleSource(vehicle), amount))
-            vehicle.Shields = vehicle.Shields + amount
-            vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
-              s"${vehicle.Actor}",
-              VehicleAction.PlanetsideAttribute(PlanetSideGUID(0), vehicle.GUID, 68, vehicle.Shields)
-            )
-          }
+      case Vehicle.ChargeShields(amount) =>
+        val now : Long = System.currentTimeMillis()
+        //make certain vehicle doesn't charge shields too quickly
+        if (
+          vehicle.Health > 0 && vehicle.Shields < vehicle.MaxShields &&
+          !vehicle.History.exists(VehicleControl.LastShieldChargeOrDamage(now))
+        ) {
+          vehicle.History(VehicleShieldCharge(VehicleSource(vehicle), amount))
+          vehicle.Shields = vehicle.Shields + amount
+          vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
+            s"${vehicle.Actor}",
+            VehicleAction.PlanetsideAttribute(PlanetSideGUID(0), vehicle.GUID, 68, vehicle.Shields)
+          )
+        }
 
-        case Vehicle.UpdateZoneInteractionProgressUI(player) =>
-          updateZoneInteractionProgressUI(player)
+      case Vehicle.UpdateZoneInteractionProgressUI(player) =>
+        updateZoneInteractionProgressUI(player)
 
-        case FactionAffinity.ConvertFactionAffinity(faction) =>
-          val originalAffinity = vehicle.Faction
-          if (originalAffinity != (vehicle.Faction = faction)) {
-            vehicle.Utilities.foreach({
-              case (_ : Int, util : Utility) => util().Actor forward FactionAffinity.ConfirmFactionAffinity()
-            })
-          }
-          sender() ! FactionAffinity.AssertFactionAffinity(vehicle, faction)
+      case FactionAffinity.ConvertFactionAffinity(faction) =>
+        val originalAffinity = vehicle.Faction
+        if (originalAffinity != (vehicle.Faction = faction)) {
+          vehicle.Utilities.foreach({
+            case (_ : Int, util : Utility) => util().Actor forward FactionAffinity.ConfirmFactionAffinity()
+          })
+        }
+        sender() ! FactionAffinity.AssertFactionAffinity(vehicle, faction)
 
-        case CommonMessages.Use(player, Some(item : SimpleItem))
-          if item.Definition == GlobalDefinitions.remote_electronics_kit =>
-          //TODO setup certifications check
-          if (vehicle.Faction != player.Faction) {
-            sender() ! CommonMessages.Progress(
-              GenericHackables.GetHackSpeed(player, vehicle),
-              Vehicles.FinishHackingVehicle(vehicle, player, 3212836864L),
-              GenericHackables.HackingTickAction(progressType = 1, player, vehicle, item.GUID)
-            )
-          }
+      case CommonMessages.Use(player, Some(item : SimpleItem))
+        if item.Definition == GlobalDefinitions.remote_electronics_kit =>
+        //TODO setup certifications check
+        if (vehicle.Faction != player.Faction) {
+          sender() ! CommonMessages.Progress(
+            GenericHackables.GetHackSpeed(player, vehicle),
+            Vehicles.FinishHackingVehicle(vehicle, player, 3212836864L),
+            GenericHackables.HackingTickAction(progressType = 1, player, vehicle, item.GUID)
+          )
+        }
 
-        case Terminal.TerminalMessage(player, msg, reply) =>
-          reply match {
-            case Terminal.VehicleLoadout(definition, weapons, inventory) =>
-              org.log4s
-                .getLogger(vehicle.Definition.Name)
-                .info(s"changing vehicle equipment loadout to ${player.Name}'s option #${msg.unk1 + 1}")
-              //remove old inventory
-              val oldInventory = vehicle.Inventory.Clear().map { case InventoryItem(obj, _) => (obj, obj.GUID) }
-              //"dropped" items are lost; if it doesn't go in the trunk, it vanishes into the nanite cloud
-              val (_, afterInventory) = inventory.partition(ContainableBehavior.DropPredicate(player))
-              val (oldWeapons, newWeapons, finalInventory) = if (vehicle.Definition == definition) {
-                //vehicles are the same type
-                //TODO want to completely swap weapons, but holster icon vanishes temporarily after swap
-                //TODO BFR arms must be swapped properly
-                //              //remove old weapons
-                //              val oldWeapons = vehicle.Weapons.values.collect { case slot if slot.Equipment.nonEmpty =>
-                //                val obj = slot.Equipment.get
-                //                slot.Equipment = None
-                //                (obj, obj.GUID)
-                //              }.toList
-                //              (oldWeapons, weapons, afterInventory)
-                //TODO for now, just refill ammo; assume weapons stay the same
-                vehicle.Weapons
-                  .collect { case (_, slot : EquipmentSlot) if slot.Equipment.nonEmpty => slot.Equipment.get }
-                  .collect {
-                    case weapon : Tool =>
-                      weapon.AmmoSlots.foreach { ammo => ammo.Box.Capacity = ammo.Box.Definition.Capacity }
-                  }
-                (Nil, Nil, afterInventory)
+      case Terminal.TerminalMessage(player, msg, reply) =>
+        reply match {
+          case Terminal.VehicleLoadout(definition, weapons, inventory) =>
+            org.log4s
+              .getLogger(vehicle.Definition.Name)
+              .info(s"changing vehicle equipment loadout to ${player.Name}'s option #${msg.unk1 + 1}")
+            //remove old inventory
+            val oldInventory = vehicle.Inventory.Clear().map { case InventoryItem(obj, _) => (obj, obj.GUID) }
+            //"dropped" items are lost; if it doesn't go in the trunk, it vanishes into the nanite cloud
+            val (_, afterInventory) = inventory.partition(ContainableBehavior.DropPredicate(player))
+            val (oldWeapons, newWeapons, finalInventory) = if (vehicle.Definition == definition) {
+              //vehicles are the same type
+              //TODO want to completely swap weapons, but holster icon vanishes temporarily after swap
+              //TODO BFR arms must be swapped properly
+              //              //remove old weapons
+              //              val oldWeapons = vehicle.Weapons.values.collect { case slot if slot.Equipment.nonEmpty =>
+              //                val obj = slot.Equipment.get
+              //                slot.Equipment = None
+              //                (obj, obj.GUID)
+              //              }.toList
+              //              (oldWeapons, weapons, afterInventory)
+              //TODO for now, just refill ammo; assume weapons stay the same
+              vehicle.Weapons
+                .collect { case (_, slot : EquipmentSlot) if slot.Equipment.nonEmpty => slot.Equipment.get }
+                .collect {
+                  case weapon : Tool =>
+                    weapon.AmmoSlots.foreach { ammo => ammo.Box.Capacity = ammo.Box.Definition.Capacity }
+                }
+              (Nil, Nil, afterInventory)
+            }
+            else {
+              //vehicle loadout is not for this vehicle
+              //do not transfer over weapon ammo
+              if (
+                vehicle.Definition.TrunkSize == definition.TrunkSize && vehicle.Definition.TrunkOffset == definition.TrunkOffset
+              ) {
+                (Nil, Nil, afterInventory) //trunk is the same dimensions, however
               }
               else {
-                //vehicle loadout is not for this vehicle
-                //do not transfer over weapon ammo
-                if (
-                  vehicle.Definition.TrunkSize == definition.TrunkSize && vehicle.Definition.TrunkOffset == definition.TrunkOffset
-                ) {
-                  (Nil, Nil, afterInventory) //trunk is the same dimensions, however
-                }
-                else {
-                  //accommodate as much of inventory as possible
-                  val (stow, _) = GridInventory.recoverInventory(afterInventory, vehicle.Inventory)
-                  (Nil, Nil, stow)
-                }
+                //accommodate as much of inventory as possible
+                val (stow, _) = GridInventory.recoverInventory(afterInventory, vehicle.Inventory)
+                (Nil, Nil, stow)
               }
-              finalInventory.foreach {
-                _.obj.Faction = vehicle.Faction
-              }
-              player.Zone.VehicleEvents ! VehicleServiceMessage(
-                player.Zone.id,
-                VehicleAction.ChangeLoadout(vehicle.GUID, oldWeapons, newWeapons, oldInventory, finalInventory)
-              )
-              player.Zone.AvatarEvents ! AvatarServiceMessage(
-                player.Name,
-                AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, true)
-              )
+            }
+            finalInventory.foreach {
+              _.obj.Faction = vehicle.Faction
+            }
+            player.Zone.VehicleEvents ! VehicleServiceMessage(
+              player.Zone.id,
+              VehicleAction.ChangeLoadout(vehicle.GUID, oldWeapons, newWeapons, oldInventory, finalInventory)
+            )
+            player.Zone.AvatarEvents ! AvatarServiceMessage(
+              player.Name,
+              AvatarAction.TerminalOrderResult(msg.terminal_guid, msg.transaction_type, true)
+            )
 
-            case _ => ;
-          }
+          case _ => ;
+        }
 
-        case VehicleControl.Disable() =>
-          PrepareForDisabled(kickPassengers = false)
-          context.become(Disabled)
+      case VehicleControl.Disable() =>
+        PrepareForDisabled(kickPassengers = false)
+        context.become(Disabled)
 
-        case Vehicle.Deconstruct(time) =>
-          time match {
-            case Some(delay) if vehicle.Definition.undergoesDecay =>
-              decaying = true
-              decayTimer.cancel()
-              decayTimer = context.system.scheduler.scheduleOnce(delay, self, VehicleControl.PrepareForDeletion())
-            case _ =>
-              PrepareForDisabled(kickPassengers = true)
-              PrepareForDeletion()
-              context.become(ReadyToDelete)
-          }
+      case Vehicle.Deconstruct(time) =>
+        time match {
+          case Some(delay) if vehicle.Definition.undergoesDecay =>
+            decaying = true
+            decayTimer.cancel()
+            decayTimer = context.system.scheduler.scheduleOnce(delay, self, VehicleControl.PrepareForDeletion())
+          case _ =>
+            PrepareForDisabled(kickPassengers = true)
+            PrepareForDeletion()
+            context.become(ReadyToDelete)
+        }
 
-        case VehicleControl.PrepareForDeletion() =>
-          PrepareForDisabled(kickPassengers = true)
-          PrepareForDeletion()
-          context.become(ReadyToDelete)
+      case VehicleControl.PrepareForDeletion() =>
+        PrepareForDisabled(kickPassengers = true)
+        PrepareForDeletion()
+        context.become(ReadyToDelete)
 
-        case VehicleControl.AssignOwnership(player) =>
-          vehicle.AssignOwnership(player)
+      case VehicleControl.AssignOwnership(player) =>
+        vehicle.AssignOwnership(player)
+    }
 
+  final def Enabled: Receive =
+    commonEnabledBehavior
+      .orElse {
         case _ => ;
       }
 
-  def Disabled : Receive =
-    checkBehavior
-      .orElse {
-        case msg : Deployment.TryUndeploy =>
-          deployBehavior.apply(msg)
+  def commonDisabledBehavior: Receive = checkBehavior
+    .orElse {
+      case msg @ Mountable.TryDismount(_, seat_num) =>
+        dismountBehavior.apply(msg)
+        dismountCleanup(seat_num)
 
-        case msg @ Mountable.TryDismount(_, seat_num) =>
-          dismountBehavior.apply(msg)
-          dismountCleanup(seat_num)
+      case Vehicle.Deconstruct(time) =>
+        time match {
+          case Some(delay) if vehicle.Definition.undergoesDecay =>
+            decaying = true
+            decayTimer.cancel()
+            decayTimer = context.system.scheduler.scheduleOnce(delay, self, VehicleControl.PrepareForDeletion())
+          case _ =>
+            PrepareForDeletion()
+            context.become(ReadyToDelete)
+        }
 
-        case Vehicle.Deconstruct(time) =>
-          time match {
-            case Some(delay) if vehicle.Definition.undergoesDecay =>
-              decaying = true
-              decayTimer.cancel()
-              decayTimer = context.system.scheduler.scheduleOnce(delay, self, VehicleControl.PrepareForDeletion())
-            case _ =>
-              PrepareForDeletion()
-              context.become(ReadyToDelete)
-          }
+      case VehicleControl.PrepareForDeletion() =>
+        PrepareForDeletion()
+        context.become(ReadyToDelete)
+    }
 
-        case VehicleControl.PrepareForDeletion() =>
-          PrepareForDeletion()
-          context.become(ReadyToDelete)
+  final def Disabled: Receive = commonDisabledBehavior
+    .orElse {
+      case _ => ;
+    }
 
-        case _ =>
-      }
+  def commonDeleteBehavior: Receive = checkBehavior
+    .orElse {
+      case VehicleControl.Deletion() =>
+        val zone = vehicle.Zone
+        zone.VehicleEvents ! VehicleServiceMessage(
+          zone.id,
+          VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, vehicle, vehicle.GUID)
+        )
+        zone.Transport.tell(Zone.Vehicle.Despawn(vehicle), zone.Transport)
+    }
 
-  def ReadyToDelete : Receive =
-    checkBehavior
-      .orElse {
-        case msg : Deployment.TryUndeploy =>
-          deployBehavior.apply(msg)
-
-        case VehicleControl.Deletion() =>
-          val zone = vehicle.Zone
-          zone.VehicleEvents ! VehicleServiceMessage(
-            zone.id,
-            VehicleAction.UnloadVehicle(Service.defaultPlayerGUID, vehicle, vehicle.GUID)
-          )
-          zone.Transport.tell(Zone.Vehicle.Despawn(vehicle), zone.Transport)
-
-        case _ =>
-      }
+  final def ReadyToDelete: Receive = commonDeleteBehavior
+    .orElse {
+      case _ => ;
+    }
 
   override protected def mountTest(
                                     obj: PlanetSideServerObject with Mountable,
@@ -387,7 +369,6 @@ class VehicleControl(vehicle: Vehicle)
     val events = zone.VehicleEvents
     //miscellaneous changes
     recoverFromEnvironmentInteracting()
-    Vehicles.BeforeUnloadVehicle(vehicle, zone)
     //escape being someone else's cargo
     vehicle.MountedIn match {
       case Some(_) =>
@@ -417,28 +398,11 @@ class VehicleControl(vehicle: Vehicle)
         }
       }
     }
-    //abandon all cargo
-    vehicle.CargoHolds.values
-      .collect {
-        case hold if hold.isOccupied =>
-          val cargo = hold.occupant.get
-          CargoBehavior.HandleVehicleCargoDismount(
-            cargo.GUID,
-            cargo,
-            guid,
-            vehicle,
-            bailed = false,
-            requestedByPassenger = false,
-            kicked = false
-          )
-      }
-    }
+  }
 
   def PrepareForDeletion() : Unit = {
     decaying = false
     val zone = vehicle.Zone
-    //miscellaneous changes
-    Vehicles.BeforeUnloadVehicle(vehicle, zone)
     //cancel jammed behavior
     CancelJammeredSound(vehicle)
     CancelJammeredStatus(vehicle)
@@ -555,119 +519,6 @@ class VehicleControl(vehicle: Vehicle)
       toChannel,
       VehicleAction.ObjectDelete(item.GUID)
     )
-  }
-
-  override def TryDeploymentChange(obj: Deployment.DeploymentObject, state: DriveState.Value): Boolean = {
-    VehicleControl.DeploymentAngleCheck(obj) && super.TryDeploymentChange(obj, state)
-  }
-
-  override def DeploymentAction(
-      obj: DeploymentObject,
-      state: DriveState.Value,
-      prevState: DriveState.Value
-  ): DriveState.Value = {
-    val out = super.DeploymentAction(obj, state, prevState)
-    obj match {
-      case vehicle: Vehicle =>
-        val guid        = vehicle.GUID
-        val zone        = vehicle.Zone
-        val zoneChannel = zone.id
-        val GUID0       = Service.defaultPlayerGUID
-        val driverChannel = vehicle.Seats(0).occupant match {
-          case Some(tplayer) => tplayer.Name
-          case None          => ""
-        }
-        Vehicles.ReloadAccessPermissions(vehicle, vehicle.Faction.toString)
-        //ams
-        if (vehicle.Definition == GlobalDefinitions.ams) {
-          val events = zone.VehicleEvents
-          state match {
-            case DriveState.Deployed =>
-              events ! VehicleServiceMessage.AMSDeploymentChange(zone)
-              events ! VehicleServiceMessage(driverChannel, VehicleAction.PlanetsideAttribute(GUID0, guid, 81, 1))
-            case _ => ;
-          }
-        }
-        //ant
-        else if (vehicle.Definition == GlobalDefinitions.ant) {
-          state match {
-            case DriveState.Deployed =>
-              // Start ntu regeneration
-              // If vehicle sends UseItemMessage with silo as target NTU regeneration will be disabled and orb particles will be disabled
-              context.system.scheduler.scheduleOnce(
-                delay = 1000 milliseconds,
-                vehicle.Actor,
-                TransferBehavior.Charging(Ntu.Nanites)
-              )
-            case _ => ;
-          }
-        }
-        //router
-        else if (vehicle.Definition == GlobalDefinitions.router) {
-          val events = zone.LocalEvents
-          state match {
-            case DriveState.Deploying =>
-              vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
-                case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Activate(util)
-                case _ => ;
-              }
-            case _ => ;
-          }
-        }
-      case _ => ;
-    }
-    out
-  }
-
-  override def UndeploymentAction(
-      obj: DeploymentObject,
-      state: DriveState.Value,
-      prevState: DriveState.Value
-  ): DriveState.Value = {
-    val out = if (decaying) state else super.UndeploymentAction(obj, state, prevState)
-    obj match {
-      case vehicle: Vehicle =>
-        val guid  = vehicle.GUID
-        val zone  = vehicle.Zone
-        val GUID0 = Service.defaultPlayerGUID
-        val driverChannel = vehicle.Seats(0).occupant match {
-          case Some(tplayer) => tplayer.Name
-          case None          => ""
-        }
-        Vehicles.ReloadAccessPermissions(vehicle, vehicle.Faction.toString)
-        //ams
-        if (vehicle.Definition == GlobalDefinitions.ams) {
-          val events = zone.VehicleEvents
-          state match {
-            case DriveState.Undeploying =>
-              events ! VehicleServiceMessage.AMSDeploymentChange(zone)
-              events ! VehicleServiceMessage(driverChannel, VehicleAction.PlanetsideAttribute(GUID0, guid, 81, 0))
-            case _ => ;
-          }
-        }
-        //ant
-        else if (vehicle.Definition == GlobalDefinitions.ant) {
-          state match {
-            case DriveState.Undeploying =>
-              TryStopChargingEvent(vehicle)
-            case _ => ;
-          }
-        }
-        //router
-        else if (vehicle.Definition == GlobalDefinitions.router) {
-          state match {
-            case DriveState.Undeploying =>
-              //deactivate internal router before trying to reset the system
-              vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
-                case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Deactivate(util)
-                case _ => ;
-              }
-            case _ => ;
-          }
-        }
-      case _ => ;
-    }
-    out
   }
 
   /**
@@ -894,9 +745,5 @@ object VehicleControl {
       case vsc: VehicleShieldCharge   => now - vsc.time < (1 seconds).toMillis      //previous charge delays next by 1s
       case _                          => false
     }
-  }
-
-  def DeploymentAngleCheck(obj: Deployment.DeploymentObject): Boolean = {
-    obj.Orientation.x <= 30 || obj.Orientation.x >= 330
   }
 }

--- a/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/PlanetsideAttributeMessage.scala
@@ -145,7 +145,7 @@ import scodec.codecs._
   * `45 - NTU charge bar 0-10, 5 = 50% full. Seems to apply to both ANT and NTU Silo (possibly siphons?)`<br>
   * `46 - Sends "Generator damage is at a critical level!" message`
   * `47 - Sets base NTU level to CRITICAL.`<br>
-  * `48 - Set to 1 to send base power loss message & turns on red warning lights throughout base.<br>
+  * `48 - Set to 1 to send base power loss message & turns on red warning lights throughout base.`<br>
   * `49 - Vehicle texture effects state? (>0 turns on ANT panel glow or ntu silo panel glow + orbs) (bit?)`<br>
   * `52 - Vehicle particle effects? (>0 turns on orbs going towards ANT. Doesn't affect silo) (bit?)`<br>
   * `53 - LFS. Value is 1 to flag LFS`<br>
@@ -191,6 +191,7 @@ import scodec.codecs._
   * `21 - Declare a player the vehicle's owner, by globally unique identifier`<br>
   * `22 - Toggles gunner and passenger mount points (1 = hides, 0 = reveals; this also locks their permissions)`<br>
   * `54 - Plays jammed buzzing sound in vicinity of target`<br>
+  * `55 - Trigger APC EMP`<br>
   * `68 - Vehicle shield health`<br>
   * `79 - ???`<br>
   * `80 - Damage vehicle (unknown value)`<br>

--- a/src/test/scala/objects/RepairableTest.scala
+++ b/src/test/scala/objects/RepairableTest.scala
@@ -13,7 +13,7 @@ import net.psforever.objects.serverobject.generator.{Generator, GeneratorControl
 import net.psforever.objects.serverobject.structures.{Building, StructureType}
 import net.psforever.objects.serverobject.terminals.{Terminal, TerminalControl}
 import net.psforever.objects.serverobject.turret.{FacilityTurret, FacilityTurretControl}
-import net.psforever.objects.vehicles.VehicleControl
+import net.psforever.objects.vehicles.control.VehicleControl
 import net.psforever.objects.zones.{Zone, ZoneMap}
 import net.psforever.packet.game.{InventoryStateMessage, RepairMessage}
 import net.psforever.types._

--- a/src/test/scala/service/LocalServiceTest.scala
+++ b/src/test/scala/service/LocalServiceTest.scala
@@ -7,7 +7,7 @@ import base.{ActorTest, FreedContextActorTest}
 import net.psforever.objects.{GlobalDefinitions, SensorDeployable, Vehicle}
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.terminals.{ProximityTerminal, Terminal}
-import net.psforever.objects.vehicles.VehicleControl
+import net.psforever.objects.vehicles.control.VehicleControl
 import net.psforever.objects.zones.{Zone, ZoneMap}
 import net.psforever.packet.game._
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}

--- a/src/test/scala/service/VehicleServiceTest.scala
+++ b/src/test/scala/service/VehicleServiceTest.scala
@@ -4,7 +4,7 @@ package service
 import akka.actor.Props
 import base.ActorTest
 import net.psforever.objects._
-import net.psforever.objects.vehicles.VehicleControl
+import net.psforever.objects.vehicles.control.VehicleControl
 import net.psforever.objects.zones.Zone
 import net.psforever.types.{PlanetSideGUID, _}
 import net.psforever.services.{Service, ServiceManager}


### PR DESCRIPTION
All vehicles now initialize a control agency that is better tailored to the specific operation of that said vehicle.  That said, most vehicles still use the generic agency and the specialized ones are only special because of that one degree of difference that makes the vehicle unique.  As there were (should be) next to no changes for any vehicles that were already functional, this effect emphasizes how many duties the default control agency performs.

This all seems underwhelming right now but it will become much more important when working with battleframe robotics (I hope).

___Features___
__`AmsControl`__, __`AntControl`__, __`RouterControl`__
The specialized control agencies for the advanced mobile spawn, the advanced nanite transport, and the Router, respectively.

__`DeployingVehicleControl`__
Asides from being a parent class of the former three specialized control agencies, the specialized control agency for the Switchblade and the Flail.

__`CargoCarrierVehicle`__
The specialized control agency for the Galaxy and for the Lodestar.

__`ApcControl`__
The specialized control agency for the armored personnel carrier vehicles - the Juggernaut, the Vindicator, and the Leviathan.  Possesses a charging capacitor that, when filled, allows the driver to cause the vehicle to emit a 15m electromagnetic pulse.

___Caveats___
1. ~~The electromagnetic pulse of the APC's is purely a radial calaculation.  It will pass through both walls and floors.  The dome calculation for explosives does exist but contains a slight mistake that would make it not work as well as expected for game entities as massive as the APC's.  The calculation oversight will be fixed in a different PR.  For now, just~~ humble yourself in the realization that letting enemy vehicles cavort about the courtyard and the perimeter of your facility is a poor idea anyway.
2. Charging time for the APC capacitor is based on numbers found in the ADB, which seem to coincide with approximate timestamps and other numbers found in the first time event captures for the APC's.  Arguments for changing the charge interval will be accepted but must be accompanied by disputing video evidence.