### PR TITLE
Enemies (No Friends)

### DIFF
--- a/server/src/main/resources/db/migration/V005__Acquaintances.sql
+++ b/server/src/main/resources/db/migration/V005__Acquaintances.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "friend" (
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "avatar_id" INT NOT NULL REFERENCES account (id),
+  "char_id" INT NOT NULL REFERENCES account (id)
+);
+
+CREATE TABLE IF NOT EXISTS "ignored" (
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "avatar_id" INT NOT NULL REFERENCES account (id),
+  "char_id" INT NOT NULL REFERENCES account (id)
+);

--- a/server/src/main/resources/db/migration/V005__Acquaintances.sql
+++ b/server/src/main/resources/db/migration/V005__Acquaintances.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS "friend" (
   "id" SERIAL PRIMARY KEY NOT NULL,
-  "avatar_id" INT NOT NULL REFERENCES account (id),
-  "char_id" INT NOT NULL REFERENCES account (id)
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "char_id" INT NOT NULL REFERENCES avatar (id)
 );
 
 CREATE TABLE IF NOT EXISTS "ignored" (
   "id" SERIAL PRIMARY KEY NOT NULL,
-  "avatar_id" INT NOT NULL REFERENCES account (id),
-  "char_id" INT NOT NULL REFERENCES account (id)
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "char_id" INT NOT NULL REFERENCES avatar (id)
 );

--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -125,6 +125,12 @@ class ChatActor(
   var chatService: Option[ActorRef[ChatService.Command]]            = None
   var cluster: Option[ActorRef[InterstellarClusterService.Command]] = None
   var silenceTimer: Cancellable                                     = Default.Cancellable
+  /**
+    * when another player is listed as one of our ignored players,
+    * and that other player sends an emote,
+    * that player is assigned a cooldown and only one emote per period will be seen<br>
+    * key - character unique avatar identifier, value - when the current cooldown period will end
+    */
   var ignoredEmoteCooldown: mutable.LongMap[Long]                   = mutable.LongMap[Long]()
 
   val chatServiceAdapter: ActorRef[ChatService.MessageResponse] = context.messageAdapter[ChatService.MessageResponse] {

--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -25,6 +25,8 @@ import akka.actor.typed.scaladsl.adapter._
 import net.psforever.services.{CavernRotationService, InterstellarClusterService}
 import net.psforever.types.ChatMessageType.UNK_229
 
+import scala.collection.mutable
+
 object ChatActor {
   def apply(
       sessionActor: ActorRef[SessionActor.Command],
@@ -123,6 +125,7 @@ class ChatActor(
   var chatService: Option[ActorRef[ChatService.Command]]            = None
   var cluster: Option[ActorRef[InterstellarClusterService.Command]] = None
   var silenceTimer: Cancellable                                     = Default.Cancellable
+  var ignoredEmoteCooldown: mutable.LongMap[Long]                   = mutable.LongMap[Long]()
 
   val chatServiceAdapter: ActorRef[ChatService.MessageResponse] = context.messageAdapter[ChatService.MessageResponse] {
     case ChatService.MessageResponse(_session, message, channel) => IncomingMessage(_session, message, channel)
@@ -699,11 +702,21 @@ class ChatActor(
               }
 
             case (CMT_TELL, _, _) if !session.player.silenced =>
-              chatService ! ChatService.Message(
-                session,
-                message,
-                ChatChannel.Default()
-              )
+              if (AvatarActor.onlineIfNotIgnored(message.recipient, session.avatar.name)) {
+                chatService ! ChatService.Message(
+                  session,
+                  message,
+                  ChatChannel.Default()
+                )
+              } else if (AvatarActor.getLiveAvatarForFunc(message.recipient, (_,_,_)=>{}).isEmpty) {
+                sessionActor ! SessionActor.SendResponse(
+                  ChatMsg(ChatMessageType.UNK_45, false, "none", "@notell_target", None)
+                )
+              } else {
+                sessionActor ! SessionActor.SendResponse(
+                  ChatMsg(ChatMessageType.UNK_45, false, "none", "@notell_ignore", None)
+                )
+              }
 
             case (CMT_BROADCAST, _, _) if !session.player.silenced =>
               chatService ! ChatService.Message(
@@ -1055,25 +1068,47 @@ class ChatActor(
 
         case IncomingMessage(fromSession, message, channel) =>
           message.messageType match {
-            case CMT_TELL | U_CMT_TELLFROM | CMT_BROADCAST | CMT_SQUAD | CMT_PLATOON | CMT_COMMAND | UNK_45 | UNK_71 |
-                CMT_NOTE | CMT_GMBROADCAST | CMT_GMBROADCAST_NC | CMT_GMBROADCAST_TR | CMT_GMBROADCAST_VS |
-                CMT_GMBROADCASTPOPUP | CMT_GMTELL | U_CMT_GMTELLFROM | UNK_227 | UNK_229 =>
-              sessionActor ! SessionActor.SendResponse(message)
+            case CMT_BROADCAST | CMT_SQUAD | CMT_PLATOON | CMT_COMMAND | CMT_NOTE =>
+              if (AvatarActor.onlineIfNotIgnored(session.avatar, message.recipient)) {
+                sessionActor ! SessionActor.SendResponse(message)
+              }
             case CMT_OPEN =>
               if (
                 session.zone == fromSession.zone &&
-                Vector3.Distance(session.player.Position, fromSession.player.Position) < 25 &&
-                session.player.Faction == fromSession.player.Faction
+                  Vector3.DistanceSquared(session.player.Position, fromSession.player.Position) < 625 &&
+                  session.player.Faction == fromSession.player.Faction &&
+                  AvatarActor.onlineIfNotIgnored(session.avatar, message.recipient)
               ) {
                 sessionActor ! SessionActor.SendResponse(message)
               }
+            case CMT_TELL | U_CMT_TELLFROM |
+                 CMT_GMOPEN | CMT_GMBROADCAST | CMT_GMBROADCAST_NC | CMT_GMBROADCAST_TR | CMT_GMBROADCAST_VS |
+                 CMT_GMBROADCASTPOPUP | CMT_GMTELL | U_CMT_GMTELLFROM | UNK_45 | UNK_71 | UNK_227 | UNK_229 =>
+              sessionActor ! SessionActor.SendResponse(message)
             case CMT_VOICE =>
               if (
                 session.zone == fromSession.zone &&
-                Vector3.Distance(session.player.Position, fromSession.player.Position) < 25 ||
+                Vector3.DistanceSquared(session.player.Position, fromSession.player.Position) < 625 ||
                 message.contents.startsWith("SH") // tactical squad voice macro
               ) {
-                sessionActor ! SessionActor.SendResponse(message)
+                val name = fromSession.avatar.name
+                if (!session.avatar.people.ignored.exists { f => f.name.equals(name) } ||
+                  {
+                    val id = fromSession.avatar.id.toLong
+                    val curr = System.currentTimeMillis()
+                    ignoredEmoteCooldown.get(id) match {
+                    case None =>
+                      ignoredEmoteCooldown.put(id, curr + 15000L)
+                      true
+                    case Some(time) if time < curr =>
+                      ignoredEmoteCooldown.put(id, curr + 15000L)
+                      true
+                    case _ =>
+                      false
+                  }}
+                ) {
+                  sessionActor ! SessionActor.SendResponse(message)
+                }
               }
             case CMT_SILENCE =>
               val args = message.contents.split(" ")

--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -913,7 +913,7 @@ class ChatActor(
               }
 
             case (CMT_TOGGLE_HAT, _, contents) =>
-              val cosmetics = session.avatar.cosmetics.getOrElse(Set())
+              val cosmetics = session.avatar.decoration.cosmetics.getOrElse(Set())
               val nextCosmetics = contents match {
                 case "off" =>
                   cosmetics.diff(Set(Cosmetic.BrimmedCap, Cosmetic.Beret))
@@ -937,7 +937,7 @@ class ChatActor(
               )
 
             case (CMT_HIDE_HELMET | CMT_TOGGLE_SHADES | CMT_TOGGLE_EARPIECE, _, contents) =>
-              val cosmetics = session.avatar.cosmetics.getOrElse(Set())
+              val cosmetics = session.avatar.decoration.cosmetics.getOrElse(Set())
 
               val cosmetic = message.messageType match {
                 case CMT_HIDE_HELMET     => Cosmetic.NoHelmet

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3605,7 +3605,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
     sendResponse(ReplicationStreamMessage(5, Some(6), Vector.empty)) //clear squad list
     sendResponse(SquadDefinitionActionMessage(PlanetSideGUID(0), 0, SquadAction.Unknown(6)))
     //only need to load these once - they persist between zone transfers and respawns
-    avatar.squadLoadouts.zipWithIndex.foreach {
+    avatar.loadouts.squad.zipWithIndex.foreach {
       case (Some(loadout), index) =>
         sendResponse(
           SquadDefinitionActionMessage(PlanetSideGUID(0), index, SquadAction.ListSquadFavorite(loadout.task))

--- a/src/main/scala/net/psforever/objects/avatar/Acquaintance.scala
+++ b/src/main/scala/net/psforever/objects/avatar/Acquaintance.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.objects.avatar
+
+import net.psforever.types.PlanetSideEmpire
+
+case class Friend(
+                   charId: Long = 0,
+                   name: String = "",
+                   faction: PlanetSideEmpire.Value,
+                   online: Boolean = false
+                 )
+
+case class Ignored(
+                    charId: Long = 0,
+                    name: String = "",
+                    online: Boolean = false
+                  ) {
+  val faction: PlanetSideEmpire.Value = PlanetSideEmpire.NEUTRAL
+}

--- a/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
@@ -105,7 +105,7 @@ object AvatarConverter {
       unk7 = false,
       on_zipline = None
     )
-    CharacterAppearanceData(aa, ab, obj.avatar.ribbonBars)
+    CharacterAppearanceData(aa, ab, obj.avatar.decoration.ribbonBars)
   }
 
   def MakeCharacterData(obj: Player): (Boolean, Boolean) => CharacterData = {
@@ -121,7 +121,7 @@ object AvatarConverter {
       0,
       obj.avatar.cr.value,
       obj.avatar.implants.flatten.filter(_.active).flatMap(_.definition.implantType.effect).toList,
-      obj.avatar.cosmetics
+      obj.avatar.decoration.cosmetics
     )
   }
 
@@ -153,7 +153,7 @@ object AvatarConverter {
       obj.avatar.implants.flatten.map(_.toEntry).toList,
       Nil,
       Nil,
-      obj.avatar.firstTimeEvents.toList,
+      obj.avatar.decoration.firstTimeEvents.toList,
       tutorials = List.empty[String], //TODO tutorial list
       0L,
       0L,
@@ -164,7 +164,7 @@ object AvatarConverter {
       Nil,
       Nil,
       unkC = false,
-      obj.avatar.cosmetics
+      obj.avatar.decoration.cosmetics
     )
     pad_length: Option[Int] => DetailedCharacterData(ba, bb(obj.avatar.bep, pad_length))(pad_length)
   }

--- a/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/CharacterSelectConverter.scala
@@ -79,7 +79,7 @@ class CharacterSelectConverter extends AvatarConverter {
       unk7 = false,
       on_zipline = None
     )
-    CharacterAppearanceData(aa, ab, obj.avatar.ribbonBars)
+    CharacterAppearanceData(aa, ab, obj.avatar.decoration.ribbonBars)
   }
 
   private def MakeDetailedCharacterData(obj: Player): Option[Int] => DetailedCharacterData = {
@@ -123,7 +123,7 @@ class CharacterSelectConverter extends AvatarConverter {
       Nil,
       Nil,
       unkC = false,
-      obj.avatar.cosmetics
+      obj.avatar.decoration.cosmetics
     )
     pad_length: Option[Int] => DetailedCharacterData(ba, bb(obj.avatar.bep, pad_length))(pad_length)
   }

--- a/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/CorpseConverter.scala
@@ -70,7 +70,7 @@ class CorpseConverter extends AvatarConverter {
       unk7 = false,
       on_zipline = None
     )
-    CharacterAppearanceData(aa, ab, obj.avatar.ribbonBars)
+    CharacterAppearanceData(aa, ab, obj.avatar.decoration.ribbonBars)
   }
 
   private def MakeDetailedCharacterData(obj: Player): Option[Int] => DetailedCharacterData = {

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/BattleframeSpawnLoadoutPage.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/BattleframeSpawnLoadoutPage.scala
@@ -20,8 +20,9 @@ import net.psforever.packet.game.ItemTransactionMessage
   */
 final case class BattleframeSpawnLoadoutPage(vehicles: Map[String, () => Vehicle]) extends LoadoutTab {
   override def Buy(player: Player, msg: ItemTransactionMessage): Terminal.Exchange = {
-    player.avatar.loadouts(msg.unk1 + 15) match {
-      case Some(loadout: VehicleLoadout) if !Exclude.contains(loadout.vehicle_definition) =>
+    player.avatar.loadouts.suit(msg.unk1 + 15) match {
+      case Some(loadout: VehicleLoadout)
+        if !Exclude.exists(_.checkRule(player, msg, loadout.vehicle_definition)) =>
         vehicles.get(loadout.vehicle_definition.Name) match {
           case Some(vehicle) =>
             val weapons = loadout.visible_slots.map(entry => {

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/InfantryLoadoutPage.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/InfantryLoadoutPage.scala
@@ -27,7 +27,7 @@ import net.psforever.packet.game.ItemTransactionMessage
   */
 final case class InfantryLoadoutPage() extends LoadoutTab {
   override def Buy(player: Player, msg: ItemTransactionMessage): Terminal.Exchange = {
-    player.avatar.loadouts(msg.unk1) match {
+    player.avatar.loadouts.suit(msg.unk1) match {
       case Some(loadout: InfantryLoadout)
         if !Exclude.exists(_.checkRule(player, msg, loadout.exosuit)) &&
            !Exclude.exists(_.checkRule(player, msg, (loadout.exosuit, loadout.subtype))) =>

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/VehicleLoadoutPage.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/tabs/VehicleLoadoutPage.scala
@@ -23,7 +23,7 @@ import net.psforever.packet.game.ItemTransactionMessage
   */
 final case class VehicleLoadoutPage(lineOffset: Int) extends LoadoutTab {
   override def Buy(player: Player, msg: ItemTransactionMessage): Terminal.Exchange = {
-    player.avatar.loadouts(msg.unk1 + lineOffset) match {
+    player.avatar.loadouts.suit(msg.unk1 + lineOffset) match {
       case Some(loadout: VehicleLoadout) =>
         val weapons = loadout.visible_slots
           .map(entry => {

--- a/src/main/scala/net/psforever/packet/game/FriendsRequest.scala
+++ b/src/main/scala/net/psforever/packet/game/FriendsRequest.scala
@@ -2,6 +2,7 @@
 package net.psforever.packet.game
 
 import net.psforever.packet.{GamePacketOpcode, Marshallable, PacketHelpers, PlanetSideGamePacket}
+import net.psforever.types.MemberAction
 import scodec.Codec
 import scodec.codecs._
 
@@ -15,23 +16,12 @@ import scodec.codecs._
   * No name will be appended or removed from any list until the response to this packet is received.<br>
   * <br>
   * Actions that involve the "remove" functionality will locate the entered name in the local list before dispatching this packet.
-  * A complaint will be logged to the event window if the name is not found.<br>
-  * <br>
-  * Actions:<br>
-  * 0 - display friends list<br>
-  * 1 - add player to friends list<br>
-  * 2 - remove player from friends list<br>
-  * 4 - display ignored player list<br>
-  * 5 - add player to ignored player list<br>
-  * 6 - remove player from ignored player list<br>
-  * <br>
-  * Exploration:<br>
-  * Are action = 3 and action = 7 supposed to do anything?
+  * A complaint will be logged to the event window if the name is not found.
   * @param action the purpose of this packet
   * @param friend the player name that was entered;
   *               blank in certain situations
   */
-final case class FriendsRequest(action: Int, friend: String) extends PlanetSideGamePacket {
+final case class FriendsRequest(action: MemberAction.Value, friend: String) extends PlanetSideGamePacket {
   type Packet = FriendsRequest
   def opcode = GamePacketOpcode.FriendsRequest
   def encode = FriendsRequest.encode(this)
@@ -39,7 +29,7 @@ final case class FriendsRequest(action: Int, friend: String) extends PlanetSideG
 
 object FriendsRequest extends Marshallable[FriendsRequest] {
   implicit val codec: Codec[FriendsRequest] = (
-    ("action" | uintL(3)) ::
+    ("action" | MemberAction.codec) ::
       ("friend" | PacketHelpers.encodedWideStringAligned(5))
   ).as[FriendsRequest]
 }

--- a/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -35,7 +35,7 @@ final case class FriendsResponse(
                                   unk1: Int,
                                   first_entry: Boolean,
                                   last_entry: Boolean,
-                                  friends: List[Friend] = Nil
+                                  friends: List[Friend]
 ) extends PlanetSideGamePacket {
   type Packet = FriendsResponse
 
@@ -46,7 +46,7 @@ final case class FriendsResponse(
 
 object Friend extends Marshallable[Friend] {
   implicit val codec: Codec[Friend] = (
-    ("name" | PacketHelpers.encodedWideStringAligned(3)) ::
+    ("name" | PacketHelpers.encodedWideStringAligned(adjustment = 3)) ::
       ("online" | bool)
   ).as[Friend]
 
@@ -55,7 +55,7 @@ object Friend extends Marshallable[Friend] {
     * Initial byte-alignment creates padding differences which requires a second `Codec`.
     */
   implicit val codec_list: Codec[Friend] = (
-    ("name" | PacketHelpers.encodedWideStringAligned(7)) ::
+    ("name" | PacketHelpers.encodedWideStringAligned(adjustment = 7)) ::
       ("online" | bool)
   ).as[Friend]
 }
@@ -87,7 +87,7 @@ object FriendsResponse extends Marshallable[FriendsResponse] {
       ("first_entry" | bool) ::
       ("last_entry" | bool) ::
       (("number_of_friends" | uint4L) >>:~ { len =>
-      conditional(len > 0, "friend" | Friend.codec) ::
+      conditional(len > 0, codec = "friend" | Friend.codec) ::
         ("friends" | PacketHelpers.listOfNSized(len - 1, Friend.codec_list))
     })
   ).xmap[FriendsResponse](

--- a/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
+++ b/src/main/scala/net/psforever/packet/game/FriendsResponse.scala
@@ -65,6 +65,14 @@ object FriendsResponse extends Marshallable[FriendsResponse] {
     FriendsResponse(action, unk1=0, first_entry=true, last_entry=true, List(friend))
   }
 
+  /**
+    * Take a list of members and construct appropriate packets by which they can be dispatched to the client.
+    * Attention needs to be paid to the number of entries in a single packet,
+    * and where the produced packets begin and end.
+    * @param action the purpose of the entry(s) in this packet
+    * @param friends a list of `Friend`s
+    * @return a list of `FriendResponse` packets
+    */
   def packetSequence(action: MemberAction.Value, friends: List[Friend]): List[FriendsResponse] = {
     val lists = friends.grouped(15)
     val size = lists.size

--- a/src/main/scala/net/psforever/persistence/Acquaintance.scala
+++ b/src/main/scala/net/psforever/persistence/Acquaintance.scala
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.persistence
 
-case class Friend(id: Int, avatarId: Long, relationship: Int, charId: Long)
+case class Friend(id: Int, avatarId: Long, charId: Long)
 
-case class Ignored(id: Int, avatarId: Long, relationship: Int, charId: Long)
+case class Ignored(id: Int, avatarId: Long, charId: Long)

--- a/src/main/scala/net/psforever/persistence/Acquaintance.scala
+++ b/src/main/scala/net/psforever/persistence/Acquaintance.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.persistence
+
+case class Friend(id: Int, avatarId: Long, relationship: Int, charId: Long)
+
+case class Ignored(id: Int, avatarId: Long, relationship: Int, charId: Long)

--- a/src/main/scala/net/psforever/persistence/Avatar.scala
+++ b/src/main/scala/net/psforever/persistence/Avatar.scala
@@ -1,7 +1,7 @@
 package net.psforever.persistence
 
 import net.psforever.objects.avatar
-import net.psforever.objects.avatar.Cosmetic
+import net.psforever.objects.avatar.{Cosmetic, ProgressDecoration}
 import org.joda.time.LocalDateTime
 import net.psforever.types.{CharacterSex, CharacterVoice, PlanetSideEmpire}
 
@@ -32,6 +32,6 @@ case class Avatar(
       CharacterVoice(voiceId),
       bep,
       cep,
-      cosmetics = cosmetics.map(c => Cosmetic.valuesFromObjectCreateValue(c))
+      decoration = ProgressDecoration(cosmetics = cosmetics.map(c => Cosmetic.valuesFromObjectCreateValue(c)))
     )
 }

--- a/src/main/scala/net/psforever/services/galaxy/GalaxyService.scala
+++ b/src/main/scala/net/psforever/services/galaxy/GalaxyService.scala
@@ -78,9 +78,20 @@ class GalaxyService extends Actor {
             )
           )
 
+        case GalaxyAction.LogStatusChange(name) =>
+          GalaxyEvents.publish(
+            GalaxyServiceResponse(
+              s"/Galaxy",
+              GalaxyResponse.LogStatusChange(name)
+            )
+          )
+
         case GalaxyAction.SendResponse(msg) =>
           GalaxyEvents.publish(
-            GalaxyServiceResponse(s"/Galaxy", GalaxyResponse.SendResponse(msg))
+            GalaxyServiceResponse(
+              s"/Galaxy",
+              GalaxyResponse.SendResponse(msg)
+            )
           )
         case _ => ;
       }

--- a/src/main/scala/net/psforever/services/galaxy/GalaxyServiceMessage.scala
+++ b/src/main/scala/net/psforever/services/galaxy/GalaxyServiceMessage.scala
@@ -39,5 +39,7 @@ object GalaxyAction {
 
   final case class UnlockedZoneUpdate(zone: Zone) extends Action
 
+  final case class LogStatusChange(name: String) extends Action
+
   final case class SendResponse(msg: PlanetSideGamePacket) extends Action
 }

--- a/src/main/scala/net/psforever/services/galaxy/GalaxyServiceResponse.scala
+++ b/src/main/scala/net/psforever/services/galaxy/GalaxyServiceResponse.scala
@@ -38,5 +38,7 @@ object GalaxyResponse {
 
   final case class UnlockedZoneUpdate(zone: Zone) extends Response
 
+  final case class LogStatusChange(name: String) extends Response
+
   final case class SendResponse(msg: PlanetSideGamePacket) extends Response
 }

--- a/src/main/scala/net/psforever/types/MemberAction.scala
+++ b/src/main/scala/net/psforever/types/MemberAction.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.types
+
+import net.psforever.packet.PacketHelpers
+import scodec.Codec
+import scodec.codecs._
+
+object MemberAction extends Enumeration {
+  type Type = Value
+
+  val InitializeFriendList, AddFriend, RemoveFriend, UpdateFriend, InitializeIgnoreList, AddIgnoredPlayer,
+  RemoveIgnoredPlayer = Value
+
+  implicit val codec: Codec[MemberAction.Value] = PacketHelpers.createEnumerationCodec(this, uint(bits = 3))
+}

--- a/src/test/scala/game/FriendsRequestTest.scala
+++ b/src/test/scala/game/FriendsRequestTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.MemberAction
 import scodec.bits._
 
 class FriendsRequestTest extends Specification {
@@ -12,7 +13,7 @@ class FriendsRequestTest extends Specification {
   "decode" in {
     PacketCoding.decodePacket(string).require match {
       case FriendsRequest(action, friend) =>
-        action mustEqual 1
+        action mustEqual MemberAction.AddFriend
         friend.length mustEqual 5
         friend mustEqual "FJHNC"
       case _ =>
@@ -21,7 +22,7 @@ class FriendsRequestTest extends Specification {
   }
 
   "encode" in {
-    val msg = FriendsRequest(1, "FJHNC")
+    val msg = FriendsRequest(MemberAction.AddFriend, "FJHNC")
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string

--- a/src/test/scala/game/FriendsResponseTest.scala
+++ b/src/test/scala/game/FriendsResponseTest.scala
@@ -4,6 +4,7 @@ package game
 import org.specs2.mutable._
 import net.psforever.packet._
 import net.psforever.packet.game._
+import net.psforever.types.MemberAction
 import scodec.bits._
 
 class FriendsResponseTest extends Specification {
@@ -15,7 +16,7 @@ class FriendsResponseTest extends Specification {
   "decode (one friend)" in {
     PacketCoding.decodePacket(stringOneFriend).require match {
       case FriendsResponse(action, unk2, unk3, unk4, list) =>
-        action mustEqual FriendAction.UpdateFriend
+        action mustEqual MemberAction.UpdateFriend
         unk2 mustEqual 0
         unk3 mustEqual true
         unk4 mustEqual true
@@ -30,7 +31,7 @@ class FriendsResponseTest extends Specification {
   "decode (multiple friends)" in {
     PacketCoding.decodePacket(stringManyFriends).require match {
       case FriendsResponse(action, unk2, unk3, unk4, list) =>
-        action mustEqual FriendAction.InitializeFriendList
+        action mustEqual MemberAction.InitializeFriendList
         unk2 mustEqual 0
         unk3 mustEqual true
         unk4 mustEqual true
@@ -53,7 +54,7 @@ class FriendsResponseTest extends Specification {
   "decode (short)" in {
     PacketCoding.decodePacket(stringShort).require match {
       case FriendsResponse(action, unk2, unk3, unk4, list) =>
-        action mustEqual FriendAction.InitializeIgnoreList
+        action mustEqual MemberAction.InitializeIgnoreList
         unk2 mustEqual 0
         unk3 mustEqual true
         unk4 mustEqual true
@@ -65,7 +66,7 @@ class FriendsResponseTest extends Specification {
 
   "encode (one friend)" in {
     val msg = FriendsResponse(
-      FriendAction.UpdateFriend,
+      MemberAction.UpdateFriend,
       0,
       true,
       true,
@@ -79,7 +80,7 @@ class FriendsResponseTest extends Specification {
 
   "encode (multiple friends)" in {
     val msg = FriendsResponse(
-      FriendAction.InitializeFriendList,
+      MemberAction.InitializeFriendList,
       0,
       true,
       true,
@@ -96,7 +97,7 @@ class FriendsResponseTest extends Specification {
   }
 
   "encode (short)" in {
-    val msg = FriendsResponse(FriendAction.InitializeIgnoreList, 0, true, true)
+    val msg = FriendsResponse(MemberAction.InitializeIgnoreList, 0, true, true)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual stringShort

--- a/src/test/scala/game/FriendsResponseTest.scala
+++ b/src/test/scala/game/FriendsResponseTest.scala
@@ -97,7 +97,7 @@ class FriendsResponseTest extends Specification {
   }
 
   "encode (short)" in {
-    val msg = FriendsResponse(MemberAction.InitializeIgnoreList, 0, true, true)
+    val msg = FriendsResponse(MemberAction.InitializeIgnoreList, 0, true, true, Nil)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual stringShort


### PR DESCRIPTION
I've developed yet another useless subsystem that no one will ever utilize.

The lists of friends and of ignored players can be access via the Players window from the appropriate tabs.  The tabs maintain buttons for the convenience of adding or removing players from that respective list, though chat commands also exist that perform the same tasks.  The friends list can also be displayed in a popout list (called "monitoring"), indicated by its own button.

The friends list will help you keep track of other players less likely to shoot you in the back.  It's not NC proof.
The ignored players list will help you manage other players who antagonize you.  They can still just shoot you in the back.  It's not NC proof.

___Commands___
These chat commands are naturally in the game.
__`/friends`__
Affectively reloads the list of friends players.  The operative word in the field guide is "display" but it does not open the popout or quickly switch to the player's tab.

__`/friends [add|remove] <name>`__
Add a player character to the list of friends in their appropriate state (online or offline) or remove them from the same list.  Nothing will happen if the player is already in the list or does not exist in the character database.

__`/ignore`__
Affectively reloads the list of friends players.  The operative word in the field guide is "display" but it does not open a popout or quickly switch to the player's tab.  There is no popout for the list of ignored players anyway.

__`/ignore [add|remove] <name>`__
Add a player character to the list of ignored players or remove them from the same list.  Nothing will happen if the player is already in the list or does not exist in the character database.  This also causes online status to update for the other player's friends lists, as well as the owner of the ignored player list.

___Features___
__`AvatarActor`__
Almost all operations of the friend list and the ignored players list is facilitated through individual avatar control agency.

__`GalaxyService`__
Routing of messages to players in regards to updates to the ignored players list is facilitated through this service.  It will message everyone subscribed to the service at this time.

__`SessionActor`__
Initialization of the friends list and the ignored players list.  Part of the `GalaxyService` update path.

__`PersistenceMonitor`__
When persistence ends, all related players who are a friend of the player who is leaving the game must have that leaving player's online status updated properly.

___Caveats___
1. `GalaxyService` is utilized as a messaging path because it is far-reaching and does not need to focus on a single given zone. Unfortunately, it is also an inefficient choice of a messaging pathways as it is unable to focus on a single specific player character which would be the optimal solution.  Eh.
2. . Ignored players will be utilized for squad selection purposes, e.g., requests, invitations, etc., in the future.  Due to the ongoing critical work on squad-based services in the branch `team-building-exercise`, however, these features will not be implemented right now.  I have to think about the ease of future pull request merges.
3. A choice was made that the ignored players list will trump the friends list.  If the same other player is in both of a single player's lists, that other player will always appear offline.  The other player is truly being ignored.  This is not a vanilla feature.
4. An ignored player is limited in their emote communication from the perspective of a player who is ignoring them.  The current system is one emote received every 15s.  This is not a vanilla feature (as far as I am aware).
5. One character should be able to poll the online status of characters who are on separate servers than their own.  Obviously, this features is pointless to us at this time.

___Addenda___
When trying to `/tell` a player who is ignoring you, an appropriate message will be displayed.  When trying to `/tell` a player who is not online, a different message appropriate to __that situation__ will be displayed.