### PR TITLE
Reduce Load More

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
@@ -271,10 +271,6 @@ class VehicleOperations(
     sessionData.validObject(mountable_guid, decorator = "MountVehicle").collect {
       case obj: Mountable =>
         obj.Actor ! Mountable.TryMount(player, entry_point)
-      case _: Mountable =>
-        log.warn(
-          s"DismountVehicleMsg: ${player.Name} can not mount while server has asserted control; please wait"
-        )
       case _ =>
         log.error(s"MountVehicleMsg: object ${mountable_guid.guid} not a mountable thing, ${player.Name}")
     }

--- a/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
+++ b/src/main/scala/net/psforever/objects/GlobalDefinitions.scala
@@ -8156,7 +8156,7 @@ object GlobalDefinitions {
     lightgunship.DrownAtMaxDepth = true
     lightgunship.MaxDepth = 2 //flying vehicles will automatically disable
     lightgunship.Geometry = GeometryForm.representByCylinder(radius = 2.375f, height = 1.98438f)
-    lightgunship.collision.avatarCollisionDamageMax = 750
+    lightgunship.collision.avatarCollisionDamageMax = 75
     lightgunship.collision.xy = CollisionXYData(Array((0.1f, 1), (0.25f, 60), (0.5f, 120), (0.75f, 180), (1f, 250)))
     lightgunship.collision.z = CollisionZData(Array((3f, 1), (9f, 30), (15f, 60), (18f, 90), (19.5f, 125)))
     lightgunship.maxForwardSpeed = 104f

--- a/src/main/scala/net/psforever/services/avatar/AvatarService.scala
+++ b/src/main/scala/net/psforever/services/avatar/AvatarService.scala
@@ -17,7 +17,7 @@ class AvatarService(zone: Zone) extends Actor {
 
   val AvatarEvents = new GenericEventBus[AvatarServiceResponse] //AvatarEventBus
 
-  def receive = {
+  def receive: Receive = {
     case Service.Join(channel) =>
       val path = s"/$channel/Avatar"
       val who  = sender()

--- a/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleService.scala
@@ -16,7 +16,7 @@ class VehicleService(zone: Zone) extends Actor {
 
   val VehicleEvents = new GenericEventBus[VehicleServiceResponse]
 
-  def receive = {
+  def receive: Receive = {
     case Service.Join(channel) =>
       val path = s"/$channel/Vehicle"
       VehicleEvents.subscribe(sender(), path)
@@ -33,6 +33,26 @@ class VehicleService(zone: Zone) extends Actor {
 
     case VehicleServiceMessage(forChannel, action) =>
       action match {
+        case VehicleAction.ChangeAmmo(player_guid, weapon_guid, weapon_slot, old_ammo_guid, ammo_id, ammo_guid, ammo_data) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(
+              s"/$forChannel/Vehicle",
+              player_guid,
+              VehicleResponse.ChangeAmmo(weapon_guid, weapon_slot, old_ammo_guid, ammo_id, ammo_guid, ammo_data)
+            )
+          )
+        case VehicleAction.ChangeFireState_Start(player_guid, weapon_guid) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(
+              s"/$forChannel/Vehicle",
+              player_guid,
+              VehicleResponse.ChangeFireState_Start(weapon_guid)
+            )
+          )
+        case VehicleAction.ChangeFireState_Stop(player_guid, weapon_guid) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.ChangeFireState_Stop(weapon_guid))
+          )
         case VehicleAction.ChildObjectState(player_guid, object_guid, pitch, yaw) =>
           VehicleEvents.publish(
             VehicleServiceResponse(
@@ -176,6 +196,11 @@ class VehicleService(zone: Zone) extends Actor {
               VehicleResponse.PlanetsideAttribute(target_guid, attribute_type, attribute_value)
             )
           )
+
+        case VehicleAction.Reload(player_guid, weapon_guid) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.Reload(weapon_guid))
+          )
         case VehicleAction.SeatPermissions(player_guid, vehicle_guid, seat_group, permission) =>
           VehicleEvents.publish(
             VehicleServiceResponse(
@@ -198,6 +223,10 @@ class VehicleService(zone: Zone) extends Actor {
                 definition.Packet.DetailedConstructorData(item).get
               )
             )
+          )
+        case VehicleAction.WeaponDryFire(player_guid, weapon_guid) =>
+          VehicleEvents.publish(
+            VehicleServiceResponse(s"/$forChannel/Vehicle", player_guid, VehicleResponse.WeaponDryFire(weapon_guid))
           )
         case VehicleAction.UnloadVehicle(player_guid, vehicle, vehicle_guid) =>
           VehicleEvents.publish(

--- a/src/main/scala/net/psforever/services/vehicle/VehicleServiceMessage.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleServiceMessage.scala
@@ -23,6 +23,17 @@ object VehicleServiceMessage {
 object VehicleAction {
   trait Action
 
+  final case class ChangeAmmo(
+                               player_guid: PlanetSideGUID,
+                               weapon_guid: PlanetSideGUID,
+                               weapon_slot: Int,
+                               old_ammo_guid: PlanetSideGUID,
+                               ammo_id: Int,
+                               ammo_guid: PlanetSideGUID,
+                               ammo_data: ConstructorData
+                             ) extends Action
+  final case class ChangeFireState_Start(player_guid: PlanetSideGUID, weapon_guid: PlanetSideGUID)   extends Action
+  final case class ChangeFireState_Stop(player_guid: PlanetSideGUID, weapon_guid: PlanetSideGUID)    extends Action
   final case class ChildObjectState(player_guid: PlanetSideGUID, object_guid: PlanetSideGUID, pitch: Float, yaw: Float)
       extends Action
   final case class DeployRequest(
@@ -89,6 +100,7 @@ object VehicleAction {
       attribute_type: Int,
       attribute_value: Long
   ) extends Action
+  final case class Reload(player_guid: PlanetSideGUID, weapon_guid: PlanetSideGUID) extends Action
   final case class SeatPermissions(
       player_guid: PlanetSideGUID,
       vehicle_guid: PlanetSideGUID,
@@ -118,6 +130,7 @@ object VehicleAction {
       unk6: Boolean
   )                                                                                     extends Action
   final case class SendResponse(player_guid: PlanetSideGUID, msg: PlanetSideGamePacket) extends Action
+  final case class WeaponDryFire(player_guid: PlanetSideGUID, weapon_guid: PlanetSideGUID) extends Action
   final case class UpdateAmsSpawnPoint(zone: Zone)                                      extends Action
 
   final case class TransferPassengerChannel(

--- a/src/main/scala/net/psforever/services/vehicle/VehicleServiceResponse.scala
+++ b/src/main/scala/net/psforever/services/vehicle/VehicleServiceResponse.scala
@@ -22,6 +22,16 @@ final case class VehicleServiceResponse(
 object VehicleResponse {
   trait Response
 
+  final case class ChangeAmmo(
+                               weapon_guid: PlanetSideGUID,
+                               weapon_slot: Int,
+                               old_ammo_guid: PlanetSideGUID,
+                               ammo_id: Int,
+                               ammo_guid: PlanetSideGUID,
+                               ammo_data: ConstructorData
+                             )                                                             extends Response
+  final case class ChangeFireState_Start(weapon_guid: PlanetSideGUID)   extends Response
+  final case class ChangeFireState_Stop(weapon_guid: PlanetSideGUID)    extends Response
   final case class ChildObjectState(object_guid: PlanetSideGUID, pitch: Float, yaw: Float) extends Response
   final case class ConcealPlayer(player_guid: PlanetSideGUID)                              extends Response
   final case class DeployRequest(
@@ -66,8 +76,9 @@ object VehicleResponse {
   final case class Ownership(vehicle_guid: PlanetSideGUID)              extends Response
   final case class PlanetsideAttribute(vehicle_guid: PlanetSideGUID, attribute_type: Int, attribute_value: Long)
       extends Response
-  final case class RevealPlayer(player_guid: PlanetSideGUID)                                          extends Response
-  final case class SeatPermissions(vehicle_guid: PlanetSideGUID, seat_group: Int, permission: Long)   extends Response
+  final case class Reload(weapon_guid: PlanetSideGUID)                                              extends Response
+  final case class RevealPlayer(player_guid: PlanetSideGUID)                                        extends Response
+  final case class SeatPermissions(vehicle_guid: PlanetSideGUID, seat_group: Int, permission: Long) extends Response
   final case class StowEquipment(
       vehicle_guid: PlanetSideGUID,
       slot: Int,
@@ -75,6 +86,7 @@ object VehicleResponse {
       iguid: PlanetSideGUID,
       idata: ConstructorData
   )                                                                              extends Response
+  final case class WeaponDryFire(weapon_guid: PlanetSideGUID)                    extends Response
   final case class UnloadVehicle(vehicle: Vehicle, vehicle_guid: PlanetSideGUID) extends Response
   final case class UnstowEquipment(item_guid: PlanetSideGUID)                    extends Response
   final case class VehicleState(


### PR DESCRIPTION
After the success of #1052, I have built upon the foundation established in reducing `PlayerStateMessage` packets to reduce other unnecessary outbound packets based on the visibility of a target player.  All of these changes affect weaponry.

___Features___
__`ChangeFireStateMessage_Start`__
Normally causes the ghost projectiles that can be seen being shot from other players's weapons, as if in auto-fire.  Result: suppressed if the player is not visible.  Only Infantry weapons are affected, nothing else.

__`ChangeFireStateMessage_Stop`__
Following a targetted `CFSM_Start` packet reception, normally causes the ghost projectiles that can be seen being shot from other players's weapons to stop firing.  Result: suppressed if the player is not visible, but will also be dispatched if the other player, when last seen, was still reported as shooting.

__`ReloadMessage`__
Normally causes a player's weapon to perform the animation that indicates ammunition reloading.  This animation is actually just an illusion as another player's weapon never actually has an empty magazine - the shooting animation is just skipped and a no-fire sound effect is played.  Result: suppressed if the player is not visible.

__`ChangeAmmoMessage`__
Normally causes a player's weapon to switch between valid ammunition types by removing the old magazine and inserting a new one.  The packet itself, however, only displays the animation.  The rest of the process is performed by `ObjectDetachMessage` packets and `ObjectCreateMessage` packets.  As a consquence, the actual `CAM` packet is suppressed when the other player is not visible; but, the remainder of the `ODM` and `OCM` operations must be performed to maintain the integrity of state of the hidden player model.

__`WeaponDryFireMessage`__
Normally causes the sound effect that plays when a weapon does not discharge a projectile during (attempted) weapon discharge. Result: suppressed if the player is not visible.

__Conclusion__
"Ghost weapon discharge" is a phenomenon of the illusory nature of other players on an avatar's client.  The projectiles that these other players shoot from their weapons are insubstantial, unaimed, and unnumbered (in terms of global unique identifier) and are merely existant to give the impression that the weapon is being discharged at all.  The tracers do not offer help with dodging the real projectiles anyway.  Suppressing `CFSM_Start` and `CFSM_Stop` is significant because they preceed and follow every instance of so-called ghost discharge.  These packets are extremely common in any firefight.  `RM` has just a slightly reduced frequency but is also common in any firefight.  `CAM` is much less common than that and `WDFM` is even less common by comparison.

__Caveats___
The `ChangeFireModeMessage` packet can not benefit from the same improvements of visibility-based suppression as is implemented for the above packets and their handling code paths.  The only action this packet performs is necessary to maintain the integrity of state of the hidden player model.  It actually switches the fire mode, which often requires changing the ammunition slot being utilized by the weapon model, and can not be skipped.

___Addenda___
1. Only Infantry weapons operations are to be affected by the following changes, as aforementioned.  To ensure other forms of weapons's discharge is unaffected, a secondary pathway is available for any form of mounted weaponry.  This is available on the `VehicleEvents` event bus and is actually a duplication of the original message handling on the `AvatarEvents` event bus.  In reality, both Infantry weaponry and vehicle weaponry originally utilized the same messages, even though there was a distinction between players and vehicles for event bus otherwise.
2. Included is a fix for the Reaver causing an unreasonable amount of damage to Infantry during roadkill events.