### PR TITLE
Login Location Persistence

### DIFF
--- a/server/src/main/resources/db/migration/V005__Acquaintances.sql
+++ b/server/src/main/resources/db/migration/V005__Acquaintances.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS "friend" (
-  "id" SERIAL PRIMARY KEY NOT NULL,
   "avatar_id" INT NOT NULL REFERENCES avatar (id),
-  "char_id" INT NOT NULL REFERENCES avatar (id)
+  "char_id" INT NOT NULL REFERENCES avatar (id),
+  UNIQUE(avatar_id, char_id)
 );
 
 CREATE TABLE IF NOT EXISTS "ignored" (
-  "id" SERIAL PRIMARY KEY NOT NULL,
   "avatar_id" INT NOT NULL REFERENCES avatar (id),
-  "char_id" INT NOT NULL REFERENCES avatar (id)
+  "char_id" INT NOT NULL REFERENCES avatar (id),
+  UNIQUE(avatar_id, char_id)
 );

--- a/server/src/main/resources/db/migration/V006__SavedCharacters.sql
+++ b/server/src/main/resources/db/migration/V006__SavedCharacters.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "savedplayer" (
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "px" INT NOT NULL,
+  "py" INT NOT NULL,
+  "pz" INT NOT NULL,
+  "orientation" INT NOT NULL,
+  "zone_num" SMALLINT NOT NULL,
+  "health" SMALLINT NOT NULL,
+  "armor" SMALLINT NOT NULL,
+  "exosuit_num" SMALLINT NOT NULL,
+  "loadout" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "savedavatar" (
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "forget_cooldown" TIMESTAMP NOT NULL,
+  "purchase_cooldowns" TEXT NOT NULL,
+  "use_cooldowns" TEXT NOT NULL
+);
+
+ALTER TABLE account
+ADD COLUMN last_faction_id SMALLINT DEFAULT 3

--- a/server/src/main/resources/db/migration/V006__SavedCharacters.sql
+++ b/server/src/main/resources/db/migration/V006__SavedCharacters.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS "savedplayer" (
-  "id" SERIAL PRIMARY KEY NOT NULL,
-  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "avatar_id" INT NOT NULL PRIMARY KEY REFERENCES avatar (id),
   "px" INT NOT NULL,
   "py" INT NOT NULL,
   "pz" INT NOT NULL,
@@ -13,8 +12,7 @@ CREATE TABLE IF NOT EXISTS "savedplayer" (
 );
 
 CREATE TABLE IF NOT EXISTS "savedavatar" (
-  "id" SERIAL PRIMARY KEY NOT NULL,
-  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "avatar_id" INT NOT NULL PRIMARY KEY REFERENCES avatar (id),
   "forget_cooldown" TIMESTAMP NOT NULL,
   "purchase_cooldowns" TEXT NOT NULL,
   "use_cooldowns" TEXT NOT NULL

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -147,6 +147,36 @@ game {
     # When set, however, the next zone unlock is carried out regardless of the amount of time remaining
     force-rotation-immediately = false
   }
+
+  saved-msg = {
+    # A brief delay to the @charsaved message, in seconds.
+    # Use this when the message should display very soon for any reason.
+    short = {
+      # This delay always occurs
+      fixed = 5
+      # This delay is applied partially - fixed + [0,delay)
+      variable = 5
+    }
+
+    # A delay to the @charsaved message whenever a previous message has been displayed, in seconds.
+    # Used as the default interval between messages.
+    # It should provide assurance to the player even if nothing happened.
+    # Actual database interaction not assured.
+    renewal = {
+      fixed = 300
+      variable = 600
+    }
+
+    # A delay to the @charsaved message
+    # whenever an action that would cause actual database interaction occurs, in seconds.
+    # Actual database interaction not assured.
+    # The variability, in this case, serves the purpose of hedging against other activity by the player
+    # that would trigger the message again in a short amount of time.
+    interrupted-by-action = {
+      fixed = 15
+      variable = 30
+    }
+  }
 }
 
 anti-cheat {

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -62,7 +62,7 @@ class Player(var avatar: Avatar)
   private var jumping: Boolean            = false
   private var cloaked: Boolean            = false
   private var afk: Boolean                = false
-  private var zoning: Zoning.Method.Value = Zoning.Method.None
+  private var zoning: Zoning.Method       = Zoning.Method.None
 
   private var vehicleSeated: Option[PlanetSideGUID] = None
 
@@ -526,9 +526,9 @@ class Player(var avatar: Avatar)
     Carrying
   }
 
-  def ZoningRequest: Zoning.Method.Value = zoning
+  def ZoningRequest: Zoning.Method = zoning
 
-  def ZoningRequest_=(request: Zoning.Method.Value): Zoning.Method.Value = {
+  def ZoningRequest_=(request: Zoning.Method): Zoning.Method = {
     zoning = request
     ZoningRequest
   }

--- a/src/main/scala/net/psforever/objects/Session.scala
+++ b/src/main/scala/net/psforever/objects/Session.scala
@@ -10,7 +10,7 @@ case class Session(
     account: Account = null,
     player: Player = null,
     avatar: Avatar = null,
-    zoningType: Zoning.Method.Value = Zoning.Method.None,
+    zoningType: Zoning.Method = Zoning.Method.None,
     deadState: DeadState.Value = DeadState.Alive,
     speed: Float = 1.0f,
     flying: Boolean = false

--- a/src/main/scala/net/psforever/objects/zones/Zoning.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zoning.scala
@@ -1,19 +1,32 @@
+// Copyright (c) 2020 PSForever
 package net.psforever.objects.zones
 
+import enumeratum.values.{StringEnum, StringEnumEntry}
 import net.psforever.objects.SpawnPoint
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 
 object Zoning {
-  object Method extends Enumeration {
-    type Type = Value
+  sealed abstract class Method(val value: String) extends StringEnumEntry
+  sealed abstract class Status(val value: String) extends StringEnumEntry
 
-    val None, InstantAction, OutfitRecall, Recall, Quit = Value
+  object Method extends StringEnum[Method] {
+    val values: IndexedSeq[Method] = findValues
+
+    case object None extends Method(value = "None")
+    case object InstantAction extends Method(value = "InstantAction")
+    case object OutfitRecall extends Method(value = "OutfitRecall")
+    case object Recall extends Method(value = "Recall")
+    case object Quit extends Method(value = "Quit")
+    case object Login extends Method(value = "Login")
+    case object Reset extends Method(value = "Reset")
   }
 
-  object Status extends Enumeration {
-    type Type = Value
+  object Status extends StringEnum[Status] {
+    val values: IndexedSeq[Status] = findValues
 
-    val None, Request, Countdown = Value
+    case object None extends Status(value = "None")
+    case object Request extends Status(value = "Request")
+    case object Countdown extends Status(value = "Countdown")
   }
 
   object Time {

--- a/src/main/scala/net/psforever/persistence/Account.scala
+++ b/src/main/scala/net/psforever/persistence/Account.scala
@@ -9,5 +9,6 @@ case class Account(
     created: LocalDateTime = LocalDateTime.now(),
     lastModified: LocalDateTime = LocalDateTime.now(),
     inactive: Boolean = false,
-    gm: Boolean = false
+    gm: Boolean = false,
+    lastFactionId: Int = 3
 )

--- a/src/main/scala/net/psforever/persistence/Acquaintance.scala
+++ b/src/main/scala/net/psforever/persistence/Acquaintance.scala
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.persistence
 
-case class Friend(id: Int, avatarId: Long, charId: Long)
+case class Friend(avatarId: Long, charId: Long)
 
-case class Ignored(id: Int, avatarId: Long, charId: Long)
+case class Ignored(avatarId: Long, charId: Long)

--- a/src/main/scala/net/psforever/persistence/SavedCharacter.scala
+++ b/src/main/scala/net/psforever/persistence/SavedCharacter.scala
@@ -4,7 +4,6 @@ package net.psforever.persistence
 import org.joda.time.LocalDateTime
 
 case class Savedplayer(
-                        id: Long,
                         avatarId: Long,
                         px: Int, //Position.x * 1000
                         py: Int, //Position.y * 1000
@@ -18,7 +17,6 @@ case class Savedplayer(
                       )
 
 case class Savedavatar(
-                        id: Long,
                         avatarId: Long,
                         forgetCooldown: LocalDateTime,
                         purchaseCooldowns: String,

--- a/src/main/scala/net/psforever/persistence/SavedCharacter.scala
+++ b/src/main/scala/net/psforever/persistence/SavedCharacter.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.persistence
+
+import org.joda.time.LocalDateTime
+
+case class Savedplayer(
+                        id: Long,
+                        avatarId: Long,
+                        px: Int, //Position.x * 1000
+                        py: Int, //Position.y * 1000
+                        pz: Int, //Position.z * 1000
+                        orientation: Int, //Orientation.z * 1000
+                        zoneNum: Int,
+                        health: Int,
+                        armor: Int,
+                        exosuitNum: Int,
+                        loadout: String
+                      )
+
+case class Savedavatar(
+                        id: Long,
+                        avatarId: Long,
+                        forgetCooldown: LocalDateTime,
+                        purchaseCooldowns: String,
+                        useCooldowns: String
+                      )

--- a/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
+++ b/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
@@ -18,6 +18,7 @@ import net.psforever.services.{Service, ServiceManager}
 import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
 import net.psforever.services.galaxy.{GalaxyAction, GalaxyServiceMessage}
 import net.psforever.zones.Zones
+
 import scala.util.Success
 
 /**

--- a/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
+++ b/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
@@ -366,7 +366,8 @@ class PersistenceMonitor(
       case (Some(avatar), Some(player)) if player.VehicleSeated.nonEmpty =>
         //alive or dead in a vehicle
         //if the avatar is dead while in a vehicle, they haven't released yet
-        //TODO perform any last minute saving now ...
+        AvatarActor.saveAvatarData(avatar)
+        AvatarActor.finalSavePlayerData(player)
         (inZone.GUID(player.VehicleSeated) match {
           case Some(obj: Mountable) =>
             (Some(obj), obj.Seat(obj.PassengerInSeat(player).getOrElse(-1)))
@@ -380,13 +381,14 @@ class PersistenceMonitor(
 
       case (Some(avatar), Some(player)) =>
         //alive or dead, as standard Infantry
-        //TODO perform any last minute saving now ...
+        AvatarActor.saveAvatarData(avatar)
+        AvatarActor.finalSavePlayerData(player)
         PlayerAvatarLogout(avatar, player)
 
       case (Some(avatar), None) =>
         //player has released
         //our last body was turned into a corpse; just the avatar remains
-        //TODO perform any last minute saving now ...
+        AvatarActor.saveAvatarData(avatar)
         inZone.GUID(avatar.vehicle) match {
           case Some(obj: Vehicle) if obj.OwnerName.contains(avatar.name) =>
             obj.Actor ! Vehicle.Ownership(None)
@@ -395,7 +397,7 @@ class PersistenceMonitor(
         AvatarLogout(avatar)
 
       case _ =>
-      //user stalled during initial session, or was caught in between zone transfer
+        //user stalled during initial session, or was caught in between zone transfer
     }
   }
 

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -158,7 +158,8 @@ case class GameConfig(
     sharedMaxCooldown: Boolean,
     baseCertifications: Seq[Certification],
     warpGates: WarpGateConfig,
-    cavernRotation: CavernRotationConfig
+    cavernRotation: CavernRotationConfig,
+    savedMsg: SavedMessageEvents
 )
 
 case class NewAvatar(
@@ -203,4 +204,15 @@ case class CavernRotationConfig(
     simultaneousUnlockedZones: Int,
     enhancedRotationOrder: Seq[Int],
     forceRotationImmediately: Boolean
+)
+
+case class SavedMessageEvents(
+    short: SavedMessageTimings,
+    renewal: SavedMessageTimings,
+    interruptedByAction: SavedMessageTimings
+)
+
+case class SavedMessageTimings(
+    fixed: Long,
+    variable: Long
 )

--- a/src/test/scala/objects/VitalityTest.scala
+++ b/src/test/scala/objects/VitalityTest.scala
@@ -42,7 +42,7 @@ class VitalityTest extends Specification {
       player.History(HealFromExoSuitChange(pSource, ExoSuitType.Standard))
       player.History(RepairFromTerm(vSource, 10, GlobalDefinitions.order_terminal))
       player.History(VehicleShieldCharge(vSource, 10))
-      player.History(PlayerSuicide())
+      player.History(PlayerSuicide(PlayerSource(player)))
       ok
     }
 
@@ -56,7 +56,7 @@ class VitalityTest extends Specification {
       player.History(HealFromExoSuitChange(pSource, ExoSuitType.Standard))
       player.History(RepairFromTerm(vSource, 10, GlobalDefinitions.order_terminal))
       player.History(VehicleShieldCharge(vSource, 10))
-      player.History(PlayerSuicide())
+      player.History(PlayerSuicide(PlayerSource(player)))
       player.History.size mustEqual 7
 
       val list = player.ClearHistory()
@@ -92,7 +92,7 @@ class VitalityTest extends Specification {
       player.History(HealFromExoSuitChange(pSource, ExoSuitType.Standard))
       player.History(RepairFromTerm(vSource, 10, GlobalDefinitions.order_terminal))
       player.History(VehicleShieldCharge(vSource, 10))
-      player.History(PlayerSuicide())
+      player.History(PlayerSuicide(PlayerSource(player)))
 
       player.LastShot match {
         case Some(resolved_projectile) =>


### PR DESCRIPTION
People have been asking for their location in the game world to be retained for durations in between logouts and logins rather than just a two minute extension to session duration between connection issues.  Who knows if it will be helpful right now.

The rules for login persistence follows:
1. If the character has never logged into the server before, that character will always spawn in his faction's sanctuary.
2. If the character logs out of the server while in their own sanctuary, that location will be retained.  It will then be restored upon the next login.
3. If the character logs out of the server in a zone other than his faction's sanctuary, the server will conduct spawn tests:
a. Check if the zone is a cavern.  If it is, that character will return to their faction's sanctuary, regardless of other conditions.
b. Check for the presence of owned buildings (facilities and towers) or a deployed AMS or allies in that zone.  If none are found, that character will return to their faction's sanctuary.
c. Check that the zone's population constraints will not exceeded by that character joining, either as far as the zone faction population is concerned, or as far as the zone's total population is concerned.  If either limit is exceeded, that character will return to their faction's sanctuary.
d.  Check whether the character's location is a sphere of influence and, if it is, whether it is a friendly sphere of influence.
d.1. If in a sphere of influence that is not friendly, that character will be sent to the nearest faction-aligned facility or tower spawn point.
d.2. If neither of the former spawn points can be found, the chartacter will be returned to their faction's sanctuary.
e.  Check that, if the character is not in a sphere of influence, that his faction has population other than himself in the zone.  If he is alone, that character will return to their faction's sanctuary.
4. If all tests above are passed, the player will spawn in a non-sanctuary zone in the recorded physical game world location.

A message will occasionally be added in the game chat that reads that one's characters has been saved.  This message serves two purposes: indicate that the database has been interacted with outside of login or logout activities, or assure the player that their location in the game world, their accomplishments, or their possessions have been retained by the server's database.  In some cases, no actual database interaction occurs and the message is merely intended for the assurance.  The following actions are accompanied by saving some data to the database and the message being displayed:
- login
- implants (adding / removing)
- certifcations (adding / removing)
- battle experience points
- command experience points
- cosmetics changes
- friends list (adding / removing entries)
- ignored players list (adding / removing entries)
- spawning
- dying
- AFK (going only)
- loadout (saving / deleteing / loading)
- equipment (purchasing / deleting)

All other apperances of the saved message are purely aesthetic.  To ensure that the message is not spammed in one's chat too much, a ramp-up time for 15+[0,30] seconds is used to buffer against chained actions.  If one purchases equipment in a slow but methodical fashion, as long as each purchase is within a 15s-45s interval of the previous one, then only one message will be displayed a few seconds after the last purchase.  A much longer interval of a few minutes exists between the purely aesthetic messages is observed.  Some actions are accompanied by a shorter interval.

___Features___
There are no new major feature files.  Mostly, introduced files include entities for database persistence; and, changed files include modifications to allow for zoning accommodation to login persistence and for displaying save messages.

__Database__
Two new tables for persistent player avatar data and for persistent player character data, changes to the schema for the previously introduced tables for the friends list and the list of ignored players, and a new field to the table for user accounts.  For anyone developing, who pulled in the previous update, your current database and where your database needs to be will be incompatible.  You will need to drop the existing tables `friend` and `ignored` and modify the table `flyway_schema_history` to remove that update's entry, which should be an `installed_rank` of 5.  Do this before running the server for this update.

___Caveats___
1.  Zones do not have implemented locking mechanics yet; that is, zones can not ever be considered "locked" to a faction.  In exchange for this, login persistence test `3.b` tests whether any buildings in a zone are owned by a faction to determine its suitability for login spawning.
2.  Home continent zones will allow characters to always pass test `3.b` regardless of other conditions due to the presence of warp gates that lead back to the faction sanctuary zone.  These warp gates are always faction-aligned to the sanctuary.  This changes the message that will report why the player had their position changed, or may stop a player from being sent back to his character's faction's sanctuary.  All of the other conditions must also apply properly to get that far.
3.  The login message `@reset_sanctuary` is in regard to previous unaligned faction login/logout behavior and is not currently implemented, though it follows the naming structure of the other messages employed by this update.  The mechanism was a method of curtailing nefarious players from "fourth-factioning" and taking advantage of game population or performing sabotage or espionage beyond the game's code of conduct.
4.  The login messages `@reset_sanctuary_locked` and `@reset_sanctuary_inactive` produce the same message "You have been returned to the sanctuary because the location you logged out is not available."  Based on the name conventions, the former is most likely based on a game mechanic and the latter on an indeterminate administrative mechanic.  Despite that, both are currently implemented, the former in test `3.b` and the latter in test `3.e`.

___Addenda___
1.  In the future, the cavern limitation for login location persistence - currently in test `3.a` - will be improved upon.  It is simplistic because caverns are simplistic at the moment.
2.  As mentioned above in `Database`, the structure of a previously-implemented database has changed in a way that conflicts with how Flyway works.  The aforementioned instructions explain how to reset any local databases.  (Only the full paid version of Flyway allows for automatic database rollbacks; and, I am not satisfied with the expected anti-migration SQL file that is expected to perform a manual rollback since that SQL then becomes part of the project migration history.)
3.  The calculations for selecting a HART campus spawn facility spawn point when transitioning to sanctuary from an undefined zone `Nowhere` have changed.  Previously, a direction was selected and, based on that, any of the spawn points in the spawn facility closest to the edge of the map in that direction were selected.  This unfortunately meant that spawn facilities closer to the edges of the sanctuary zone map are the only possible destinations when first manifesting in the game.  Now, one of the HART campuses is selected, a direction is selected, and a distance is selected, and then the closest spawn facility is discovered from those accumulated translations.  The number of directions has also increased from four ordinal directions to all eight cardinal directions and ordinal directions.  All spawn facilities are now available as a potential spawn point.  Why I devoted any development time to this change, I don't know.