### PR TITLE
Scorpion Death Message

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2434,6 +2434,7 @@ class SessionData(
       case obj: PlayerSource => obj.Seated
       case _                 => false
     }
+    sendResponse(ChatMsg(ChatMessageType.CMT_OPEN, wideContents=false, "", s"Killer method: $method", note=None))
     new DestroyDisplayMessage(
       killer.Name,
       killer.CharId,

--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2434,7 +2434,6 @@ class SessionData(
       case obj: PlayerSource => obj.Seated
       case _                 => false
     }
-    sendResponse(ChatMsg(ChatMessageType.CMT_OPEN, wideContents=false, "", s"Killer method: $method", note=None))
     new DestroyDisplayMessage(
       killer.Name,
       killer.CharId,

--- a/src/main/scala/net/psforever/actors/session/support/WeaponAndProjectileOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/WeaponAndProjectileOperations.scala
@@ -21,7 +21,7 @@ import net.psforever.objects.serverobject.turret.FacilityTurret
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.vital.base.{DamageResolution, DamageType}
-import net.psforever.objects.vital.etc.ExplodingEntityReason
+import net.psforever.objects.vital.etc.OicwLilBuddyReason
 import net.psforever.objects.vital.interaction.DamageInteraction
 import net.psforever.objects.vital.projectile.ProjectileReason
 import net.psforever.objects.zones.{Zone, ZoneProjectile}
@@ -1188,7 +1188,7 @@ private[support] class WeaponAndProjectileOperations(
     //explosion
     val obj = new DummyExplodingEntity(proxy, proxy.owner.Faction)
     obj.Position = obj.Position + orientation * distance
-    val explosionFunc: ()=>Unit = WeaponAndProjectileOperations.detonateLittleBuddy(continent, obj, proxy.owner)
+    val explosionFunc: ()=>Unit = WeaponAndProjectileOperations.detonateLittleBuddy(continent, obj, proxy, proxy.owner)
     context.system.scheduler.scheduleOnce(500.milliseconds) { explosionFunc() }
   }
 
@@ -1259,9 +1259,10 @@ object WeaponAndProjectileOperations {
   private def detonateLittleBuddy(
                                    zone: Zone,
                                    source: PlanetSideGameObject with FactionAffinity with Vitality,
+                                   proxy: Projectile,
                                    owner: SourceEntry
                                  )(): Unit = {
-    Zone.serverSideDamage(zone, source, littleBuddyExplosionDamage(owner, source.Position))
+    Zone.serverSideDamage(zone, source, littleBuddyExplosionDamage(owner, proxy.id, source.Position))
   }
 
   /**
@@ -1279,16 +1280,13 @@ object WeaponAndProjectileOperations {
    */
   private def littleBuddyExplosionDamage(
                                           owner: SourceEntry,
+                                          projectileId: Long,
                                           explosionPosition: Vector3
                                         )
                                         (
                                           source: PlanetSideGameObject with FactionAffinity with Vitality,
                                           target: PlanetSideGameObject with FactionAffinity with Vitality
                                         ): DamageInteraction = {
-    DamageInteraction(
-      SourceEntry(target),
-      ExplodingEntityReason(owner, source.Definition.innateDamage.get, target.DamageModel, None),
-      explosionPosition
-    )
+    DamageInteraction(SourceEntry(target), OicwLilBuddyReason(owner, projectileId, target.DamageModel), explosionPosition)
   }
 }

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -180,13 +180,14 @@ class ZoningOperations(
     sendResponse(PlanetsideAttributeMessage(PlanetSideGUID(0), 112, 0)) // disable festive backpacks
 
     //find and reclaim own deployables, if any
-    val foundDeployables =
-      continent.DeployableList.filter(obj => obj.OwnerName.contains(player.Name) && obj.Health > 0)
-    foundDeployables.foreach(obj => {
-      if (avatar.deployables.AddOverLimit(obj)) {
+    val foundDeployables = continent.DeployableList.filter {
+      case _: BoomerDeployable => false //if we do find boomers for any reason, ignore them
+      case dobj => dobj.OwnerName.contains(player.Name) && dobj.Health > 0
+    }
+    foundDeployables.collect {
+      case obj if avatar.deployables.AddOverLimit(obj) =>
         obj.Actor ! Deployable.Ownership(player)
-      }
-    })
+    }
     //render deployable objects
     val (turrets, normal) = continent.DeployableList.partition(obj =>
       DeployableToolbox.UnifiedType(obj.Definition.Item) == DeployedItem.portable_manned_turret

--- a/src/main/scala/net/psforever/objects/DummyExplodingEntity.scala
+++ b/src/main/scala/net/psforever/objects/DummyExplodingEntity.scala
@@ -63,7 +63,7 @@ private class DefinitionWrappedInVitality(private val entity: PlanetSideGameObje
 
   override def ObjectId: Int = entity match {
     case p: Projectile => p.tool_def.ObjectId //projectiles point back to the weapon of origin
-    case _             => super.ObjectId //we're no projectile; we're entirely to blame
+    case _             => internalDefinition.ObjectId //what are we?
   }
 }
 

--- a/src/main/scala/net/psforever/objects/DummyExplodingEntity.scala
+++ b/src/main/scala/net/psforever/objects/DummyExplodingEntity.scala
@@ -1,11 +1,12 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.objects
 
+import net.psforever.objects.ballistics.Projectile
 import net.psforever.objects.definition.{ObjectDefinition, ProjectileDefinition}
 import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.vital.resolution.{DamageAndResistance, DamageResistanceModel}
 import net.psforever.objects.vital.{Vitality, VitalityDefinition}
-import net.psforever.types.{PlanetSideEmpire, Vector3}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 class DummyExplodingEntity(
                             private val obj: PlanetSideGameObject,
@@ -14,7 +15,7 @@ class DummyExplodingEntity(
   extends PlanetSideGameObject
   with FactionAffinity
   with Vitality {
-  override def GUID = obj.GUID
+  override def GUID: PlanetSideGUID = obj.GUID
 
   override def Position: Vector3 = {
     if (super.Position == Vector3.Zero) {
@@ -41,20 +42,29 @@ class DummyExplodingEntity(
   def DamageModel: DamageAndResistance = DummyExplodingEntity.DefaultDamageResistanceModel
 
   def Definition: ObjectDefinition with VitalityDefinition = {
-    new DefinitionWrappedInVitality(obj.Definition)
+    new DefinitionWrappedInVitality(obj)
   }
 }
 
-private class DefinitionWrappedInVitality(definition: ObjectDefinition)
-  extends ObjectDefinition(definition.ObjectId)
+private class DefinitionWrappedInVitality(private val entity: PlanetSideGameObject)
+  extends ObjectDefinition(entity.Definition.ObjectId)
   with VitalityDefinition {
-  innateDamage = definition match {
+  private val internalDefinition = entity.Definition
+
+  innateDamage = internalDefinition match {
     case v: VitalityDefinition if v.innateDamage.nonEmpty => v.innateDamage.get
     case p: ProjectileDefinition                          => p
     case _                                                => GlobalDefinitions.no_projectile
   }
-  Name = { definition.Name }
+
+  Name = internalDefinition.Name
+
   DefaultHealth = 1 //just cuz
+
+  override def ObjectId: Int = entity match {
+    case p: Projectile => p.tool_def.ObjectId //projectiles point back to the weapon of origin
+    case _             => super.ObjectId //we're no projectile; we're entirely to blame
+  }
 }
 
 object DummyExplodingEntity {

--- a/src/main/scala/net/psforever/objects/vital/etc/OicwLilBuddyReason.scala
+++ b/src/main/scala/net/psforever/objects/vital/etc/OicwLilBuddyReason.scala
@@ -1,0 +1,26 @@
+package net.psforever.objects.vital.etc
+
+import net.psforever.objects.GlobalDefinitions
+import net.psforever.objects.sourcing.SourceEntry
+import net.psforever.objects.vital.base.{DamageReason, DamageResolution}
+import net.psforever.objects.vital.prop.DamageProperties
+import net.psforever.objects.vital.resolution.DamageAndResistance
+
+case class OicwLilBuddyReason(
+                               entity: SourceEntry,
+                               projectileId: Long,
+                               damageModel: DamageAndResistance
+                             ) extends DamageReason {
+  def resolution: DamageResolution.Value = DamageResolution.Explosion
+
+  def same(test: DamageReason): Boolean = test match {
+    case eer: OicwLilBuddyReason => eer.projectileId == projectileId
+    case _                       => false
+  }
+
+  def adversary: Option[SourceEntry] = Some(entity)
+
+  def source: DamageProperties = GlobalDefinitions.oicw_little_buddy
+
+  override def attribution: Int = GlobalDefinitions.oicw.ObjectId
+}


### PR DESCRIPTION
Corrects incorrectly attributed blame for death by Scorpion little buddy sub-projectiles, thus that the player who fired the weapon is blamed in the death message and not the sub-projectiles.

Maybe.

I don't know.

You couldn't pay me to stand out in the Ceryshean tundra and fire the weapon on the remote possibility that it hits something.