### PR TITLE
Locker Fix

### DIFF
--- a/src/main/scala/net/psforever/objects/LocalLockerItem.scala
+++ b/src/main/scala/net/psforever/objects/LocalLockerItem.scala
@@ -23,7 +23,10 @@ class LocalLockerItem extends PlanetSideServerObject {
 
 object LocalLockerItem {
   import net.psforever.objects.definition.ObjectDefinition
-  def local = new ObjectDefinition(0) { Name = "locker-equipment" }
+  def local = new ObjectDefinition(0) {
+    Name = "locker-equipment"
+    registerAs = "locker-contents"
+  }
 
   /**
     * Instantiate and configure a `LocalProjectile` object.

--- a/src/main/scala/net/psforever/objects/LocalProjectile.scala
+++ b/src/main/scala/net/psforever/objects/LocalProjectile.scala
@@ -22,7 +22,10 @@ class LocalProjectile extends PlanetSideServerObject {
 
 object LocalProjectile {
   import net.psforever.objects.definition.ObjectDefinition
-  def local = new ObjectDefinition(0) { Name = "projectile" }
+  def local = new ObjectDefinition(0) {
+    Name = "projectile"
+    registerAs = "projectiles"
+  }
 
   /**
     * Instantiate and configure a `LocalProjectile` object.

--- a/src/main/scala/net/psforever/objects/locker/LockerContainerControl.scala
+++ b/src/main/scala/net/psforever/objects/locker/LockerContainerControl.scala
@@ -12,7 +12,7 @@ import net.psforever.types.{PlanetSideEmpire, Vector3}
 
 /**
   * A control agency mainly for manipulating the equipment stowed by a player in a `LockerContainer`
-  * and reporting back to a specific xchannel in the event system about these changes.
+  * and reporting back to a specific channel in the event system about these changes.
   * @param locker the governed player-facing locker component
   * @param toChannel the channel to which to publish events, typically the owning player's name
   */

--- a/src/main/scala/net/psforever/zones/Zones.scala
+++ b/src/main/scala/net/psforever/zones/Zones.scala
@@ -339,13 +339,6 @@ object Zones {
             turretWeaponGuid
           )
 
-          (Projectile.baseUID until Projectile.rangeUID) foreach {
-            zoneMap.addLocalObject(_, LocalProjectile.Constructor)
-          }
-          40150 until 40450 foreach {
-            zoneMap.addLocalObject(_, LocalLockerItem.Constructor)
-          }
-
           lattice.asObject.get(mapid).foreach { obj =>
             obj.asArray.get.foreach { entry =>
               val arr = entry.asArray.get
@@ -687,6 +680,16 @@ object Zones {
         override def SetupNumberPools() : Unit = addPoolsFunc()
 
         override def init(implicit context: ActorContext): Unit = {
+          guids.find { pool => pool.name.equals("projectiles") } match {
+            case Some(pool) =>
+              (pool.start to pool.max).foreach { map.addLocalObject(_, LocalProjectile.Constructor) }
+            case None => ;
+          }
+          guids.find { pool => pool.name.equals("locker-contents") } match {
+            case Some(pool) =>
+              (pool.start to pool.max).foreach { map.addLocalObject(_, LocalLockerItem.Constructor) }
+            case None => ;
+          }
           super.init(context)
 
           if (!info.id.startsWith("tz")) {


### PR DESCRIPTION
This fix should make lockers functional again.  Not only will items be safely moved between the player's hand and the locker space, and the other way, but the locker will correctly load and save its items as a database persistent state.  Existing database information about locker contents should have remained functional but being blanked is always a possibility due to load/save exchanges.

They should have been functional from the beginning.

I do not want to discuss how dumb the reason for the failure was here; go read the Trello ticket.