### PR TITLE
Item Swapping

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionTerminalHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionTerminalHandlers.scala
@@ -102,7 +102,7 @@ class SessionTerminalHandlers(
         lastTerminalOrderFulfillment = true
 
       case Terminal.BuyVehicle(vehicle, _, _)
-        if tplayer.avatar.purchaseCooldown(vehicle.Definition).nonEmpty =>
+        if tplayer.avatar.purchaseCooldown(vehicle.Definition).nonEmpty || tplayer.spectator =>
         sendResponse(ItemTransactionResultMessage(msg.terminal_guid, TransactionType.Buy, success = false))
         lastTerminalOrderFulfillment = true
 

--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -323,7 +323,7 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
               player.Name,
               AvatarAction.ObjectHeld(player.GUID, before, -1)
             )
-          } else if (!resistance && before != slot && (player.DrawnSlot = slot) != before) {
+          } else if ((!resistance && before != slot && (player.DrawnSlot = slot) != before) && ItemSwapSlot != before) {
             val mySlot = if (updateMyHolsterArm) slot else -1 //use as a short-circuit
             events ! AvatarServiceMessage(
               player.Continent,
@@ -352,6 +352,9 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
                   log.info(s"${player.Name} lowers ${player.Sex.possessive} hand")
               }
             }
+            UpdateItemSwapSlot
+          } else if (ItemSwapSlot == before) {
+            UpdateItemSwapSlot
           }
 
         case Terminal.TerminalMessage(_, msg, order) =>

--- a/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -42,6 +42,7 @@ trait ContainableBehavior {
     * The destination is set back to normal - flag to `0` - when both of the attempts short-circuit due to timeout.
     */
   private var waitOnMoveItemOps: Int = 0
+  private var itemSwapSlot: Int = 10 // Just a number higher than any inventory item slots
 
   final val containerBehavior: Receive = {
     /* messages that modify delivery order */
@@ -136,6 +137,15 @@ trait ContainableBehavior {
   }
 
   /* Functions (item transfer) */
+  // For issue 1108
+  def UpdateItemSwapSlot: Int = {
+    itemSwapSlot = 10
+    itemSwapSlot
+  }
+  // For issue 1108
+  def ItemSwapSlot: Int = {
+    itemSwapSlot
+  }
 
   protected def ContainableMoveItem(
                                    destination: PlanetSideServerObject with Container,
@@ -154,6 +164,7 @@ trait ContainableBehavior {
             LocalPutItemInSlot(item, dest) match {
               case Containable.ItemPutInSlot(_, _, _, None) => ; //success
               case Containable.ItemPutInSlot(_, _, _, Some(swapItem)) => //success, but with swap item
+                itemSwapSlot = dest
                 LocalPutItemInSlotOnlyOrAway(swapItem, slot) match {
                   case Containable.ItemPutInSlot(_, _, _, None) => ;
                   case _ =>
@@ -174,6 +185,7 @@ trait ContainableBehavior {
               case Success(Containable.ItemPutInSlot(_, _, _, None)) => ; //successful
 
               case Success(Containable.ItemPutInSlot(_, _, _, Some(swapItem))) => //successful, but with swap item
+                itemSwapSlot = dest
                 PutItBackOrDropIt(source, swapItem, slot, destination.Actor)
 
               case Success(_: Containable.CanNotPutItemInSlot) => //failure case ; try restore original item placement

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -28,7 +28,6 @@ import scala.util.{Random, Success}
  */
 class HackCaptureActor extends Actor {
   private[this] val log = org.log4s.getLogger
-
   /** main timer for completing or clearing hacked states */
   private var clearTrigger: Cancellable = Default.Cancellable
   /** list of currently hacked server objects */
@@ -168,6 +167,7 @@ class HackCaptureActor extends Actor {
       case Some((owner, _, _)) =>
         log.error(s"TrySpawnCaptureFlag: couldn't find any neighbouring $hackingFaction facilities of ${owner.Name} for LLU hack")
         owner.GetFlagSocket.foreach { _.clearOldFlagData() }
+        terminal.Zone.LocalEvents ! CaptureFlagManager.Lost(owner.GetFlag.get, CaptureFlagLostReasonEnum.Ended)
         false
       case _ =>
         log.error(s"TrySpawnCaptureFlag: expecting a terminal ${terminal.GUID.guid} with the ctf owning facility")


### PR DESCRIPTION
Crafted this to fix #1108 
Right click swapping an item into a slot already behaved correctly. Left clicking an item and freely moving it to a slot would cause an issue if that slot was currently equipped (being held in the player's hands). This should fix that issue so the player and others both see the item holstered or unholstered correctly. This applies to both moving items around in your inventory as well as looting a corpse inventory and moving an item from that one into one of your slots. No more shooting while it appears there is no weapon drawn (I think).

Also threw in the quick fix for one of the spectator comments to not allow a spectator pull a vehicle. By accessing the terminal, then enabling spectator allowed the player to pull a vehicle, which spectators shouldn't be able to do. If someone were to mount a vehicle, then enable spectator mode, this already didn't seem to cause any issues. When a player destroys a vehicle with a spectator inside, they are rewarded with the kill and not kicked.