### PR TITLE
SocketActor terminates when bind fails (#434)

### DIFF
--- a/src/main/scala/net/psforever/actors/net/SocketActor.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketActor.scala
@@ -43,6 +43,9 @@ object SocketActor {
     def receive: Receive = {
       case Udp.Bound(_) =>
         ref ! Bound(sender())
+
+      case Udp.CommandFailed(_:Udp.Bind) =>
+        context.system.terminate()
     }
   }
 


### PR DESCRIPTION
Adding a case for `Udp.CommandFailed(_:Udp.Bind)` seems to do the job. Not sure if it needs to be more complex than just adding it to `SenderHack` under `SocketActor`.