### PR TITLE
Vehicle Gating with Cargo

### DIFF
--- a/src/main/scala/net/psforever/actors/session/SessionActor.scala
+++ b/src/main/scala/net/psforever/actors/session/SessionActor.scala
@@ -3,7 +3,7 @@ package net.psforever.actors.session
 
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.{Actor, MDCContextAware, SupervisorStrategy, typed}
+import akka.actor.{Actor, MDCContextAware, typed}
 import org.joda.time.LocalDateTime
 import org.log4s.MDC
 import scala.collection.mutable
@@ -115,8 +115,6 @@ class SessionActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], con
 
   private[this] val buffer: mutable.ListBuffer[Any] = new mutable.ListBuffer[Any]()
   private[this] val sessionFuncs                    = new SessionData(middlewareActor, context)
-
-  override val supervisorStrategy: SupervisorStrategy = sessionFuncs.sessionSupervisorStrategy
 
   ServiceManager.serviceManager ! Lookup("accountIntermediary")
   ServiceManager.serviceManager ! Lookup("accountPersistence")

--- a/src/main/scala/net/psforever/actors/session/support/SessionGalaxyHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionGalaxyHandlers.scala
@@ -45,52 +45,7 @@ class SessionGalaxyHandlers(
         sendResponse(msg)
 
       case GalaxyResponse.TransferPassenger(temp_channel, vehicle, _, manifest) =>
-        val playerName = player.Name
-        log.debug(s"TransferPassenger: $playerName received the summons to transfer to ${vehicle.Zone.id} ...")
-        (manifest.passengers.find { _.name.equals(playerName) } match {
-          case Some(entry) if vehicle.Seats(entry.mount).occupant.isEmpty =>
-            player.VehicleSeated = None
-            vehicle.Seats(entry.mount).mount(player)
-            player.VehicleSeated = vehicle.GUID
-            Some(vehicle)
-          case Some(entry) if vehicle.Seats(entry.mount).occupant.contains(player) =>
-            Some(vehicle)
-          case Some(entry) =>
-            log.warn(
-              s"TransferPassenger: $playerName tried to mount seat ${entry.mount} during summoning, but it was already occupied, and ${player.Sex.pronounSubject} was rebuked"
-            )
-            None
-          case None =>
-            //log.warn(s"TransferPassenger: $playerName is missing from the manifest of a summoning ${vehicle.Definition.Name} from ${vehicle.Zone.id}")
-            None
-        }).orElse {
-          manifest.cargo.find { _.name.equals(playerName) } match {
-            case Some(entry) =>
-              vehicle.CargoHolds(entry.mount).occupant match {
-                case out @ Some(cargo) if cargo.Seats(0).occupants.exists(_.Name.equals(playerName)) =>
-                  out
-                case _ =>
-                  None
-              }
-            case None =>
-              None
-          }
-        } match {
-          case Some(v: Vehicle) =>
-            galaxyService ! Service.Leave(Some(temp_channel)) //temporary vehicle-specific channel (see above)
-            sessionData.zoning.spawn.deadState = DeadState.Release
-            sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, player.Position, player.Faction, unk5=true))
-            sessionData.zoning.interstellarFerry = Some(v) //on the other continent and registered to that continent's GUID system
-            sessionData.zoning.spawn.LoadZonePhysicalSpawnPoint(v.Continent, v.Position, v.Orientation, 1 seconds, None)
-          case _ =>
-            sessionData.zoning.interstellarFerry match {
-              case None =>
-                galaxyService ! Service.Leave(Some(temp_channel)) //no longer being transferred between zones
-                sessionData.zoning.interstellarFerryTopLevelGUID = None
-              case Some(_) => ;
-              //wait patiently
-            }
-        }
+        sessionData.zoning.handleTransferPassenger(temp_channel, vehicle, manifest)
 
       case GalaxyResponse.LockedZoneUpdate(zone, time) =>
         sendResponse(ZoneInfoMessage(zone.Number, empire_status=false, lock_time=time))
@@ -103,10 +58,8 @@ class SessionGalaxyHandlers(
         val popVS = zone.Players.count(_.faction == PlanetSideEmpire.VS)
         sendResponse(ZonePopulationUpdateMessage(zone.Number, 414, 138, popTR, 138, popNC, 138, popVS, 138, popBO))
 
-      case GalaxyResponse.LogStatusChange(name) =>
-        if (avatar.people.friend.exists { _.name.equals(name) }) {
-          avatarActor ! AvatarActor.MemberListRequest(MemberAction.UpdateFriend, name)
-        }
+      case GalaxyResponse.LogStatusChange(name) if (avatar.people.friend.exists { _.name.equals(name) })  =>
+        avatarActor ! AvatarActor.MemberListRequest(MemberAction.UpdateFriend, name)
 
       case GalaxyResponse.SendResponse(msg) =>
         sendResponse(msg)

--- a/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
@@ -309,11 +309,8 @@ class VehicleOperations(
           obj.PassengerInSeat(player) match {
             case Some(seat_num) =>
               obj.Actor ! Mountable.TryDismount(player, seat_num, bailType)
-              if (sessionData.zoning.interstellarFerry.isDefined) {
-                //short-circuit the temporary channel for transferring between zones, the player is no longer doing that
-                //see above in VehicleResponse.TransferPassenger case
-                sessionData.zoning.interstellarFerry = None
-              }
+              //short-circuit the temporary channel for transferring between zones, the player is no longer doing that
+              sessionData.zoning.interstellarFerry = None
               // Deconstruct the vehicle if the driver has bailed out and the vehicle is capable of flight
               //todo: implement auto landing procedure if the pilot bails but passengers are still present instead of deconstructing the vehicle
               //todo: continue flight path until aircraft crashes if no passengers present (or no passenger seats), then deconstruct.
@@ -626,6 +623,7 @@ class VehicleOperations(
     }
   }
 
+  //noinspection ScalaUnusedSymbol
   def TotalDriverVehicleControl(vehicle: Vehicle): Unit = {
     serverVehicleControlVelocity = None
     sendResponse(ServerVehicleOverrideMsg(lock_accelerator=false, lock_wheel=false, reverse=false, unk4=false, 0, 0, 0, None))

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -762,19 +762,19 @@ class ZoningOperations(
           None
       }
     } match {
-      case Some(v: Vehicle) =>
+      case Some(cargo: Vehicle) =>
         galaxyService ! Service.Leave(Some(temp_channel)) //temporary vehicle-specific channel (see above)
         spawn.deadState = DeadState.Release
         sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, player.Position, player.Faction, unk5=true))
-        interstellarFerry = Some(v) //on the other continent and registered to that continent's GUID system
-        spawn.LoadZonePhysicalSpawnPoint(v.Continent, v.Position, v.Orientation, 1 seconds, None)
+        interstellarFerry = Some(cargo) //on the other continent and registered to that continent's GUID system
+        cargo.MountedIn = vehicle.GUID
+        spawn.LoadZonePhysicalSpawnPoint(cargo.Continent, cargo.Position, cargo.Orientation, respawnTime = 1 seconds, None)
       case _ =>
         interstellarFerry match {
           case None =>
             galaxyService ! Service.Leave(Some(temp_channel)) //no longer being transferred between zones
             interstellarFerryTopLevelGUID = None
-          case Some(_) => ;
-          //wait patiently
+          case Some(_) => () //wait patiently
         }
     }
   }

--- a/src/main/scala/net/psforever/objects/Vehicle.scala
+++ b/src/main/scala/net/psforever/objects/Vehicle.scala
@@ -113,13 +113,6 @@ class Vehicle(private val vehicleDef: VehicleDefinition)
   private var utilities: Map[Int, Utility]       = Map.empty
   private var subsystems: List[VehicleSubsystem] = Nil
   private val trunk: GridInventory               = GridInventory()
-
-  /*
-    * Records the GUID of the cargo vehicle (galaxy/lodestar) this vehicle is stored in for DismountVehicleCargoMsg use
-    * DismountVehicleCargoMsg only passes the player_guid and this vehicle's guid
-    */
-  //private var mountedIn: Option[PlanetSideGUID] = None
-
   private var vehicleGatingManifest: Option[VehicleManifest]         = None
   private var previousVehicleGatingManifest: Option[VehicleManifest] = None
 

--- a/src/test/scala/objects/VehicleControlTest.scala
+++ b/src/test/scala/objects/VehicleControlTest.scala
@@ -218,7 +218,7 @@ class VehicleControlPrepareForDeletionMountedCargoTest extends FreedContextActor
       lodestar.Actor ! Vehicle.Deconstruct()
 
       val vehicle_msg = vehicleProbe.receiveN(6, 500 milliseconds)
-      vehicle_msg(5) match {
+      vehicle_msg.head match {
         case VehicleServiceMessage("test", VehicleAction.KickPassenger(PlanetSideGUID(4), 4, true, PlanetSideGUID(2))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-1: ${vehicle_msg(5)}")
@@ -226,27 +226,27 @@ class VehicleControlPrepareForDeletionMountedCargoTest extends FreedContextActor
       assert(player2.VehicleSeated.isEmpty)
       assert(lodestar.Seats(0).occupant.isEmpty)
       //cargo dismounting messages
-      vehicle_msg.head match {
+      vehicle_msg(1) match {
         case VehicleServiceMessage(_, VehicleAction.SendResponse(_, PlanetsideAttributeMessage(PlanetSideGUID(1), 0, _))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-2: ${vehicle_msg.head}")
       }
-      vehicle_msg(1) match {
+      vehicle_msg(2) match {
         case VehicleServiceMessage(_, VehicleAction.SendResponse(_, PlanetsideAttributeMessage(PlanetSideGUID(1), 68, _))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-3: ${vehicle_msg(1)}")
       }
-      vehicle_msg(2) match {
+      vehicle_msg(3) match {
         case VehicleServiceMessage("test", VehicleAction.SendResponse(_, CargoMountPointStatusMessage(PlanetSideGUID(2), _, PlanetSideGUID(1), _, 1, CargoStatus.InProgress, 0))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-4: ${vehicle_msg(2)}")
       }
-      vehicle_msg(3) match {
+      vehicle_msg(4) match {
         case VehicleServiceMessage("test", VehicleAction.SendResponse(_, ObjectDetachMessage(PlanetSideGUID(2), PlanetSideGUID(1), _, _, _, _))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-5: ${vehicle_msg(3)}")
       }
-      vehicle_msg(4) match {
+      vehicle_msg(5) match {
         case VehicleServiceMessage("test", VehicleAction.SendResponse(_, CargoMountPointStatusMessage(PlanetSideGUID(2), _, _, PlanetSideGUID(1), 1, CargoStatus.Empty, 0))) => ;
         case _ =>
           assert(false, s"VehicleControlPrepareForDeletionMountedCargoTest-6: ${vehicle_msg(4)}")


### PR DESCRIPTION
When a ferrying vehicle passes through a warp gate, its cargo vehicle will be able to disembark safely on the destination side by remembering that it actually counts as the cargo of some other vehicle again.

Addenda:
I removed the pointless `SessionActor` supervisory strategy.  In theory, it should work that way; in practice, there's no governance from `SA` over the true point of exception.  Will work on this some other day.