### PR TITLE
A few more fix attempts

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -963,13 +963,26 @@ class SessionData(
     log.debug(s"$pkt")
   }
 
+  // This is for excluding cargo vehicles from attempting to charge their shield while mounted in a carrier vehicle.
+  // As per issue 1126, this would cause the client of the cargo vehicle occupant(s) to disconnect
+  def handleGetCargoVehicles(vehicle: Vehicle): List[Vehicle] = {
+    val mountedVehicle = vehicle.MountedIn.flatMap { mountedGUID =>
+      continent.GUID(mountedGUID.guid).collect { case mountedVehicle: Vehicle => mountedVehicle }
+    }.toList
+    mountedVehicle
+  }
+
+  def handleIsCargoVehicle(vehicle: Vehicle): Boolean = {
+    handleGetCargoVehicles(vehicle).nonEmpty
+  }
+
   def handleFacilityBenefitShieldChargeRequest(pkt: FacilityBenefitShieldChargeRequestMessage): Unit = {
     val FacilityBenefitShieldChargeRequestMessage(_) = pkt
     val vehicleGuid = player.VehicleSeated
     continent
       .GUID(vehicleGuid)
       .foreach {
-        case obj: Vehicle if !obj.Destroyed => //vehicle will try to charge even if destroyed
+        case obj: Vehicle if !obj.Destroyed && !handleIsCargoVehicle(obj) => // vehicle will try to charge even if destroyed
           obj.Actor ! CommonMessages.ChargeShields(
             15,
             Some(continent.blockMap.sector(obj).buildingList.maxBy(_.Definition.SOIRadius))

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -8,6 +8,7 @@ import net.psforever.actors.session.AvatarActor
 import net.psforever.actors.zone.ZoneActor
 import net.psforever.objects.{GlobalDefinitions, PlanetSideGameObject, Player, Vehicle, Vehicles}
 import net.psforever.objects.definition.{BasicDefinition, ObjectDefinition}
+import net.psforever.objects.serverobject.hackable.GenericHackables.getTurretUpgradeTime
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.terminals.implant.ImplantTerminalMech
 import net.psforever.objects.serverobject.turret.{FacilityTurret, WeaponTurret}
@@ -147,7 +148,8 @@ class SessionMountHandlers(
         MountingAction(tplayer, obj, seatNumber)
 
       case Mountable.CanMount(obj: FacilityTurret, seatNumber, _)
-        if !obj.isUpgrading =>
+        if !obj.isUpgrading || System.currentTimeMillis() - getTurretUpgradeTime >= 1500L =>
+        obj.setMiddleOfUpgrade(false)
         sessionData.zoning.CancelZoningProcessWithDescriptiveReason("cancel_mount")
         log.info(s"${player.Name} mounts the ${obj.Definition.Name}")
         sendResponse(PlanetsideAttributeMessage(obj.GUID, attribute_type=0, obj.Health))

--- a/src/main/scala/net/psforever/objects/serverobject/turret/WeaponTurret.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/WeaponTurret.scala
@@ -48,7 +48,6 @@ trait WeaponTurret
   def Upgrade: TurretUpgrade.Value = upgradePath
 
   def Upgrade_=(upgrade: TurretUpgrade.Value): TurretUpgrade.Value = {
-    middleOfUpgrade = true //blocking flag; block early
     var updated = false
     //upgrade each weapon as long as that weapon has a valid option for that upgrade
     Definition match {
@@ -64,8 +63,6 @@ trait WeaponTurret
     }
     if (updated) {
       upgradePath = upgrade
-    } else {
-      middleOfUpgrade = false //reset
     }
     Upgrade
   }
@@ -78,6 +75,10 @@ trait WeaponTurret
   }
 
   def isUpgrading: Boolean = middleOfUpgrade
+
+  def setMiddleOfUpgrade(value: Boolean): Unit = {
+    middleOfUpgrade = value
+  }
 
   def Definition: TurretDefinition
 }


### PR DESCRIPTION
**Cargo vehicles and shield charging**
Fixes #1126 . If a cargo vehicle attempts to charge shield, it crashes the client of all cargo occupants. Cargo vehicles are now excluded from shield charge attempts.

**Turret upgrading**
Fixes #440 . This was a doozy to come up with a janky solution for. The isUpgrading flag was not being set when the upgrade started so other players were allowed to mount the turret. This caused the upgrading player to get stuck. The flag is now set to true in the correct place when the upgrade starts. Everything worked fine as long as the upgrade finished. But what if the upgrading player gets shot, killed, or decides they don't want to finish the upgrade? That would leave the turret in a state with isUpgrading true and nobody could mount it unless someone went back and finished the upgrade. As with other hacking logic (upgrading a turret uses some of the same things as hacking objects), there was no means to cancel the upgrade or set that bool back to false as far as I could tell. 

_Insert solution I came up with_. A variable is set to keep track of the system time during the upgrade process. If a player stops in the middle of the upgrade, the time stops updating. If someone then attempts to mount the turret at least 1.5 seconds after the upgrade progress is stopped, it will allow them to mount it despite the isUpgrading flag still being set to true. Once mounted, it immediately sets that to false and everyone can go on their merry way mounting the turret even though it never finished upgrading.