### PR TITLE
The Flail

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -5184,6 +5184,17 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
               case Some(hitInfo) =>
                 val hitPos     = hitInfo.hit_pos
                 ValidObject(hitInfo.hitobject_guid) match {
+                  case _ if projectile.profile == GlobalDefinitions.flail_projectile =>
+                    val radius  = projectile.profile.DamageRadius * projectile.profile.DamageRadius
+                    val targets = Zone.findAllTargets(hitPos)(continent, player, projectile.profile)
+                      .filter { target =>
+                        Vector3.DistanceSquared(target.Position, hitPos) <= radius
+                      }
+                    targets.map { target =>
+                      CheckForHitPositionDiscrepancy(projectile_guid, hitPos, target)
+                      (target, hitPos, target.Position)
+                    }
+
                   case Some(target: PlanetSideGameObject with FactionAffinity with Vitality) =>
                     CheckForHitPositionDiscrepancy(projectile_guid, hitPos, target)
                     List((target, hitInfo.shot_origin, hitPos))
@@ -5217,17 +5228,6 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
                       }
                     } else {
                       Nil
-                    }
-
-                  case None if projectile.profile == GlobalDefinitions.flail_projectile =>
-                    val radius  = projectile.profile.DamageRadius * projectile.profile.DamageRadius
-                    val targets = Zone.findAllTargets(hitPos)(continent, player, projectile.profile)
-                      .filter { target =>
-                        Vector3.DistanceSquared(target.Position, hitPos) <= radius
-                      }
-                    targets.map { target =>
-                      CheckForHitPositionDiscrepancy(projectile_guid, hitPos, target)
-                      (target, hitPos, target.Position)
                     }
 
                   case _ =>

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -4752,6 +4752,14 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
                     player,
                     ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "router_telepad", 0, PlanetSideGUID(0))
                   )
+                } else if (tdef == GlobalDefinitions.targeting_laser_dispenser) {
+                  //explicit request
+                  log.info(s"${player.Name} is purchasing a targeting laser")
+                  CancelZoningProcessWithDescriptiveReason("cancel_use")
+                  terminal.Actor ! Terminal.Request(
+                    player,
+                    ItemTransactionMessage(object_guid, TransactionType.Buy, 0, "flail_targeting_laser", 0, PlanetSideGUID(0))
+                  )
                 } else {
                   log.info(s"${player.Name} is accessing a ${terminal.Definition.Name}")
                   CancelZoningProcessWithDescriptiveReason("cancel_use")

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -4913,10 +4913,10 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         continent.GUID(object_guid) match {
           case Some(obj: Terminal with ProximityUnit) =>
             HandleProximityTerminalUse(obj)
-          case Some(obj) => ;
+          case Some(obj) =>
             log.warn(s"ProximityTerminalUse: $obj does not have proximity effects for ${player.Name}")
           case None =>
-            log.error(s"ProximityTerminalUse: ${player.Name} can not find an oject with guid $object_guid")
+            log.error(s"ProximityTerminalUse: ${player.Name} can not find an object with guid $object_guid")
         }
 
       case msg @ UnuseItemMessage(player_guid, object_guid) =>

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3982,6 +3982,9 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
             log.warn(s"ProjectileState: constructed projectile ${projectile_guid.guid} can not be found")
         }
 
+      case msg @ LongRangeProjectileInfoMessage(guid, pos, vel) =>
+        log.info(s"$msg")
+
       case msg @ ReleaseAvatarRequestMessage() =>
         log.info(s"${player.Name} on ${continent.id} has released")
         reviveTimer.cancel()

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2657,7 +2657,10 @@ object GlobalDefinitions {
     flail_projectile.InitialVelocity = 75
     flail_projectile.Lifespan = 40f
     ProjectileDefinition.CalculateDerivedFields(flail_projectile)
-    //TODO flail_projectile.Modifiers = RadialDegrade?
+    flail_projectile.Modifiers = List(
+      FlailDistanceDamageBoost,
+      RadialDegrade
+    )
 
     flamethrower_fireball.Name = "flamethrower_fireball"
     flamethrower_fireball.Damage0 = 30
@@ -6586,8 +6589,8 @@ object GlobalDefinitions {
     flail.TrunkOffset = 30
     flail.TrunkLocation = Vector3(-3.75f, 0f, 0f)
     flail.Deployment = true
-    flail.DeployTime = 5750
-    flail.UndeployTime = 5750
+    flail.DeployTime = 5500
+    flail.UndeployTime = 5500
     flail.AutoPilotSpeeds = (14, 6)
     flail.Packet = variantConverter
     flail.DestroyedModel = Some(DestroyedVehicle.Flail)

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1046,6 +1046,8 @@ object GlobalDefinitions {
 
   val repair_silo = new MedicalTerminalDefinition(729)
 
+  val recharge_terminal = new MedicalTerminalDefinition(724)
+
   val mb_pad_creation = new VehicleSpawnPadDefinition(525)
 
   val dropship_pad_doors = new VehicleSpawnPadDefinition(261)
@@ -1583,6 +1585,18 @@ object GlobalDefinitions {
     edef match {
       case `spiker` | `maelstrom` | `radiator` | `ancient_ammo_combo` | `maelstrom_ammo` => true
       case _                                                                             => false
+    }
+  }
+
+  /**
+    * Using the definition for a `Vehicle` determine whether it is a "cavern Vehicle."
+    * @param vdef the `VehicleDefinition` of the item
+    * @return `true`, if it is; otherwise, `false`
+    */
+  def isCavernVehicle(vdef: VehicleDefinition): Boolean = {
+    vdef match {
+      case `router` | `switchblade` | `flail` => true
+      case _                                  => false
     }
   }
 
@@ -7759,6 +7773,13 @@ object GlobalDefinitions {
     repair_silo.TargetValidation += EffectTarget.Category.Vehicle -> EffectTarget.Validation.RepairSilo
     repair_silo.Damageable = false
     repair_silo.Repairable = false
+
+    recharge_terminal.Name = "recharge_terminal"
+    recharge_terminal.Interval = 1000
+    recharge_terminal.UseRadius = 20
+    recharge_terminal.TargetValidation += EffectTarget.Category.Vehicle -> EffectTarget.Validation.AncientVehicleWeaponRecharge
+    recharge_terminal.Damageable = false
+    recharge_terminal.Repairable = false
 
     mb_pad_creation.Name = "mb_pad_creation"
     mb_pad_creation.Damageable = false

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -2667,6 +2667,7 @@ object GlobalDefinitions {
     flail_projectile.DamageRadius = 15f
     flail_projectile.ProjectileDamageType = DamageType.Splash
     flail_projectile.DegradeDelay = 1.5f
+    //a DegradeDelay of 1.5s equals a DistanceNoDegrade of 112.5m
     flail_projectile.DegradeMultiplier = 5f
     flail_projectile.InitialVelocity = 75
     flail_projectile.Lifespan = 40f

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1108,6 +1108,8 @@ object GlobalDefinitions {
   val generator = new GeneratorDefinition(351)
 
   val obbasemesh = new AmenityDefinition(598) {}
+
+  val targeting_laser_dispenser = new OrderTerminalDefinition(851)
   initMiscellaneous()
 
   /*
@@ -6578,13 +6580,14 @@ object GlobalDefinitions {
     flail.Seats += 0             -> new SeatDefinition()
     flail.controlledWeapons += 0 -> 1
     flail.Weapons += 1           -> flail_weapon
+    flail.Utilities += 2         -> UtilityType.targeting_laser_dispenser
     flail.MountPoints += 1       -> MountInfo(0)
     flail.TrunkSize = InventoryTile.Tile1511
     flail.TrunkOffset = 30
     flail.TrunkLocation = Vector3(-3.75f, 0f, 0f)
     flail.Deployment = true
-    flail.DeployTime = 2000
-    flail.UndeployTime = 2000
+    flail.DeployTime = 5750
+    flail.UndeployTime = 5750
     flail.AutoPilotSpeeds = (14, 6)
     flail.Packet = variantConverter
     flail.DestroyedModel = Some(DestroyedVehicle.Flail)
@@ -7671,6 +7674,11 @@ object GlobalDefinitions {
     teleportpad_terminal.Tab += 0 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.routerTerminal)
     teleportpad_terminal.Damageable = false
     teleportpad_terminal.Repairable = false
+
+    targeting_laser_dispenser.Name = "targeting_laser_dispenser"
+    targeting_laser_dispenser.Tab += 0 -> OrderTerminalDefinition.EquipmentPage(EquipmentTerminalDefinition.flailTerminal)
+    targeting_laser_dispenser.Damageable = false
+    targeting_laser_dispenser.Repairable = false
 
     medical_terminal.Name = "medical_terminal"
     medical_terminal.Interval = 500

--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -918,9 +918,9 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
     //log message
     cause.adversarial match {
       case Some(a) =>
-        damageLog.info(s"DisplayDestroy: ${a.defender} was killed by ${a.attacker}")
+        damageLog.info(s"${a.defender.Name} was killed by ${a.attacker.Name}")
       case _ =>
-        damageLog.info(s"DisplayDestroy: ${player.Name} killed ${player.Sex.pronounObject}self.")
+        damageLog.info(s"${player.Name} killed ${player.Sex.pronounObject}self")
     }
 
     // This would normally happen async as part of AvatarAction.Killed, but if it doesn't happen before deleting calling AvatarAction.ObjectDelete on the player the LLU will end up invisible to others if carried

--- a/src/main/scala/net/psforever/objects/equipment/EffectTarget.scala
+++ b/src/main/scala/net/psforever/objects/equipment/EffectTarget.scala
@@ -42,7 +42,7 @@ object EffectTarget {
     def RepairSilo(target: PlanetSideGameObject): Boolean =
       target match {
         case v: Vehicle =>
-          !GlobalDefinitions.isFlightVehicle(v.Definition) && v.Health > 0 && v.Health < v.MaxHealth && v.History.exists(x => x.isInstanceOf[DamagingActivity] && x.time >= (System.currentTimeMillis() - 5000000000L))
+          !GlobalDefinitions.isFlightVehicle(v.Definition) && v.Health > 0 && v.Health < v.MaxHealth && v.History.exists(x => x.isInstanceOf[DamagingActivity] && x.time >= (System.currentTimeMillis() - 5000L))
         case _ =>
           false
       }
@@ -51,6 +51,21 @@ object EffectTarget {
       target match {
         case v: Vehicle =>
           GlobalDefinitions.isFlightVehicle(v.Definition) && v.Health > 0 && v.Health < v.MaxHealth && v.History.exists(x => x.isInstanceOf[DamagingActivity] && x.time >= (System.currentTimeMillis() - 5000000000L))
+        case _ =>
+          false
+      }
+
+    def AncientVehicleWeaponRecharge(target: PlanetSideGameObject): Boolean =
+      target match {
+        case v: Vehicle =>
+          GlobalDefinitions.isCavernVehicle(v.Definition) && v.Health > 0 &&
+          v.Weapons.values
+            .map { _.Equipment }
+            .flatMap {
+              case Some(weapon: Tool) => weapon.AmmoSlots
+              case _                  => Nil
+            }
+            .exists { slot => slot.Box.Capacity < slot.Definition.Magazine }
         case _ =>
           false
       }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/EquipmentTerminalDefinition.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/EquipmentTerminalDefinition.scala
@@ -214,6 +214,11 @@ object EquipmentTerminalDefinition {
   val routerTerminal: Map[String, () => Equipment] = Map("router_telepad" -> MakeTelepad(router_telepad))
 
   /**
+    * A single-element `Map` of the one piece of `Equipment` for the Flail.
+    */
+  val flailTerminal: Map[String, () => Equipment] = Map("flail_targeting_laser" -> MakeSimpleItem(flail_targeting_laser))
+
+  /**
     * Create a new `Tool` from provided `EquipmentDefinition` objects.
     *
     * @param tdef the `ToolDefinition` object

--- a/src/main/scala/net/psforever/objects/teamwork/SquadFeatures.scala
+++ b/src/main/scala/net/psforever/objects/teamwork/SquadFeatures.scala
@@ -2,7 +2,7 @@
 package net.psforever.objects.teamwork
 
 import akka.actor.{ActorContext, ActorRef, Props}
-import net.psforever.types.SquadWaypoints
+import net.psforever.types.SquadWaypoint
 import net.psforever.services.teamwork.SquadService.WaypointData
 import net.psforever.services.teamwork.SquadSwitchboard
 
@@ -29,7 +29,9 @@ class SquadFeatures(val Squad: Squad) {
   /**
     * Waypoint data.
     * The first four slots are used for squad waypoints.
-    * The fifth slot is used for the squad leader experience waypoint.<br>
+    * The fifth slot is used for the squad leader experience waypoint.
+    * There is a sixth waypoint used for a target that has been indicated by the laze pointer
+    * but its id indication does not follow the indexes of the previous waypoints.<br>
     * <br>
     * All of the waypoints constantly exist as long as the squad to which they are attached exists.
     * They are merely "activated" and "deactivated."
@@ -75,7 +77,7 @@ class SquadFeatures(val Squad: Squad) {
 
   def Start(implicit context: ActorContext): SquadFeatures = {
     switchboard = context.actorOf(Props[SquadSwitchboard](), s"squad_${Squad.GUID.guid}_${System.currentTimeMillis}")
-    waypoints = Array.fill[WaypointData](SquadWaypoints.values.size)(new WaypointData())
+    waypoints = Array.fill[WaypointData](SquadWaypoint.values.size)(new WaypointData())
     this
   }
 

--- a/src/main/scala/net/psforever/objects/vehicles/Utility.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/Utility.scala
@@ -25,7 +25,8 @@ import net.psforever.types.{PlanetSideGUID, Vector3}
 object UtilityType extends Enumeration {
   type Type = Value
   val ams_respawn_tube, bfr_rearm_terminal, lodestar_repair_terminal, matrix_terminalc, multivehicle_rearm_terminal,
-      order_terminala, order_terminalb, teleportpad_terminal, internal_router_telepad_deployable = Value
+      order_terminala, order_terminalb, targeting_laser_dispenser, teleportpad_terminal,
+      internal_router_telepad_deployable = Value
 }
 
 /**
@@ -126,6 +127,8 @@ object Utility {
         new TerminalUtility(GlobalDefinitions.order_terminala)
       case UtilityType.order_terminalb =>
         new TerminalUtility(GlobalDefinitions.order_terminalb)
+      case UtilityType.targeting_laser_dispenser =>
+        new TerminalUtility(GlobalDefinitions.targeting_laser_dispenser)
       case UtilityType.teleportpad_terminal =>
         new TeleportPadTerminalUtility(GlobalDefinitions.teleportpad_terminal)
       case UtilityType.internal_router_telepad_deployable =>
@@ -249,6 +252,8 @@ object Utility {
       case UtilityType.order_terminala =>
         OrderTerminalDefinition.Setup
       case UtilityType.order_terminalb =>
+        OrderTerminalDefinition.Setup
+      case UtilityType.targeting_laser_dispenser =>
         OrderTerminalDefinition.Setup
       case UtilityType.teleportpad_terminal =>
         OrderTerminalDefinition.Setup

--- a/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
+++ b/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
@@ -306,6 +306,29 @@ case object MeleeBoosted extends ProjectileDamageModifiers.Mod {
   }
 }
 
+/**
+  * If the Flail's projectile exceeds it's distance before degrade in travel distance,
+  * the damage caused by the projectile increases by up to multiple times its base damage at 600m.
+  * It does not inflate for further beyond 600m.
+  */
+case object FlailDistanceDamageBoost extends ProjectileDamageModifiers.Mod {
+  override def calculate(damage: Int, data: DamageInteraction, cause: ProjectileReason): Int = {
+    val projectile = cause.projectile
+    val profile = projectile.profile
+    val distance   = Vector3.Distance(data.hitPos, projectile.shot_origin) //TODO calculate arc distance?
+    val distanceNoDegrade = profile.DistanceNoDegrade
+    val distanceNoMultiplier = 600f - distanceNoDegrade
+    if (distance > profile.DistanceMax) {
+      0
+    } else if (distance >= distanceNoDegrade) {
+      damage + (damage * (profile.DegradeMultiplier - 1) *
+                math.min(distance - distanceNoDegrade, distanceNoMultiplier) / distanceNoMultiplier).toInt
+    } else {
+      damage
+    }
+  }
+}
+
 /* Functions */
 object ProjectileDamageModifierFunctions {
   /**

--- a/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
+++ b/src/main/scala/net/psforever/objects/vital/projectile/ProjectileDamageModifierFunctions.scala
@@ -315,7 +315,7 @@ case object FlailDistanceDamageBoost extends ProjectileDamageModifiers.Mod {
   override def calculate(damage: Int, data: DamageInteraction, cause: ProjectileReason): Int = {
     val projectile = cause.projectile
     val profile = projectile.profile
-    val distance   = Vector3.Distance(data.hitPos, projectile.shot_origin) //TODO calculate arc distance?
+    val distance   = Vector3.Distance(data.hitPos.xy, projectile.shot_origin.xy)
     val distanceNoDegrade = profile.DistanceNoDegrade
     val distanceNoMultiplier = 600f - distanceNoDegrade
     if (distance > profile.DistanceMax) {

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -1215,7 +1215,7 @@ object Zone {
                       source: PlanetSideGameObject with Vitality,
                       damagePropertiesBySource: DamageWithPosition
                     ): List[PlanetSideServerObject with Vitality] = {
-    findAllTargets(zone, source.Position, damagePropertiesBySource).filter { target => target ne source }
+    findAllTargets(zone, sourcePosition, damagePropertiesBySource).filter { target => target ne source }
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -1193,7 +1193,45 @@ object Zone {
                       source: PlanetSideGameObject with Vitality,
                       damagePropertiesBySource: DamageWithPosition
                     ): List[PlanetSideServerObject with Vitality] = {
-    val sourcePosition = source.Position
+    findAllTargets(zone, source.Position, damagePropertiesBySource).filter { target => target ne source }
+  }
+
+  /**
+    * na
+    * @see `DamageWithPosition`
+    * @see `Zone.blockMap.sector`
+    * @param sourcePosition a custom position that is used as the origin of the explosion;
+    *                       not necessarily related to source
+    * @param zone   the zone in which the explosion should occur
+    * @param source a game entity that is treated as the origin and is excluded from results
+    * @param damagePropertiesBySource information about the effect/damage
+    * @return a list of affected entities
+    */
+  def findAllTargets(
+                      sourcePosition: Vector3
+                    )
+                    (
+                      zone: Zone,
+                      source: PlanetSideGameObject with Vitality,
+                      damagePropertiesBySource: DamageWithPosition
+                    ): List[PlanetSideServerObject with Vitality] = {
+    findAllTargets(zone, source.Position, damagePropertiesBySource).filter { target => target ne source }
+  }
+
+  /**
+    * na
+    * @see `DamageWithPosition`
+    * @see `Zone.blockMap.sector`
+    * @param zone   the zone in which the explosion should occur
+    * @param sourcePosition a position that is used as the origin of the explosion
+    * @param damagePropertiesBySource information about the effect/damage
+    * @return a list of affected entities
+    */
+  def findAllTargets(
+                      zone: Zone,
+                      sourcePosition: Vector3,
+                      damagePropertiesBySource: DamageWithPosition
+                    ): List[PlanetSideServerObject with Vitality] = {
     val sourcePositionXY = sourcePosition.xy
     val sectors = zone.blockMap.sector(sourcePositionXY, damagePropertiesBySource.DamageRadius)
     //collect all targets that can be damaged
@@ -1206,7 +1244,7 @@ object Zone {
     //amenities
     val soiTargets = sectors.amenityList.collect { case amenity: Vitality if !amenity.Destroyed => amenity }
     //altogether ...
-    (playerTargets ++ vehicleTargets ++ deployableTargets ++ soiTargets).filter { target => target ne source }
+    playerTargets ++ vehicleTargets ++ deployableTargets ++ soiTargets
   }
 
   /**

--- a/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -538,7 +538,7 @@ object GamePacketOpcode extends Enumeration {
       case 0xc4 => game.QuantityDeltaUpdateMessage.decode
       case 0xc5 => game.ChainLashMessage.decode
       case 0xc6 => game.ZoneInfoMessage.decode
-      case 0xc7 => noDecoder(LongRangeProjectileInfoMessage)
+      case 0xc7 => game.LongRangeProjectileInfoMessage.decode
       // 0xc8
       case 0xc8 => game.WeaponLazeTargetPositionMessage.decode
       case 0xc9 => noDecoder(ModuleLimitsMessage)

--- a/src/main/scala/net/psforever/packet/game/LongRangeProjectileInfoMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/LongRangeProjectileInfoMessage.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.{PlanetSideGUID, Vector3}
+import scodec.Codec
+import scodec.codecs._
+
+final case class LongRangeProjectileInfoMessage(
+                                                 guid: PlanetSideGUID,
+                                                 pos: Vector3,
+                                                 vel: Option[Vector3]
+                                               )
+  extends PlanetSideGamePacket {
+  type Packet = LongRangeProjectileInfoMessage
+  def opcode = GamePacketOpcode.LongRangeProjectileInfoMessage
+  def encode = LongRangeProjectileInfoMessage.encode(this)
+}
+
+object LongRangeProjectileInfoMessage extends Marshallable[LongRangeProjectileInfoMessage] {
+  def apply(guid: PlanetSideGUID, pos: Vector3, vel: Vector3): LongRangeProjectileInfoMessage =
+    LongRangeProjectileInfoMessage(guid, pos, Some(vel))
+
+  implicit val codec: Codec[LongRangeProjectileInfoMessage] = (
+    ("guid" | PlanetSideGUID.codec) ::
+    ("pos" | Vector3.codec_pos) ::
+    ("vel" | optional(bool, Vector3.codec_vel))
+  ).as[LongRangeProjectileInfoMessage]
+}

--- a/src/main/scala/net/psforever/packet/game/SquadWaypointEvent.scala
+++ b/src/main/scala/net/psforever/packet/game/SquadWaypointEvent.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
-import net.psforever.types.{SquadWaypoints, Vector3}
+import net.psforever.types.{SquadWaypoint, Vector3}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}
@@ -13,7 +13,7 @@ final case class SquadWaypointEvent(
     event_type: WaypointEventAction.Value,
     unk: Int,
     char_id: Long,
-    waypoint_type: SquadWaypoints.Value,
+    waypoint_type: SquadWaypoint,
     unk5: Option[Long],
     waypoint_info: Option[WaypointEvent]
 ) extends PlanetSideGamePacket {
@@ -23,13 +23,13 @@ final case class SquadWaypointEvent(
 }
 
 object SquadWaypointEvent extends Marshallable[SquadWaypointEvent] {
-  def Add(unk: Int, char_id: Long, waypoint_type: SquadWaypoints.Value, waypoint: WaypointEvent): SquadWaypointEvent =
+  def Add(unk: Int, char_id: Long, waypoint_type: SquadWaypoint, waypoint: WaypointEvent): SquadWaypointEvent =
     SquadWaypointEvent(WaypointEventAction.Add, unk, char_id, waypoint_type, None, Some(waypoint))
 
-  def Unknown1(unk: Int, char_id: Long, waypoint_type: SquadWaypoints.Value, unk_a: Long): SquadWaypointEvent =
+  def Unknown1(unk: Int, char_id: Long, waypoint_type: SquadWaypoint, unk_a: Long): SquadWaypointEvent =
     SquadWaypointEvent(WaypointEventAction.Unknown1, unk, char_id, waypoint_type, Some(unk_a), None)
 
-  def Remove(unk: Int, char_id: Long, waypoint_type: SquadWaypoints.Value): SquadWaypointEvent =
+  def Remove(unk: Int, char_id: Long, waypoint_type: SquadWaypoint): SquadWaypointEvent =
     SquadWaypointEvent(WaypointEventAction.Remove, unk, char_id, waypoint_type, None, None)
 
   private val waypoint_codec: Codec[WaypointEvent] = (
@@ -42,7 +42,7 @@ object SquadWaypointEvent extends Marshallable[SquadWaypointEvent] {
     ("event_type" | WaypointEventAction.codec) >>:~ { event_type =>
       ("unk" | uint16L) ::
         ("char_id" | uint32L) ::
-        ("waypoint_type" | SquadWaypoints.codec) ::
+        ("waypoint_type" | SquadWaypoint.codec) ::
         ("unk5" | conditional(event_type == WaypointEventAction.Unknown1, uint32L)) ::
         ("waypoint_info" | conditional(event_type == WaypointEventAction.Add, waypoint_codec))
     }

--- a/src/main/scala/net/psforever/packet/game/SquadWaypointRequest.scala
+++ b/src/main/scala/net/psforever/packet/game/SquadWaypointRequest.scala
@@ -2,7 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
-import net.psforever.types.{SquadWaypoints, Vector3}
+import net.psforever.types.{SquadWaypoint, Vector3}
 import scodec.{Attempt, Codec, Err}
 import scodec.codecs._
 import shapeless.{::, HNil}
@@ -42,7 +42,7 @@ final case class WaypointInfo(zone_number: Int, pos: Vector3)
 final case class SquadWaypointRequest(
     request_type: WaypointEventAction.Value,
     char_id: Long,
-    waypoint_type: SquadWaypoints.Value,
+    waypoint_type: SquadWaypoint,
     unk4: Option[Long],
     waypoint_info: Option[WaypointInfo]
 ) extends PlanetSideGamePacket {
@@ -52,13 +52,13 @@ final case class SquadWaypointRequest(
 }
 
 object SquadWaypointRequest extends Marshallable[SquadWaypointRequest] {
-  def Add(char_id: Long, waypoint_type: SquadWaypoints.Value, waypoint: WaypointInfo): SquadWaypointRequest =
+  def Add(char_id: Long, waypoint_type: SquadWaypoint, waypoint: WaypointInfo): SquadWaypointRequest =
     SquadWaypointRequest(WaypointEventAction.Add, char_id, waypoint_type, None, Some(waypoint))
 
-  def Unknown1(char_id: Long, waypoint_type: SquadWaypoints.Value, unk_a: Long): SquadWaypointRequest =
+  def Unknown1(char_id: Long, waypoint_type: SquadWaypoint, unk_a: Long): SquadWaypointRequest =
     SquadWaypointRequest(WaypointEventAction.Unknown1, char_id, waypoint_type, Some(unk_a), None)
 
-  def Remove(char_id: Long, waypoint_type: SquadWaypoints.Value): SquadWaypointRequest =
+  def Remove(char_id: Long, waypoint_type: SquadWaypoint): SquadWaypointRequest =
     SquadWaypointRequest(WaypointEventAction.Remove, char_id, waypoint_type, None, None)
 
   private val waypoint_codec: Codec[WaypointInfo] = (
@@ -76,7 +76,7 @@ object SquadWaypointRequest extends Marshallable[SquadWaypointRequest] {
   implicit val codec: Codec[SquadWaypointRequest] = (
     ("request_type" | WaypointEventAction.codec) >>:~ { request_type =>
       ("char_id" | uint32L) ::
-        ("waypoint_type" | SquadWaypoints.codec) ::
+        ("waypoint_type" | SquadWaypoint.codec) ::
         ("unk4" | conditional(request_type == WaypointEventAction.Unknown1, uint32L)) ::
         ("waypoint" | conditional(request_type == WaypointEventAction.Add, waypoint_codec))
     }

--- a/src/main/scala/net/psforever/services/teamwork/SquadServiceMessage.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadServiceMessage.scala
@@ -4,7 +4,7 @@ package net.psforever.services.teamwork
 import net.psforever.objects.Player
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.{WaypointEventAction, WaypointInfo, SquadAction => PacketSquadAction}
-import net.psforever.types.{PlanetSideGUID, SquadRequestType, SquadWaypoints, Vector3}
+import net.psforever.types.{PlanetSideGUID, SquadRequestType, SquadWaypoint, Vector3}
 
 final case class SquadServiceMessage(tplayer: Player, zone: Zone, actionMessage: Any)
 
@@ -29,7 +29,7 @@ object SquadAction {
   ) extends Action
   final case class Waypoint(
       event_type: WaypointEventAction.Value,
-      waypoint_type: SquadWaypoints.Value,
+      waypoint_type: SquadWaypoint,
       unk: Option[Long],
       waypoint_info: Option[WaypointInfo]
   ) extends Action

--- a/src/main/scala/net/psforever/services/teamwork/SquadServiceResponse.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadServiceResponse.scala
@@ -3,7 +3,7 @@ package net.psforever.services.teamwork
 
 import net.psforever.objects.teamwork.Squad
 import net.psforever.packet.game.{SquadDetail, SquadInfo, WaypointEventAction, WaypointInfo}
-import net.psforever.types.{PlanetSideGUID, SquadResponseType, SquadWaypoints}
+import net.psforever.types.{PlanetSideGUID, SquadResponseType, SquadWaypoint}
 import net.psforever.services.GenericEventBusMsg
 
 final case class SquadServiceResponse(channel: String, exclude: Iterable[Long], response: SquadResponse.Response)
@@ -48,12 +48,12 @@ object SquadResponse {
 
   final case class Detail(guid: PlanetSideGUID, squad_detail: SquadDetail) extends Response
 
-  final case class InitWaypoints(char_id: Long, waypoints: Iterable[(SquadWaypoints.Value, WaypointInfo, Int)])
+  final case class InitWaypoints(char_id: Long, waypoints: Iterable[(SquadWaypoint, WaypointInfo, Int)])
       extends Response
   final case class WaypointEvent(
       event_type: WaypointEventAction.Value,
       char_id: Long,
-      waypoint_type: SquadWaypoints.Value,
+      waypoint_type: SquadWaypoint,
       unk5: Option[Long],
       waypoint_info: Option[WaypointInfo],
       unk: Int

--- a/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
@@ -354,7 +354,7 @@ class VehicleService(zone: Zone) extends Actor {
       val healAmount = medDef.HealAmount
       if (!target.Destroyed && term.Validate(target)) {
         //repair vehicle
-        if (healAmount != 0 && target.Health < target.MaxHealth) {
+        if (healAmount > 0 && target.Health < target.MaxHealth) {
           val healAmount = medDef.HealAmount
           target.Health = target.Health + healAmount
           target.History(RepairFromTerm(VehicleSource(target), healAmount, medDef))
@@ -367,8 +367,8 @@ class VehicleService(zone: Zone) extends Actor {
           )
         }
         //recharge ammunition of cavern vehicles
-        else if (GlobalDefinitions.isCavernVehicle(target.Definition)) {
-          //TODO check cavern module benefits on facility
+        if (GlobalDefinitions.isCavernVehicle(target.Definition) && term.Definition == GlobalDefinitions.recharge_terminal) {
+          //TODO check cavern module benefits on facility; unlike facility benefits, it's faked for now
           val channel = s"/${target.Actor.toString}/Vehicle"
           val parent = target.GUID
           val excludeNone = Service.defaultPlayerGUID

--- a/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
@@ -2,7 +2,7 @@
 package net.psforever.services.vehicle
 
 import akka.actor.{Actor, ActorRef, Props}
-import net.psforever.objects.Vehicle
+import net.psforever.objects.{GlobalDefinitions, Tool, Vehicle}
 import net.psforever.objects.ballistics.VehicleSource
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.objects.serverobject.terminals.{MedicalTerminalDefinition, ProximityUnit}
@@ -352,16 +352,45 @@ class VehicleService(zone: Zone) extends Actor {
     case ProximityUnit.Action(term, target: Vehicle) =>
       val medDef     = term.Definition.asInstanceOf[MedicalTerminalDefinition]
       val healAmount = medDef.HealAmount
-      if (healAmount != 0 && term.Validate(target) && target.Health < target.MaxHealth) {
-        target.Health = target.Health + healAmount
-        target.History(RepairFromTerm(VehicleSource(target), healAmount, medDef))
-        VehicleEvents.publish(
-          VehicleServiceResponse(
-            s"/${term.Continent}/Vehicle",
-            PlanetSideGUID(0),
-            VehicleResponse.PlanetsideAttribute(target.GUID, 0, target.Health)
+      if (!target.Destroyed && term.Validate(target)) {
+        //repair vehicle
+        if (healAmount != 0 && target.Health < target.MaxHealth) {
+          val healAmount = medDef.HealAmount
+          target.Health = target.Health + healAmount
+          target.History(RepairFromTerm(VehicleSource(target), healAmount, medDef))
+          VehicleEvents.publish(
+            VehicleServiceResponse(
+              s"/${term.Continent}/Vehicle",
+              PlanetSideGUID(0),
+              VehicleResponse.PlanetsideAttribute(target.GUID, 0, target.Health)
+            )
           )
-        )
+        }
+        //recharge ammunition of cavern vehicles
+        else if (GlobalDefinitions.isCavernVehicle(target.Definition)) {
+          //TODO check cavern module benefits on facility
+          val channel = s"/${target.Actor.toString}/Vehicle"
+          val parent = target.GUID
+          val excludeNone = Service.defaultPlayerGUID
+          target.Weapons.values
+            .map { _.Equipment }
+            .collect { case Some(weapon: Tool) =>
+              weapon.AmmoSlots
+                .foreach { slot =>
+                  val box = slot.Box
+                  if (box.Capacity < slot.Definition.Magazine) {
+                    val capacity = box.Capacity += 1
+                    VehicleEvents.publish(
+                      VehicleServiceResponse(
+                        channel,
+                        excludeNone,
+                        VehicleResponse.InventoryState2(box.GUID, parent, capacity)
+                      )
+                    )
+                  }
+              }
+            }
+        }
       }
 
     case msg =>

--- a/src/main/scala/net/psforever/types/SquadWaypoints.scala
+++ b/src/main/scala/net/psforever/types/SquadWaypoints.scala
@@ -1,12 +1,43 @@
 // Copyright (c) 2019 PSForever
 package net.psforever.types
 
-import net.psforever.packet.PacketHelpers
 import scodec.codecs._
 
-object SquadWaypoints extends Enumeration {
+object WaypointSubtype extends Enumeration {
   type Type = Value
-  val One, Two, Three, Four, ExperienceRally = Value
 
-  implicit val codec = PacketHelpers.createEnumerationCodec(this, uint8L)
+  val Squad, Laze = Value
+}
+
+sealed trait SquadWaypoint {
+  def value: Int
+  def subtype: WaypointSubtype.Value
+}
+
+sealed abstract class StandardWaypoint(override val value: Int) extends SquadWaypoint {
+  def subtype: WaypointSubtype.Value = WaypointSubtype.Squad
+}
+
+sealed class LazeWaypoint(override val value: Int) extends SquadWaypoint {
+  def subtype: WaypointSubtype.Value = WaypointSubtype.Laze
+}
+
+object SquadWaypoint {
+  def apply(value: Int): SquadWaypoint = {
+    if(value < 5) {
+      values(value)
+    } else {
+      new LazeWaypoint(value)
+    }
+  }
+
+  def values = Seq(One, Two, Three, Four, ExperienceRally)
+
+  case object One extends StandardWaypoint(value = 0)
+  case object Two extends StandardWaypoint(value = 1)
+  case object Three extends StandardWaypoint(value = 2)
+  case object Four extends StandardWaypoint(value = 3)
+  case object ExperienceRally extends StandardWaypoint(value = 4)
+
+  implicit val codec = uint8L.xmap[SquadWaypoint]( n => apply(n), waypoint => waypoint.value )
 }

--- a/src/main/scala/net/psforever/types/SquadWaypoints.scala
+++ b/src/main/scala/net/psforever/types/SquadWaypoints.scala
@@ -3,40 +3,78 @@ package net.psforever.types
 
 import scodec.codecs._
 
+/**
+  * Distinction of purpose of the waypoint.
+  */
 object WaypointSubtype extends Enumeration {
   type Type = Value
 
   val Squad, Laze = Value
 }
 
+/**
+  * Base of all waypoints visible to members of a particular squad.
+  */
 sealed trait SquadWaypoint {
+  /** the index of this kind of waypoint */
   def value: Int
+  /** the distinction of this kind of waypoint */
   def subtype: WaypointSubtype.Value
 }
 
+/**
+  * Permanently-defined waypoints known to all squads, set only by the squad leader, accessible by command rank status.
+  */
 sealed abstract class StandardWaypoint(override val value: Int) extends SquadWaypoint {
   def subtype: WaypointSubtype.Value = WaypointSubtype.Squad
 }
 
-sealed class LazeWaypoint(override val value: Int) extends SquadWaypoint {
+/**
+  * General waypoint produced by the Flail targeting laser (laze pointer)
+  * that is visible by all squad members for a short duration.
+  * Any squad member may place this waypoint.
+  * A laze waypoint is yellow,
+  * is indicated in the game world, on the proximity map, and on the continental map,
+  * and is designated by the number of the squad member that produced it.
+  * Only one laze waypoint may be made visible from any one squad member at any given time, overwritten when replaced.
+  * When viewed by a squad member seated in a Flail, the waypoint includes an elevation reticle for aiming purposes.
+  * YMMV.
+  * @see `SquadWaypointEvent`
+  * @see `SquadWaypointRequest`
+  * @param value the index of the waypoint can be any number five and above
+  */
+sealed case class LazeWaypoint(value: Int) extends SquadWaypoint {
   def subtype: WaypointSubtype.Value = WaypointSubtype.Laze
 }
 
 object SquadWaypoint {
+  /**
+    * Overloaded constructor
+    * that returns either the specific squad waypoint as the index value
+    * or a laze waypoint with the same value.
+    * @param value the index of this kind of waypoint
+    * @return a waypoint object
+    */
   def apply(value: Int): SquadWaypoint = {
     if(value < 5) {
       values(value)
     } else {
-      new LazeWaypoint(value)
+      LazeWaypoint(value)
     }
   }
 
+  /** the five squad-specific waypoints */
+  //does not include the multitude of possible laze waypoints
   def values = Seq(One, Two, Three, Four, ExperienceRally)
-
+  /** the first squad rally */
   case object One extends StandardWaypoint(value = 0)
+  /** the second squad rally */
   case object Two extends StandardWaypoint(value = 1)
+  /** the third squad rally */
   case object Three extends StandardWaypoint(value = 2)
+  /** the fourth squad rally */
   case object Four extends StandardWaypoint(value = 3)
+  /** the squad experience bonus rally */
   case object ExperienceRally extends StandardWaypoint(value = 4)
 
   implicit val codec = uint8L.xmap[SquadWaypoint]( n => apply(n), waypoint => waypoint.value )

--- a/src/main/scala/net/psforever/zones/Zones.scala
+++ b/src/main/scala/net/psforever/zones/Zones.scala
@@ -490,6 +490,11 @@ object Zones {
                 Terminal.Constructor(obj.position, GlobalDefinitions.ground_rearm_terminal),
                 owningBuildingGuid = ownerGuid
               )
+              zoneMap.addLocalObject(
+                obj.guid + 3,
+                ProximityTerminal.Constructor(obj.position, GlobalDefinitions.recharge_terminal),
+                owningBuildingGuid = ownerGuid
+              )
             case "pad_landing_frame" | "pad_landing_tower_frame" =>
               // startup.pak-out/game_objects.adb.lst:22518:add_property pad_landing_frame has_aggregate_rearm_terminal true
               // startup.pak-out/game_objects.adb.lst:22519:add_property pad_landing_frame has_aggregate_recharge_terminal true
@@ -498,6 +503,11 @@ object Zones {
               zoneMap.addLocalObject(
                 obj.guid + 1,
                 Terminal.Constructor(obj.position, GlobalDefinitions.air_rearm_terminal),
+                owningBuildingGuid = ownerGuid
+              )
+              zoneMap.addLocalObject(
+                obj.guid + 2,
+                ProximityTerminal.Constructor(obj.position, GlobalDefinitions.recharge_terminal),
                 owningBuildingGuid = ownerGuid
               )
             case _ => ;

--- a/src/test/scala/game/LongRangeProjectileInfoMessageTest.scala
+++ b/src/test/scala/game/LongRangeProjectileInfoMessageTest.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 PSForever
+package game
+
+import org.specs2.mutable._
+import net.psforever.packet._
+import net.psforever.packet.game._
+import net.psforever.types.{PlanetSideGUID, Vector3}
+import scodec.bits._
+
+class LongRangeProjectileInfoMessageTest extends Specification {
+  val string = hex"c7 d214 006c485fd9c307ed30790f84a0"
+
+  "decode" in {
+    PacketCoding.decodePacket(string).require match {
+      case LongRangeProjectileInfoMessage(guid, pos, vel) =>
+        guid mustEqual PlanetSideGUID(5330)
+        pos mustEqual Vector3(2264, 5115.039f, 31.046875f)
+        vel.contains(Vector3(-57.1875f, 9.875f, 47.5f)) mustEqual true
+      case _ =>
+        ko
+    }
+  }
+
+  "encode" in {
+    val msg = LongRangeProjectileInfoMessage(
+      PlanetSideGUID(5330),
+      Vector3(2264, 5115.039f, 31.046875f),
+      Vector3(-57.1875f, 9.875f, 47.5f)
+    )
+    val pkt = PacketCoding.encodePacket(msg).require.toByteVector
+    pkt mustEqual string
+  }
+}

--- a/src/test/scala/game/SquadWaypointEventTest.scala
+++ b/src/test/scala/game/SquadWaypointEventTest.scala
@@ -4,7 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game.{SquadWaypointEvent, WaypointEvent, WaypointEventAction}
-import net.psforever.types.{SquadWaypoints, Vector3}
+import net.psforever.types.{SquadWaypoint, Vector3}
 import scodec.bits._
 
 class SquadWaypointEventTest extends Specification {
@@ -19,7 +19,7 @@ class SquadWaypointEventTest extends Specification {
         unk1 mustEqual WaypointEventAction.Remove
         unk2 mustEqual 11
         unk3 mustEqual 31155863L
-        unk4 mustEqual SquadWaypoints.One
+        unk4 mustEqual SquadWaypoint.One
         unk5.isEmpty mustEqual true
         unk6.isEmpty mustEqual true
       case _ =>
@@ -33,7 +33,7 @@ class SquadWaypointEventTest extends Specification {
         unk1 mustEqual WaypointEventAction.Remove
         unk2 mustEqual 10
         unk3 mustEqual 0L
-        unk4 mustEqual SquadWaypoints.ExperienceRally
+        unk4 mustEqual SquadWaypoint.ExperienceRally
         unk5.isEmpty mustEqual true
         unk6.isEmpty mustEqual true
       case _ =>
@@ -47,7 +47,7 @@ class SquadWaypointEventTest extends Specification {
         unk1 mustEqual WaypointEventAction.Add
         unk2 mustEqual 3
         unk3 mustEqual 41581052L
-        unk4 mustEqual SquadWaypoints.Two
+        unk4 mustEqual SquadWaypoint.Two
         unk5.isEmpty mustEqual true
         unk6.contains(WaypointEvent(10, Vector3(3457.9688f, 5514.4688f, 0.0f), 1)) mustEqual true
       case _ =>
@@ -61,7 +61,7 @@ class SquadWaypointEventTest extends Specification {
         unk1 mustEqual WaypointEventAction.Unknown1
         unk2 mustEqual 3
         unk3 mustEqual 41581052L
-        unk4 mustEqual SquadWaypoints.Two
+        unk4 mustEqual SquadWaypoint.Two
         unk5.contains(4L) mustEqual true
         unk6.isEmpty mustEqual true
       case _ =>
@@ -70,14 +70,14 @@ class SquadWaypointEventTest extends Specification {
   }
 
   "encode (1)" in {
-    val msg = SquadWaypointEvent.Remove(11, 31155863L, SquadWaypoints.One)
+    val msg = SquadWaypointEvent.Remove(11, 31155863L, SquadWaypoint.One)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string_1
   }
 
   "encode (2)" in {
-    val msg = SquadWaypointEvent.Remove(10, 0L, SquadWaypoints.ExperienceRally)
+    val msg = SquadWaypointEvent.Remove(10, 0L, SquadWaypoint.ExperienceRally)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string_2
@@ -87,7 +87,7 @@ class SquadWaypointEventTest extends Specification {
     val msg = SquadWaypointEvent.Add(
       3,
       41581052L,
-      SquadWaypoints.Two,
+      SquadWaypoint.Two,
       WaypointEvent(10, Vector3(3457.9688f, 5514.4688f, 0.0f), 1)
     )
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
@@ -96,7 +96,7 @@ class SquadWaypointEventTest extends Specification {
   }
 
   "encode (4)" in {
-    val msg = SquadWaypointEvent.Unknown1(3, 41581052L, SquadWaypoints.Two, 4L)
+    val msg = SquadWaypointEvent.Unknown1(3, 41581052L, SquadWaypoint.Two, 4L)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string_4


### PR DESCRIPTION
So basically your plan is to Flail about helplessly. - Harlan Coben

The Flail is a unique vehicle.  It can be best described as dedicated anti-vehicular artillery.

For starters, it's a piece of Ancient Technology equipment that normally requires an owned cavern facility with an AT plant, a faction affine cavern connection to a major above ground facility, or a Vehicle Module installed in a major above ground facility, before it can be spawned and utilized in combat.  The vehicle does not have magazine reserves in its trunk and must seek other means of ammunition replenishment.  It is the only vehicle in the game that has both installed utilities and mounted weaponry, and the only vehicle with mounted weapons that can not discharge unless the vehicle itself is deployed.  It is tall enough to walk underneath when deployed.  The projectiles of the primary weapon of the Flail are designed to fly an incredible distance, way beyond any measure of the game's ability to render its environment, and deal tremendous damage the further they soar.  Projectiles can do up to five times the amount of damage were they to hit a target beyond 600m!

The Flail utilizes a weapon aiming mechanic by way of the Flail Laser Pointer, colloquially called the "Laze Pointer".  Utilizing squad coordination, one player explores the world environment and uses the Lazer Pointer to produce a waypoint marker that is visible to all members of the squad for a short duration (15s).  To the driver of the Flail, this waypoint marker features a second marker on top of the primary marker stalk which guides the elevation of the main weapon while the waypoint itself demonstrates the anticipated target's direction.  This greatly assists the operator in targeting locations well beyond the weapon's normal line of sight and taking advantage of the increased damage output.

___Features___
__`LongRangeProjectileInfoMessage`__
A packet that is related to the generated Flail projectile, and only to the generated Flail projectile.  We don't actually have a use for it.

Additionally:
__`SquadWaypoint`__
Modified to include indeterminate waypoint indices above the `ExperienceRally` value that are all attributed as `LazeWaypoint` target markers.  The corresponding packets are `SquadWaypointRequest` and `SquadWaypointEvent`.
__`SquadService`__
Laze waypoints are managed local to the service for now. Laze waypoints are only visible through association with a squad.
__`ProximityTerminal`__
The repair/rearm silo has the third of its four functions operating now and can remotely restore ammunition to AT vehicles that require it.  This capability is also present in air landing pads (three of three functions).
__`WeaponLazeTargetPositionMessage`__
Already existed and indicates Laze Pointer is being applied.  A progress bar fills up and, in the meanwhile, about fifty packets are generated before a request to produce the waypoint is dispatched.  We don't actually have a use for it.

___Caveats___
1.  Although not a failing of the Flail itself, the offset aim issue that plagues the game is most prevalent with its propensity for and rewarding of long-range warfare.  @Mazo has been reporting about tank battle projectiles sailing over the top of the tank hull that it actually damages at what we would consider near-medium range, and the projectiles of the Flail suffer from this issue at a much worse capacity.  From the perspective of the user, the projectile may be entirely on target.  From the perspective of the target, the projectile may have missed by a dozen meters, or flown overhead and kept going.  I currently have no means of increasing the angular sensitivity of "aiming" beyond where it currently corrects itself.
2. We don't respect any of the Caverns right now so all facilities are automatically gifted the appropriate capabilities of spawning AT vehicles, including the Flail, the Switchblade, and the Router.
3. It is hard to say whether the new ammunition regeneration mechanic works too quickly or too slowly.  No ADB attributes seem related to it beyond a basic "on/off" flag and I've not found any video footage of the effect in action either.  Additionally, ammunition regeneration uses the same silo animation as vehicle repair.  Silo animation states may transition poorly at times.
4. The green cavern crystals that restore AT vehicle energy (ammunition) are not rigged to work at the moment so it is not possible to replenish expended ammunition when if in the caverns.  (We don't respect any of the Caverns right now ...)

___Addenda___
1. Part of the solution for ensuring that Laze Pointer waypoints are properly visible to all squad members intersects with overeager squad creation.  By reigning in squad founding, squad operations should hopefully flow much better in general from now on.
2. The Flail possesses a utility that allows players to obtain a Laze Pointer (and only a Laze Pointer) that is hidden in the same sense that the Router telepad dispenser is hidden - there's no glyph indicating where to stand.  When facing the driver's seat mount for the vehicle, step to the right and look to the curved faction-flavor decoration for splash text prompting.  That's the dispenser.  I have included this note in "Addenda" rather than the overview section or in "Features" for additional irony.
3. The Switchblade is an amazing vehicle.