### PR TITLE
Implant: Melee Boost

### DIFF
--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -864,8 +864,11 @@ class AvatarActor(
           Behaviors.same
 
         case ConsumeStamina(stamina) =>
-          assert(stamina > 0, s"consumed stamina must be larger than 0, but is: $stamina")
-          consumeStamina(stamina)
+          if (stamina > 0) {
+            consumeStamina(stamina)
+          } else {
+            log.warn(s"consumed stamina must be larger than 0, but is: $stamina")
+          }
           Behaviors.same
 
         case SuspendStaminaRegeneration(duration) =>

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2415,7 +2415,7 @@ object GlobalDefinitions {
     chainblade_projectile.InitialVelocity = 100
     chainblade_projectile.Lifespan = .02f
     ProjectileDefinition.CalculateDerivedFields(chainblade_projectile)
-    chainblade_projectile.Modifiers = MaxDistanceCutoff
+    chainblade_projectile.Modifiers = List(MeleeBoosted, MaxDistanceCutoff)
 
     colossus_100mm_projectile.Name = "colossus_100mm_projectile"
     colossus_100mm_projectile.Damage0 = 58
@@ -2766,7 +2766,7 @@ object GlobalDefinitions {
     forceblade_projectile.InitialVelocity = 100
     forceblade_projectile.Lifespan = .02f
     ProjectileDefinition.CalculateDerivedFields(forceblade_projectile)
-    forceblade_projectile.Modifiers = MaxDistanceCutoff
+    forceblade_projectile.Modifiers = List(MeleeBoosted, MaxDistanceCutoff)
 
     frag_cartridge_projectile.Name = "frag_cartridge_projectile"
     // TODO for later, maybe : set_resource_parent frag_cartridge_projectile game_objects frag_grenade_projectile
@@ -3243,7 +3243,7 @@ object GlobalDefinitions {
     magcutter_projectile.InitialVelocity = 100
     magcutter_projectile.Lifespan = .02f
     ProjectileDefinition.CalculateDerivedFields(magcutter_projectile)
-    magcutter_projectile.Modifiers = MaxDistanceCutoff
+    magcutter_projectile.Modifiers = List(MeleeBoosted, MaxDistanceCutoff)
 
     melee_ammo_projectile.Name = "melee_ammo_projectile"
     melee_ammo_projectile.Damage0 = 25
@@ -3252,7 +3252,7 @@ object GlobalDefinitions {
     melee_ammo_projectile.InitialVelocity = 100
     melee_ammo_projectile.Lifespan = .02f
     ProjectileDefinition.CalculateDerivedFields(melee_ammo_projectile)
-    melee_ammo_projectile.Modifiers = MaxDistanceCutoff
+    melee_ammo_projectile.Modifiers = List(MeleeBoosted, MaxDistanceCutoff)
 
     meteor_common.Name = "meteor_common"
     meteor_common.DamageAtEdge = .1f

--- a/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
+++ b/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
@@ -293,6 +293,19 @@ case object FlakBurst extends ProjectileDamageModifiers.Mod {
   }
 }
 
+/**
+  * If the damage is resolved by way of a melee weapon,
+  * the damage might be increased if the attack was initiated
+  * while the attacker was under the effect of an active Melee Boost implant.
+  * @see `GlobalDefinitions.melee_booster`
+  * @see `ProjectileQuality`
+  */
+case object MeleeBoosted extends ProjectileDamageModifiers.Mod {
+  override def calculate(damage: Int, data: DamageInteraction, cause: ProjectileReason): Int = {
+    cause.projectile.quality.mod.toInt + damage
+  }
+}
+
 /* Functions */
 object ProjectileDamageModifierFunctions {
   /**


### PR DESCRIPTION
Melee boost actually makes a bit of sense.  You get a little more tired as you swing the knife harder.

Melee boosted attacks are guarded to work only if the player has the minimum amount of stamina to drain - 10.  You can not drain <10 stamina to get a stronger slash.  Perhaps the booster should also avoid activating if that one swing would drain stamina to 0, or is that supposed to be possible?