### PR TITLE
Not Really a Door Opener

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -177,6 +177,8 @@ game {
       variable = 30
     }
   }
+
+  doors-can-be-opened-by-med-app-from-this-distance = 5.05
 }
 
 anti-cheat {

--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -540,7 +540,7 @@ class SessionData(
     }
     validObject(pkt.object_guid, decorator = "UseItem") match {
       case Some(door: Door) =>
-        handleUseDoor(door)
+        handleUseDoor(door, equipment)
       case Some(resourceSilo: ResourceSilo) =>
         handleUseResourceSilo(resourceSilo, equipment)
       case Some(panel: IFFLock) =>
@@ -1245,8 +1245,17 @@ class SessionData(
     }
   }
 
-  private def handleUseDoor(door: Door): Unit = {
-    door.Actor ! CommonMessages.Use(player)
+  private def handleUseDoor(door: Door, equipment: Option[Equipment]): Unit = {
+    equipment match {
+      case Some(tool: Tool) if tool.Definition == GlobalDefinitions.medicalapplicator =>
+        val distance: Float = math.max(
+          Config.app.game.doorsCanBeOpenedByMedAppFromThisDistance,
+          door.Definition.initialOpeningDistance
+        )
+        door.Actor ! CommonMessages.Use(player, Some(distance))
+      case _ =>
+        door.Actor ! CommonMessages.Use(player)
+    }
   }
 
   private def handleUseResourceSilo(resourceSilo: ResourceSilo, equipment: Option[Equipment]): Unit = {

--- a/src/main/scala/net/psforever/objects/Doors.scala
+++ b/src/main/scala/net/psforever/objects/Doors.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 PSForever
+package net.psforever.objects
+
+import net.psforever.objects.serverobject.doors.Door
+import net.psforever.types.Vector3
+
+object Doors {
+  /**
+   * If a player was considered as holding the door open,
+   * check that if that player is still in the same zone as a door
+   * and is still standing within a certain distance of that door.
+   * If the target player no longer qualifies to hold the door open,
+   * search for a new player to hold the door open.
+   * If the target player did not initially exist (the door was closed),
+   * do not search any further.
+   * @param door door that is installed somewhere
+   * @param maximumDistance permissible square distance between the player and the door
+   * @return optional player;
+   *         `None` if the no player can trigger the door
+   */
+  def testForTargetHoldingDoorOpen(
+                                    door: Door,
+                                    maximumDistance: Float
+                                  ): Option[Player] = {
+    door.Open
+      .flatMap {
+        testForSpecificTargetHoldingDoorOpen(_, door, maximumDistance * maximumDistance)
+          .orElse { testForAnyTargetHoldingDoorOpen(door, maximumDistance) }
+      }
+  }
+
+  /**
+   * Check that a player is in the same zone as a door
+   * and is standing within a certain distance of that door.
+   * @see `Vector3.MagnitudeSquared`
+   * @param player player who is standing somewhere
+   * @param door door that is installed somewhere
+   * @param maximumDistance permissible square distance between the player and the door
+   *                        before one can not influence the other
+   * @return optional player (same as parameter);
+   *         `None` if the parameter player can not trigger the door
+   */
+  def testForSpecificTargetHoldingDoorOpen(
+                                            player: Player,
+                                            door: Door,
+                                            maximumDistance: Float
+                                          ): Option[Player] = {
+    if (player.Zone == door.Zone && Vector3.MagnitudeSquared(door.Position - player.Position) <= maximumDistance) {
+      Some(player)
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Find a player, any player, that can hold the door open.
+   * Prop it open with a dead body if no one is available.
+   * @param door door that is installed somewhere
+   * @param maximumDistance permissible square distance between a player and the door
+   *                        before one can not influence the other
+   * @return optional player;
+   *         `None` if no player can trigger the door
+   */
+  private def testForAnyTargetHoldingDoorOpen(
+                                               door: Door,
+                                               maximumDistance: Float
+                                             ): Option[Player] = {
+    //search for nearby players and nearby former players who would block open the door
+    val zone = door.Zone
+    val maximumDistanceSq = maximumDistance * maximumDistance
+    val bmap = zone.blockMap.sector(door.Position, maximumDistance)
+    (bmap.livePlayerList ++ bmap.corpseList)
+      .find { testForSpecificTargetHoldingDoorOpen(_, door, maximumDistanceSq).nonEmpty } match {
+      case out @ Some(newOpener) =>
+        door.Open = newOpener //another player is near the door, keep it open
+        out
+      case _ =>
+        None
+    }
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/doors/DoorDefinition.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/doors/DoorDefinition.scala
@@ -9,4 +9,9 @@ import net.psforever.objects.serverobject.structures.AmenityDefinition
 class DoorDefinition(objectId: Int)
   extends AmenityDefinition(objectId) {
   Name = "door"
+  /** range wherein the door may first be opened
+   * (note: intentionally inflated as the initial check on the client occurs further than expected) */
+  var initialOpeningDistance: Float = 7.5f
+  /** range within which the door must detect a target player to remain open */
+  var continuousOpenDistance: Float = 5.05f
 }

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -46,7 +46,7 @@ object Config {
     viaNonEmptyStringOpt[A](
       v =>
         e.values.toList.collectFirst {
-          case e if e.toString.toLowerCase == v.toLowerCase => e.asInstanceOf[A]
+          case e if e.toString.toLowerCase == v.toLowerCase => e
         },
       _.toString
     )
@@ -62,25 +62,23 @@ object Config {
   // Raw config object - prefer app when possible
   lazy val config: TypesafeConfig = source.config() match {
     case Right(config) => config
-    case Left(failures) => {
+    case Left(failures) =>
       logger.error("Loading config failed")
       failures.toList.foreach { failure =>
         logger.error(failure.toString)
       }
       sys.exit(1)
-    }
   }
 
   // Typed config object
   lazy val app: AppConfig = source.load[AppConfig] match {
     case Right(config) => config
-    case Left(failures) => {
+    case Left(failures) =>
       logger.error("Loading config failed")
       failures.toList.foreach { failure =>
         logger.error(failure.toString)
       }
       sys.exit(1)
-    }
   }
 }
 
@@ -159,7 +157,8 @@ case class GameConfig(
     baseCertifications: Seq[Certification],
     warpGates: WarpGateConfig,
     cavernRotation: CavernRotationConfig,
-    savedMsg: SavedMessageEvents
+    savedMsg: SavedMessageEvents,
+    doorsCanBeOpenedByMedAppFromThisDistance: Float
 )
 
 case class NewAvatar(


### PR DESCRIPTION
The medical applicator was capable of opening faction-aligned or unlocked doors from a distance.  I find this ability too amusing to completely eliminate, nor can I actually eliminate the tendency of the client/server to try to open any door towards which the applicator can be pointed.  As a consequence, there's now an optional configuration parameter that decides how far away one must be before activating the door.

By default, the value is set low enough that the normal trigger distance will assert itself first.