### PR TITLE
Shortcut to Grenade

### DIFF
--- a/server/src/main/resources/db/migration/V007__Shortcuts.sql
+++ b/server/src/main/resources/db/migration/V007__Shortcuts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "shortcut" (
+  "avatar_id" INT NOT NULL REFERENCES avatar (id),
+  "slot" SMALLINT NOT NULL,
+  "purpose" SMALLINT NOT NULL,
+  "tile" VARCHAR(20) NOT NULL,
+  "effect1" VARCHAR(3),
+  "effect2" TEXT,
+  UNIQUE(avatar_id, slot)
+);

--- a/server/src/test/scala/actor/service/AvatarServiceTest.scala
+++ b/server/src/test/scala/actor/service/AvatarServiceTest.scala
@@ -237,8 +237,8 @@ class ObjectHeldTest extends ActorTest {
       ServiceManager.boot(system)
       val service = system.actorOf(Props(classOf[AvatarService], Zone.Nowhere), AvatarServiceTest.TestName)
       service ! Service.Join("test")
-      service ! AvatarServiceMessage("test", AvatarAction.ObjectHeld(PlanetSideGUID(10), 1))
-      expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.ObjectHeld(1)))
+      service ! AvatarServiceMessage("test", AvatarAction.ObjectHeld(PlanetSideGUID(10), 1, 2))
+      expectMsg(AvatarServiceResponse("/test/Avatar", PlanetSideGUID(10), AvatarResponse.ObjectHeld(1, 2)))
     }
   }
 }

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
 import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 //
-import net.psforever.objects.avatar.{Friend => AvatarFriend, Ignored => AvatarIgnored, _}
+import net.psforever.objects.avatar.{Friend => AvatarFriend, Ignored => AvatarIgnored, Shortcut => AvatarShortcut, _}
 import net.psforever.objects.definition.converter.CharacterSelectConverter
 import net.psforever.objects.definition._
 import net.psforever.objects.inventory.Container
@@ -188,6 +188,10 @@ object AvatarActor {
   private case class SetImplantInitialized(implantType: ImplantType) extends Command
 
   final case class MemberListRequest(action: MemberAction.Value, name: String) extends Command
+
+  final case class AddShortcut(slot: Int, shortcut: Shortcut) extends Command
+
+  final case class RemoveShortcut(slot: Int) extends Command
 
   final case class AvatarResponse(avatar: Avatar)
 
@@ -826,7 +830,7 @@ class AvatarActor(
               characters.headOption match {
                 case None =>
                   val result = for {
-                    id <- ctx.run(
+                    _ <- ctx.run(
                       query[persistence.Avatar]
                         .insert(
                           _.name      -> lift(name),
@@ -838,17 +842,6 @@ class AvatarActor(
                           _.bep       -> lift(Config.app.game.newAvatar.br.experience),
                           _.cep       -> lift(Config.app.game.newAvatar.cr.experience)
                         )
-                        .returningGenerated(_.id)
-                    )
-                    _ <- ctx.run(
-                      liftQuery(
-                        List(
-                          persistence.Certification(Certification.MediumAssault.value, id),
-                          persistence.Certification(Certification.ReinforcedExoSuit.value, id),
-                          persistence.Certification(Certification.ATV.value, id),
-                          persistence.Certification(Certification.Harasser.value, id)
-                        )
-                      ).foreach(c => query[persistence.Certification].insert(c))
                     )
                   } yield ()
 
@@ -921,53 +914,46 @@ class AvatarActor(
         case LoginAvatar(replyTo) =>
           import ctx._
           val avatarId = avatar.id
-          val result = for {
-            //log this login
-            _ <- ctx.run(query[persistence.Avatar].filter(_.id == lift(avatarId))
-              .update(_.lastLogin -> lift(LocalDateTime.now()))
-            )
-            //log this choice of faction (no empire switching)
-            _ <- ctx.run(query[persistence.Account].filter(_.id == lift(account.id))
-              .update(_.lastFactionId -> lift(avatar.faction.id))
-            )
-            //retrieve avatar data
-            loadouts <- initializeAllLoadouts()
-            implants <- ctx.run(query[persistence.Implant].filter(_.avatarId == lift(avatarId)))
-            certs    <- ctx.run(query[persistence.Certification].filter(_.avatarId == lift(avatarId)))
-            locker   <- loadLocker(avatarId)
-            friends  <- loadFriendList(avatarId)
-            ignored  <- loadIgnoredList(avatarId)
-            saved    <- AvatarActor.loadSavedAvatarData(avatarId)
-          } yield (loadouts, implants, certs, locker, friends, ignored, saved)
-          result.onComplete {
-            case Success((_loadouts, implants, certs, locker, friendsList, ignoredList, saved)) =>
-              avatarCopy(
-                avatar.copy(
-                  loadouts = avatar.loadouts.copy(suit = _loadouts),
-                  certifications =
-                    certs.map(cert => Certification.withValue(cert.id)).toSet ++ Config.app.game.baseCertifications,
-                  implants = implants.map(implant => Some(Implant(implant.toImplantDefinition))).padTo(3, None),
-                  locker = locker,
-                  people = MemberLists(
-                    friend = friendsList,
-                    ignored = ignoredList
-                  ),
-                  cooldowns = Cooldowns(
-                    purchase = AvatarActor.buildCooldownsFromClob(saved.purchaseCooldowns, Avatar.purchaseCooldowns, log),
-                    use = AvatarActor.buildCooldownsFromClob(saved.useCooldowns, Avatar.useCooldowns, log)
-                  )
-                )
-              )
-              // if we need to start stamina regeneration
-              tryRestoreStaminaForSession(stamina = 1) match {
-                case Some(_) =>
-                  defaultStaminaRegen(initialDelay = 0.5f seconds)
-                case _ => ;
-              }
-              replyTo ! AvatarLoginResponse(avatar)
-            case Failure(e) =>
-              log.error(e)("db failure")
-          }
+          ctx.run(
+            query[persistence.Avatar]
+              .filter(_.id == lift(avatarId))
+              .map { c => (c.created, c.lastLogin) }
+          )
+            .onComplete {
+              case Success(value) if value.nonEmpty =>
+                val (created, lastLogin) = value.head
+                if (created.equals(lastLogin)) {
+                  //first login
+                  //initialize default values that would be compromised during login if blank
+                  val inits = for {
+                    _ <- ctx.run(
+                      liftQuery(
+                        List(
+                          persistence.Certification(Certification.StandardExoSuit.value, avatarId),
+                          persistence.Certification(Certification.AgileExoSuit.value, avatarId),
+                          persistence.Certification(Certification.ReinforcedExoSuit.value, avatarId),
+                          persistence.Certification(Certification.StandardAssault.value, avatarId),
+                          persistence.Certification(Certification.MediumAssault.value, avatarId),
+                          persistence.Certification(Certification.ATV.value, avatarId),
+                          persistence.Certification(Certification.Harasser.value, avatarId)
+                        )
+                      ).foreach(c => query[persistence.Certification].insert(c))
+                    )
+                    _ <- ctx.run(
+                      liftQuery(
+                        List(persistence.Shortcut(avatarId, 0, 0, "medkit"))
+                      ).foreach(c => query[persistence.Shortcut].insert(c))
+                    )
+                  } yield true
+                  inits.onComplete {
+                    case Success(_) => performAvatarLogin(avatarId, account.id, replyTo)
+                    case Failure(e) => log.error(e)("db failure")
+                  }
+                } else {
+                  performAvatarLogin(avatarId, account.id, replyTo)
+                }
+              case Failure(e) => log.error(e)("db failure")
+            }
           Behaviors.same
 
         case ReplaceAvatar(newAvatar) =>
@@ -1617,6 +1603,99 @@ class AvatarActor(
         case MemberListRequest(action, name) =>
           memberListAction(action, name)
           Behaviors.same
+
+        case AddShortcut(slot, shortcut) =>
+          import ctx._
+          val targetShortcut = avatar.shortcuts.lift(slot).flatten
+          //short-circuit if the shortcut already exists at the given location
+          val isDifferentShortcut = !(targetShortcut match {
+            case Some(target) =>
+              target.purpose.equals(shortcut.purpose) &&
+              (if (target.purpose != 1) {
+                target.tile == shortcut.tile
+              } else {
+                target.effect1.equals(shortcut.effect1) && target.effect2.equals(shortcut.effect2)
+              })
+            case _ =>
+              false
+          })
+          if (isDifferentShortcut) {
+            if (shortcut.purpose != 1 && avatar.shortcuts.exists {
+              case Some(a) => a.tile.equals(shortcut.tile)
+              case None    => false
+            }) {
+              //duplicate implant or medkit found
+              if (shortcut.purpose == 2) {
+                //duplicate implant
+                targetShortcut match {
+                  case Some(existingShortcut) =>
+                    //redraw redundant shortcut slot with existing shortcut
+                    sessionActor ! SessionActor.SendResponse(
+                      CreateShortcutMessage(
+                        session.get.player.GUID,
+                        slot + 1,
+                        Some(Shortcut(existingShortcut.purpose, existingShortcut.tile, existingShortcut.effect1, existingShortcut.effect2))
+                      )
+                    )
+                  case _ =>
+                    //blank shortcut slot
+                    sessionActor ! SessionActor.SendResponse(CreateShortcutMessage(session.get.player.GUID, slot + 1, None))
+                }
+              }
+            } else {
+              //macro, or implant or medkit
+              val (optEffect1, optEffect2, optShortcut) = if (shortcut.purpose == 1) {
+                (
+                  shortcut.effect1,
+                  shortcut.effect2,
+                  Some(AvatarShortcut(shortcut.purpose, shortcut.tile, shortcut.effect1, shortcut.effect2))
+                )
+              } else {
+                (null, null, Some(AvatarShortcut(shortcut.purpose, shortcut.tile)))
+              }
+              targetShortcut match {
+                case Some(_) =>
+                  ctx.run(
+                    query[persistence.Shortcut]
+                      .filter(_.avatarId == lift(avatar.id.toLong))
+                      .filter(_.slot == lift(slot))
+                      .update(
+                        _.purpose -> lift(shortcut.purpose),
+                        _.tile -> lift(shortcut.tile),
+                        _.effect1 -> Option(lift(optEffect1)),
+                        _.effect2 -> Option(lift(optEffect2))
+                      )
+                  )
+                case None =>
+                  ctx.run(
+                    query[persistence.Shortcut].insert(
+                      _.avatarId -> lift(avatar.id.toLong),
+                      _.slot -> lift(slot),
+                      _.purpose -> lift(shortcut.purpose),
+                      _.tile -> lift(shortcut.tile),
+                      _.effect1 -> Option(lift(optEffect1)),
+                      _.effect2 -> Option(lift(optEffect2))
+                    )
+                  )
+              }
+              avatar.shortcuts.update(slot, optShortcut)
+            }
+          }
+          Behaviors.same
+
+        case RemoveShortcut(slot) =>
+          import ctx._
+          avatar.shortcuts.lift(slot).flatten match {
+            case None => ;
+            case Some(_) =>
+              ctx.run(query[persistence.Shortcut]
+                .filter(_.avatarId == lift(avatar.id.toLong))
+                .filter(_.slot == lift(slot))
+                .delete
+              )
+              avatar.shortcuts.update(slot, None)
+          }
+          Behaviors.same
       }
       .receiveSignal {
         case (_, PostStop) =>
@@ -1634,6 +1713,78 @@ class AvatarActor(
 
   def throwLoadoutFailure(ex: Throwable): Future[Loadout] = {
     Future.failed(ex).asInstanceOf[Future[Loadout]]
+  }
+
+  def performAvatarLogin(avatarId: Long, accountId: Long, replyTo: ActorRef[AvatarLoginResponse]): Unit = {
+    import ctx._
+
+    val result = for {
+      //log this login
+      _ <- ctx.run(query[persistence.Avatar].filter(_.id == lift(avatarId))
+        .update(_.lastLogin -> lift(LocalDateTime.now()))
+      )
+      //log this choice of faction (no empire switching)
+      _ <- ctx.run(query[persistence.Account].filter(_.id == lift(accountId))
+        .update(_.lastFactionId -> lift(avatar.faction.id))
+      )
+      //retrieve avatar data
+      loadouts  <- initializeAllLoadouts()
+      implants  <- ctx.run(query[persistence.Implant].filter(_.avatarId == lift(avatarId)))
+      certs     <- ctx.run(query[persistence.Certification].filter(_.avatarId == lift(avatarId)))
+      locker    <- loadLocker(avatarId)
+      friends   <- loadFriendList(avatarId)
+      ignored   <- loadIgnoredList(avatarId)
+      shortcuts <- loadShortcuts(avatarId)
+      saved     <- AvatarActor.loadSavedAvatarData(avatarId)
+    } yield (loadouts, implants, certs, locker, friends, ignored, shortcuts, saved)
+    result.onComplete {
+      case Success((_loadouts, implants, certs, locker, friendsList, ignoredList, shortcutList, saved)) =>
+        //shortcuts must have a hotbar option for each implant
+//        val implantShortcuts = shortcutList.filter {
+//          case Some(e) => e.purpose == 0
+//          case None    => false
+//        }
+//        implants.filterNot { implant =>
+//          implantShortcuts.exists {
+//            case Some(a) => a.tile.equals(implant.name)
+//            case None    => false
+//          }
+//        }.foreach { c =>
+//          shortcutList.indexWhere { _.isEmpty } match {
+//            case -1 => ;
+//            case index =>
+//              shortcutList.update(index, Some(AvatarShortcut(2, c.name)))
+//          }
+//        }
+        //
+        avatarCopy(
+          avatar.copy(
+            loadouts = avatar.loadouts.copy(suit = _loadouts),
+            certifications =
+              certs.map(cert => Certification.withValue(cert.id)).toSet ++ Config.app.game.baseCertifications,
+            implants = implants.map(implant => Some(Implant(implant.toImplantDefinition))).padTo(3, None),
+            shortcuts = shortcutList,
+            locker = locker,
+            people = MemberLists(
+              friend = friendsList,
+              ignored = ignoredList
+            ),
+            cooldowns = Cooldowns(
+              purchase = AvatarActor.buildCooldownsFromClob(saved.purchaseCooldowns, Avatar.purchaseCooldowns, log),
+              use = AvatarActor.buildCooldownsFromClob(saved.useCooldowns, Avatar.useCooldowns, log)
+            )
+          )
+        )
+        // if we need to start stamina regeneration
+        tryRestoreStaminaForSession(stamina = 1) match {
+          case Some(_) =>
+            defaultStaminaRegen(initialDelay = 0.5f seconds)
+          case _ => ;
+        }
+        replyTo ! AvatarLoginResponse(avatar)
+      case Failure(e) =>
+        log.error(e)("db failure")
+    }
   }
 
   /**
@@ -1781,8 +1932,6 @@ class AvatarActor(
           CreateShortcutMessage(
             session.get.player.GUID,
             slot + 2,
-            0,
-            addShortcut = true,
             Some(implant.definition.implantType.shortcut)
           )
         )
@@ -2299,6 +2448,30 @@ class AvatarActor(
         ))
       case _ =>
         out.completeWith(Future(List.empty[AvatarIgnored]))
+    }
+    out.future
+  }
+
+  def loadShortcuts(avatarId: Long): Future[Array[Option[AvatarShortcut]]] = {
+    import ctx._
+    val out: Promise[Array[Option[AvatarShortcut]]] = Promise()
+
+    val queryResult = ctx.run(
+      query[persistence.Shortcut].filter { _.avatarId == lift(avatarId) }
+        .map { shortcut => (shortcut.slot, shortcut.purpose, shortcut.tile, shortcut.effect1, shortcut.effect2) }
+    )
+    val output = Array.fill[Option[AvatarShortcut]](64)(None)
+    queryResult.onComplete {
+      case Success(list) =>
+        list.foreach { case (slot, purpose, tile, effect1, effect2) =>
+          output.update(slot, Some(AvatarShortcut(purpose, tile, effect1.getOrElse(""), effect2.getOrElse(""))))
+        }
+        out.completeWith(Future(output))
+      case Failure(e) =>
+        //something went wrong, but we can recover
+        log.warn(e)("db failure")
+        //output.update(0, Some(AvatarShortcut(0, "medkit")))
+        out.completeWith(Future(output))
     }
     out.future
   }

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -1353,7 +1353,7 @@ class AvatarActor(
                   updatePurchaseTimer(
                     name,
                     cooldown.toSeconds,
-                    DefinitionUtil.fromString(name).isInstanceOf[VehicleDefinition]
+                    item.isInstanceOf[VehicleDefinition]
                   )
                 case _ => ;
               }

--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -1,31 +1,33 @@
 package net.psforever.actors.session
 
 import akka.actor.Cancellable
-import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.{ActorRef, Behavior, PostStop, SupervisorStrategy}
+import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
+import akka.actor.typed.scaladsl.adapter._
+import net.psforever.packet.game.objectcreate.DrawnSlot
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+//
 import net.psforever.actors.zone.BuildingActor
+import net.psforever.login.WorldSession
+import net.psforever.objects.{Default, Player, Session}
 import net.psforever.objects.avatar.{BattleRank, Certification, CommandRank, Cosmetic}
 import net.psforever.objects.serverobject.pad.{VehicleSpawnControl, VehicleSpawnPad}
-import net.psforever.objects.{Default, Player, Session}
 import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.structures.{Amenity, Building}
 import net.psforever.objects.serverobject.turret.{FacilityTurret, TurretUpgrade, WeaponTurrets}
 import net.psforever.objects.zones.Zoning
 import net.psforever.packet.game.{ChatMsg, DeadState, RequestDestroyMessage, ZonePopulationUpdateMessage}
+import net.psforever.services.{CavernRotationService, InterstellarClusterService}
+import net.psforever.services.chat.ChatService
+import net.psforever.services.chat.ChatService.ChatChannel
+import net.psforever.types.ChatMessageType.UNK_229
 import net.psforever.types.{ChatMessageType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 import net.psforever.util.{Config, PointOfInterest}
 import net.psforever.zones.Zones
-import net.psforever.services.chat.ChatService
-import net.psforever.services.chat.ChatService.ChatChannel
-
-import scala.concurrent.ExecutionContextExecutor
-import scala.concurrent.duration._
-import akka.actor.typed.scaladsl.adapter._
-import net.psforever.services.{CavernRotationService, InterstellarClusterService}
-import net.psforever.types.ChatMessageType.UNK_229
-
-import scala.collection.mutable
 
 object ChatActor {
   def apply(
@@ -522,6 +524,9 @@ class ChatActor(
                   val tplayer = session.player
                   tplayer.Revive
                   tplayer.Actor ! Player.Die()
+
+                case (_, _, content) if content.startsWith("!grenade") =>
+                  WorldSession.QuickSwapToAGrenade(session.player, DrawnSlot.Pistol1.id, log)
 
                 case _ =>
                 // unknown ! commands are ignored

--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -9,7 +9,7 @@ import net.psforever.actors.net.MiddlewareActor
 import net.psforever.actors.zone.ZoneActor
 import net.psforever.login.WorldSession._
 import net.psforever.objects._
-import net.psforever.objects.avatar._
+import net.psforever.objects.avatar.{Shortcut => AvatarShortcut, _}
 import net.psforever.objects.ballistics._
 import net.psforever.objects.ce._
 import net.psforever.objects.definition._
@@ -56,7 +56,7 @@ import net.psforever.objects.zones.blockmap.{BlockMap, BlockMapEntity}
 import net.psforever.packet._
 import net.psforever.packet.game.PlanetsideAttributeEnum.PlanetsideAttributeEnum
 import net.psforever.packet.game.objectcreate._
-import net.psforever.packet.game.{HotSpotInfo => PacketHotSpotInfo, Shortcut => GameShortcut, _}
+import net.psforever.packet.game.{HotSpotInfo => PacketHotSpotInfo, _}
 import net.psforever.services.CavernRotationService.SendCavernRotationUpdates
 import net.psforever.services.ServiceManager.{Lookup, LookupResult}
 import net.psforever.services.account.{AccountPersistenceService, PlayerToken, ReceiveAccountData, RetrieveAccountData}
@@ -3630,7 +3630,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
         sendResponse(CreateShortcutMessage(
           guid,
           index + 1,
-          Some(GameShortcut(shortcut.purpose, shortcut.tile, shortcut.effect1, shortcut.effect2))
+          Some(AvatarShortcut.convert(shortcut))
         ))
       }
     sendResponse(ChangeShortcutBankMessage(guid, 0))

--- a/src/main/scala/net/psforever/login/WorldSession.scala
+++ b/src/main/scala/net/psforever/login/WorldSession.scala
@@ -3,6 +3,7 @@ package net.psforever.login
 import akka.actor.ActorRef
 import akka.pattern.{AskTimeoutException, ask}
 import akka.util.Timeout
+import net.psforever.objects._
 import net.psforever.objects.equipment.{Ammo, Equipment, EquipmentSize}
 import net.psforever.objects.guid._
 import net.psforever.objects.inventory.{Container, InventoryItem}
@@ -10,9 +11,7 @@ import net.psforever.objects.locker.LockerContainer
 import net.psforever.objects.serverobject.PlanetSideServerObject
 import net.psforever.objects.serverobject.containable.Containable
 import net.psforever.objects.zones.Zone
-import net.psforever.objects._
-import net.psforever.packet.game.ObjectHeldMessage
-import net.psforever.types.{PlanetSideGUID, TransactionType, Vector3}
+import net.psforever.types.{ExoSuitType, PlanetSideGUID, TransactionType, Vector3}
 import net.psforever.services.Service
 import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
 
@@ -35,7 +34,7 @@ object WorldSession {
   private implicit val timeout            = new Timeout(5000 milliseconds)
 
   /**
-    * Use this for placing equipment that has yet to be registered into a container,
+    * Use this for placing equipment that has already been registered into a container,
     * such as in support of changing ammunition types in `Tool` objects (weapons).
     * If the object can not be placed into the container, it will be dropped onto the ground.
     * It will also be dropped if it takes too long to be placed.
@@ -299,46 +298,38 @@ object WorldSession {
     if (player.VisibleSlots.contains(slot)) {
       val localZone = player.Zone
       TaskBundle(
-        new StraightforwardTask() {
-          private val localPlayer   = player
-          private val localGUID     = player.GUID
-          private val localItem     = item
-          private val localSlot     = slot
-
-          def action(): Future[Any] = {
-            ask(localPlayer.Actor, Containable.PutItemInSlotOnly(localItem, localSlot))
-              .onComplete {
-                case Failure(_) | Success(_: Containable.CanNotPutItemInSlot) =>
-                  TaskWorkflow.execute(GUIDTask.unregisterEquipment(localZone.GUID, localItem))
-                case _ =>
-                  if (localPlayer.DrawnSlot != Player.HandsDownSlot) {
-                    localPlayer.DrawnSlot = Player.HandsDownSlot
-                    localZone.AvatarEvents ! AvatarServiceMessage(
-                      localPlayer.Name,
-                      AvatarAction.SendResponse(
-                        Service.defaultPlayerGUID,
-                        ObjectHeldMessage(localGUID, Player.HandsDownSlot, false)
-                      )
-                    )
-                    localZone.AvatarEvents ! AvatarServiceMessage(
-                      localZone.id,
-                      AvatarAction.ObjectHeld(localGUID, localPlayer.LastDrawnSlot)
-                    )
-                  }
-                  localPlayer.DrawnSlot = localSlot
-                  localZone.AvatarEvents ! AvatarServiceMessage(
-                    localZone.id,
-                    AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectHeldMessage(localGUID, localSlot, false))
-                  )
-              }
-            Future(this)
-          }
-        },
+        TaskToHoldEquipmentUp(player)(item, slot),
         GUIDTask.registerEquipment(localZone.GUID, item)
       )
     } else {
       //TODO log.error
       throw new RuntimeException(s"provided slot $slot is not a player visible slot (holsters)")
+    }
+  }
+
+  def TaskToHoldEquipmentUp(player: Player)(item: Equipment, slot: Int): Task = {
+    new StraightforwardTask() {
+      private val localPlayer = player
+      private val localGUID   = player.GUID
+      private val localItem   = item
+      private val localSlot   = slot
+      private val localZone   = player.Zone
+
+      def action(): Future[Any] = {
+        ask(localPlayer.Actor, Containable.PutItemInSlotOnly(localItem, localSlot))
+          .onComplete {
+            case Failure(_) | Success(_: Containable.CanNotPutItemInSlot) =>
+              TaskWorkflow.execute(GUIDTask.unregisterEquipment(localZone.GUID, localItem))
+            case _ =>
+              forcedTolowerRaisedArm(localPlayer, localPlayer.GUID, localZone)
+              localPlayer.DrawnSlot = localSlot
+              localZone.AvatarEvents ! AvatarServiceMessage(
+                localZone.id,
+                AvatarAction.ObjectHeld(localGUID, localSlot, localSlot)
+              )
+          }
+        Future(this)
+      }
     }
   }
 
@@ -723,6 +714,194 @@ object WorldSession {
       }
       val result = ask(source.Actor, Containable.RemoveItemFromSlot(item))
       result.onComplete(resultOnComplete)
+    }
+  }
+
+  /**
+   * Quickly draw a grenade from anywhere on the player's person and place it into a certain hand
+   * at the ready to be used as a weapon.
+   * Soldiers in mechanized assault exo-suits can not perform this action.<br>
+   * <br>
+   * This is not vanilla behavior.<br>
+   * <br>
+   * Search for a grenade of either fragmentation- or plasma-type in the hands (holsters) or backpack (inventory)
+   * and bring it to hand and draw that grenade as a weapon as quickly as possible.
+   * If the player has a weapon already drawn, remove it from his active hand quickly.
+   * It may be placed back into the slot once the hand is / will be occupied by a grenade.
+   * For anything in the first sidearm weapon slot, where the grenade will be placed,
+   * either find room in the backpack for it or drop it on the ground.
+   * If the player's already-drawn hand is the same as the one that will hold the grenade (first sidearm holster),
+   * treat it like the sidearm occupier rather than the already-drawn weapon -
+   * the old weapon goes into the backpack or onto the ground.
+   * @see `AvatarAction.ObjectHeld`
+   * @see `AvatarServiceMessage`
+   * @see `Containable.RemoveItemFromSlot`
+   * @see `countRestrictAttempts`
+   * @see `forcedTolowerRaisedArm`
+   * @see `GlobalDefinitions.isGrenade`
+   * @see `InventoryItem`
+   * @see `Player.DrawnSlot`
+   * @see `Player.HandsDownSlot`
+   * @see `Player.Holsters`
+   * @see `Player.ResistArmMotion`
+   * @see `Player.Slot`
+   * @see `PutEquipmentInInventoryOrDrop`
+   * @see `PutEquipmentInInventorySlot`
+   * @see `TaskBundle`
+   * @see `TaskToHoldEquipmentUp`
+   * @see `TaskWorkflow.execute`
+   * @param tplayer player who wants to draw a grenade
+   * @param equipSlot slot being used as the final destination for any discovered grenade
+   * @param log reference to the messaging protocol
+   * @return if there was a discovered grenade
+   */
+  def QuickSwapToAGrenade(
+                           tplayer: Player,
+                           equipSlot: Int,
+                           log: org.log4s.Logger): Boolean = {
+    if (tplayer.ExoSuit != ExoSuitType.MAX) {
+      val previouslyDrawnSlot = tplayer.DrawnSlot
+      val optGrenadeInSlot = {
+        tplayer.Holsters().zipWithIndex.find { case (slot, _) =>
+          slot.Equipment match {
+            case Some(equipment) =>
+              val definition = equipment.Definition
+              val name = definition.Name
+              GlobalDefinitions.isGrenade(definition) && (name.contains("frag") || name.contains("plasma"))
+            case _ =>
+              false
+          }
+        } match {
+          case Some((_, slotNum)) if slotNum == previouslyDrawnSlot =>
+            //grenade already in hand; do nothing
+            None
+          case Some((grenadeSlot, slotNum)) =>
+            //grenade is holstered in some other slot; just extend it (or swap hands)
+            val guid = tplayer.GUID
+            val zone = tplayer.Zone
+            val grenade = grenadeSlot.Equipment.get
+            val drawnSlotItem = tplayer.Slot(tplayer.DrawnSlot).Equipment
+            if (forcedTolowerRaisedArm(tplayer, guid, zone)) {
+              log.info(s"${tplayer.Name} has dropped ${tplayer.Sex.possessive} ${drawnSlotItem.get.Definition.Name}")
+            }
+            //put up hand with grenade in it
+            tplayer.DrawnSlot = slotNum
+            zone.AvatarEvents ! AvatarServiceMessage(
+              zone.id,
+              AvatarAction.ObjectHeld(guid, slotNum, slotNum)
+            )
+            log.info(s"${tplayer.Name} has quickly drawn a ${grenade.Definition.Name}")
+            None
+          case None =>
+            //check inventory for a grenade
+            tplayer.Inventory.Items.find { case InventoryItem(equipment, _) =>
+              val definition = equipment.Definition
+              val name = definition.Name
+              GlobalDefinitions.isGrenade(definition) && (name.contains("frag") || name.contains("plasma"))
+            } match {
+              case Some(InventoryItem(equipment, slotNum)) =>Some(equipment.asInstanceOf[Tool], slotNum)
+              case None                                    => None
+            }
+        }
+      }
+      optGrenadeInSlot match {
+        case Some((grenade, slotNum)) =>
+          tplayer.ResistArmMotion(countRestrictAttempts(count=1))
+          val itemInPreviouslyDrawnSlotToDrop = if (equipSlot != previouslyDrawnSlot) {
+            forcedTolowerRaisedArm(tplayer, tplayer.GUID, tplayer.Zone)
+            tplayer.Slot(previouslyDrawnSlot).Equipment match {
+              case out @ Some(_) => out
+              case _             => None
+            }
+          } else {
+            None
+          }
+          val itemPreviouslyInPistolSlot = tplayer.Slot(equipSlot).Equipment
+          val result = for {
+            //remove grenade from inventory
+            a <- ask(tplayer.Actor, Containable.RemoveItemFromSlot(slotNum))
+            //remove equipment from pistol slot, where grenade will go
+            b <- itemPreviouslyInPistolSlot match {
+              case Some(_) => ask(tplayer.Actor, Containable.RemoveItemFromSlot(equipSlot))
+              case _       => Future(true)
+            }
+            //remove held equipment (if any)
+            c <- itemInPreviouslyDrawnSlotToDrop match {
+              case Some(_) => ask(tplayer.Actor, Containable.RemoveItemFromSlot(previouslyDrawnSlot))
+              case _       => Future(false)
+            }
+          } yield (a, b, c)
+          result.onComplete {
+            case Success((_, _, _)) =>
+              //put equipment in hand and hold grenade up
+              TaskWorkflow.execute(TaskBundle(TaskToHoldEquipmentUp(tplayer)(grenade, equipSlot)))
+              //what to do with the equipment that was removed for the grenade
+              itemPreviouslyInPistolSlot match {
+                case Some(e) =>
+                  log.info(s"${tplayer.Name} has dropped ${tplayer.Sex.possessive} ${e.Definition.Name}")
+                  PutEquipmentInInventoryOrDrop(tplayer)(e)
+                case _ => ;
+              }
+              //restore previously-held-up equipment
+              itemInPreviouslyDrawnSlotToDrop match {
+                case Some(e) => PutEquipmentInInventorySlot(tplayer)(e, previouslyDrawnSlot)
+                case _ => ;
+              }
+              log.info(s"${tplayer.Name} has quickly drawn a ${grenade.Definition.Name}")
+            case _ => ;
+          }
+        case None => ;
+      }
+      optGrenadeInSlot.nonEmpty
+    } else {
+      false
+    }
+  }
+
+  /**
+   * If the player has a raised arm, lower it.
+   * Do it manually, bypassing the checks in the normal procedure.
+   * @see `AvatarAction.ObjectHeld`
+   * @see `AvatarServiceMessage`
+   * @see `Player.DrawnSlot`
+   * @see `Player.HandsDownSlot`
+   * @param tplayer the player
+   * @param guid target guid (usually the player)
+   * @param zone the zone of reporting
+   * @return if the hand has a drawn equipment in it and tries to lower
+   */
+  private def forcedTolowerRaisedArm(tplayer: Player, guid:PlanetSideGUID, zone: Zone): Boolean = {
+    val slot = tplayer.DrawnSlot
+    if (slot != Player.HandsDownSlot) {
+      tplayer.DrawnSlot = Player.HandsDownSlot
+      zone.AvatarEvents ! AvatarServiceMessage(
+        zone.id,
+        AvatarAction.ObjectHeld(guid, Player.HandsDownSlot, slot)
+      )
+      true
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Restriction logic that stops the player
+   * from lowering or raising any drawn equipment a certain number of times.
+   * Reset to default restriction behavior when no longer valid.
+   * @see `Player.neverRestrict`
+   * @see `Player.ResistArmMotion`
+   * @param count number of times to stop the player from adjusting their arm
+   * @param player target player
+   * @param slot slot being switched to (unused here)
+   * @return if the motion is restricted
+   */
+  def countRestrictAttempts(count: Int)(player: Player, slot: Int): Boolean = {
+    if (count > 0) {
+      player.ResistArmMotion(countRestrictAttempts(count - 1))
+      true
+    } else {
+      player.ResistArmMotion(Player.neverRestrict) //reset
+      false
     }
   }
 

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -14,6 +14,7 @@ import net.psforever.objects.serverobject.environment.InteractWithEnvironment
 import net.psforever.objects.serverobject.mount.MountableEntity
 import net.psforever.objects.vital.resistance.ResistanceProfile
 import net.psforever.objects.vital.Vitality
+import net.psforever.objects.vital.damage.DamageProfile
 import net.psforever.objects.vital.interaction.DamageInteraction
 import net.psforever.objects.vital.resolution.DamageResistanceModel
 import net.psforever.objects.zones.blockmap.{BlockMapEntity, SectorPopulation}
@@ -78,6 +79,8 @@ class Player(var avatar: Avatar)
   var PlanetsideAttribute: Array[Long] = Array.ofDim(120)
 
   val squadLoadouts = new LoadoutManager(10)
+
+  var resistArmMotion: (Player,Int)=>Boolean = Player.neverRestrict
 
   //init
   Health = 0       //player health is artificially managed as a part of their lifecycle; start entity as dead
@@ -176,8 +179,8 @@ class Player(var avatar: Avatar)
     capacitorState
   }
 
-  def CapacitorLastUsedMillis    = capacitorLastUsedMillis
-  def CapacitorLastChargedMillis = capacitorLastChargedMillis
+  def CapacitorLastUsedMillis: Long    = capacitorLastUsedMillis
+  def CapacitorLastChargedMillis: Long = capacitorLastChargedMillis
 
   def VisibleSlots: Set[Int] =
     if (exosuit.SuitType == ExoSuitType.MAX) {
@@ -253,7 +256,7 @@ class Player(var avatar: Avatar)
     }
   }
 
-  def FreeHand = freeHand
+  def FreeHand: EquipmentSlot = freeHand
 
   def FreeHand_=(item: Option[Equipment]): Option[Equipment] = {
     if (freeHand.Equipment.isEmpty || item.isEmpty) {
@@ -313,6 +316,18 @@ class Player(var avatar: Avatar)
     }
   }
 
+  def ResistArmMotion(func: (Player,Int)=>Boolean): Unit = {
+    resistArmMotion = func
+  }
+
+  def TestArmMotion(): Boolean = {
+    resistArmMotion(this, drawnSlot)
+  }
+
+  def TestArmMotion(slot: Int): Boolean = {
+    resistArmMotion(this, slot)
+  }
+
   def DrawnSlot: Int = drawnSlot
 
   def DrawnSlot_=(slot: Int): Int = {
@@ -339,15 +354,15 @@ class Player(var avatar: Avatar)
     ChangeSpecialAbility()
   }
 
-  def Subtract = exosuit.Subtract
+  def Subtract: DamageProfile = exosuit.Subtract
 
-  def ResistanceDirectHit = exosuit.ResistanceDirectHit
+  def ResistanceDirectHit: Int = exosuit.ResistanceDirectHit
 
-  def ResistanceSplash = exosuit.ResistanceSplash
+  def ResistanceSplash: Int = exosuit.ResistanceSplash
 
-  def ResistanceAggravated = exosuit.ResistanceAggravated
+  def ResistanceAggravated: Int = exosuit.ResistanceAggravated
 
-  def RadiationShielding = exosuit.RadiationShielding
+  def RadiationShielding: Float = exosuit.RadiationShielding
 
   def FacingYawUpper: Float = facingYawUpper
 
@@ -533,7 +548,7 @@ class Player(var avatar: Avatar)
     ZoningRequest
   }
 
-  def DamageModel = exosuit.asInstanceOf[DamageResistanceModel]
+  def DamageModel: DamageResistanceModel = exosuit.asInstanceOf[DamageResistanceModel]
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[Player]
 
@@ -600,6 +615,10 @@ object Player {
     } else {
       player
     }
+  }
+
+  def neverRestrict(player: Player, slot: Int): Boolean = {
+    false
   }
 }
 

--- a/src/main/scala/net/psforever/objects/Players.scala
+++ b/src/main/scala/net/psforever/objects/Players.scala
@@ -440,12 +440,8 @@ object Players {
             if (player.DrawnSlot == Player.HandsDownSlot) {
               player.DrawnSlot = index
               events ! AvatarServiceMessage(
-                name,
-                AvatarAction.SendResponse(Service.defaultPlayerGUID, ObjectHeldMessage(pguid, index, true))
-              )
-              events ! AvatarServiceMessage(
                 zone.id,
-                AvatarAction.ObjectHeld(pguid, index)
+                AvatarAction.ObjectHeld(pguid, index, index)
               )
             }
           }

--- a/src/main/scala/net/psforever/objects/avatar/Avatar.scala
+++ b/src/main/scala/net/psforever/objects/avatar/Avatar.scala
@@ -123,6 +123,7 @@ case class Avatar(
     fatigued: Boolean = false,
     certifications: Set[Certification] = Set(),
     implants: Seq[Option[Implant]] = Seq(None, None, None),
+    shortcuts: Array[Option[Shortcut]] = Array.fill[Option[Shortcut]](64)(None),
     locker: LockerContainer = Avatar.makeLocker(),
     deployables: DeployableToolbox = new DeployableToolbox(),
     lookingForSquad: Boolean = false,

--- a/src/main/scala/net/psforever/objects/avatar/Shortcut.scala
+++ b/src/main/scala/net/psforever/objects/avatar/Shortcut.scala
@@ -1,9 +1,76 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.objects.avatar
 
+import net.psforever.packet.game.{Shortcut => GameShortcut}
+
+/**
+ * The internal respresentation of a shortcut on the hotbar.
+ * @param purpose integer value related to the type of shortcut
+ * @param tile details how the shortcut is to be used (net.psforever.packet.game.Schortcut)
+ * @param effect1 three letters emblazoned on the shortcut icon;
+ *                defaults to empty string
+ * @param effect2 the message published to text chat;
+ *                defaults to empty string
+ */
 case class Shortcut(
                      purpose: Int,
                      tile: String,
                      effect1: String = "",
                      effect2: String = ""
                    )
+
+object Shortcut {
+  /**
+   * Transform the internal form of the `Shortcut`
+   * into the packet form of the `Shortcut`.
+   * @see `net.psforever.packet.game.Shortcut`
+   * @param shortcut internal form of the `Shortcut`
+   * @return equivalent packet form of the `Shortcut`
+   * @throws `AssertionError` if an implant is not named
+   */
+  def convert(shortcut: Shortcut): GameShortcut = {
+    shortcut.tile match {
+      case "medkit"         => GameShortcut.Medkit()
+      case "shortcut_macro" => GameShortcut.Macro(shortcut.effect1, shortcut.effect2)
+      case _                => GameShortcut.Implant(shortcut.tile)
+    }
+  }
+
+  /**
+   * Is an internal form of the `Shortcut` equivalent to a packet form of the `Shortcut`?
+   * @param a internal form of the `Shortcut`
+   * @param b packet form of the `Shortcut`
+   * @return `true`, if the forms of `Shortcut` are equivalent;
+   *         `false`, otherwise
+   */
+  def equals(a: Shortcut, b: GameShortcut): Boolean = {
+    a.purpose == b.code && typeEquals(a, b)
+  }
+  /**
+   * Is an internal form of the `Shortcut` equivalent to a packet form of the `Shortcut`?
+   * @param a internal form of the `Shortcut`
+   * @param b packet form of the `Shortcut`
+   * @return `true`, if the forms of `Shortcut` are equivalent;
+   *         `false`, otherwise
+   */
+  def equals(b: GameShortcut, a: Shortcut): Boolean = {
+    a.purpose == b.code && typeEquals(a, b)
+  }
+
+  /**
+   * Is an internal form of the `Shortcut` equivalent to a packet form of the `Shortcut`?
+   * Test against individual types of packet forms and then the fields associated with that form.
+   * @param a internal form of the `Shortcut`
+   * @param b packet form of the `Shortcut`
+   * @return `true`, if the forms of `Shortcut` are equivalent;
+   *         `false`, otherwise
+   */
+  private def typeEquals(a: Shortcut, b: GameShortcut): Boolean = {
+    b match {
+      case GameShortcut.Medkit()      => true
+      case GameShortcut.Macro(x, y)   => x.equals(a.effect1) && y.equals(a.effect2)
+      case GameShortcut.Implant(tile) => tile.equals(a.tile)
+      case _                          => true
+    }
+  }
+}

--- a/src/main/scala/net/psforever/objects/avatar/Shortcut.scala
+++ b/src/main/scala/net/psforever/objects/avatar/Shortcut.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.objects.avatar
+
+case class Shortcut(
+                     purpose: Int,
+                     tile: String,
+                     effect1: String = "",
+                     effect2: String = ""
+                   )

--- a/src/main/scala/net/psforever/persistence/Shortcut.scala
+++ b/src/main/scala/net/psforever/persistence/Shortcut.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 PSForever
+package net.psforever.persistence
+
+case class Shortcut(
+                     avatarId: Long,
+                     slot: Int,
+                     purpose: Int,
+                     tile: String,
+                     effect1: Option[String] = None,
+                     effect2: Option[String] = None
+                   )

--- a/src/main/scala/net/psforever/services/avatar/AvatarService.scala
+++ b/src/main/scala/net/psforever/services/avatar/AvatarService.scala
@@ -173,9 +173,9 @@ class AvatarService(zone: Zone) extends Actor {
           AvatarEvents.publish(
             AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.ObjectDelete(item_guid, unk))
           )
-        case AvatarAction.ObjectHeld(player_guid, slot) =>
+        case AvatarAction.ObjectHeld(player_guid, slot, previousSlot) =>
           AvatarEvents.publish(
-            AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.ObjectHeld(slot))
+            AvatarServiceResponse(s"/$forChannel/Avatar", player_guid, AvatarResponse.ObjectHeld(slot, previousSlot))
           )
         case AvatarAction.OxygenState(player, vehicle) =>
           AvatarEvents.publish(

--- a/src/main/scala/net/psforever/services/avatar/AvatarServiceMessage.scala
+++ b/src/main/scala/net/psforever/services/avatar/AvatarServiceMessage.scala
@@ -67,7 +67,7 @@ object AvatarAction {
       cdata: ConstructorData
   )                                                                                                   extends Action
   final case class ObjectDelete(player_guid: PlanetSideGUID, item_guid: PlanetSideGUID, unk: Int = 0) extends Action
-  final case class ObjectHeld(player_guid: PlanetSideGUID, slot: Int)                                 extends Action
+  final case class ObjectHeld(player_guid: PlanetSideGUID, slot: Int, previousSLot: Int)              extends Action
   final case class OxygenState(player: OxygenStateTarget, vehicle: Option[OxygenStateTarget])         extends Action
   final case class PlanetsideAttribute(player_guid: PlanetSideGUID, attribute_type: Int, attribute_value: Long)
       extends Action

--- a/src/main/scala/net/psforever/services/avatar/AvatarServiceResponse.scala
+++ b/src/main/scala/net/psforever/services/avatar/AvatarServiceResponse.scala
@@ -47,7 +47,7 @@ object AvatarResponse {
   final case class LoadPlayer(pkt: ObjectCreateMessage)                                            extends Response
   final case class LoadProjectile(pkt: ObjectCreateMessage)                                        extends Response
   final case class ObjectDelete(item_guid: PlanetSideGUID, unk: Int)                               extends Response
-  final case class ObjectHeld(slot: Int)                                                           extends Response
+  final case class ObjectHeld(slot: Int, previousSLot: Int)                                        extends Response
   final case class OxygenState(player: OxygenStateTarget, vehicle: Option[OxygenStateTarget])      extends Response
   final case class PlanetsideAttribute(attribute_type: Int, attribute_value: Long)                 extends Response
   final case class PlanetsideAttributeToAll(attribute_type: Int, attribute_value: Long)            extends Response

--- a/src/main/scala/net/psforever/types/ImplantType.scala
+++ b/src/main/scala/net/psforever/types/ImplantType.scala
@@ -5,6 +5,7 @@ import enumeratum.values.{IntEnum, IntEnumEntry}
 import net.psforever.packet.PacketHelpers
 import net.psforever.packet.game.Shortcut
 import net.psforever.packet.game.objectcreate.ImplantEffects
+import scodec.Codec
 import scodec.codecs._
 
 sealed abstract class ImplantType(
@@ -16,52 +17,60 @@ sealed abstract class ImplantType(
 ) extends IntEnumEntry
 
 case object ImplantType extends IntEnum[ImplantType] {
-
   case object AdvancedRegen
       extends ImplantType(
         value = 0,
-        shortcut = Shortcut(2, "advanced_regen"),
+        shortcut = Shortcut.Implant("advanced_regen"),
         effect = Some(ImplantEffects.RegenEffects)
       )
 
-  case object Targeting extends ImplantType(value = 1, shortcut = Shortcut(2, "targeting"))
+  case object Targeting extends ImplantType(value = 1, shortcut = Shortcut.Implant("targeting"))
 
-  case object AudioAmplifier extends ImplantType(value = 2, shortcut = Shortcut(2, "audio_amplifier"))
+  case object AudioAmplifier extends ImplantType(value = 2, shortcut = Shortcut.Implant("audio_amplifier"))
 
   case object DarklightVision
       extends ImplantType(
         value = 3,
-        shortcut = Shortcut(2, "darklight_vision"),
+        shortcut = Shortcut.Implant("darklight_vision"),
         effect = Some(ImplantEffects.DarklightEffects)
       )
 
-  case object MeleeBooster extends ImplantType(value = 4, shortcut = Shortcut(2, "melee_booster"))
+  case object MeleeBooster extends ImplantType(value = 4, shortcut = Shortcut.Implant("melee_booster"))
 
   case object PersonalShield
       extends ImplantType(
         value = 5,
-        shortcut = Shortcut(2, "personal_shield"),
+        shortcut = Shortcut.Implant("personal_shield"),
         disabledFor = Set(ExoSuitType.Infiltration),
         effect = Some(ImplantEffects.PersonalShieldEffects)
       )
 
-  case object RangeMagnifier extends ImplantType(value = 6, shortcut = Shortcut(2, "range_magnifier"))
+  case object RangeMagnifier extends ImplantType(value = 6, shortcut = Shortcut.Implant("range_magnifier"))
 
-  case object SecondWind extends ImplantType(value = 7, shortcut = Shortcut(2, "second_wind"))
+  case object SecondWind extends ImplantType(value = 7, shortcut = Shortcut.Implant("second_wind"))
 
-  case object SilentRun extends ImplantType(value = 8, shortcut = Shortcut(2, "silent_run"))
+  case object SilentRun extends ImplantType(value = 8, shortcut = Shortcut.Implant("silent_run"))
 
-  case object Surge
-      extends ImplantType(
-        value = 9,
-        shortcut = Shortcut(2, "surge"),
-        disabledFor = Set(ExoSuitType.MAX),
-        effect = Some(ImplantEffects.SurgeEffects)
-      )
+  case object Surge extends ImplantType(
+    value = 9,
+    shortcut = Shortcut.Implant("surge"),
+    disabledFor = Set(ExoSuitType.MAX),
+    effect = Some(ImplantEffects.SurgeEffects)
+  )
 
-  case object None extends ImplantType(value = 15, shortcut = Shortcut(2, ""))
+  case object None extends ImplantType(
+    value = 15,
+    shortcut = Shortcut.Macro(acronym="ERR", msg=""),
+    disabledFor = ExoSuitType.values
+  )
 
   def values: IndexedSeq[ImplantType] = findValues
 
-  implicit val codec = PacketHelpers.createIntEnumCodec(this, uint4L)
+  final val names: Seq[String] = Seq(
+    "advanced_regen", "targeting", "audio_amplifier",
+    "darklight_vision", "melee_booster", "personal_shield", "range_magnifier",
+    "second_wind", "silent_run", "surge"
+  )
+
+  implicit val codec: Codec[ImplantType] = PacketHelpers.createIntEnumCodec(this, uint4L)
 }

--- a/src/test/scala/game/CreateShortcutMessageTest.scala
+++ b/src/test/scala/game/CreateShortcutMessageTest.scala
@@ -15,11 +15,9 @@ class CreateShortcutMessageTest extends Specification {
 
   "decode (medkit)" in {
     PacketCoding.decodePacket(stringMedkit).require match {
-      case CreateShortcutMessage(player_guid, slot, unk, addShortcut, shortcut) =>
+      case CreateShortcutMessage(player_guid, slot, shortcut) =>
         player_guid mustEqual PlanetSideGUID(4210)
         slot mustEqual 1
-        unk mustEqual 0
-        addShortcut mustEqual true
         shortcut.isDefined mustEqual true
         shortcut.get.purpose mustEqual 0
         shortcut.get.tile mustEqual "medkit"
@@ -32,11 +30,9 @@ class CreateShortcutMessageTest extends Specification {
 
   "decode (macro)" in {
     PacketCoding.decodePacket(stringMacro).require match {
-      case CreateShortcutMessage(player_guid, slot, unk, addShortcut, shortcut) =>
+      case CreateShortcutMessage(player_guid, slot, shortcut) =>
         player_guid mustEqual PlanetSideGUID(1356)
         slot mustEqual 8
-        unk mustEqual 0
-        addShortcut mustEqual true
         shortcut.isDefined mustEqual true
         shortcut.get.purpose mustEqual 1
         shortcut.get.tile mustEqual "shortcut_macro"
@@ -49,11 +45,9 @@ class CreateShortcutMessageTest extends Specification {
 
   "decode (remove)" in {
     PacketCoding.decodePacket(stringRemove).require match {
-      case CreateShortcutMessage(player_guid, slot, unk, addShortcut, shortcut) =>
+      case CreateShortcutMessage(player_guid, slot, shortcut) =>
         player_guid mustEqual PlanetSideGUID(1356)
         slot mustEqual 1
-        unk mustEqual 0
-        addShortcut mustEqual false
         shortcut.isDefined mustEqual false
       case _ =>
         ko
@@ -61,7 +55,7 @@ class CreateShortcutMessageTest extends Specification {
   }
 
   "encode (medkit)" in {
-    val msg = CreateShortcutMessage(PlanetSideGUID(4210), 1, 0, true, Some(Shortcut(0, "medkit")))
+    val msg = CreateShortcutMessage(PlanetSideGUID(4210), 1, Some(Shortcut(0, "medkit")))
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual stringMedkit
@@ -71,8 +65,6 @@ class CreateShortcutMessageTest extends Specification {
     val msg = CreateShortcutMessage(
       PlanetSideGUID(1356),
       8,
-      0,
-      true,
       Some(Shortcut(1, "shortcut_macro", "NTU", "/platoon Incoming NTU spam!"))
     )
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
@@ -81,7 +73,7 @@ class CreateShortcutMessageTest extends Specification {
   }
 
   "encode (remove)" in {
-    val msg = CreateShortcutMessage(PlanetSideGUID(1356), 1, 0, false)
+    val msg = CreateShortcutMessage(PlanetSideGUID(1356), 1, None)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual stringRemove

--- a/src/test/scala/game/CreateShortcutMessageTest.scala
+++ b/src/test/scala/game/CreateShortcutMessageTest.scala
@@ -18,11 +18,10 @@ class CreateShortcutMessageTest extends Specification {
       case CreateShortcutMessage(player_guid, slot, shortcut) =>
         player_guid mustEqual PlanetSideGUID(4210)
         slot mustEqual 1
-        shortcut.isDefined mustEqual true
-        shortcut.get.purpose mustEqual 0
-        shortcut.get.tile mustEqual "medkit"
-        shortcut.get.effect1 mustEqual ""
-        shortcut.get.effect2 mustEqual ""
+        shortcut match {
+          case Some(Shortcut.Medkit()) => ok
+          case _ => ko
+        }
       case _ =>
         ko
     }
@@ -33,11 +32,10 @@ class CreateShortcutMessageTest extends Specification {
       case CreateShortcutMessage(player_guid, slot, shortcut) =>
         player_guid mustEqual PlanetSideGUID(1356)
         slot mustEqual 8
-        shortcut.isDefined mustEqual true
-        shortcut.get.purpose mustEqual 1
-        shortcut.get.tile mustEqual "shortcut_macro"
-        shortcut.get.effect1 mustEqual "NTU"
-        shortcut.get.effect2 mustEqual "/platoon Incoming NTU spam!"
+        shortcut match {
+          case Some(Shortcut.Macro("NTU", "/platoon Incoming NTU spam!")) => ok
+          case _ => ko
+        }
       case _ =>
         ko
     }
@@ -55,7 +53,7 @@ class CreateShortcutMessageTest extends Specification {
   }
 
   "encode (medkit)" in {
-    val msg = CreateShortcutMessage(PlanetSideGUID(4210), 1, Some(Shortcut(0, "medkit")))
+    val msg = CreateShortcutMessage(PlanetSideGUID(4210), 1, Some(Shortcut.Medkit()))
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual stringMedkit
@@ -65,7 +63,7 @@ class CreateShortcutMessageTest extends Specification {
     val msg = CreateShortcutMessage(
       PlanetSideGUID(1356),
       8,
-      Some(Shortcut(1, "shortcut_macro", "NTU", "/platoon Incoming NTU spam!"))
+      Some(Shortcut.Macro("NTU", "/platoon Incoming NTU spam!"))
     )
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
@@ -80,35 +78,33 @@ class CreateShortcutMessageTest extends Specification {
   }
 
   "macro" in {
-    val MACRO: Some[Shortcut] = Shortcut.MACRO("NTU", "/platoon Incoming NTU spam!")
-    MACRO.get.purpose mustEqual 1
-    MACRO.get.tile mustEqual "shortcut_macro"
-    MACRO.get.effect1 mustEqual "NTU"
-    MACRO.get.effect2 mustEqual "/platoon Incoming NTU spam!"
+    val MACRO: Shortcut.Macro = Shortcut.Macro("NTU", "/platoon Incoming NTU spam!")
+    MACRO.acronym mustEqual "NTU"
+    MACRO.msg mustEqual "/platoon Incoming NTU spam!"
   }
 
   "presets" in {
-    ImplantType.AudioAmplifier.shortcut.purpose mustEqual 2
+    ImplantType.AudioAmplifier.shortcut.code mustEqual 2
     ImplantType.AudioAmplifier.shortcut.tile mustEqual "audio_amplifier"
-    ImplantType.DarklightVision.shortcut.purpose mustEqual 2
+    ImplantType.DarklightVision.shortcut.code mustEqual 2
     ImplantType.DarklightVision.shortcut.tile mustEqual "darklight_vision"
-    ImplantType.Targeting.shortcut.purpose mustEqual 2
+    ImplantType.Targeting.shortcut.code mustEqual 2
     ImplantType.Targeting.shortcut.tile mustEqual "targeting"
-    Shortcut.Medkit.get.purpose mustEqual 0
-    Shortcut.Medkit.get.tile mustEqual "medkit"
-    ImplantType.MeleeBooster.shortcut.purpose mustEqual 2
+    Shortcut.Medkit().code mustEqual 0
+    Shortcut.Medkit().tile mustEqual "medkit"
+    ImplantType.MeleeBooster.shortcut.code mustEqual 2
     ImplantType.MeleeBooster.shortcut.tile mustEqual "melee_booster"
-    ImplantType.PersonalShield.shortcut.purpose mustEqual 2
+    ImplantType.PersonalShield.shortcut.code mustEqual 2
     ImplantType.PersonalShield.shortcut.tile mustEqual "personal_shield"
-    ImplantType.RangeMagnifier.shortcut.purpose mustEqual 2
+    ImplantType.RangeMagnifier.shortcut.code mustEqual 2
     ImplantType.RangeMagnifier.shortcut.tile mustEqual "range_magnifier"
-    ImplantType.AdvancedRegen.shortcut.purpose mustEqual 2
+    ImplantType.AdvancedRegen.shortcut.code mustEqual 2
     ImplantType.AdvancedRegen.shortcut.tile mustEqual "advanced_regen"
-    ImplantType.SecondWind.shortcut.purpose mustEqual 2
+    ImplantType.SecondWind.shortcut.code mustEqual 2
     ImplantType.SecondWind.shortcut.tile mustEqual "second_wind"
-    ImplantType.SilentRun.shortcut.purpose mustEqual 2
+    ImplantType.SilentRun.shortcut.code mustEqual 2
     ImplantType.SilentRun.shortcut.tile mustEqual "silent_run"
-    ImplantType.Surge.shortcut.purpose mustEqual 2
+    ImplantType.Surge.shortcut.code mustEqual 2
     ImplantType.Surge.shortcut.tile mustEqual "surge"
   }
 }


### PR DESCRIPTION
This first major feature development fueled by development of a function that is not vanilla to the game.

If the player has a grenade - either a fragmentation grenade or a plasma grenade - somewhere on their person and they wish to switch to it quickly, a command is now available that summons the grenade into his hand and brandishes it for throwing.  The player has to throw it manually since the act involves variable strength.  Any weapon that he is holding previously is replaced into the same holster while the hand is down.  The grenade is placed into the **first sidearm holster** and whatever was originally in that holster is either placed into the player's backpack or dropped onto the ground if there isn't enough room.  If the grenade is in the other holster, the hands are merely swapped without modifying the position of any equipment; if already in a holster but no weapons are drawn, that grenade is merely drawn.  Of course, any player donning a mechanized assault exo-suit may not do this.  A maneuvering of equipment allows for the grenade to be drawn very slightly faster than usual if it comes out of the backpack.

Along the base of the player HUD are eight slots that are intended to be a hotbar.  When things are assigned to these slots, they are called "shortcuts".  An additional seven sets of hotbar slots can be accessed using vertical arrows alongside the hotbar area, resulting in sixty-four shortcuts, with eight available at a given moment.  Quick-use access to these hotbar shortcuts is normally assigned the function keys (F1 to F8) but keybindings may modify this.  The game defaults the first hotbar element as a quick access to any medkits in one's backpack, while each implant the player installs will also add an hotbar icon.  By making use of the text chat command `/macro`, the player may create their own text change message that will be automatically spoken within an assigned domain (local, squad, platoon).  This custom message appears in the shape of a word bubble with three letters that will hopefully indicate the nature of the underlying chat message.  Clicking on an open hotbar slot places the message there while clicking on an occupied hotbar slot will cause the shortcuts to swap between cursor and slot and will require the swapped shortcut be placed somewhere else.  Left clicking on an occupied hotbar slot when in cursor mode removes the shortcut but allows it to be moved to another slot; right clicking on a shortcut deletes it entirely and it must be remade.  Exit cursor mode to forget about any yet-to-be-placed shortcuts that are attached to the cursor.  These shortcuts are persisted in the database but must be reloaded to the client every character redraw event (zoning, respawn, reconstruction, etc..).

___Commands___
These chat commands are naturally in the game.
`/macro [acronym] [message]`
The normal method of adding macros to the hotbar.  The process has been described previously.

These chat commands have been added.
`!macro medkit`
Run a sanity test to make certain the medkit shortcut icon is available on the hotbar.

`!macro implants`
Run a sanity test to make certain all of the avatar's installed implants have a shortcut icon available on the hotbar.

`!macro [implant]`
Run a sanity test to make certain this implant has a shortcut icon available on the hotbar if it is installed on the avatar.

`!macro [acronym] [message]`
A backup method of adding macros to the hotbar.  Follows the same process that has been described previously.

`!grenade`
The quick-switch ...-to-grenade command.  Proof of concept not-vanilla feature.  Follows the same process that has been described previously.

___Features___
__`AvatarActor`__
Preexisting class.  Loads shortcuts at the time of avatar login; and, reads and writes them over the course of the avatar's lifetime. Sets an initial login condition that adjusts the time when things like certifications and initial shortcuts are established.

__`ObjectHeldMessage`__
Preexisting class.  Logic pathways for `ObjectHeldMessage` have been moved from `SessionActor` to `PlayerControl` and completely propagates through `AvatarService` to `SessionActor`'s rather than half of the result immediately returning to the sending client.  An additional variable check allows for the player's arm to be held is a certain position (arm up or arm down) until a condition is satified or the check is unset, which is useful for stopping the arm from lowering when wearing a mechanized assault exo-suit, for example.

__`CreateShortcutMessage`__
Preexisting class.  The process of transcoding the shortcut has been simplified to remove quote-unquote unnecessary fields.

__`net.psforever.objects.avatar.Shortcut`__
A storage medium for hotbar shortcuts previously read from the database or added by the client, maintained by the `Avatar` entity.  Restored once per client refresh (respawn, etc..).

__`net.psforever.persistence.Shortcut`__
A transfer medium between the server and the database for hotbar shortcuts.

__`ChatService`__
Since all new commands re completely normal packets that are distinguished only by their "commands" being preceded with a bang character (!), custom functionality is facilitated by `ChatMsg` packets

__`WorldSession`__
The quick grenade action is mainly handled by a function added to this support object.

___Caveats___
1. The player may not quick draw jammer grenades.  Jammer grenades are far too strategic to be quick-draw-able.
2. The player may only quick-draw actual grenades.  As a response to the command, he will not draw any weapon that is a grenade launcher (Thumper) or has a grenade launcher (Punisher) or that utilizes grenade-like projectiles (Rocket Rifle), whether or not the appropriate grenade type is loaded.  The anti-vehicular Terran Republic mechanized assault exo-suit is, of course, right out ...
3. The determination of whether a fragmentation grenade or a plasma grenade gets drawn is based on the order in which the grenade was inserted into the player's inventory.  It won't matter whether that first available grenade is in the top left-most position of the backpack space or the bottom right place, or if a jammer grenade was put into the backpack before any other type of grenade.
4. Implants always want to install their icons into the earliest slots of the hotbar - two through four mainly - but will also always install in the latest hotbar slot before trying to overwrite earlier ones.  A workaround that should stop this from happening has been implemented, though holes in the logic may exist.  Please report these bugs immediately as they may cause the database to break down.
5. The player may prune their shortcuts in anyw ay they want, including removed the default-by-feature shortcuts for medkit and implants.  While these shortcuts as missing, status of and application of these features is still possible through alternate means.  Medkits are visible in and can be used from the inventory window.  Restoring the medkit shortcut requires putting more medkits into one's backpack.  Implants can have their initialization and activation statuses checked and they can be activated from the character information window.  Restoring implant icons requires uninstalling and then reinstalling the implant.  Implants can have their initialization and activation statuses checked and they can be activated from the character information window.  Restoring the medkit shortcut requires putting more medkits into one's backpack.  To make this restoration process easier, however, custom text chat commands have been added.

___Addenda___
1. In case it isn't obvious, the features in this update are intended to be used together in this way: `/macro [acronym] !grenade`.  This is the only sensible way the quick grenade option could be made useful.
2. Discord user tijon better appreciate this.