### PR TITLE
Relog Fix

### DIFF
--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -297,12 +297,20 @@ class MiddlewareActor(
                 send(ServerStart(nonce, serverNonce), None, None)
                 cryptoSetup()
 
-              /** Unknown30 is used to reuse an existing crypto session when switching from login to world
-                * When not handling it, it appears that the client will fall back to using ClientStart
-                * TODO implement this
-                */
               case (Unknown30(nonce), _) =>
+                /*
+                Unknown30 is used to reuse an existing crypto session when switching from login to world
+                When not handling it, it appears that the client will fall back to using ClientStart
+                Do we need to implement this?
+                */
                 connectionClose()
+
+              case (ConnectionClose(), _) =>
+                /*
+                indicates the user has willingly quit the game world
+                we do not need to implement this
+                */
+                Behaviors.same
 
               // TODO ResetSequence
               case _ =>

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -856,7 +856,7 @@ class AvatarActor(
                     case Success(_) =>
                       log.debug(s"AvatarActor: created character $name for account ${account.name}")
                       sessionActor ! SessionActor.SendResponse(ActionResultMessage.Pass)
-                      //sendAvatars(account)
+                      sendAvatars(account)
                     case Failure(e) => log.error(e)("db failure")
                   }
                 case Some(_) =>

--- a/src/main/scala/net/psforever/packet/game/ActionResultMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/ActionResultMessage.scala
@@ -6,34 +6,34 @@ import scodec.Codec
 import scodec.codecs._
 
 /**
-  * Is sent by the server when the client has performed an action from a menu item
-  * (i.e create character, delete character, etc...)
-  */
-final case class ActionResultMessage(successful: Boolean, errorCode: Option[Long]) extends PlanetSideGamePacket {
+ * Is sent by the server when the client has performed an action from a menu item
+ * (i.e create character, delete character, etc...).
+ * Error messages usually are accompanied by an angry beep.<br>
+ * Error 0 is a common code but it doesn't do anything specific on its own.<br>
+ * Error 1 generates the message box: a character with that name already exists.<br>
+ * Error 2 generates the message box: something to do with the word filter.<br>
+ * Other errors during the character login screen generate a generic error message box and list the code.
+ */
+final case class ActionResultMessage(errorCode: Option[Long]) extends PlanetSideGamePacket {
   type Packet = ActionResultMessage
   def opcode = GamePacketOpcode.ActionResultMessage
   def encode = ActionResultMessage.encode(this)
 }
 
 object ActionResultMessage extends Marshallable[ActionResultMessage] {
-
   /**
     * A message where the result is always a pass.
     * @return an `ActionResultMessage` object
     */
-  def Pass: ActionResultMessage = ActionResultMessage(true, None)
+  def Pass: ActionResultMessage = ActionResultMessage(None)
 
   /**
     * A message where the result is always a failure.
     * @param error the error code
     * @return an `ActionResultMessage` object
     */
-  def Fail(error: Long): ActionResultMessage = ActionResultMessage(false, Some(error))
+  def Fail(error: Long): ActionResultMessage = ActionResultMessage(Some(error))
 
-  implicit val codec: Codec[ActionResultMessage] = (
-    ("successful" | bool) >>:~ { res =>
-      // if not successful, look for an error code
-      conditional(!res, "error_code" | uint32L).hlist
-    }
-  ).as[ActionResultMessage]
+  implicit val codec: Codec[ActionResultMessage] =
+    ("error_code" | optional(bool.xmap[Boolean](state => !state, state => !state), uint32L)).as[ActionResultMessage]
 }

--- a/src/test/scala/game/ActionResultMessageTest.scala
+++ b/src/test/scala/game/ActionResultMessageTest.scala
@@ -12,9 +12,8 @@ class ActionResultMessageTest extends Specification {
 
   "decode (pass)" in {
     PacketCoding.decodePacket(string_pass).require match {
-      case ActionResultMessage(okay, code) =>
-        okay mustEqual true
-        code mustEqual None
+      case ActionResultMessage(code) =>
+        code.isEmpty mustEqual true
       case _ =>
         ko
     }
@@ -22,16 +21,15 @@ class ActionResultMessageTest extends Specification {
 
   "decode (fail)" in {
     PacketCoding.decodePacket(string_fail).require match {
-      case ActionResultMessage(okay, code) =>
-        okay mustEqual false
-        code mustEqual Some(1)
+      case ActionResultMessage(code) =>
+        code.contains(1) mustEqual true
       case _ =>
         ko
     }
   }
 
   "encode (pass, full)" in {
-    val msg = ActionResultMessage(true, None)
+    val msg = ActionResultMessage(None)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string_pass
@@ -45,7 +43,7 @@ class ActionResultMessageTest extends Specification {
   }
 
   "encode (fail, full)" in {
-    val msg = ActionResultMessage(false, Some(1))
+    val msg = ActionResultMessage(Some(1))
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
 
     pkt mustEqual string_fail


### PR DESCRIPTION
Introduction: ever notice that all my PR's are formatted exactly the same?  Let me change it up this time.

Problem statement: relogging into the game world before the persistence timer has completely logged a character out but a character dies while it's user is disconnected causes the character to lose some attachment to the game world.  The primary demonstration is that manipulation of items in the inventory is not respected, but other symptoms can be observed easily.  Switching game zones (when you can) corrects the issue.

Problem explanation: a restored location login causes the old zone and the new zone to be the same location during login.  At one point in the original login protocol, the new zone gains an anchoring event subscription long before the normal subscription hooks are made.  All of the meaningful unsubscriptions in the old zone are removed entirely immediately after that.  When the two zones are the same, even this anchoring subscription is lost and is never remade; and, this anchoring subscription goes on to become one of the most important subscriptions for that character and session, at least until the next zone proper transfer occurs and everything is executed normally.

Problem scope: the very specific scope of the issue was logging back into the game and the game respawning you on the same continent in which you logged out last.  The end of persistence does not matter.  The dying in between logout and login was not a necessary step, it merely brought greater attention to the issue.  Additionally, this problem was originally reported after a client crash.  The client crash, too, was merely an event that highlighted the problem and did not contribute to it.

Solution: flip the order of the subscription addition and the subscription removals such that the anchor subscription is always set properly.  Cleanup where necessary.

Addenda:
1. For some reason, I rewrote the order of events in `AvatarActor` because I encountered a different bug when it came to the player avatar not being set when it should have been and was expected to be set.  While this may have just been another symptom, you can't help but admit the final result looks tidy.
2. I rewrote the `ActionResultMessage` transcoder because the inefficiency of the original was bugging me.
3. Special thanks to ScrawnyRonnie for reminding me that the easiest way to crash the client was not to actually crash the client.