### PR TITLE
Sentry Fixes

### DIFF
--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -277,7 +277,7 @@ class Player(var avatar: Avatar)
       None
     } else {
       val slot = iter.next()
-      if (slot.Equipment.isDefined && slot.Equipment.get.GUID == guid) {
+      if (slot.Equipment match { case Some(o) => o.GUID == guid; case _ => false }) {
         Some(index)
       } else {
         findInHolsters(iter, guid, index + 1)

--- a/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
+++ b/src/main/scala/net/psforever/objects/ce/TelepadLike.scala
@@ -167,9 +167,10 @@ class TelepadControl(obj: InternalTelepad) extends akka.actor.Actor {
       obj.Active = false
       val zone = obj.Zone
       zone.GUID(obj.Telepad) match {
-        case Some(oldTpad: TelepadDeployable) if !obj.Active && !setup.isCancelled =>
+        case Some(oldTpad: TelepadDeployable)
+          if !obj.Active && !setup.isCancelled =>
           oldTpad.Actor ! TelepadLike.SeverLink(obj)
-        case None => ;
+        case _ => ;
       }
       obj.Telepad = None
       zone.LocalEvents ! LocalServiceMessage(zone.id, LocalAction.SendResponse(ObjectDeleteMessage(obj.GUID, 0)))

--- a/src/main/scala/net/psforever/packet/CryptoPacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/CryptoPacketOpcode.scala
@@ -8,8 +8,9 @@ object CryptoPacketOpcode extends Enumeration {
   type Type = Value
   val Ignore, ClientChallengeXchg, ServerChallengeXchg, ClientFinished, ServerFinished = Value
 
-  def getPacketDecoder(opcode: CryptoPacketOpcode.Type): (BitVector) => Attempt[DecodeResult[PlanetSideCryptoPacket]] =
+  def getPacketDecoder(opcode: CryptoPacketOpcode.Type): BitVector => Attempt[DecodeResult[PlanetSideCryptoPacket]] =
     opcode match {
+      case Ignore              => crypto.Ignore.decode
       case ClientChallengeXchg => crypto.ClientChallengeXchg.decode
       case ServerChallengeXchg => crypto.ServerChallengeXchg.decode
       case ServerFinished      => crypto.ServerFinished.decode
@@ -17,7 +18,7 @@ object CryptoPacketOpcode extends Enumeration {
       case default =>
         (a: BitVector) =>
           Attempt.failure(
-            Err(s"Could not find a marshaller for crypto packet ${opcode}")
+            Err(s"Could not find a marshaller for crypto packet $opcode")
               .pushContext("get_marshaller")
           )
     }

--- a/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -446,7 +446,7 @@ object GamePacketOpcode extends Enumeration {
       case 0x77 => game.SquadState.decode
       // 0x78
       case 0x78 => game.OxygenStateMessage.decode
-      case 0x79 => noDecoder(TradeMessage)
+      case 0x79 => game.TradeMessage.decode
       case 0x7a => noDecoder(UnknownMessage122)
       case 0x7b => game.DamageFeedbackMessage.decode
       case 0x7c => game.DismountBuildingMsg.decode

--- a/src/main/scala/net/psforever/packet/crypto/ClientFinished.scala
+++ b/src/main/scala/net/psforever/packet/crypto/ClientFinished.scala
@@ -2,22 +2,43 @@
 package net.psforever.packet.crypto
 
 import net.psforever.packet.{CryptoPacketOpcode, Marshallable, PlanetSideCryptoPacket}
+import scodec.Attempt.Successful
 import scodec.Codec
 import scodec.bits.{ByteVector, _}
 import scodec.codecs._
+import shapeless.{::, HNil}
 
-final case class ClientFinished(pubKey: ByteVector, challengeResult: ByteVector) extends PlanetSideCryptoPacket {
+final case class ClientFinished(
+                                 obj_type: Int,
+                                 pubKey: ByteVector,
+                                 challengeResult: ByteVector
+                               ) extends PlanetSideCryptoPacket {
   type Packet = ClientFinished
   def opcode = CryptoPacketOpcode.ClientFinished
   def encode = ClientFinished.encode(this)
 }
 
 object ClientFinished extends Marshallable[ClientFinished] {
+  def apply(pubKey: ByteVector, challengeResult: ByteVector): ClientFinished =
+    ClientFinished(16, pubKey, challengeResult)
+
   implicit val codec: Codec[ClientFinished] = (
-    ("obj_type?" | constant(hex"10".bits)) ::
+    ("obj_type?" | uint8) ::
       ("pub_key_len" | constant(hex"1000")) ::
       ("pub_key" | bytes(16)) ::
       ("unknown" | constant(hex"0114".bits)) ::
       ("challenge_result" | bytes(0xc))
-  ).as[ClientFinished]
+  ).exmap[ClientFinished](
+    {
+      case 16 :: () :: c :: () :: e :: HNil =>
+        Successful(ClientFinished(16, c, e))
+      case a :: () :: c :: () :: e :: HNil =>
+        org.log4s.getLogger("ClientFinished").warn(s"obj_type?: expected 16 but got $a; attempting to bypass")
+        Successful(ClientFinished(a, c, e))
+    },
+    {
+      case ClientFinished(a, c, e) =>
+        Successful(a :: () :: c :: () :: e :: HNil)
+    }
+  )
 }

--- a/src/main/scala/net/psforever/packet/crypto/Ignore.scala
+++ b/src/main/scala/net/psforever/packet/crypto/Ignore.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.packet.crypto
+
+import net.psforever.packet.{CryptoPacketOpcode, Marshallable, PlanetSideCryptoPacket}
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs._
+
+final case class Ignore(data: ByteVector) extends PlanetSideCryptoPacket {
+  type Packet = Ignore
+  def opcode = CryptoPacketOpcode.Ignore
+  def encode = Ignore.encode(this)
+}
+
+object Ignore extends Marshallable[Ignore] {
+  implicit val codec: Codec[Ignore] = ("data" | bytes).as[Ignore]
+}
+

--- a/src/main/scala/net/psforever/packet/game/TradeMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/TradeMessage.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 PSForever
+package net.psforever.packet.game
+
+import net.psforever.packet.{GamePacketOpcode, Marshallable, PlanetSideGamePacket}
+import net.psforever.types.PlanetSideGUID
+import scodec.Codec
+import scodec.codecs._
+import shapeless.{::, HNil}
+
+sealed trait Trade {
+  def value: Int
+}
+
+final case class NoTrade(value: Int) extends Trade {
+  assert(value == 1 || value == 2 || value == 3, s"NoTrade has wrong code value - $value not in [a-f]")
+}
+
+final case class TradeOne(value: Int, unk1: PlanetSideGUID, unk2: PlanetSideGUID, unk3: PlanetSideGUID) extends Trade {
+  assert(value == 1 || value == 2 || value == 3, s"TradeOne has wrong code value - $value not in [1,2,3]")
+}
+
+final case class TradeTwo(value: Int, unk1: PlanetSideGUID, unk2: PlanetSideGUID) extends Trade {
+  assert(value == 4 || value == 5 || value == 7, s"TradeTwo has wrong code value - $value not in [4,5,7]")
+}
+
+final case class TradeThree(value: Int, unk: PlanetSideGUID) extends Trade {
+  assert(value == 6 || value == 8, s"TradeThree has wrong code value - $value not in [6,8]")
+}
+
+final case class TradeFour(value: Int, unk: Int) extends Trade {
+  assert(value == 9, s"TradeFour has wrong code value - $value not in [9]")
+}
+
+final case class TradeMessage(unk: Int, trade: Trade)
+  extends PlanetSideGamePacket {
+  type Packet = TradeMessage
+  def opcode = GamePacketOpcode.TradeMessage
+  def encode = TradeMessage.encode(this)
+}
+
+object TradeMessage extends Marshallable[TradeMessage] {
+  private def tradeOneCodec(value: Int): Codec[TradeOne] = (
+    ("u1" | PlanetSideGUID.codec) ::
+    ("u2" | PlanetSideGUID.codec) ::
+    ("u3" | PlanetSideGUID.codec)
+  ).xmap[TradeOne](
+    {
+      case a :: b :: c :: HNil => TradeOne(value, a, b, c)
+    },
+    {
+      case TradeOne(_, a, b, c) => a :: b :: c :: HNil
+    }
+  )
+
+  private def tradeTwoCodec(value: Int): Codec[TradeTwo] = (
+    ("u1" | PlanetSideGUID.codec) ::
+    ("u2" | PlanetSideGUID.codec)
+  ).xmap[TradeTwo](
+    {
+      case a :: b :: HNil => TradeTwo(value, a, b)
+    },
+    {
+      case TradeTwo(_, a, b) => a :: b :: HNil
+    }
+  )
+
+  private def tradeThreeCodec(value: Int): Codec[TradeThree] = ("u1" | PlanetSideGUID.codec).xmap[TradeThree](
+    a => TradeThree(value, a),
+    {
+      case TradeThree(_, a) => a
+    }
+  )
+
+  private def tradeFourCodec(value: Int): Codec[TradeFour] = ("u1" | uint4).xmap[TradeFour](
+    a => TradeFour(value, a),
+    {
+      case TradeFour(_, a) => a
+    }
+  )
+
+  private def noTradeCodec(value: Int): Codec[NoTrade] = conditional(included = false, ignore(size = 1)).xmap[NoTrade](
+    _ => NoTrade(value),
+    {
+      case NoTrade(_) => None
+    }
+  )
+
+  private def selectTradeCodec(code: Int): Codec[Trade] = {
+    (code match {
+      case 1 | 2 | 3 => tradeOneCodec(code)
+      case 4 | 5 | 7 => tradeTwoCodec(code)
+      case 6 | 8     => tradeThreeCodec(code)
+      case 9         => tradeFourCodec(code)
+      case _         => noTradeCodec(code)
+    }).asInstanceOf[Codec[Trade]]
+  }
+
+  implicit val codec: Codec[TradeMessage] = (
+    ("unk" | uint8) ::
+    (uint4 >>:~ { code =>
+      ("trade" | selectTradeCodec(code)).hlist
+    })
+    ).xmap[TradeMessage](
+    {
+      case unk :: _ :: trade :: HNil => TradeMessage(unk, trade)
+    },
+    {
+      case TradeMessage(unk, trade) => unk :: trade.value :: trade :: HNil
+    }
+  )
+}

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -2067,7 +2067,12 @@ class SquadService extends Actor {
       case (Some((fromMember, fromPosition)), (toMember, _)) if fromPosition != 0 =>
         val name = fromMember.Name
         SwapMemberPosition(toMember, fromMember)
-        Publish(squadFeatures(guid).ToChannel, SquadResponse.AssignMember(squad, fromPosition, position))
+        squadFeatures.get(guid) match {
+          case Some(features) =>
+            Publish(features.ToChannel, SquadResponse.AssignMember(squad, fromPosition, position))
+          case None =>
+            //we might be in trouble; we might not ...
+        }
         UpdateSquadDetail(
           squad.GUID,
           SquadDetail().Members(


### PR DESCRIPTION
These are various issues encountered on sentry.io that can be linked to actionable code changes, as well as a suggestion regarding the mostly concistent 50-minute crash being related to changing ammo.

___Packets___
1. Packet `ClientFinished` normally resolves its first field to 16.  It's so reliable that Chord only ever wrote it to only resolve to 16, except when it resolves to 1.  So now it resolves to whatever it wants to resolve to, but mostly 16.  And 1.
2. Packet `Ignore` is a late `CryptoPacket` that not only represents the default cryptographic state but is also its own message of the same kind.  Its decode has also been ignored for quite some time due to lack of information about it.  It should at least have a decode state now, even if that's only to a payload dump.  Much like `ResetMessage`, the goal is to collect more data regarding the packet's data.
3. Packet `TradeMessage` is one of those packets that we sometimes trigger but no one really knows that much about.  Supposedly, it was related to a window that facilitated "trade" back in the halycon yesteryear of 2003 when PlanetSide Alpha was envisioned to be more of an MMO.  We have no relevant packet captures regarding it but somehow we are capable of triggering it.  I don't know.