### PR TITLE
Vehicle Loadout Weapon Ammunition

### DIFF
--- a/src/main/scala/net/psforever/objects/Tool.scala
+++ b/src/main/scala/net/psforever/objects/Tool.scala
@@ -183,7 +183,7 @@ object Tool {
     private var ammoTypeIndex: Int = 0
 
     /** a reference to the actual `AmmoBox` of this slot */
-    private var box: AmmoBox = AmmoBox(AmmoDefinition, fdef.Magazine)
+    private var box: AmmoBox = AmmoBox(AmmoDefinition, MaxMagazine())
     private var chamber      = fdef.Chamber
 
     def AmmoTypeIndex: Int = ammoTypeIndex
@@ -221,6 +221,13 @@ object Tool {
     def Chamber_=(chmbr: Int): Int = {
       chamber = math.min(math.max(0, chmbr), fdef.Chamber)
       Chamber
+    }
+
+    def MaxMagazine(): Int = {
+      fdef.CustomMagazine.get(AmmoType) match {
+        case Some(value) => value
+        case None        => fdef.Magazine
+      }
     }
 
     def Box: AmmoBox = box

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -486,11 +486,11 @@ class VehicleControl(vehicle: Vehicle)
       if (obj.VisibleSlots.contains(slot)) zone.id else channel,
       VehicleAction.SendResponse(
         Service.defaultPlayerGUID,
-        ObjectCreateMessage(
+        ObjectCreateDetailedMessage(
           definition.ObjectId,
           iguid,
           ObjectCreateMessageParent(oguid, slot),
-          definition.Packet.ConstructorData(item).get
+          definition.Packet.DetailedConstructorData(item).get
         )
       )
     )

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -178,10 +178,10 @@ class VehicleControl(vehicle: Vehicle)
               //              (oldWeapons, weapons, afterInventory)
               //TODO for now, just refill ammo; assume weapons stay the same
               vehicle.Weapons
-                .collect { case (_, slot : EquipmentSlot) if slot.Equipment.nonEmpty => slot.Equipment.get }
+                .collect { case (_, slot: EquipmentSlot) if slot.Equipment.nonEmpty => slot.Equipment.get }
                 .collect {
-                  case weapon : Tool =>
-                    weapon.AmmoSlots.foreach { ammo => ammo.Box.Capacity = ammo.Box.Definition.Capacity }
+                  case weapon: Tool =>
+                    weapon.AmmoSlots.foreach { ammo => ammo.Box.Capacity = ammo.MaxMagazine() }
                 }
               (Nil, Nil, afterInventory)
             }


### PR DESCRIPTION
On a loadout change, correctly set the ammunition in a weapon to the fire mode's magazine capacity, not the capacity of the underlying amunition type.

___Caveats___
~~A bug exists where, after vehicle loadout change, the count in the weapon's ammunition pool may report incorrectly.  In the case of the Reaver, expending ammunition from its default inventory and then reloading the default inventory through a loadout causes the weapon's ammunition pool to report 201 (one ammo box + ?) rather than 400 (two ammunition boxes).  The vehicle's trunk will definitely contain two ammmunition boxes after the loadout change adding up to the expected ammunition pool amount.  The "problem" is purely visual and forcing the HUD to reload either through dismounting and re-mounting the vehicle or reloading the offending weapon will correct it immediately.  The ammunition pool count for a weapon is entirely managed by the client's knowledge of the contents of the vehicle's trunk or player's backpack.~~

___Addenda___
1.  Internally, the game will always try to report the `OCM` version of an ammo box as having a single round and, when it updates the inventory quantity associated with that ammo box, it will not reflect in the appropriate weapon's ammo pool until the client itself forces the update.  The `OCM` of an 200-round ammo box will continue to contribute just 1 round to an ammo pool even after an `InventoryStateMessage` bumps the subscript number of that ammo box to 200 rounds.  Moving that ammo box in and out of the inventory without rebuilding it locally will retain these properties of the ammo box.  Moving a different item in and out of the inventory will force the client to reconsider its inventory contents and update to the subscript value.
2. When a player clears their backpack inventory, any item that they are holding (on the cursor) at the time is also deleted.  When a player clears their vehicle inventory, any item that they are holding (on the cursor) at the time may not be deleted.