### PR TITLE
Turn off Awards

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3164,7 +3164,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
       sendResponse(PlanetsideAttributeMessage(guid, 7, tplayer.Capacitor.toLong))
     }
     // AvatarAwardMessage
-    populateAvatarAwardRibbonsFunc(1, 20L)
+    //populateAvatarAwardRibbonsFunc(1, 20L)
 
     sendResponse(PlanetsideStringAttributeMessage(guid, 0, "Outfit Name"))
     //squad stuff (loadouts, assignment)


### PR DESCRIPTION
A previous update - the population of merit commendations and allowance of their selection as shoulder decoration - #988 - was determined to be problematic for the stability of the client, despite my best efforts to mitigate any potential issue, so it is being revoked.  The systems themselves will remain in place for future purposes.

The live server should be updated and restarted.