### PR TITLE
tweak jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,4 @@
--Xmx2048M
--Xss6M
+-Xss1M
 -Dconfig.override_with_env_vars=true
 -Dsbt.server.forcestart=true
 -Dquill.macro.log=false


### PR DESCRIPTION
* Removed memory max (Xmx), the default of 25% of system memory is generally fine
* Reduced  default stack size (Xss) to the value set in newer Java versions