### PR TITLE
Fix AMS, ANT, Router and BFR siphon undeploying when owner leaves zone

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1443,14 +1443,10 @@ class ZoningOperations(
       continent.GUID(player.avatar.vehicle) match {
         case Some(vehicle: Vehicle) if vehicle.Actor != Default.Actor =>
 
-          // allow AMS, router, ANT and BFR siphon to remain deployed when owner leaves the zone
-          // TODO: do we need to check for left/right siphon?
+          // allow AMS, ANT and Router to remain deployed when owner leaves the zone
           vehicle.Definition match {
-            case GlobalDefinitions.ams | GlobalDefinitions.ant | GlobalDefinitions.router |
-                 GlobalDefinitions.aphelion_ntu_siphon | //GlobalDefinitions.aphelion_ntu_siphon_left | GlobalDefinitions.aphelion_ntu_siphon_right |
-                 GlobalDefinitions.colossus_ntu_siphon | //GlobalDefinitions.colossus_ntu_siphon_left | GlobalDefinitions.colossus_ntu_siphon_right |
-                 GlobalDefinitions.peregrine_ntu_siphon //| GlobalDefinitions.peregrine_ntu_siphon_left | GlobalDefinitions.peregrine_ntu_siphon_right
-              => // do noting to keep them deployed
+            case GlobalDefinitions.ams | GlobalDefinitions.ant | GlobalDefinitions.router
+              => sessionData.vehicles.ConditionalDriverVehicleControl(vehicle)
 
             case _ => sessionData.vehicles.TotalDriverVehicleControl(vehicle)
           }

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1442,8 +1442,22 @@ class ZoningOperations(
     if (player.avatar.vehicle.nonEmpty && player.VehicleSeated != player.avatar.vehicle) {
       continent.GUID(player.avatar.vehicle) match {
         case Some(vehicle: Vehicle) if vehicle.Actor != Default.Actor =>
-          sessionData.vehicles.TotalDriverVehicleControl(vehicle)
+
+          // allow AMS, router, ANT and BFR siphon to remain deployed when owner leaves the zone
+          // TODO: do we need to check for left/right siphon?
+          vehicle.Definition match {
+            case GlobalDefinitions.ams | GlobalDefinitions.ant | GlobalDefinitions.router |
+                 GlobalDefinitions.aphelion_ntu_siphon | //GlobalDefinitions.aphelion_ntu_siphon_left | GlobalDefinitions.aphelion_ntu_siphon_right |
+                 GlobalDefinitions.colossus_ntu_siphon | //GlobalDefinitions.colossus_ntu_siphon_left | GlobalDefinitions.colossus_ntu_siphon_right |
+                 GlobalDefinitions.peregrine_ntu_siphon //| GlobalDefinitions.peregrine_ntu_siphon_left | GlobalDefinitions.peregrine_ntu_siphon_right
+              => // do noting to keep them deployed
+
+            case _ => sessionData.vehicles.TotalDriverVehicleControl(vehicle)
+          }
+
+          // remove owner
           vehicle.Actor ! Vehicle.Ownership(None)
+
         case _ => ;
       }
       avatarActor ! AvatarActor.SetVehicle(None)


### PR DESCRIPTION
Fixes issue #1109 where AMS, ANT, Router and BFR siphons undeploy when the owner leaves the zone.

AMS and Router were tested and are working. I'm not 100% sure that the BFR part works.
The AMS looses its cloaking for 1-2 seconds, but I could not find the cause. Maybe the owner change causes the client to disable cloak for a second.