### PR TITLE
Vehicle Gating with Passengers

### DIFF
--- a/src/main/scala/net/psforever/actors/session/ChatActor.scala
+++ b/src/main/scala/net/psforever/actors/session/ChatActor.scala
@@ -717,6 +717,7 @@ class ChatActor(
                   sessionActor ! SessionActor.SendResponse(
                     message.copy(messageType = UNK_229, contents = "@CMT_ZONE_usage")
                   )
+                case _ => ()
               }
 
             case (CMT_WARP, _, contents) if gmCommandAllowed =>

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -732,18 +732,19 @@ class ZoningOperations(
     (manifest.passengers.find {
       _.name.equals(playerName)
     } match {
-      case Some(entry) if vehicle.Seats(entry.mount).occupant.isEmpty =>
+      case Some(entry) if vehicle.Seat(entry.mount).flatMap { _.occupant }.isEmpty =>
         player.VehicleSeated = None
         vehicle.Seats(entry.mount).mount(player)
         player.VehicleSeated = vehicle.GUID
-        Some(vehicle)
-      case Some(entry) if vehicle.Seats(entry.mount).occupant.contains(player) =>
-        Some(vehicle)
+        Some((None, Some(vehicle)))
+      case Some(entry) if vehicle.Seat(entry.mount).flatMap { _.occupant }.contains(player) =>
+        player.VehicleSeated = vehicle.GUID
+        Some((None, Some(vehicle)))
       case Some(entry) =>
         log.warn(
           s"TransferPassenger: $playerName tried to mount seat ${entry.mount} during summoning, but it was already occupied, and ${player.Sex.pronounSubject} was rebuked"
         )
-        None
+        Some((None, None))
       case None =>
         //log.warn(s"TransferPassenger: $playerName is missing from the manifest of a summoning ${vehicle.Definition.Name} from ${vehicle.Zone.id}")
         None
@@ -753,8 +754,8 @@ class ZoningOperations(
       } match {
         case Some(entry) =>
           vehicle.CargoHolds(entry.mount).occupant match {
-            case out@Some(cargo) if cargo.Seats(0).occupants.exists(_.Name.equals(playerName)) =>
-              out
+            case out @ Some(cargo) if cargo.Seats(0).occupants.exists(_.Name.equals(playerName)) =>
+              Some((Some(vehicle), out))
             case _ =>
               None
           }
@@ -762,13 +763,11 @@ class ZoningOperations(
           None
       }
     } match {
-      case Some(cargo: Vehicle) =>
-        galaxyService ! Service.Leave(Some(temp_channel)) //temporary vehicle-specific channel (see above)
-        spawn.deadState = DeadState.Release
-        sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, player.Position, player.Faction, unk5=true))
-        interstellarFerry = Some(cargo) //on the other continent and registered to that continent's GUID system
-        cargo.MountedIn = vehicle.GUID
-        spawn.LoadZonePhysicalSpawnPoint(cargo.Continent, cargo.Position, cargo.Orientation, respawnTime = 1 seconds, None)
+      case Some((Some(ferry), Some(cargo))) =>
+        cargo.MountedIn = ferry.GUID
+        handleTransferPassengerVehicle(cargo, temp_channel)
+      case Some((None, Some(_: Vehicle))) =>
+        handleTransferPassengerVehicle(vehicle, temp_channel)
       case _ =>
         interstellarFerry match {
           case None =>
@@ -777,6 +776,14 @@ class ZoningOperations(
           case Some(_) => () //wait patiently
         }
     }
+  }
+
+  private def handleTransferPassengerVehicle(vehicle: Vehicle, temporaryChannel: String): Unit = {
+    galaxyService ! Service.Leave(Some(temporaryChannel)) //temporary vehicle-specific channel (see above)
+    spawn.deadState = DeadState.Release
+    sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, player.Position, player.Faction, unk5=true))
+    interstellarFerry = Some(vehicle) //on the other continent and registered to that continent's GUID system
+    spawn.LoadZonePhysicalSpawnPoint(vehicle.Continent, vehicle.Position, vehicle.Orientation, respawnTime = 1 seconds, None)
   }
 
   def handleDroppodLaunchDenial(errorCode: DroppodError): Unit = {
@@ -1446,7 +1453,6 @@ class ZoningOperations(
     Deployables.Disown(continent, avatar, context.self)
     spawn.drawDeloyableIcon = spawn.RedrawDeployableIcons //important for when SetCurrentAvatar initializes the UI next zone
     sessionData.squad.squadSetup = sessionData.squad.ZoneChangeSquadSetup
-    sessionData.avatarResponse.lastSeenStreamMessage = SessionAvatarHandlers.blankUpstreamMessages(65535)
   }
 
   /**
@@ -1923,6 +1929,7 @@ class ZoningOperations(
         if (zoningStatus == Zoning.Status.Deconstructing) {
           sessionData.stopDeconstructing()
         }
+        sessionData.avatarResponse.lastSeenStreamMessage = SessionAvatarHandlers.blankUpstreamMessages(65535)
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()
@@ -1956,6 +1963,7 @@ class ZoningOperations(
         if (zoningStatus == Zoning.Status.Deconstructing) {
           sessionData.stopDeconstructing()
         }
+        sessionData.avatarResponse.lastSeenStreamMessage = SessionAvatarHandlers.blankUpstreamMessages(65535)
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1929,7 +1929,7 @@ class ZoningOperations(
         if (zoningStatus == Zoning.Status.Deconstructing) {
           sessionData.stopDeconstructing()
         }
-        sessionData.avatarResponse.lastSeenStreamMessage = SessionAvatarHandlers.blankUpstreamMessages(65535)
+        sessionData.avatarResponse.lastSeenStreamMessage.clear()
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()
@@ -1963,7 +1963,7 @@ class ZoningOperations(
         if (zoningStatus == Zoning.Status.Deconstructing) {
           sessionData.stopDeconstructing()
         }
-        sessionData.avatarResponse.lastSeenStreamMessage = SessionAvatarHandlers.blankUpstreamMessages(65535)
+        sessionData.avatarResponse.lastSeenStreamMessage.clear()
         upstreamMessageCount = 0
         setAvatar = false
         sessionData.persist()

--- a/src/main/scala/net/psforever/login/WorldSession.scala
+++ b/src/main/scala/net/psforever/login/WorldSession.scala
@@ -804,8 +804,8 @@ object WorldSession {
               val name = definition.Name
               GlobalDefinitions.isGrenade(definition) && (name.contains("frag") || name.contains("plasma"))
             } match {
-              case Some(InventoryItem(equipment, slotNum)) =>Some(equipment.asInstanceOf[Tool], slotNum)
-              case None                                    => None
+              case Some(InventoryItem(equipment, slotNum)) => Some(equipment.asInstanceOf[Tool], slotNum)
+              case _                                       => None
             }
         }
       }

--- a/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
+++ b/src/main/scala/net/psforever/objects/inventory/GridInventory.scala
@@ -86,7 +86,7 @@ class GridInventory extends Container {
     items.values.find({ case InventoryItem(obj, _) => obj.HasGUID && obj.GUID == guid }) match {
       case Some(InventoryItem(_, index)) =>
         Some(index)
-      case None =>
+      case _ =>
         None
     }
   }

--- a/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
@@ -69,7 +69,7 @@ trait SectorTraits {
   * @param eqFunc a custom equivalence function to distinguish between the entities in the list
   * @tparam A the type of object that will be the entities stored in the list
   */
-class SectorListOf[A](eqFunc: (A, A) => Boolean = (a: A, b: A) => a equals b) {
+class SectorListOf[A](eqFunc: (A, A) => Boolean = (a: A, b: A) => a == b) {
   private val internalList: ListBuffer[A] = ListBuffer[A]()
 
   /**

--- a/src/main/scala/net/psforever/packet/game/LoginMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/LoginMessage.scala
@@ -59,6 +59,7 @@ object LoginMessage extends Marshallable[LoginMessage] {
       a match {
         case username :: Some(password) :: None :: HNil => Left(username :: password :: HNil)
         case username :: None :: Some(token) :: HNil    => Right(token :: username :: HNil)
+        case username :: _ :: _ :: HNil                 => Right(username :: "" :: HNil) //this will fail
       }
 
     either(bool, passwordPath, tokenPath).xmap[Struct](from, to)

--- a/src/main/scala/net/psforever/packet/game/PropertyOverrideMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/PropertyOverrideMessage.scala
@@ -166,6 +166,9 @@ object PropertyOverrideMessage extends Marshallable[PropertyOverrideMessage] {
 
         case target :: _ :: Some(first) :: Some(other) :: HNil =>
           GamePropertyTarget(target, first +: other)
+
+        case target :: _ :: _ :: Some(other) :: HNil =>
+          GamePropertyTarget(target, other)
       },
       {
         case GamePropertyTarget(target, list) =>
@@ -202,6 +205,9 @@ object PropertyOverrideMessage extends Marshallable[PropertyOverrideMessage] {
 
       case zone :: _ :: Some(first) :: Some(other) :: HNil =>
         GamePropertyScope(zone, first +: other)
+
+      case zone :: _ :: None :: Some(other) :: HNil =>
+        GamePropertyScope(zone, other)
     },
     {
       case GamePropertyScope(zone, list) =>

--- a/src/main/scala/net/psforever/packet/game/objectcreate/InventoryData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/InventoryData.scala
@@ -48,7 +48,7 @@ object InventoryData {
       }
     ).xmap[InventoryData](
       {
-        case _ :: 0 :: c :: HNil =>
+        case _ :: _ :: c :: HNil =>
           InventoryData(c)
       },
       {

--- a/src/main/scala/net/psforever/packet/game/objectcreate/LittleBuddyProjectileData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/LittleBuddyProjectileData.scala
@@ -29,7 +29,7 @@ object LittleBuddyProjectileData extends Marshallable[LittleBuddyProjectileData]
       ("unk4" | bool)
     ).exmap[LittleBuddyProjectileData](
     {
-      case data :: u2 :: 31 :: u4 :: HNil =>
+      case data :: u2 :: _ :: u4 :: HNil =>
         Attempt.successful(LittleBuddyProjectileData(data, u2, u4))
     },
     {

--- a/src/main/scala/net/psforever/packet/game/objectcreate/MountableInventory.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/MountableInventory.scala
@@ -3,10 +3,10 @@ package net.psforever.packet.game.objectcreate
 
 import net.psforever.packet.PacketHelpers
 import net.psforever.types.PlanetSideGUID
-import scodec.Attempt.Successful
-import scodec.Codec
+import scodec.Attempt.{Failure, Successful}
+import scodec.{Codec, Err}
 import scodec.codecs._
-import shapeless.HNil //note: do not import shapeless.:: at top level; it messes up List's :: functionality
+import shapeless.HNil
 
 import scala.collection.mutable.ListBuffer
 
@@ -222,6 +222,9 @@ object MountableInventory {
 
         case _ :: slot :: Some(next) :: HNil =>
           Successful(Some(InventorySeat(slot, next)))
+
+        case _ =>
+          Failure(Err("bad seat decoding"))
       },
       {
         case None =>

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -642,7 +642,7 @@ class SquadService extends Actor {
             val squad = features.Squad
             LeaveSquad(squad.Membership(position).CharId, features)
             out
-          case None =>
+          case _ =>
             None
         }
       case FindLfsSoldiersForRole(_) =>


### PR DESCRIPTION
When a ferrying vehicle passes through a warp gate, its passengers will be able to disembark safely on the destination side by remembering that they actually count as the "passengers" of the vehicle.  Additionally, the ferrying vehicle will not start assuming that it is being ferried inside itself, thus locking its passengers into their seats.

Addenda:
1. Increased the frequency that the `PlayerStateMessage` retention array is cleared (to "between lives" from "between zoning") in an effort to eliminate instances of stationary players being invisible to each other.
2. Expanded various instances that might counter a `MatchError` that could arise and threaten stability.
