### PR TITLE
Quick Grenade, But a Little Slower

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -2315,7 +2315,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
           sendResponse(ObjectDeleteMessage(item_guid, unk))
         }
 
-      case AvatarResponse.ObjectHeld(slot, previousSLot) =>
+      case AvatarResponse.ObjectHeld(slot, previousSlot) =>
         if (tplayer_guid == guid) {
           if (slot > -1) {
             sendResponse(ObjectHeldMessage(guid, slot, unk1=true))
@@ -2329,7 +2329,7 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
             }
           }
         } else {
-          sendResponse(ObjectHeldMessage(guid, previousSLot, unk1=false))
+          sendResponse(ObjectHeldMessage(guid, previousSlot, unk1=false))
         }
 
       case AvatarResponse.OxygenState(player, vehicle) =>

--- a/src/main/scala/net/psforever/login/WorldSession.scala
+++ b/src/main/scala/net/psforever/login/WorldSession.scala
@@ -806,12 +806,14 @@ object WorldSession {
       }
       optGrenadeInSlot match {
         case Some((grenade, slotNum)) =>
-          tplayer.ResistArmMotion(countRestrictAttempts(count=1))
           val itemInPreviouslyDrawnSlotToDrop = if (equipSlot != previouslyDrawnSlot) {
             forcedTolowerRaisedArm(tplayer, tplayer.GUID, tplayer.Zone)
             tplayer.Slot(previouslyDrawnSlot).Equipment match {
-              case out @ Some(_) => out
-              case _             => None
+              case out @ Some(_) =>
+                tplayer.ResistArmMotion(countRestrictAttempts(count=1))
+                out
+              case _ =>
+                None
             }
           } else {
             None


### PR DESCRIPTION
Long story short, I wrote a method of stopping the arm from moving and its countermeasure was to send a packet back to the client to restore it to its original position.  It was firing in a situation where it should not have been, resulting in the original arm with the quick grenade being drawn as well as the swapped-to equipment being drawn.  The failsafe packet is only sent back to the specific client so only the player would see the bizarre fusion of grenade and other weapon.