### PR TITLE
No Hot Spots from Hacking

### DIFF
--- a/src/main/scala/net/psforever/objects/zones/ZoneHotSpotProjector.scala
+++ b/src/main/scala/net/psforever/objects/zones/ZoneHotSpotProjector.scala
@@ -349,8 +349,11 @@ class ZoneHotSpotHistory(zone: Zone, hotspots: ListBuffer[HotSpotInfo], blanking
           val out = progressionOfIntervals
             .flatMap { y =>
               val yFloat = span * y.toFloat
-              progressionOfIntervals.map { x => TryHotSpot(lowerLeftCorner + Vector3(span * x.toFloat, yFloat, 0f)) }
+              progressionOfIntervals.map { x =>
+                hotspots.find { _.DisplayLocation == lowerLeftCorner + Vector3(span * x.toFloat, yFloat, 0f) }
+              }
             }
+            .flatten
             .filter { info => Vector3.DistanceSquared(center, info.DisplayLocation) < squareRadius }
             .distinctBy { _.DisplayLocation }
             .toList


### PR DESCRIPTION
When I was working on the original experience calculation branch, I got far enough to need to do something with squad experience.  Squad experience was originally awarded to players whenever they were awarded combat experience (for kills).  That is obviously not correct and something had to be done with the code.   I started on an implementation of proper squad experience calculation.  Part of that involved allocating a measure of contribution during the facility capture; furthermore, that involves testing how the facility maintained combat heat, important for ruling out situations where lots of players were just standing around doing nothing though they were present for (the majority of) the capture.  The projector projection functionality can convert physical zone coordinates to the quantized hot spot locations on the game map.  The most common implementation used by the projector looks for an existing hot spot to which heat will be added, or creates a __new hot spot at that location to hold the heat__.  During mere polling operations, __it will not pay attention to hot spot blanking__ and enough hot spot data that will not clear without additional combat heat is generated in those same regions.

I should not have to explain further why hacking a facility or tower creates weird hot spots.

___Addenda___
Polling hot spot history data is currently managed in two ways - this slower but exact message-dependent way, and a much more expedient but more expensive general list duplication.  Not certain which will work better going forward, or why both are a part of the code, but I am certain it has to do with typed actors and classic actors.