### PR TITLE
Less Block Map

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -94,7 +94,7 @@ class SessionAvatarHandlers(
           lazy val targetDelay = {
             val populationOver = math.max(
               0,
-              continent.blockMap.sector(ourPosition, range=drawConfig.rangeMax.toFloat).livePlayerList.size - drawConfig.populationThreshold
+              sessionData.localSector.livePlayerList.size - drawConfig.populationThreshold
             )
             val distanceAdjustment = math.pow(populationOver / drawConfig.populationStep * drawConfig.rangeStep, 2) //sq.m
             val adjustedDistance = currentDistance + distanceAdjustment //sq.m

--- a/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionVehicleHandlers.scala
@@ -55,6 +55,7 @@ class SessionVehicleHandlers(
         player.Position = pos
         player.Orientation = orient
         player.Velocity = vel
+        sessionData.updateLocalBlockMap(pos)
 
       case VehicleResponse.VehicleState(
       vehicleGuid,

--- a/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/VehicleOperations.scala
@@ -44,7 +44,7 @@ class VehicleOperations(
         sessionData.turnCounterFunc(player.GUID)
         sessionData.fallHeightTracker(pos.z)
         if (obj.MountedIn.isEmpty) {
-          sessionData.updateBlockMap(obj, continent, pos)
+          sessionData.updateBlockMap(obj, pos)
         }
         player.Position = pos //convenient
         if (obj.WeaponControlledFromSeat(0).isEmpty) {
@@ -127,7 +127,7 @@ class VehicleOperations(
         sessionData.turnCounterFunc(player.GUID)
         val (position, angle, velocity, notMountedState) = continent.GUID(obj.MountedIn) match {
           case Some(v: Vehicle) =>
-            sessionData.updateBlockMap(obj, continent, pos)
+            sessionData.updateBlockMap(obj, pos)
             (pos, v.Orientation - Vector3.z(value = 90f) * Vehicles.CargoOrientation(obj).toFloat, v.Velocity, false)
           case _ =>
             (pos, ang, vel, true)
@@ -243,7 +243,7 @@ class VehicleOperations(
         obj.Position = pos
         obj.Orientation = ang
         obj.Velocity = vel
-        sessionData.updateBlockMap(obj, continent, pos)
+        sessionData.updateBlockMap(obj, pos)
         obj.zoneInteractions()
         continent.VehicleEvents ! VehicleServiceMessage(
           continent.id,

--- a/src/main/scala/net/psforever/objects/zones/blockmap/BlockMap.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/BlockMap.scala
@@ -74,13 +74,25 @@ class BlockMap(fullMapWidth: Int, fullMapHeight: Int, desiredSpanSize: Int) {
     * find the sector conglomerate to which this range allocates.
     * @see `BlockMap.findSectorIndices`
     * @see `BlockMap.quickToSectorGroup`
+    * @see `BlockMap::sector(Iterable[Int], Float)`
     * @param p the game world coordinates
     * @param range the axis distance from the provided coordinates
     * @return a conglomerate sector which lists all of the entities in the discovered sector(s)
     */
   def sector(p: Vector3, range: Float): SectorPopulation = {
-    val indices = BlockMap.findSectorIndices(blockMap = this, p, range)
+    sector(BlockMap.findSectorIndices(blockMap = this, p, range), range)
+  }
 
+  /**
+   * Given a coordinate position within representable space and a range from that representable space,
+   * find the sector conglomerate to which this range allocates.
+   * @see `BlockMap.findSectorIndices`
+   * @see `BlockMap.quickToSectorGroup`
+   * @param indices an enumeration that directly associates with the structure of the block map
+   * @param range the axis distance from the provided coordinates
+   * @return a conglomerate sector which lists all of the entities in the discovered sector(s)
+   */
+  def sector(indices: Iterable[Int], range: Float): SectorPopulation = {
     if (indices.max < blocks.size) {
       BlockMap.quickToSectorGroup(range, BlockMap.sectorsOnlyWithinBlockStructure(indices, blocks) )
     } else {


### PR DESCRIPTION
As per @Resaec's profiling of an active server with players waiting around for nothing to happen, the next place to strike is with the block map.  On the inbound, the block map is polled at least once an upstream packet, twice if the players moves between sectors at the same time.  On the outbound, every other player also causes polling on the block map for that first client session to check sector player population, which doesn't usually change much at the frequency in which the calls are made.  That means the block map will be called to task on average `4*n` times per second for one client session and `4*n^2` times per second for all applicable sessions, where `n` is the population within the player draw distance, a.k.a., "client sessions".

By updating a semi-persistent reference to the grouped block map sector upon inbound and calling that reference during the outbound, the number of polls on the block map becomes `4` per second for one client session and `4*n` for all applicable client sessions.  Going from `n` to `1` individually and from `n^2` to `n` for groups would be a huge improvement, I think.

The chance of the sector reference getting too stale in 250ms to matter should be insignificant and that brief moment during zone transfer where it will be exceptionally stale for one or two inbound sessions should be inconsequential.  Making the reference even more stale by dropping the polling once every four inbound packets - once a second - may also yield optimizations.