### PR TITLE
Deconstruct in Privacy

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -163,7 +163,7 @@ class SessionAvatarHandlers(
           case term: Terminal with ProximityUnit => sessionData.terminals.StopUsingProximityUnit(term)
         }
         if (sessionData.zoning.zoningStatus == Zoning.Status.Deconstructing) {
-          sessionData.zoning.zoningStatus = Zoning.Status.None
+          sessionData.stopDeconstructing()
         }
 
       case AvatarResponse.ObjectHeld(slot, _)

--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -69,27 +69,24 @@ class SessionAvatarHandlers(
       isJumping,
       jumpThrust,
       isCloaking,
-      spectating,
+      isNotRendered,
       canSeeReallyFar
       ) if isNotSameTarget =>
         val pstateToSave = pstate.copy(timestamp = 0)
-        val (lastMsg, lastTime, lastPosition, wasSpectating, wasVisible) = lastSeenStreamMessage(guid.guid) match {
-          case SessionAvatarHandlers.LastUpstream(Some(msg), visible, time) => (Some(msg), time, msg.pos, msg.spectator, visible)
-          case _ => (None, 0L, Vector3.Zero, false, false)
+        val (lastMsg, lastTime, lastPosition, wasVisible) = lastSeenStreamMessage(guid.guid) match {
+          case SessionAvatarHandlers.LastUpstream(Some(msg), visible, time) => (Some(msg), time, msg.pos, visible)
+          case _ => (None, 0L, Vector3.Zero, false)
         }
-        val drawConfig = Config.app.game.playerDraw
+        val drawConfig = Config.app.game.playerDraw //m
         val maxRange = drawConfig.rangeMax * drawConfig.rangeMax //sq.m
-        val ourPosition = player.Position
+        val ourPosition = player.Position //xyz
         val currentDistance = Vector3.DistanceSquared(ourPosition, pos) //sq.m
-        val inVisibleRange = currentDistance <= maxRange
-        val wasInVisibleRange = Vector3.DistanceSquared(lastPosition, pos) <= maxRange
-        val comingIntoVisibleRange = inVisibleRange && !wasInVisibleRange
+        val inDrawableRange = currentDistance <= maxRange
         val now = System.currentTimeMillis() //ms
-        val durationSince = now - lastTime //ms
-        val released = player.isReleased
-        if (!released &&
-          !spectating &&
-          (comingIntoVisibleRange || (inVisibleRange && !lastMsg.contains(pstateToSave)))) {
+        if (!isNotRendered && inDrawableRange) {
+          //conditions where visibility is assured
+          val durationSince = now - lastTime //ms
+          lazy val previouslyInDrawableRange = Vector3.DistanceSquared(ourPosition, lastPosition) <= maxRange
           lazy val targetDelay = {
             val populationOver = math.max(
               0,
@@ -102,12 +99,17 @@ class SessionAvatarHandlers(
               case index => drawConfig.delays(index)
             }
           } //ms
-          if (comingIntoVisibleRange ||
-            canSeeReallyFar ||
-            currentDistance < drawConfig.rangeMin * drawConfig.rangeMin ||
-            durationSince > drawConfig.delayMax ||
-            sessionData.canSeeReallyFar ||
-            durationSince > targetDelay) {
+          if (!wasVisible ||
+            !previouslyInDrawableRange ||
+            (!lastMsg.contains(pstateToSave) &&
+              (canSeeReallyFar ||
+                currentDistance < drawConfig.rangeMin * drawConfig.rangeMin ||
+                durationSince > drawConfig.delayMax ||
+                sessionData.canSeeReallyFar ||
+                durationSince > targetDelay
+                )
+              )
+          ) {
             //must draw
             sendResponse(
               PlayerStateMessage(
@@ -126,28 +128,31 @@ class SessionAvatarHandlers(
             )
             lastSeenStreamMessage(guid.guid) = SessionAvatarHandlers.LastUpstream(Some(pstateToSave), visible=true, now)
           } else {
+            //is visible, but skip reinforcement
+            lastSeenStreamMessage(guid.guid) = SessionAvatarHandlers.LastUpstream(Some(pstateToSave), visible=true, lastTime)
+          }
+        } else {
+          //conditions where the target is not currently visible
+          if (wasVisible) {
+            //the target was JUST PREVIOUSLY visible; one last draw to move target beyond a renderable distance
+            val lat = (1 + hidingPlayerRandomizer.nextInt(continent.map.scale.height.toInt)).toFloat
+            sendResponse(
+              PlayerStateMessage(
+                guid,
+                Vector3(1f, lat, 1f),
+                vel=None,
+                facingYaw=0f,
+                facingPitch=0f,
+                facingYawUpper=0f,
+                timestamp=0, //is this okay?
+                is_cloaked = isCloaking
+              )
+            )
+            lastSeenStreamMessage(guid.guid) = SessionAvatarHandlers.LastUpstream(Some(pstateToSave), visible=false, now)
+          } else {
+            //skip drawing altogether
             lastSeenStreamMessage(guid.guid) = SessionAvatarHandlers.LastUpstream(Some(pstateToSave), visible=false, lastTime)
           }
-        } else if (
-          (!spectating && wasInVisibleRange && !inVisibleRange) ||
-            (inVisibleRange && !wasSpectating && spectating) ||
-            (wasVisible && released)
-        ) {
-          //must hide
-          val lat = (1 + hidingPlayerRandomizer.nextInt(continent.map.scale.height.toInt)).toFloat
-          sendResponse(
-            PlayerStateMessage(
-              guid,
-              Vector3(1f, lat, 1f),
-              vel=None,
-              facingYaw=0f,
-              facingPitch=0f,
-              facingYawUpper=0f,
-              timestamp=0, //is this okay?
-              is_cloaked = isCloaking
-            )
-          )
-          lastSeenStreamMessage(guid.guid) = SessionAvatarHandlers.LastUpstream(Some(pstateToSave), visible=false, now)
         }
 
       case AvatarResponse.ObjectHeld(slot, _)
@@ -156,6 +161,9 @@ class SessionAvatarHandlers(
         //Stop using proximity terminals if player unholsters a weapon
         continent.GUID(sessionData.terminals.usingMedicalTerminal).collect {
           case term: Terminal with ProximityUnit => sessionData.terminals.StopUsingProximityUnit(term)
+        }
+        if (sessionData.zoning.zoningStatus == Zoning.Status.Deconstructing) {
+          sessionData.zoning.zoningStatus = Zoning.Status.None
         }
 
       case AvatarResponse.ObjectHeld(slot, _)

--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -83,7 +83,10 @@ class SessionAvatarHandlers(
         val currentDistance = Vector3.DistanceSquared(ourPosition, pos) //sq.m
         val inDrawableRange = currentDistance <= maxRange
         val now = System.currentTimeMillis() //ms
-        if (!isNotRendered && inDrawableRange) {
+        if (
+          sessionData.zoning.zoningStatus != Zoning.Status.Deconstructing &&
+          !isNotRendered && inDrawableRange
+        ) {
           //conditions where visibility is assured
           val durationSince = now - lastTime //ms
           lazy val previouslyInDrawableRange = Vector3.DistanceSquared(ourPosition, lastPosition) <= maxRange

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1920,6 +1920,7 @@ class ZoningOperations(
             TurnCounterDuringInterim
         }
         sessionData.keepAliveFunc = NormalKeepAlive
+        zoningStatus = Zoning.Status.None
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()
@@ -1950,6 +1951,7 @@ class ZoningOperations(
             TurnCounterDuringInterim
         }
         sessionData.keepAliveFunc = NormalKeepAlive
+        zoningStatus = Zoning.Status.None
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1920,7 +1920,9 @@ class ZoningOperations(
             TurnCounterDuringInterim
         }
         sessionData.keepAliveFunc = NormalKeepAlive
-        zoningStatus = Zoning.Status.None
+        if (zoningStatus == Zoning.Status.Deconstructing) {
+          sessionData.stopDeconstructing()
+        }
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()
@@ -1951,7 +1953,9 @@ class ZoningOperations(
             TurnCounterDuringInterim
         }
         sessionData.keepAliveFunc = NormalKeepAlive
-        zoningStatus = Zoning.Status.None
+        if (zoningStatus == Zoning.Status.Deconstructing) {
+          sessionData.stopDeconstructing()
+        }
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2082,6 +2082,7 @@ class ZoningOperations(
         player.Health = health
         player.Armor = armor
       }
+      player.death_by = math.min(player.death_by, 0)
       sessionData.vehicles.GetKnownVehicleAndSeat() match {
         case (Some(vehicle: Vehicle), Some(seat: Int)) =>
           //if the vehicle is the cargo of another vehicle in this zone

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -547,6 +547,10 @@ class Player(var avatar: Avatar)
     ZoningRequest
   }
 
+  override def CanDamage: Boolean = {
+    death_by < 1 && super.CanDamage
+  }
+
   def DamageModel: DamageResistanceModel = exosuit.asInstanceOf[DamageResistanceModel]
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[Player]

--- a/src/main/scala/net/psforever/objects/zones/Zoning.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zoning.scala
@@ -25,6 +25,7 @@ object Zoning {
     val values: IndexedSeq[Status] = findValues
 
     case object None extends Status(value = "None")
+    case object Deconstructing extends Status(value = "Deconstructing")
     case object Request extends Status(value = "Request")
     case object Countdown extends Status(value = "Countdown")
   }


### PR DESCRIPTION
When deconstructing at any spawn tube - in a facility or at an advanced mobile spawn - the player will be concealed thus that they can be allowed to select their destination and complete the passage without interference by external forces.

This utilizes the changes in "Reduced Upstream/Downstream Load" (a1cf6c27018109c7909dbb8ca591a2e56fad4e91) to stop any player that attempts to deconstruct from being visible to other players.

___Addenda___
1. The calculation for determining whether or not the `PlayerStateMessage` packet will be sent - the aforementioned "Reduced Upstream/Downstream Load" - has been simplified out of necessity to eliminate some issues discovered during deconstruction testing.  Play around with it a bit, though I think walking through the simplicity of the remaining checks should speak for themselves.
2. Various allowances have been included in the off-chance that the deconstruction process is cancelled before making a destination selection.  If the player regains control and the deconstruction will not happen, they shall not be permanently hidden from other players.  These triggers include basic movement, drawing weaponry, and implant activation.  As should be expected, this does mean that attempting to deconstruct will lower one's drawn weaponry (the process already messed with active implants).
3. I don't even remember what `death_by` is supposed to have been used for in the first place.  I set it to -1 when the player is to be kicked, I set to 1 when the player is to be protected from all damage, and it's normally 0.
4. I am not going to force the spawn tube door closed during the deconstruction process.  It's not worth it.