### PR TITLE
Gate Spawn Positions

### DIFF
--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -12,7 +12,7 @@ import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Amenity, Building}
 import net.psforever.objects.serverobject.turret.{FacilityTurret, TurretUpgrade, WeaponTurrets}
 import net.psforever.objects.zones.Zoning
-import net.psforever.packet.game.{ChatMsg, DeadState, RequestDestroyMessage, ZonePopulationUpdateMessage}
+import net.psforever.packet.game.{AvatarDeadStateMessage, ChatMsg, DeadState, RequestDestroyMessage, ZonePopulationUpdateMessage}
 import net.psforever.types.{ChatMessageType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 import net.psforever.util.{Config, PointOfInterest}
 import net.psforever.zones.Zones
@@ -22,6 +22,7 @@ import net.psforever.services.chat.ChatService.ChatChannel
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import akka.actor.typed.scaladsl.adapter._
+import net.psforever.objects.vital.PlayerSuicide
 import net.psforever.services.{CavernRotationService, InterstellarClusterService}
 import net.psforever.types.ChatMessageType.UNK_229
 
@@ -507,6 +508,12 @@ class ChatActor(
                     case _ =>
                       CavernRotationService.HurryNextRotation
                   })
+
+                case (_, _, content) if content.startsWith("!suicide") =>
+                  //this is like CMT_SUICIDE but it ignores checks and forces a suicide state
+                  val tplayer = session.player
+                  tplayer.Revive
+                  tplayer.Actor ! Player.Die()
 
                 case _ =>
                 // unknown ! commands are ignored

--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -12,7 +12,7 @@ import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Amenity, Building}
 import net.psforever.objects.serverobject.turret.{FacilityTurret, TurretUpgrade, WeaponTurrets}
 import net.psforever.objects.zones.Zoning
-import net.psforever.packet.game.{AvatarDeadStateMessage, ChatMsg, DeadState, RequestDestroyMessage, ZonePopulationUpdateMessage}
+import net.psforever.packet.game.{ChatMsg, DeadState, RequestDestroyMessage, ZonePopulationUpdateMessage}
 import net.psforever.types.{ChatMessageType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 import net.psforever.util.{Config, PointOfInterest}
 import net.psforever.zones.Zones
@@ -22,7 +22,6 @@ import net.psforever.services.chat.ChatService.ChatChannel
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import akka.actor.typed.scaladsl.adapter._
-import net.psforever.objects.vital.PlayerSuicide
 import net.psforever.services.{CavernRotationService, InterstellarClusterService}
 import net.psforever.types.ChatMessageType.UNK_229
 

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -75,7 +75,6 @@ import net.psforever.zones.Zones
 import org.joda.time.LocalDateTime
 import org.log4s.MDC
 
-import java.io.{PrintWriter, StringWriter}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -502,6 +501,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
   }
 
   def writeLogException(e: Throwable): Unit = {
+    import java.io.{PrintWriter, StringWriter}
     val sw = new StringWriter
     e.printStackTrace(new PrintWriter(sw))
     log.error(sw.toString)

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -358,14 +358,14 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         attemptRecoveryFromInventoryDisarrayException(ide.inventory)
         //re-evaluate results
         if (ide.inventory.ElementsOnGridMatchList() > 0) {
-          writeLogException(ide)
+          writeLogExceptionAndStop(ide)
           SupervisorStrategy.stop
         } else {
           SupervisorStrategy.resume
         }
 
       case e =>
-        writeLogException(e)
+        writeLogExceptionAndStop(e)
         SupervisorStrategy.stop
     }
   }
@@ -406,7 +406,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
           }
           SupervisorStrategy.resume
         case _ =>
-          writeLogException(e)
+          writeLogExceptionAndStop(e)
           SupervisorStrategy.stop
       }
     } else {
@@ -505,6 +505,11 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     val sw = new StringWriter
     e.printStackTrace(new PrintWriter(sw))
     log.error(sw.toString)
+    ImmediateDisconnect()
+  }
+
+  def writeLogExceptionAndStop(e: Throwable): Unit = {
+    writeLogException(e)
     ImmediateDisconnect()
   }
 

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -1334,7 +1334,7 @@ object GlobalDefinitions {
 
   val hst = new WarpGateDefinition(402)
   hst.Name = "hst"
-  hst.UseRadius = 64.96882005f
+  hst.UseRadius = 44.96882005f
   hst.SOIRadius = 82
   hst.VehicleAllowance = true
   hst.NoWarp += dropship
@@ -1346,28 +1346,28 @@ object GlobalDefinitions {
   hst.NoWarp += colossus_flight
   hst.NoWarp += peregrine_gunner
   hst.NoWarp += peregrine_flight
-  hst.SpecificPointFunc = SpawnPoint.SmallGate(innerRadius = 5f)
+  hst.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 6f)
 
   val warpgate = new WarpGateDefinition(993)
   warpgate.Name = "warpgate"
-  warpgate.UseRadius = 67.81070029f //301.8713f
-  warpgate.SOIRadius = 302
+  warpgate.UseRadius = 67.81070029f
+  warpgate.SOIRadius = 302 //301.8713f
   warpgate.VehicleAllowance = true
   warpgate.SpecificPointFunc = SpawnPoint.Gate
 
   val warpgate_cavern = new WarpGateDefinition(994)
   warpgate_cavern.Name = "warpgate_cavern"
-  warpgate_cavern.UseRadius = 20.72639434f
-  warpgate_cavern.SOIRadius = 52
+  warpgate_cavern.UseRadius = 19.72639434f
+  warpgate_cavern.SOIRadius = 41
   warpgate_cavern.VehicleAllowance = true
-  warpgate_cavern.SpecificPointFunc = SpawnPoint.CavernGate
+  warpgate_cavern.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 4.5f)
 
   val warpgate_small = new WarpGateDefinition(995)
   warpgate_small.Name = "warpgate_small"
   warpgate_small.UseRadius = 69.03687655f
   warpgate_small.SOIRadius = 103
   warpgate_small.VehicleAllowance = true
-  warpgate_small.SpecificPointFunc = SpawnPoint.SmallGate(innerRadius = 27.60654127f)
+  warpgate_small.SpecificPointFunc = SpawnPoint.SmallGate(innerRadius = 27.60654127f, flightlessZOffset = 0.5f)
 
   val bunker_gauntlet = new BuildingDefinition(150) { Name = "bunker_gauntlet" }
   val bunker_lg       = new BuildingDefinition(151) { Name = "bunker_lg" }
@@ -1581,7 +1581,7 @@ object GlobalDefinitions {
   def isMaxArms(tdef: ToolDefinition): Boolean = {
     tdef match {
       case `trhev_dualcycler` | `nchev_scattercannon` | `vshev_quasar` | `trhev_pounder` | `nchev_falcon` |
-          `vshev_comet` | `trhev_burster` | `nchev_sparrow` | `vshev_starfire` =>
+           `vshev_comet` | `trhev_burster` | `nchev_sparrow` | `vshev_starfire` =>
         true
       case _ =>
         false
@@ -1691,13 +1691,13 @@ object GlobalDefinitions {
   def isFactionWeapon(edef: EquipmentDefinition): PlanetSideEmpire.Value = {
     edef match {
       case `chainblade` | `repeater` | `anniversary_guna` | `cycler` | `mini_chaingun` | `striker` |
-          `trhev_dualcycler` | `trhev_pounder` | `trhev_burster` =>
+           `trhev_dualcycler` | `trhev_pounder` | `trhev_burster` =>
         PlanetSideEmpire.TR
       case `magcutter` | `isp` | `anniversary_gun` | `gauss` | `r_shotgun` | `hunterseeker` | `nchev_scattercannon` |
-          `nchev_falcon` | `nchev_sparrow` =>
+           `nchev_falcon` | `nchev_sparrow` =>
         PlanetSideEmpire.NC
       case `forceblade` | `beamer` | `anniversary_gunb` | `pulsar` | `lasher` | `lancer` | `vshev_quasar` |
-          `vshev_comet` | `vshev_starfire` =>
+           `vshev_comet` | `vshev_starfire` =>
         PlanetSideEmpire.VS
       case _ =>
         PlanetSideEmpire.NEUTRAL
@@ -1713,16 +1713,16 @@ object GlobalDefinitions {
   def isFactionEquipment(edef: EquipmentDefinition): PlanetSideEmpire.Value = {
     edef match {
       case `chainblade` | `repeater` | `anniversary_guna` | `cycler` | `mini_chaingun` | `striker` |
-          `striker_missile_ammo` | `trhev_dualcycler` | `trhev_pounder` | `trhev_burster` | `dualcycler_ammo` |
-          `pounder_ammo` | `burster_ammo` =>
+           `striker_missile_ammo` | `trhev_dualcycler` | `trhev_pounder` | `trhev_burster` | `dualcycler_ammo` |
+           `pounder_ammo` | `burster_ammo` =>
         PlanetSideEmpire.TR
       case `magcutter` | `isp` | `anniversary_gun` | `gauss` | `r_shotgun` | `hunterseeker` | `hunter_seeker_missile` |
-          `nchev_scattercannon` | `nchev_falcon` | `nchev_sparrow` | `scattercannon_ammo` | `falcon_ammo` |
-          `sparrow_ammo` =>
+           `nchev_scattercannon` | `nchev_falcon` | `nchev_sparrow` | `scattercannon_ammo` | `falcon_ammo` |
+           `sparrow_ammo` =>
         PlanetSideEmpire.NC
       case `forceblade` | `beamer` | `anniversary_gunb` | `pulsar` | `lasher` | `lancer` | `energy_cell` |
-          `lancer_cartridge` | `vshev_quasar` | `vshev_comet` | `vshev_starfire` | `quasar_ammo` | `comet_ammo` |
-          `starfire_ammo` =>
+           `lancer_cartridge` | `vshev_quasar` | `vshev_comet` | `vshev_starfire` | `quasar_ammo` | `comet_ammo` |
+           `starfire_ammo` =>
         PlanetSideEmpire.VS
       case _ =>
         PlanetSideEmpire.NEUTRAL
@@ -1905,7 +1905,7 @@ object GlobalDefinitions {
   def isFlightVehicle(vdef: VehicleDefinition): Boolean = {
     vdef match {
       case `mosquito` | `lightgunship` | `wasp` | `liberator` | `vulture` | `phantasm` | `lodestar` | `dropship` |
-          `galaxy_gunship` =>
+           `galaxy_gunship` =>
         true
       case _ =>
         false

--- a/src/main/scala/net/psforever/objects/SpawnPoint.scala
+++ b/src/main/scala/net/psforever/objects/SpawnPoint.scala
@@ -3,6 +3,7 @@ package net.psforever.objects
 
 import net.psforever.objects.definition.{ObjectDefinition, VehicleDefinition}
 import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.mount.MountableEntity
 import net.psforever.types.{PlanetSideGUID, Vector3}
 
 import scala.collection.mutable
@@ -93,10 +94,10 @@ object SpawnPoint {
     ) * (3 * side).toFloat //x=sin, y=cos because compass-0 is East, not North
     (
       obj.Position + shift + (if (x >= 330) { //ams leaning to the left
-                                Vector3.z(xsin)
-                              } else { //ams leaning to the right
-                                Vector3.z(-xsin)
-                              }),
+        Vector3.z(xsin)
+      } else { //ams leaning to the right
+        Vector3.z(-xsin)
+      }),
       if (side == 1) {
         Vector3.z(zrot)
       } else {
@@ -111,8 +112,8 @@ object SpawnPoint {
         val ori  = target.Orientation
         val zrad = math.toRadians(ori.z)
         val radius =
-          scala.math.random().toFloat * (d.UseRadius - innerRadius) + innerRadius
-      val shift = Vector3(math.sin(zrad).toFloat, math.cos(zrad).toFloat, 0) * radius
+          scala.math.random().toFloat * 0.5f * (d.UseRadius - innerRadius) + innerRadius
+        val shift = Vector3(math.sin(zrad).toFloat, math.cos(zrad).toFloat, 0) * radius
         val altitudeShift = target.Definition match {
           case vdef: VehicleDefinition if GlobalDefinitions.isFlightVehicle(vdef) =>
             Vector3.z(scala.math.random().toFloat * d.UseRadius)
@@ -136,23 +137,26 @@ object SpawnPoint {
     )
   }
 
-  def CavernGate(obj: SpawnPoint, target: PlanetSideGameObject): (Vector3, Vector3) = {
-    val (a, b) = metaGate(obj, target, innerRadius = 5f)
+  def CavernGate(innerRadius: Float)(obj: SpawnPoint, target: PlanetSideGameObject): (Vector3, Vector3) = {
+    val (a, b) = metaGate(obj, target, innerRadius)
     target match {
       case v: Vehicle if GlobalDefinitions.isFlightVehicle(v.Definition) =>
         (a.xy + Vector3.z((target.Position.z + a.z) * 0.5f), b)
+      case m: MountableEntity =>
+        m.BailProtection = true
+        (a + Vector3.z(obj.Definition.UseRadius * 0.5f), b)
       case _ =>
-        (a + Vector3.z(value = 3f), b)
+        (a, b)
     }
   }
 
-  def SmallGate(innerRadius: Float)(obj: SpawnPoint, target: PlanetSideGameObject): (Vector3, Vector3) = {
+  def SmallGate(innerRadius: Float, flightlessZOffset: Float)(obj: SpawnPoint, target: PlanetSideGameObject): (Vector3, Vector3) = {
     val (a, b) = metaGate(obj, target, innerRadius)
     target match {
       case v: Vehicle if GlobalDefinitions.isFlightVehicle(v.Definition) =>
         (a.xy + Vector3.z((target.Position.z + a.z) * 0.5f), b)
       case _ =>
-        (a + Vector3.z(value = 0.5f), b)
+        (a + Vector3.z(flightlessZOffset), b)
     }
   }
 }


### PR DESCRIPTION
Positional corrections for warp gate zoning when using geowarp gates and cavern gates, with the goal of not falling through the ground.  It's nearly impossible to test.

___Addenda___
1) Attempted to write recovery for instances of `NoGUIDException` that intersect with `SessionActor` behavior.  As the original conditions are difficult to determine in exact details, these are hopeful fixes.
2) Attempted recovery for being stuck on the deployment map, dead, in the wrong zone.  It's the command `!suicide`.