### PR TITLE
Fixed doors on Forseral - Gwydion

### DIFF
--- a/src/main/resources/zonemaps/map05.json
+++ b/src/main/resources/zonemaps/map05.json
@@ -7899,7 +7899,7 @@
     "AbsY": 3843.5144,
     "AbsZ": 57.60156,
     "Yaw": 224.0,
-    "GUID": 628,
+    "GUID": 629,
     "MapID": null,
     "IsChildObject": true
   },
@@ -7912,7 +7912,7 @@
     "AbsY": 3837.8584,
     "AbsZ": 77.60156,
     "Yaw": 314.0,
-    "GUID": 629,
+    "GUID": 628,
     "MapID": null,
     "IsChildObject": true
   },


### PR DESCRIPTION
This PR fixes the 2 broken doors on Foreral in Gwydion

- stairway door to aircraft spawn room
- lower stairway, northern door

Fixes doors mentioned by @Dethdeath in #1084 

No wrongly associated doors on Forseral left.