### PR TITLE
No Kit Spam

### DIFF
--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -745,9 +745,10 @@ class AvatarActor(
 
         case UpdateUseTime(definition, time) =>
           if (!Avatar.useCooldowns.contains(definition)) {
-            log.warn(s"UpdateUseTime message for item '${definition.Name}' without cooldown")
+            log.warn(s"${avatar.name} is updating a use time for item '${definition.Name}' thta has no cooldown")
           }
           avatar = avatar.copy(useTimes = avatar.useTimes.updated(definition.Name, time))
+          sessionActor ! SessionActor.UseCooldownRenewed(definition, time)
           Behaviors.same
 
         case RefreshPurchaseTimes() =>

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -745,7 +745,7 @@ class AvatarActor(
 
         case UpdateUseTime(definition, time) =>
           if (!Avatar.useCooldowns.contains(definition)) {
-            log.warn(s"${avatar.name} is updating a use time for item '${definition.Name}' thta has no cooldown")
+            log.warn(s"${avatar.name} is updating a use time for item '${definition.Name}' that has no cooldown")
           }
           avatar = avatar.copy(useTimes = avatar.useTimes.updated(definition.Name, time))
           sessionActor ! SessionActor.UseCooldownRenewed(definition, time)


### PR DESCRIPTION
Slower resolution of an explicit cooldown block reset, eliminating an uncommon instance of multiple kit uses before the cooldown is registered by the client.