### PR TITLE
Simple Regex Filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,7 @@ lazy val psforeverSettings = Seq(
     "io.circe"                   %% "circe-generic"              % "0.14.1",
     "io.circe"                   %% "circe-parser"               % "0.14.1",
     "org.scala-lang.modules"     %% "scala-parallel-collections" % "1.0.3",
-    "org.bouncycastle"            % "bcprov-jdk15on"             % "1.69",
-    "org.codehaus.janino"         % "janino"                     % "3.1.4"
+    "org.bouncycastle"            % "bcprov-jdk15on"             % "1.69"
   ),
   // TODO(chord): remove exclusion when SessionActor is refactored: https://github.com/psforever/PSF-LoginServer/issues/279
   coverageExcludedPackages := "net\\.psforever\\.actors\\.session\\.SessionActor.*"

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -20,17 +20,9 @@
     <encoder>
       <pattern>%date{ISO8601} %5level %logger{35} - %msg%n</pattern>
     </encoder>
-    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-      <evaluator>
-        <matcher>
-          <Name>encrypted</Name>
-          <!-- occurs during latency or relogging complications; the messages are useless -->
-          <regex>Unexpected packet type EncryptedPacket</regex>
-        </matcher>
-        <expression>encrypted.matches(formattedMessage)</expression>
-      </evaluator>
-      <OnMatch>DENY</OnMatch>
-      <OnMismatch>NEUTRAL</OnMismatch>
+    <filter class="net.psforever.filter.MsgRegexFilter">
+      <!-- occurs during latency or relogging complications; the messages are useless -->
+      <regex>Unexpected packet type EncryptedPacket</regex>
     </filter>
     <filter class="net.psforever.filters.LoggerPrefixFilter">
       <!--
@@ -103,17 +95,9 @@
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>
     </filter>
-    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-      <evaluator>
-        <matcher>
-          <Name>encrypted</Name>
-          <!-- occurs during logging or relogging complications; the messages are useless -->
-          <regex>Unexpected packet type EncryptedPacket</regex>
-        </matcher>
-        <expression>encrypted.matches(formattedMessage)</expression>
-      </evaluator>
-      <OnMatch>DENY</OnMatch>
-      <OnMismatch>NEUTRAL</OnMismatch>
+    <filter class="net.psforever.filters.MsgRegexFilter">
+      <!-- occurs during logging or relogging complications; the messages are useless -->
+      <regex>Unexpected packet type EncryptedPacket</regex>
     </filter>
   </appender>
 

--- a/server/src/main/java/net/psforever/filters/MsgRegexFilter.java
+++ b/server/src/main/java/net/psforever/filters/MsgRegexFilter.java
@@ -1,0 +1,29 @@
+package net.psforever.filters;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Disrupts a variety of messages that, when formatted, match against the configured regular expression.
+ * A replacement for the `EvaluatorFilter`.
+ */
+public class MsgRegexFilter extends Filter<ILoggingEvent> {
+    private String regex;
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (isStarted() && event.getFormattedMessage().matches(regex)) {
+            return FilterReply.DENY;
+        } else {
+            return FilterReply.NEUTRAL;
+        }
+    }
+
+    @Override
+    public void start() {
+        if (this.regex != null) {
+            super.start();
+        }
+    }
+}


### PR DESCRIPTION
Replaces `EvaluatorFilter` using a patternized `<matcher>` and interpreted `matches` instructions with a a filter that uses an explicit `matches` call.  The dependency requirement is a very minor (but obsessive) beef remaining from the previous logging update.