### PR TITLE
Misc Fixes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -211,7 +211,7 @@ game {
     # Use the index of that sample distance from this sequence in the sequence `delays` below.
     ranges = [150, 300, 400]
     # The absolute time delay before a successful packet must be dispatched regardless of distance. (s)
-    delay-max = 1000
+    delay-max = 1500
     # The time delays for each distance range before a successful packet must be dispatched. [s]
     # The index for an entry in this sequence is expected to be discovered using the `ranges` sequence above.
     # Delays between packets may not be as precise as desired

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -90,6 +90,9 @@ game {
   # Purchases timers for the mechanized assault exo-suits all update at the same time when any of them would update
   shared-max-cooldown = no
 
+  # Purchases timers for the battleframe robotics vehicles all update at the same time when either of them would update
+  shared-bfr-cooldown = yes
+
   # HART system, shuttles and facilities
   hart {
     # How long the shuttle is not boarding passengers (going through the motions)

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -1606,11 +1606,7 @@ class AvatarActor(
           Behaviors.same
 
         case RestoreStamina(stamina) =>
-          tryRestoreStaminaForSession(stamina) match {
-            case Some(sess) =>
-              actuallyRestoreStamina(stamina, sess)
-            case _ => ;
-          }
+          tryRestoreStaminaForSession(stamina).collect { actuallyRestoreStamina(stamina, _) }
           Behaviors.same
 
         case RestoreStaminaPeriodically(stamina) =>
@@ -1871,11 +1867,7 @@ class AvatarActor(
           )
         )
         // if we need to start stamina regeneration
-        tryRestoreStaminaForSession(stamina = 1) match {
-          case Some(_) =>
-            defaultStaminaRegen(initialDelay = 0.5f seconds)
-          case _ => ;
-        }
+        tryRestoreStaminaForSession(stamina = 1).collect { _ => defaultStaminaRegen(initialDelay = 0.5f seconds) }
         replyTo ! AvatarLoginResponse(avatar)
       case Failure(e) =>
         log.error(e)("db failure")
@@ -1965,11 +1957,7 @@ class AvatarActor(
   }
 
   def restoreStaminaPeriodically(stamina: Int): Unit = {
-    tryRestoreStaminaForSession(stamina) match {
-      case Some(sess) =>
-        actuallyRestoreStaminaIfStationary(stamina, sess)
-      case _ => ;
-    }
+    tryRestoreStaminaForSession(stamina).collect { actuallyRestoreStaminaIfStationary(stamina, _) }
     startIfStoppedStaminaRegen(initialDelay = 0.5f seconds)
   }
 

--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -425,8 +425,7 @@ class SessionAvatarHandlers(
         sessionData.zoning.zoningStatus = Zoning.Status.None
         sessionData.zoning.spawn.deadState = DeadState.Dead
         continent.GUID(mount).collect { case obj: Vehicle =>
-          sessionData.vehicles.ConditionalDriverVehicleControl(obj)
-          sessionData.vehicles.serverVehicleControlVelocity = None
+          sessionData.vehicles.DriverVehicleControl(obj)
           sessionData.unaccessContainer(obj)
         }
         sessionData.playerActionsToCancel()

--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -104,10 +104,10 @@ class SessionAvatarHandlers(
           } //ms
           if (!wasVisible ||
             !previouslyInDrawableRange ||
+            durationSince > drawConfig.delayMax ||
             (!lastMsg.contains(pstateToSave) &&
               (canSeeReallyFar ||
                 currentDistance < drawConfig.rangeMin * drawConfig.rangeMin ||
-                durationSince > drawConfig.delayMax ||
                 sessionData.canSeeReallyFar ||
                 durationSince > targetDelay
                 )

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -302,7 +302,7 @@ class SessionMountHandlers(
       case v: Vehicle
         if seatNum == 0 && Vector3.MagnitudeSquared(v.Velocity.getOrElse(Vector3.Zero)) > 0f =>
         sessionData.vehicles.serverVehicleControlVelocity.collect { _ =>
-          sessionData.vehicles.ServerVehicleOverrideEnd(v)
+          sessionData.vehicles.ServerVehicleOverrideStop(v)
         }
         v.Velocity = Vector3.Zero
         continent.VehicleEvents ! VehicleServiceMessage(

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -301,6 +301,9 @@ class SessionMountHandlers(
     obj match {
       case v: Vehicle
         if seatNum == 0 && Vector3.MagnitudeSquared(v.Velocity.getOrElse(Vector3.Zero)) > 0f =>
+        sessionData.vehicles.serverVehicleControlVelocity.collect { _ =>
+          sessionData.vehicles.ServerVehicleOverrideEnd(v)
+        }
         v.Velocity = Vector3.Zero
         continent.VehicleEvents ! VehicleServiceMessage(
           continent.id,

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -56,6 +56,7 @@ class SessionMountHandlers(
         sendResponse(PlanetsideAttributeMessage(obj_guid, obj.Definition.shieldUiAttribute, obj.Shields))
         sendResponse(PlanetsideAttributeMessage(obj_guid, attribute_type=45, obj.NtuCapacitorScaled))
         sendResponse(GenericObjectActionMessage(obj_guid, code=11))
+        sessionData.accessContainer(obj)
         MountingAction(tplayer, obj, seatNumber)
 
       case Mountable.CanMount(obj: Vehicle, seatNumber, _)

--- a/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
@@ -55,17 +55,17 @@ class SessionSquadHandlers(
   /* packet */
 
   def handleSquadDefinitionAction(pkt: SquadDefinitionActionMessage): Unit = {
-    val SquadDefinitionActionMessage(u1, u2, action) = pkt
-    squadService ! SquadServiceMessage(player, continent, SquadServiceAction.Definition(u1, u2, action))
+//    val SquadDefinitionActionMessage(u1, u2, action) = pkt
+//    squadService ! SquadServiceMessage(player, continent, SquadServiceAction.Definition(u1, u2, action))
   }
 
   def handleSquadMemberRequest(pkt: SquadMembershipRequest): Unit = {
-    val SquadMembershipRequest(request_type, char_id, unk3, player_name, unk5) = pkt
-    squadService ! SquadServiceMessage(
-      player,
-      continent,
-      SquadServiceAction.Membership(request_type, char_id, unk3, player_name, unk5)
-    )
+//    val SquadMembershipRequest(request_type, char_id, unk3, player_name, unk5) = pkt
+//    squadService ! SquadServiceMessage(
+//      player,
+//      continent,
+//      SquadServiceAction.Membership(request_type, char_id, unk3, player_name, unk5)
+//    )
   }
 
   def handleSquadWaypointRequest(pkt: SquadWaypointRequest): Unit = {

--- a/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
@@ -34,7 +34,7 @@ class SessionVehicleHandlers(
     val resolvedPlayerGuid = if (player.HasGUID) {
       player.GUID
     } else {
-      Service.defaultPlayerGUID
+      PlanetSideGUID(-1)
     }
     val isNotSameTarget = resolvedPlayerGuid != guid
     reply match {
@@ -253,12 +253,13 @@ class SessionVehicleHandlers(
         }
 
       case VehicleResponse.StartPlayerSeatedInVehicle(vehicle, _) =>
-        val vehicle_guid = vehicle.GUID
+        val vehicleGuid = vehicle.GUID
+        val playerGuid = player.GUID
         sessionData.playerActionsToCancel()
         sessionData.vehicles.serverVehicleControlVelocity = Some(0)
         sessionData.terminals.CancelAllProximityUnits()
-        sendResponse(PlanetsideAttributeMessage(vehicle_guid, attribute_type=22, attribute_value=1L)) //mount points off
-        sendResponse(PlanetsideAttributeMessage(player.GUID, attribute_type=21, vehicle_guid)) //ownership
+        sendResponse(PlanetsideAttributeMessage(vehicleGuid, attribute_type=22, attribute_value=1L)) //mount points off
+        sendResponse(PlanetsideAttributeMessage(playerGuid, attribute_type=21, vehicleGuid)) //ownership
         vehicle.MountPoints.find { case (_, mp) => mp.seatIndex == 0 }.collect {
           case (mountPoint, _) => vehicle.Actor ! Mountable.TryMount(player, mountPoint)
         }

--- a/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
@@ -265,8 +265,6 @@ class SessionVehicleHandlers(
         }
 
       case VehicleResponse.PlayerSeatedInVehicle(vehicle, _) =>
-        val vehicle_guid = vehicle.GUID
-        sendResponse(PlanetsideAttributeMessage(vehicle_guid, attribute_type=22, attribute_value=0L)) //mount points on
         Vehicles.ReloadAccessPermissions(vehicle, player.Name)
         sessionData.vehicles.ServerVehicleLock(vehicle)
 
@@ -279,8 +277,7 @@ class SessionVehicleHandlers(
         )
 
       case VehicleResponse.ServerVehicleOverrideEnd(vehicle, _) =>
-        session = session.copy(avatar = avatar.copy(vehicle = Some(vehicle.GUID)))
-        sessionData.vehicles.DriverVehicleControl(vehicle, vehicle.Definition.AutoPilotSpeed2)
+        sessionData.vehicles.ServerVehicleOverrideEnd(vehicle)
 
       case VehicleResponse.PeriodicReminder(VehicleSpawnPad.Reminders.Blocked, data) =>
         sendResponse(ChatMsg(

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -5411,6 +5411,7 @@ object GlobalDefinitions {
     dynomite.Tile = InventoryTile.Tile22
 
     trhev_dualcycler.Name = "trhev_dualcycler"
+    trhev_dualcycler.Descriptor = "trhev_antipersonnel"
     trhev_dualcycler.Size = EquipmentSize.Max
     trhev_dualcycler.AmmoTypes += dualcycler_ammo
     trhev_dualcycler.ProjectileTypes += dualcycler_projectile
@@ -5428,6 +5429,7 @@ object GlobalDefinitions {
     trhev_dualcycler.FireModes(2).Magazine = 200
 
     trhev_pounder.Name = "trhev_pounder"
+    trhev_pounder.Descriptor = "trhev_antivehicular"
     trhev_pounder.Size = EquipmentSize.Max
     trhev_pounder.AmmoTypes += pounder_ammo
     trhev_pounder.ProjectileTypes += pounder_projectile
@@ -5461,6 +5463,7 @@ object GlobalDefinitions {
     trhev_pounder.FireModes(5).Magazine = 30
 
     trhev_burster.Name = "trhev_burster"
+    trhev_burster.Descriptor = "trhev_antiaircraft"
     trhev_burster.Size = EquipmentSize.Max
     trhev_burster.AmmoTypes += burster_ammo
     trhev_burster.ProjectileTypes += burster_projectile
@@ -5470,6 +5473,7 @@ object GlobalDefinitions {
     trhev_burster.FireModes.head.Magazine = 40
 
     nchev_scattercannon.Name = "nchev_scattercannon"
+    nchev_scattercannon.Descriptor = "nchev_antipersonnel"
     nchev_scattercannon.Size = EquipmentSize.Max
     nchev_scattercannon.AmmoTypes += scattercannon_ammo
     nchev_scattercannon.ProjectileTypes += scattercannon_projectile
@@ -5490,6 +5494,7 @@ object GlobalDefinitions {
     nchev_scattercannon.FireModes(2).Chamber = 10 //40 shells * 10 pellets = 400
 
     nchev_falcon.Name = "nchev_falcon"
+    nchev_falcon.Descriptor = "nchev_antivehicular"
     nchev_falcon.Size = EquipmentSize.Max
     nchev_falcon.AmmoTypes += falcon_ammo
     nchev_falcon.ProjectileTypes += falcon_projectile
@@ -5499,6 +5504,7 @@ object GlobalDefinitions {
     nchev_falcon.FireModes.head.Magazine = 20
 
     nchev_sparrow.Name = "nchev_sparrow"
+    nchev_sparrow.Descriptor = "nchev_antiaircraft"
     nchev_sparrow.Size = EquipmentSize.Max
     nchev_sparrow.AmmoTypes += sparrow_ammo
     nchev_sparrow.ProjectileTypes += sparrow_projectile
@@ -5508,6 +5514,7 @@ object GlobalDefinitions {
     nchev_sparrow.FireModes.head.Magazine = 12
 
     vshev_quasar.Name = "vshev_quasar"
+    vshev_quasar.Descriptor = "vshev_antipersonnel"
     vshev_quasar.Size = EquipmentSize.Max
     vshev_quasar.AmmoTypes += quasar_ammo
     vshev_quasar.ProjectileTypes += quasar_projectile
@@ -5523,6 +5530,7 @@ object GlobalDefinitions {
     vshev_quasar.FireModes(1).Magazine = 120
 
     vshev_comet.Name = "vshev_comet"
+    vshev_comet.Descriptor = "vshev_antivehicular"
     vshev_comet.Size = EquipmentSize.Max
     vshev_comet.AmmoTypes += comet_ammo
     vshev_comet.ProjectileTypes += comet_projectile
@@ -5532,6 +5540,7 @@ object GlobalDefinitions {
     vshev_comet.FireModes.head.Magazine = 10
 
     vshev_starfire.Name = "vshev_starfire"
+    vshev_starfire.Descriptor = "vshev_antiaircraft"
     vshev_starfire.Size = EquipmentSize.Max
     vshev_starfire.AmmoTypes += starfire_ammo
     vshev_starfire.ProjectileTypes += starfire_projectile

--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -802,7 +802,7 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
     //choose
     if (target.Health > 0) {
       //alive
-      if (target.Health <= 25 && target.Health + damageToHealth > 25 &&
+      if (target.Health <= 25 &&
           (player.avatar.implants.flatten.find { _.definition.implantType == ImplantType.SecondWind } match {
             case Some(wind) => wind.initialized
             case _          => false
@@ -810,8 +810,8 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
         //activate second wind
         player.Health += 25
         player.LogActivity(HealFromImplant(ImplantType.SecondWind, 25))
-        avatarActor ! AvatarActor.ResetImplant(ImplantType.SecondWind)
         avatarActor ! AvatarActor.RestoreStamina(25)
+        avatarActor ! AvatarActor.ResetImplant(ImplantType.SecondWind)
       }
       //take damage/update
       DamageAwareness(target, cause, damageToHealth, damageToArmor, damageToStamina, damageToCapacitor)

--- a/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
@@ -36,7 +36,7 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
           health,
           unk4 = false,
           no_mount_points = false,
-          obj.DeploymentState,
+          SterilizedDeploymentState(obj),
           unk5 = false,
           unk6 = false,
           obj.Cloaked,
@@ -103,6 +103,13 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
           InventoryItemData(utilDef.ObjectId, util.GUID, index, utilDef.Packet.ConstructorData(util).get)
       })
       .toList
+  }
+
+  private def SterilizedDeploymentState(obj: Vehicle): DriveState.Value = {
+    obj.DeploymentState match {
+      case state if state.id < 0 => DriveState.Mobile
+      case state => state
+    }
   }
 
   protected def SpecificFormatModifier: VehicleFormat.Value = VehicleFormat.Normal

--- a/src/main/scala/net/psforever/objects/sourcing/AmenitySource.scala
+++ b/src/main/scala/net/psforever/objects/sourcing/AmenitySource.scala
@@ -59,7 +59,9 @@ object AmenitySource {
     )
     amenity.copy(occupants = obj match {
       case o: Mountable =>
-        o.Seats.values.flatMap { _.occupants }.map { p => PlayerSource.inSeat(p, o, amenity) }.toList
+        o.Seats
+          .collect { case (num, seat) if seat.isOccupied => (num, seat.occupants.head) }
+          .map { case (num, p) => PlayerSource.inSeat(p, amenity, num) }.toList
       case _ =>
         Nil
     })

--- a/src/main/scala/net/psforever/objects/sourcing/PlayerSource.scala
+++ b/src/main/scala/net/psforever/objects/sourcing/PlayerSource.scala
@@ -109,17 +109,17 @@ object PlayerSource {
    * even if this function is entirely for the purpose of establishing that the player is an occupant of the mountable entity.<br>
    * Don't think too much about it.
    * @param player player
-   * @param mount mountable entity in which the player should be seated
    * @param source a `SourceEntry` for the aforementioned mountable entity
+   * @param seatNumber the attributed seating index in which the player is mounted in `source`
    * @return a `PlayerSource` entity
    */
-  def inSeat(player: Player, mount: Mountable, source: SourceEntry): PlayerSource = {
+  def inSeat(player: Player, source: SourceEntry, seatNumber: Int): PlayerSource = {
     val exosuit = player.ExoSuit
     val faction = player.Faction
     PlayerSource(
       player.Definition,
       exosuit,
-      Some((source, mount.PassengerInSeat(player).get)),
+      Some((source, seatNumber)),
       player.Health,
       player.Armor,
       player.Position,

--- a/src/main/scala/net/psforever/objects/sourcing/TurretSource.scala
+++ b/src/main/scala/net/psforever/objects/sourcing/TurretSource.scala
@@ -57,7 +57,9 @@ object TurretSource {
     )
     turret.copy(occupants = obj match {
       case o: Mountable =>
-        o.Seats.values.flatMap { _.occupants }.map { p => PlayerSource.inSeat(p, o, turret) }.toList
+        o.Seats
+          .collect { case (num, seat) if seat.isOccupied => (num, seat.occupants.head) }
+          .map { case (num, p) => PlayerSource.inSeat(p, turret, num) }.toList
       case _ =>
         Nil
     })

--- a/src/main/scala/net/psforever/objects/sourcing/VehicleSource.scala
+++ b/src/main/scala/net/psforever/objects/sourcing/VehicleSource.scala
@@ -53,9 +53,9 @@ object VehicleSource {
       )
     )
     vehicle.copy(occupants = {
-      obj.Seats.values.map { seat =>
+      obj.Seats.map { case (seatNumber, seat) =>
         seat.occupant match {
-          case Some(p) => PlayerSource.inSeat(p, obj, vehicle) //shallow
+          case Some(p) => PlayerSource.inSeat(p, vehicle, seatNumber) //shallow
           case _ => PlayerSource.Nobody
         }
       }.toList

--- a/src/main/scala/net/psforever/objects/vehicles/AntTransferBehavior.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/AntTransferBehavior.scala
@@ -50,7 +50,7 @@ trait AntTransferBehavior extends TransferBehavior with NtuStorageBehavior {
 
   def UpdateNtuUI(vehicle: Vehicle with NtuContainer): Unit = {
     if (vehicle.Seats.values.exists(_.isOccupied)) {
-      val display = scala.math.ceil(vehicle.NtuCapacitorScaled).toLong
+      val display = vehicle.NtuCapacitorScaled.toLong
       vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
         vehicle.Actor.toString,
         VehicleAction.PlanetsideAttribute(Service.defaultPlayerGUID, vehicle.GUID, 45, display)

--- a/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/AntControl.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 class AntControl(vehicle: Vehicle)
   extends DeployingVehicleControl(vehicle)
     with AntTransferBehavior {
-  def ChargeTransferObject = vehicle
+  def ChargeTransferObject: Vehicle = vehicle
 
   override def commonEnabledBehavior: Receive = super.commonEnabledBehavior.orElse(antBehavior)
 
@@ -38,7 +38,7 @@ class AntControl(vehicle: Vehicle)
           vehicle.Actor,
           TransferBehavior.Charging(Ntu.Nanites)
         )
-      case _ => ;
+      case _ => ()
     }
   }
 
@@ -51,7 +51,7 @@ class AntControl(vehicle: Vehicle)
     state match {
       case DriveState.Undeploying =>
         TryStopChargingEvent(vehicle)
-      case _ => ;
+      case _ => ()
     }
   }
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/DeployingVehicleControl.scala
@@ -20,7 +20,7 @@ import net.psforever.types._
 class DeployingVehicleControl(vehicle: Vehicle)
   extends VehicleControl(vehicle)
     with DeploymentBehavior {
-  def DeploymentObject = vehicle
+  def DeploymentObject: Vehicle = vehicle
 
   override def commonEnabledBehavior : Receive = super.commonEnabledBehavior.orElse(deployBehavior)
 
@@ -45,7 +45,7 @@ class DeployingVehicleControl(vehicle: Vehicle)
   override def commonDeleteBehavior : Receive =
     super.commonDeleteBehavior
       .orElse {
-        case msg : Deployment.TryUndeploy =>
+        case msg: Deployment.TryUndeploy =>
           deployBehavior.apply(msg)
       }
 
@@ -53,7 +53,7 @@ class DeployingVehicleControl(vehicle: Vehicle)
     * Even when disabled, the vehicle can be made to undeploy.
     */
   override def PrepareForDisabled(kickPassengers: Boolean) : Unit = {
-    vehicle.Actor ! Deployment.TryUndeploy(DriveState.Undeploying)
+    TryUndeployStateChange(DriveState.Undeploying)
     super.PrepareForDisabled(kickPassengers)
   }
 

--- a/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/RouterControl.scala
@@ -24,11 +24,10 @@ class RouterControl(vehicle: Vehicle)
   override def specificResponseToDeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Deployed =>
-        vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
-          case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Activate(util)
-          case _ => ;
+        vehicle.Utility(UtilityType.internal_router_telepad_deployable).collect {
+          case util: Utility.InternalTelepad => util.Actor ! TelepadLike.Activate(util)
         }
-      case _ => ;
+      case _ => ()
     }
   }
 
@@ -40,11 +39,10 @@ class RouterControl(vehicle: Vehicle)
   override def specificResponseToUndeployment(state: DriveState.Value): Unit = {
     state match {
       case DriveState.Undeploying =>
-        vehicle.Utility(UtilityType.internal_router_telepad_deployable) match {
-          case Some(util: Utility.InternalTelepad) => util.Actor ! TelepadLike.Deactivate(util)
-          case _ => ;
+        vehicle.Utility(UtilityType.internal_router_telepad_deployable).collect {
+          case util: Utility.InternalTelepad => util.Actor ! TelepadLike.Deactivate(util)
         }
-      case _ => ;
+      case _ => ()
     }
   }
 }

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -13,6 +13,7 @@ import net.psforever.objects.inventory.{GridInventory, InventoryItem}
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject, ServerObjectControl}
 import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
 import net.psforever.objects.serverobject.containable.{Containable, ContainableBehavior}
+import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.{AggravatedBehavior, DamageableVehicle}
 import net.psforever.objects.serverobject.environment._
 import net.psforever.objects.serverobject.hackable.GenericHackables
@@ -864,10 +865,15 @@ class VehicleControl(vehicle: Vehicle)
       )
     }
   }
+
+  override protected def DestructionAwareness(target: Target, cause: DamageResult): Unit = {
+    passengerRadiationCloudTimer.cancel()
+    super.DestructionAwareness(target, cause)
+  }
 }
 
 object VehicleControl {
-  import net.psforever.objects.vital.{ShieldCharge}
+  import net.psforever.objects.vital.ShieldCharge
 
   private case class PrepareForDeletion()
 

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -121,6 +121,9 @@ class VehicleControl(vehicle: Vehicle)
       case Vehicle.Ownership(Some(player)) =>
         GainOwnership(player)
 
+      case Mountable.TryMount(user, mountPoint) if vehicle.DeploymentState == DriveState.AutoPilot =>
+        sender() ! Mountable.MountMessages(user, Mountable.CanNotMount(vehicle, mountPoint))
+
       case msg @ Mountable.TryMount(player, mount_point) =>
         mountBehavior.apply(msg)
         mountCleanup(mount_point, player)

--- a/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
@@ -69,7 +69,7 @@ trait SectorTraits {
   * @param eqFunc a custom equivalence function to distinguish between the entities in the list
   * @tparam A the type of object that will be the entities stored in the list
   */
-class SectorListOf[A](eqFunc: (A, A) => Boolean = (a: A, b: A) => a equals b) {
+class SectorListOf[A](eqFunc: (A, A) => Boolean = (a: A, b: A) => a == b) {
   private val internalList: ListBuffer[A] = ListBuffer[A]()
 
   /**

--- a/src/main/scala/net/psforever/packet/game/ServerVehicleOverrideMsg.scala
+++ b/src/main/scala/net/psforever/packet/game/ServerVehicleOverrideMsg.scala
@@ -31,7 +31,8 @@ import scodec.codecs._
   * For flight vehicles, for `n`, the forward air speed for the value in this packet will be at least `1.18 * n`.
   * This approximation is not always going to be accurate but serves as a good rule of thumb.
   * @param lock_accelerator driver has no control over vehicle acceleration
-  * @param lock_wheel driver has no control over vehicle turning
+  * @param lock_wheel driver has no control over vehicle turning;
+ *                   generally, the driver never has turning control
   * @param reverse move in reverse
   *                0 = forward
   *                1 = reverse

--- a/src/main/scala/net/psforever/types/DriveState.scala
+++ b/src/main/scala/net/psforever/types/DriveState.scala
@@ -21,5 +21,7 @@ object DriveState extends Enumeration {
   val State7      = Value(7)   //unknown; not encountered on a vehicle that can deploy; functions like Mobile
   val State127    = Value(127) //unknown
 
-  val Kneeling    = Value(-1) //flag bfr kneeling state; should not not encode
+  //the following values should never be encoded
+  val Kneeling    = Value(-1) //flag bfr kneeling state
+  val AutoPilot   = Value(-2) //when emerging from spawn pad, or being kicked from a ferry, during server guidance
 }

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -154,6 +154,7 @@ case class GameConfig(
     newAvatar: NewAvatar,
     hart: HartConfig,
     sharedMaxCooldown: Boolean,
+    sharedBfrCooldown: Boolean,
     baseCertifications: Seq[Certification],
     warpGates: WarpGateConfig,
     cavernRotation: CavernRotationConfig,

--- a/src/test/scala/objects/DamageableTest.scala
+++ b/src/test/scala/objects/DamageableTest.scala
@@ -32,7 +32,7 @@ import org.specs2.mutable.Specification
 import scala.concurrent.duration._
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.serverobject.terminals.implant.{ImplantTerminalMech, ImplantTerminalMechControl}
-import net.psforever.objects.sourcing.{PlayerSource, SourceEntry, VehicleSource}
+import net.psforever.objects.sourcing.{PlayerSource, SourceEntry}
 import net.psforever.objects.vital.interaction.DamageInteraction
 import net.psforever.objects.vital.base.DamageResolution
 import net.psforever.objects.vital.projectile.ProjectileReason
@@ -327,21 +327,17 @@ class DamageableEntityDamageTest extends ActorTest {
       gen.Actor ! Vitality.Damage(applyDamageTo)
       val msg1 = avatarProbe.receiveOne(500 milliseconds)
       val msg2 = activityProbe.receiveOne(500 milliseconds)
-      assert(
-        msg1 match {
-          case AvatarServiceMessage("test", AvatarAction.PlanetsideAttributeToAll(PlanetSideGUID(2), 0, _)) => true
-          case _                                                                                            => false
-        }
-      )
-      assert(
-        msg2 match {
-          case activity: Zone.HotSpot.Activity =>
-            activity.attacker == PlayerSource(player1) &&
-              activity.defender == SourceEntry(gen) &&
-              activity.location == Vector3(1, 0, 0)
-          case _ => false
-        }
-      )
+      msg1 match {
+        case AvatarServiceMessage("test", AvatarAction.PlanetsideAttributeToAll(ValidPlanetSideGUID(2), 0, 3600)) => ()
+        case _ => assert(false, "DamageableEntity:handle taking damage - player not messaged")
+      }
+      msg2 match {
+        case activity: Zone.HotSpot.Activity
+          if activity.attacker == PlayerSource(player1) &&
+            activity.defender == SourceEntry(gen) &&
+            activity.location == Vector3(1, 0, 0) => ()
+        case _ => assert(false, "DamageableEntity:handle taking damage - activity not messaged")
+      }
     }
   }
 }

--- a/src/test/scala/objects/DeployableBehaviorTest.scala
+++ b/src/test/scala/objects/DeployableBehaviorTest.scala
@@ -320,15 +320,12 @@ class DeployableBehaviorDeconstructOwnedTest extends FreedContextActorTest {
       jmine.Actor ! Deployable.Deconstruct()
       val eventsMsgs = eventsProbe.receiveN(3, 10.seconds)
       eventsMsgs.head match {
-        case LocalServiceMessage("test", LocalAction.EliminateDeployable(`jmine`, PlanetSideGUID(1), Vector3(1,2,3), 2)) => ;
+        case LocalServiceMessage("test",LocalAction.EliminateDeployable(mine, ValidPlanetSideGUID(1), Vector3(1.0,2.0,3.0),2))
+          if mine eq jmine => ;
         case _ => assert(false, "owned deconstruct test - not eliminating deployable")
       }
       eventsMsgs(1) match {
-        case LocalServiceMessage("TestCharacter1", LocalAction.DeployableUIFor(DeployedItem.jammer_mine)) => ;
-        case _ => assert(false, "")
-      }
-      eventsMsgs(2) match {
-          case LocalServiceMessage(
+        case LocalServiceMessage(
           "TR",
           LocalAction.DeployableMapIcon(
             PlanetSideGUID(0),
@@ -337,6 +334,10 @@ class DeployableBehaviorDeconstructOwnedTest extends FreedContextActorTest {
           )
         ) => ;
         case _ => assert(false, "owned deconstruct test - not removing icon")
+      }
+      eventsMsgs(2) match {
+        case LocalServiceMessage("TestCharacter1", LocalAction.DeployableUIFor(DeployedItem.jammer_mine)) => ;
+        case _ => assert(false, "")
       }
 
       assert(deployableList.isEmpty, "owned deconstruct test - deployable still in list")


### PR DESCRIPTION
1. New charater creation should no longer result in multiple same-name copies of a character who has been deleted and "recreated".  A deleted character will instead have their character entry reclaimed.
a. The only fields that were not originally part of character creation but are retained by this mechanic are combat experience points and squad experience points.
_If the original character was `("CharacterA", TR, M ...)`, attempting to create a new `("CharacterA", NC, F, ...)` over the memory of the deleted CharacterA will always reactivate the `("CharacterA", TR, M ...)`._
b. To ensure that legacy character conditions are kept stable, living characters have priority over dead characters, and dead characters are prioritized based on which account owns the earliest created character with that name.
_AccountA creates CharacterA, deleted CharacterA, and then AccountB created their own CharacterA, all under the old system's rules.  If AccountA wants to reclaim CharacterA now, they may not while AccountB's character exists.  Meanwhile, if `AccountB` deletes their version of CharacterA, AccountB may not reclaim the character because AccountA has seniority over the name._

2. When mounting an Advanced Nanite Transport driver seat, one will pay attention to events concerning that ANT exclusively.
3. The implant Second Wind will now activate whenever player's health is greater than zero but less than 26 upon taking damage
4. Combat engineer deployable entities will properly coordinate the updates for own deconstructions such that their former owner doesn't struggle to update the number of active deployable entities.

___Caveats___
1. Multiple characters with the same name probably exist in the live player database, almost all of them deleted but perhaps one active.  This is not an acceptable situation but it should not cause any issues.
2. The linked issue for the ANT suggests inconsistent deployment when it comes to depositing in facility resource silos.  Without steps for reproduction, and due to the inconsistency in staging a manifestation of the issue, it's not possible to theorize wherein the code is the faulty logic, or wherein was that faulty logic.
3. Some of these changes exist merely to address warnings by the compiler about potential `MatchError` issues that could arise.