### PR TITLE
Floor Is Lava

### DIFF
--- a/src/main/scala/net/psforever/objects/zones/MapInfo.scala
+++ b/src/main/scala/net/psforever/objects/zones/MapInfo.scala
@@ -382,7 +382,7 @@ case object MapInfo extends StringEnum[MapInfo] {
         checksum = 3797992164L,
         scale = MapScale.Dim2048,
         hotSpotSpan = 80,
-        environment = List(SeaLevel(EnvironmentAttribute.Death, 52.414f)) //abd: 51.414
+        environment = List(Pool(EnvironmentAttribute.Death, DeepSurface(51.414f, 2048, 2048, 0, 0)))
       )
 
   case object Ugd05

--- a/src/main/scala/net/psforever/objects/zones/MapInfo.scala
+++ b/src/main/scala/net/psforever/objects/zones/MapInfo.scala
@@ -382,7 +382,7 @@ case object MapInfo extends StringEnum[MapInfo] {
         checksum = 3797992164L,
         scale = MapScale.Dim2048,
         hotSpotSpan = 80,
-        environment = List(SeaLevel(EnvironmentAttribute.Death, 51f)) //ADB: 51.414f
+        environment = List(SeaLevel(EnvironmentAttribute.Death, 52.414f)) //abd: 51.414
       )
 
   case object Ugd05


### PR DESCRIPTION
Making the Byblos lava desytroy hover vehicles that get caught in the chasms.

___Addenda___
Originally, I created a variable depth environment collision entity - the first of its kind for the server - and added a lava effect above the Byblos death lava to handle hover vehicle death.  I was concerned that the Searhus lava pools had a similar issue as the lava in the cavern; and, because of the geometry that represented those, raising the height of the lava was going to create massive overflow of the damage field onto the ground; so, raising them was just not going to work correctly.  When testing the lava on Searhus came up, however, the geometry entity used for the pools were sufficient to cause the hover vehicles damage.  Thus, instead of an altitude adjustment, there was a representation swap.

Things above the lava should get damaged from the intense heat; but, this is video game lava and not real lava so it's all good.