### PR TITLE
May 20th Event Fixes (maybe)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import xerial.sbt.pack.PackPlugin._
+//import xerial.sbt.pack.PackPlugin._
 
 lazy val psforeverSettings = Seq(
   organization := "net.psforever",
@@ -22,12 +22,12 @@ lazy val psforeverSettings = Seq(
   // Quiet test options
   // https://github.com/etorreborre/specs2/blob/8305db76c5084e4b3ce5827ce23117f6fb6beee4/common/shared/src/main/scala/org/specs2/main/Report.scala#L94
   // https://etorreborre.github.io/specs2/guide/SPECS2-2.4.17/org.specs2.guide.Runners.html
-  testOptions in QuietTest += Tests.Argument(TestFrameworks.Specs2, "showOnly", "x!"),
+  QuietTest / testOptions += Tests.Argument(TestFrameworks.Specs2, "showOnly", "x!"),
   // http://www.scalatest.org/user_guide/using_the_runner
-  testOptions in QuietTest += Tests.Argument(TestFrameworks.ScalaTest, "-oCEHILMNOPQRX"),
+  QuietTest / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oCEHILMNOPQRX"),
   // Trick taken from https://groups.google.com/d/msg/scala-user/mxV9ok7J_Eg/kt-LnsrD0bkJ
   // scaladoc flags: https://github.com/scala/scala/blob/2.11.x/src/scaladoc/scala/tools/nsc/doc/Settings.scala
-  scalacOptions in (Compile, doc) ++= Seq(
+  Compile / doc / scalacOptions ++= Seq(
     "-groups",
     "-doc-title",
     "PSF-LoginServer - ",
@@ -64,6 +64,8 @@ lazy val psforeverSettings = Seq(
     "com.github.nscala-time"     %% "nscala-time"                % "2.30.0",
     "com.github.t3hnar"          %% "scala-bcrypt"               % "4.3.0",
     "org.scala-graph"            %% "graph-core"                 % "1.13.3",
+    "io.kamon"                   %% "kamon-bundle"               % "2.3.1",
+    "io.kamon"                   %% "kamon-apm-reporter"         % "2.3.1",
     "org.json4s"                 %% "json4s-native"              % "4.0.3",
     "io.getquill"                %% "quill-jasync-postgres"      % "3.18.0",
     "org.flywaydb"                % "flyway-core"                % "9.0.0",
@@ -104,14 +106,14 @@ lazy val server = (project in file("server"))
   .settings(
     name := "server",
     // ActorTests have specific timing requirements and will be flaky if run in parallel
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
     // Copy all tests from Test -> QuietTest (we're only changing the run options)
     inConfig(QuietTest)(Defaults.testTasks),
     packMain := Map("psforever-server" -> "net.psforever.server.Server"),
     packArchivePrefix := "psforever-server",
     packJvmOpts := Map("psforever-server" -> Seq("-Dstacktrace.app.packages=net.psforever")),
     packExtraClasspath := Map("psforever-server" -> Seq("${PROG_HOME}/config")),
-    packResourceDir += (baseDirectory.in(psforever).value / "config" -> "config")
+    packResourceDir += ((psforever / baseDirectory).value / "config" -> "config")
   )
   .dependsOn(psforever)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.xerial.sbt" % "sbt-pack"      % "0.17")
-addSbtPlugin("org.scoverage"  % "sbt-scoverage" % "2.0.7")
-addSbtPlugin("com.eed3si9n"   % "sbt-unidoc"    % "0.4.3")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"  % "2.5.0")
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"  % "0.10.4")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack"          % "0.17")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"     % "2.0.7")
+addSbtPlugin("io.kamon"       % "sbt-kanela-runner" % "2.0.14")
+addSbtPlugin("com.eed3si9n"   % "sbt-unidoc"        % "0.4.3")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"      % "2.5.0")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"      % "0.10.4")

--- a/server/src/main/scala/net/psforever/server/Server.scala
+++ b/server/src/main/scala/net/psforever/server/Server.scala
@@ -7,7 +7,6 @@ import java.util.UUID.randomUUID
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.Future
 import scala.concurrent.Await
-
 import akka.actor.ActorSystem
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
@@ -36,8 +35,10 @@ import org.fusesource.jansi.Ansi._
 import org.slf4j
 import scopt.OParser
 import akka.actor.typed.scaladsl.adapter._
+import kamon.Kamon
 import net.psforever.packet.PlanetSidePacket
 import net.psforever.services.hart.HartService
+
 import scala.concurrent.duration.Duration
 
 object Server {
@@ -82,6 +83,10 @@ object Server {
         case None          => InetAddress.getByName(Config.app.bind) // address from config
       }
 
+    if (Config.app.kamon.enable) {
+      logger.info("Starting Kamon")
+      Kamon.init()
+    }
     if (Config.app.sentry.enable) {
       logger.info(s"Enabling Sentry")
       val options = new SentryOptions()

--- a/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -65,10 +65,10 @@ object Vehicles {
       case Some(player: Player) =>
         if (player.avatar.vehicle.contains(guid)) {
           player.avatar.vehicle = None
-          vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
-            player.Name,
-            VehicleAction.Ownership(player.GUID, PlanetSideGUID(0))
-          )
+//          vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
+//            player.Name,
+//            VehicleAction.Ownership(player.GUID, PlanetSideGUID(0))
+//          )
         }
         vehicle.AssignOwnership(None)
         val empire         = VehicleLockState.Empire.id
@@ -118,17 +118,18 @@ object Vehicles {
   }
 
   /**
-    * Disassociate a player from a vehicle that he owns without associating a different player as the owner.
-    * Set the vehicle's driver mount permissions and passenger and gunner mount permissions to "allow empire,"
-    * then reload them for all clients.
-    * This is the vehicle side of vehicle ownership removal.
-    * @param player the player
-    */
+   * Disassociate a player from a vehicle that he owns without associating a different player as the owner.
+   * Set the vehicle's driver mount permissions and passenger and gunner mount permissions to "allow empire,"
+   * then reload them for all clients.
+   * This is the vehicle side of vehicle ownership removal.
+   * @param player the player
+   * @param vehicle the vehicle
+   */
   def Disown(player: Player, vehicle: Vehicle): Option[Vehicle] = {
     val pguid = player.GUID
     if (vehicle.Owner.contains(pguid)) {
       vehicle.AssignOwnership(None)
-      vehicle.Zone.VehicleEvents ! VehicleServiceMessage(player.Name, VehicleAction.Ownership(pguid, PlanetSideGUID(0)))
+      //vehicle.Zone.VehicleEvents ! VehicleServiceMessage(player.Name, VehicleAction.Ownership(pguid, PlanetSideGUID(0)))
       val vguid  = vehicle.GUID
       val empire = VehicleLockState.Empire.id
       (0 to 2).foreach(group => {

--- a/src/main/scala/net/psforever/objects/serverobject/deploy/Deployment.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/deploy/Deployment.scala
@@ -80,8 +80,7 @@ object Deployment {
     * Two sequences are defined.
     * The more elaborate sequence proceeds from `Mobile --> Deploying --> Deployed --> Undeploying --> Mobile`.
     * This is the standard in-game deploy cycle.
-    * The sequence void of complexity is `State7 --> State7`.
-    * `State7` is an odd condition possessed mainly by vehicles that do not deploy.
+    * All other sequences are void of complexity and should not mutate from their original value.
     * @param from_state the original deployment state
     * @return the deployment state that is being transitioned
     */
@@ -91,7 +90,7 @@ object Deployment {
       case DriveState.Deploying   => DriveState.Deployed
       case DriveState.Deployed    => DriveState.Undeploying
       case DriveState.Undeploying => DriveState.Mobile
-      case DriveState.State7      => DriveState.State7
+      case _                      => from_state
     }
   }
 


### PR DESCRIPTION
There was a significant `MatchError` caused by the introduction of an `AutoPilot` state to indicate a spawning vehicle; that was 
resolved.

Attempted to restore Kanon telemetry but undoing the changes @jgillich enacted.  I have no clue if that's all that is needed.  There were plugin issues that may or may not be related to `sbt-kanela-runner`.

Attempted to resolve health reporting issues with vehicles after noticing that they tend to break when switching to a new vehicle for ownership.  It's been previously demonstrated that this breaks the model of the vehicle that was previously owned by setting it to its nearly destroyed condition.  This condition also causes the health bar state of the vehicle to break and it will always display as being full health.  By eliminating the previous packet that makes it "unowned" the visual state of the vehicle is no longer set to its trashed state but the health reporting is still unresponsive.