### PR TITLE
Decode Packets, Again

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ make install PREFIX=$HOME/.local
 ```
 Now you can run the program like that:
 ```
-psf-decode-packets -o ./output-directory foo.gcap bar.gcap
+psf-decode-packets -o ./output-directory -f foo.gcap bar.gcap
 ```
 By default, decodePackets takes in `.gcap` files, but it can also take gcapy ascii files with the
 `-p` option. Run `psf-decode-packets --help` to get usage info.

--- a/src/main/scala/net/psforever/packet/game/objectcreate/ObjectCreateBase.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/ObjectCreateBase.scala
@@ -98,8 +98,9 @@ object ObjectCreateBase {
       }
     } catch {
       case ex: Exception =>
-        log.error(s"Decoding error - ${ex.getClass.toString} - ${ex.toString} ($objectClass)")
-        Attempt.failure(Err(ex.getMessage))
+        val msg = s"Decoding error - ${ex.toString} ($objectClass)"
+        log.error(msg)
+        Attempt.failure(Err(msg))
     }
   }
 

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -26,12 +26,10 @@ case class Config(
 
 object DecodePackets {
   private val utf8Decoder = Codec.UTF8.decoder.onMalformedInput(CodingErrorAction.REPORT)
+  /** important: must be Java's System.out! */
   private val normalSystemOut = System.out
-  private val outCapture: PrintStream = new PrintStream(new OutputStream() {
-    @Override
-    @throws(classOf[Exception])
-    def write(arg0: Int): Unit = { }
-  })
+  /** important: must be composed of Java classes; log4j interacts with the system as a Java library */
+  private val outCapture: PrintStream = new PrintStream(new DeafMuteStream())
 
   def main(args: Array[String]): Unit = {
     val builder = OParser.builder[Config]
@@ -139,6 +137,8 @@ object DecodePackets {
       )
       deleteThese.foreach(FileUtils.forceDelete)
     }
+    //close the decoy console output stream that's been running since the application started
+    outCapture.close()
   }
 
   /**
@@ -437,4 +437,14 @@ object DecodePackets {
   private def errorWriter(directoryPath: String, fileName: String): WriterWrapper = {
     DecodeErrorWriter(directoryPath, fileName)
   }
+}
+
+/**
+ * I thought what I'd do was, I'd pretend I was one of those deaf-mutes.
+ * That way I wouldn't have to have any goddam stupid useless conversations with anybody.
+ */
+private class DeafMuteStream() extends OutputStream {
+  override def write(arg0: Int): Unit = { /* do nothing */ }
+  override def write(arg0: Array[Byte]): Unit = { /* do nothing */ }
+  override def write(arg0: Array[Byte],  arg1: Int, arg2: Int): Unit = { /* do nothing */ }
 }

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -12,7 +12,7 @@ import scopt.OParser
 import scala.collection.parallel.CollectionConverters._
 import scala.io.{Codec, Source}
 import scala.sys.process._
-import scala.util.{Try, Using}
+import scala.util.Using
 
 case class Config(
     inDir: String = System.getProperty("user.dir"),
@@ -41,7 +41,7 @@ object DecodePackets {
           .text("Input directory"),
         opt[Unit]('p', "preprocessed")
           .action((_, c) => c.copy(preprocessed = true))
-          .text("Files are already preprocessed gcapy ascii files (do not call gcapy)"),
+          .text("Files are already preprocessed gcapy ASCII files"),
         opt[Unit]('s', "skip-existing")
           .action((_, c) => c.copy(skipExisting = true))
           .text("Skip files that already exist in out-dir"),
@@ -91,6 +91,12 @@ object DecodePackets {
     FileUtils.forceDelete(tmpFolder)
   }
 
+  /**
+   * Enumerate over file names found in the given directory for later.
+   * @param directory where the files are found
+   * @param opts configuration entity where the files are collated
+   * @return configuration entity
+   */
   private def getAllFilesFromDirectory(directory: String, opts: Config): Config = {
     val inDir = Paths.get(directory)
     if (Files.exists(inDir) && Files.isDirectory(inDir)) {
@@ -108,28 +114,37 @@ object DecodePackets {
     }
   }
 
+  /**
+   * The primary entry point into the process of parsing the packet capture files
+   * and producing the decoded packet data.
+   * Should be configurable for whatever state that the packet capture file can be structured.
+   * @param files all of the discovered files for consideration
+   * @param extension file extension being concatenated
+   * @param temporaryDirectory destination directory where files temporarily exist while being written
+   * @param outDirectory destination directory where the files are stored after being written
+   * @param skipExisting do not write a file that already exists at the destination directory
+   * @param readDecodeAndWrite next step of the file decoding process
+   */
   private def decodeFilesUsing(
                                 files: Seq[File],
                                 extension: String,
                                 temporaryDirectory: File,
                                 outDirectory: String,
                                 skipExisting: Boolean,
-                                decodingFunc: (File,BufferedWriter)=>Try[List[String]]
+                                readDecodeAndWrite: (File,BufferedWriter)=>Unit
                               ): Unit = {
     files.par.foreach { file =>
       val fileName = file.getName.split(extension)(0)
-      val outFilePath = outDirectory + "/" + fileName + ".txt"
+      val fileNameWithExtension = fileName + ".txt"
+      val outFilePath = outDirectory + "/" + fileNameWithExtension
       val outFile = new File(outFilePath)
       if (skipExisting && outFile.exists()) {
         println(s"file $fileName skipped due to params")
       } else {
-        val tmpFilePath = temporaryDirectory.getAbsolutePath + "/" + fileName + ".txt"
+        val tmpFilePath = temporaryDirectory.getAbsolutePath + "/" + fileNameWithExtension
         val writer = new BufferedWriter(new FileWriter(new File(tmpFilePath), false))
         try {
-          decodingFunc(file, writer).collect { lines =>
-            println(s"${lines.size} lines read from file $fileName")
-            processAndRewriteFileContents(writer, lines)
-          }
+          readDecodeAndWrite(file, writer)
           writer.close()
           Files.move(Paths.get(tmpFilePath), Paths.get(outFilePath), StandardCopyOption.REPLACE_EXISTING)
         } catch {
@@ -142,22 +157,41 @@ object DecodePackets {
     }
   }
 
-  private def preprocessed(file: File, writer: BufferedWriter): Try[List[String]] = {
+  /**
+   * Read data from ASCII transcribed gcapy files.
+   * @param file file to read
+   * @param writer writer for output
+   */
+  private def preprocessed(file: File, writer: BufferedWriter): Unit = {
     Using(Source.fromFile(file.getAbsolutePath)(decoder)) { source =>
-      source.getLines().toList
+      println(s"${decodeFileContents(writer, source.getLines())} lines read from file ${file.getName}")
     }
   }
 
-  private def gcapy(file: File, writer: BufferedWriter): Try[List[String]] = {
+  /**
+   * Read data from gcapy files.
+   * @param file file to read
+   * @param writer writer for output
+   */
+  private def gcapy(file: File, writer: BufferedWriter): Unit = {
     Using(Source.fromString(s"gcapy -xa '${file.getAbsolutePath}'" !!)) { source =>
-      source.getLines().toList
+      println(s"${decodeFileContents(writer, source.getLines())} lines read from file ${file.getName}")
     }
   }
 
+  /**
+   * Decode each line from the original file, decode it, then write it to the output file.
+   * @param writer writer for output
+   * @param lines raw packet data from the source
+   * @throws java.io.IOException if writing data goes incorrectly
+   * @return number of lines read from the source
+   */
   @throws(classOf[IOException])
-  private def processAndRewriteFileContents(writer: BufferedWriter, lines: List[String]): Unit = {
+  private def decodeFileContents(writer: BufferedWriter, lines: Iterator[String]): Int = {
     var linesToSkip = 0
+    var linesRead: Int = 0
     for (line <- lines.drop(1)) {
+      linesRead += 1
       if (linesToSkip > 0) {
         linesToSkip -= 1
       } else {
@@ -186,12 +220,25 @@ object DecodePackets {
         writer.newLine()
       }
     }
+    linesRead
   }
 
-  /** Traverse down any nested packets such as SlottedMetaPacket, MultiPacket and MultiPacketEx and add indent for each layer down
-    * The number of lines to skip will be returned so duplicate lines following SlottedMetaPackets in the gcapy output can be filtered out
-    */
-  private def recursivelyHandleNestedPacket(decodedLine: String, writer: BufferedWriter, depth: Int = 0): Int = {
+  /**
+   * Traverse down any nested packets such as `SlottedMetaPacket`, `MultiPacket`, and `MultiPacketEx`
+   * and add indent for each layer down.
+   * A number of lines to skip will be returned so duplicate lines following the nested packet can be filtered out.
+   * @param decodedLine decoded packet data
+   * @param writer writer for output
+   * @param depth the number of layers to indent
+   * @throws java.io.IOException if writing data goes incorrectly
+   * @return current indent layer
+   */
+  @throws(classOf[IOException])
+  private def recursivelyHandleNestedPacket(
+                                             decodedLine: String,
+                                             writer: BufferedWriter,
+                                             depth: Int = 0
+                                           ): Int = {
     if (decodedLine.indexOf("Failed to parse") >= 0) return depth
     val regex   = "(0x[a-f0-9]+)".r
     val matches = regex.findAllIn(decodedLine)
@@ -213,6 +260,11 @@ object DecodePackets {
     linesToSkip
   }
 
+  /**
+   * Reformat data common to gcapy packet data files and their derivation form of ASCII transcription.
+   * @param line original string
+   * @return transformed string
+   */
   private def shortGcapyString(line: String): String = {
     val regex = "Game record ([0-9]+) at ([0-9.]+s) is from ([S|C]).* to ([S|C]).*contents (.*)".r
     line match {
@@ -222,11 +274,21 @@ object DecodePackets {
     }
   }
 
+  /**
+   * A nested packet contains more packets.
+   * @param decodedLine decoded packet data
+   * @return `true`, if the packet is nested; `false`, otherwise
+   */
   private def isNestedPacket(decodedLine: String): Boolean = {
     // Also matches MultiPacketEx
     decodedLine.indexOf("MultiPacket") >= 0 || decodedLine.indexOf("SlottedMetaPacket") >= 0
   }
 
+  /**
+   * Actually decode the packet data.
+   * @param hexString raw packet data
+   * @return decoded packet data
+   */
   private def decodePacket(hexString: String): String = {
     PacketCoding.decodePacket(ByteVector.fromValidHex(hexString)) match {
       case Successful(value) => value.toString

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -29,7 +29,7 @@ object DecodePackets {
   /** important: must be Java's System.out! */
   private val normalSystemOut = System.out
   /** important: must be composed of Java classes; log4j interacts with the system as a Java library */
-  private val outCapture: PrintStream = new PrintStream(new DeafMuteStream())
+  private var outCapture: PrintStream = _
 
   def main(args: Array[String]): Unit = {
     val builder = OParser.builder[Config]
@@ -120,11 +120,16 @@ object DecodePackets {
       normalWriter
     }
 
+    //create a decoy console output stream (suppress output from the decode process)
+    outCapture = new PrintStream(new DeafMuteStream())
     if (opts.preprocessed) {
       decodeFilesUsing(files, extension = ".txt", tmpFolder, opts.outDir, bufferedWriter, preprocessed)
     } else {
       decodeFilesUsing(files, extension = ".gcap", tmpFolder, opts.outDir, bufferedWriter, gcapy)
     }
+    //close and null the decoy console output stream
+    outCapture.close()
+    outCapture = null
 
     if (deleteTempFolderAfterwards) {
       //if the temporary directory only exists because of this script, it should be safe to delete it
@@ -137,8 +142,6 @@ object DecodePackets {
       )
       deleteThese.foreach(FileUtils.forceDelete)
     }
-    //close the decoy console output stream that's been running since the application started
-    outCapture.close()
   }
 
   /**

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -129,7 +129,7 @@ object DecodePackets {
       //delete just the files that were created (if files were overwrote, nothing we can do)
       val (deleteThese, _) = filesWithSameNameAs(
         files,
-        getAllFilePathsFromDirectory(tmpFolder.getAbsolutePath).map(_.toFile)
+        getAllFilePathsFromDirectory(tmpFolder.getAbsolutePath).toIndexedSeq.map(_.toFile)
       )
       deleteThese.foreach(FileUtils.forceDelete)
     }
@@ -147,7 +147,7 @@ object DecodePackets {
    */
   private def filesWithSameNameInDirectory(directory: String, files: Seq[File]): (Seq[File], Seq[File]) = {
     filesWithSameNameAs(
-      getAllFilePathsFromDirectory(directory).map(_.toFile),
+      getAllFilePathsFromDirectory(directory).toIndexedSeq.map(_.toFile),
       files
     )
   }
@@ -327,8 +327,9 @@ object DecodePackets {
         if (i == 0) writer.write("> ")
         else writer.write("-")
       }
-      val nextDecodedLine = decodePacket(header="", packet).text
-      writer.write(nextDecodedLine)
+      val nextDecoded = decodePacket(decodedLine, packet)
+      val nextDecodedLine = nextDecoded.text
+      writer.write(nextDecoded)
       writer.newLine()
       if (isNestedPacket(nextDecodedLine)) {
         linesToSkip += recursivelyHandleNestedPacket(nextDecodedLine, writer, depth + 1)

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/DecodePackets.scala
@@ -1,9 +1,8 @@
 package net.psforever.tools.decodePackets
 
-import java.io.{BufferedWriter, File, FileWriter}
+import java.io.{BufferedWriter, File, FileWriter, IOException}
 import java.nio.charset.CodingErrorAction
 import java.nio.file.{Files, Paths, StandardCopyOption}
-
 import net.psforever.packet.PacketCoding
 import org.apache.commons.io.FileUtils
 import scodec.Attempt.{Failure, Successful}
@@ -13,9 +12,10 @@ import scopt.OParser
 import scala.collection.parallel.CollectionConverters._
 import scala.io.{Codec, Source}
 import scala.sys.process._
-import scala.util.Using
+import scala.util.{Try, Using}
 
 case class Config(
+    inDir: String = System.getProperty("user.dir"),
     outDir: String = System.getProperty("user.dir"),
     preprocessed: Boolean = false,
     skipExisting: Boolean = false,
@@ -23,10 +23,10 @@ case class Config(
 )
 
 object DecodePackets {
+  private val decoder = Codec.UTF8.decoder.onMalformedInput(CodingErrorAction.REPORT)
+
   def main(args: Array[String]): Unit = {
-
     val builder = OParser.builder[Config]
-
     val parser = {
       import builder._
       OParser.sequence(
@@ -34,15 +34,19 @@ object DecodePackets {
         opt[String]('o', "out-dir")
           .action((x, c) => c.copy(outDir = x))
           .text("Output directory"),
+        opt[String]('i', "in-dir")
+          .action { (x, c) =>
+            getAllFilesFromDirectory(x, c).copy(inDir = x)
+          }
+          .text("Input directory"),
         opt[Unit]('p', "preprocessed")
-          .action((x, c) => c.copy(preprocessed = true))
+          .action((_, c) => c.copy(preprocessed = true))
           .text("Files are already preprocessed gcapy ascii files (do not call gcapy)"),
         opt[Unit]('s', "skip-existing")
-          .action((x, c) => c.copy(skipExisting = true))
+          .action((_, c) => c.copy(skipExisting = true))
           .text("Skip files that already exist in out-dir"),
-        arg[File]("<file>...")
+        opt[File]('f', "file")
           .unbounded()
-          .required()
           .action((x, c) => c.copy(files = c.files :+ x))
       )
     }
@@ -54,7 +58,7 @@ object DecodePackets {
         sys.exit(1)
     }
 
-    val outDir = new File(opts.outDir);
+    val outDir = new File(opts.outDir)
     if (!outDir.exists()) {
       outDir.mkdirs()
     } else if (outDir.isFile) {
@@ -62,6 +66,10 @@ object DecodePackets {
       sys.exit(1)
     }
 
+    if (opts.files.isEmpty) {
+      println("error: input files not defined; set directory or indicate files")
+      sys.exit(1)
+    }
     opts.files.foreach { file =>
       if (!file.exists) {
         println(s"file ${file.getAbsolutePath} does not exist")
@@ -74,120 +82,155 @@ object DecodePackets {
       tmpFolder.mkdirs()
     }
 
-    opts.files.par.foreach { file =>
-      val outFilePath = opts.outDir + "/" + file.getName.split(".gcap")(0) + ".txt"
-      val outFile     = new File(outFilePath);
+    println(s"${opts.files.size} files found")
+    if (opts.preprocessed) {
+      decodeFilesUsing(opts.files, extension=".txt", tmpFolder, opts.outDir, opts.skipExisting, preprocessed)
+    } else {
+      decodeFilesUsing(opts.files, extension=".gcap", tmpFolder, opts.outDir, opts.skipExisting, gcapy)
+    }
+    FileUtils.forceDelete(tmpFolder)
+  }
 
-      if (outFile.exists() && opts.skipExisting) {
-        return
-      }
+  private def getAllFilesFromDirectory(directory: String, opts: Config): Config = {
+    val inDir = Paths.get(directory)
+    if (Files.exists(inDir) && Files.isDirectory(inDir)) {
+      var outOpts = opts
+      Files.list(inDir).forEach(file =>
+        outOpts = outOpts.copy(files = outOpts.files :+ file.toFile)
+      )
+      outOpts
+    } else if (!Files.exists(inDir)) {
+      println(s"error: in-dir does not exist")
+      opts
+    } else {
+      println(s"error: in-dir is file")
+      opts
+    }
+  }
 
-      val tmpFilePath = tmpFolder.getAbsolutePath + "/" + file.getName.split(".gcap")(0) + ".txt"
-      val writer      = new BufferedWriter(new FileWriter(new File(tmpFilePath), false))
-
-      try {
-        val lines = if (opts.preprocessed) {
-          val decoder = Codec.UTF8.decoder.onMalformedInput(CodingErrorAction.REPORT)
-          Using(Source.fromFile(file.getAbsolutePath)(decoder)) { source => source.getLines() }.get
-        } else {
-          Using(Source.fromString(s"gcapy -xa '${file.getAbsolutePath}'" !!)) { source => source.getLines() }.get
-        }
-
-        var linesToSkip = 0
-        for (line <- lines.drop(1)) {
-          if (linesToSkip > 0) {
-            linesToSkip -= 1
-          } else {
-            val decodedLine = decodePacket(line.drop(line.lastIndexOf(' ')))
-            writer.write(s"${shortGcapyString(line)}")
-            writer.newLine()
-
-            if (!isNestedPacket(decodedLine)) {
-              // Standard line, output as is with a bit of extra whitespace for readability
-              writer.write(decodedLine.replace(",", ", "))
-              writer.newLine()
-            } else {
-              // Packet with nested packets, including possibly other nested packets within e.g. SlottedMetaPacket containing a MultiPacketEx
-              writer.write(s"${decodedLine.replace(",", ", ")}")
-              writer.newLine()
-              val nestedLinesToSkip = recursivelyHandleNestedPacket(decodedLine, writer)
-
-              // Gcapy output has duplicated lines for SlottedMetaPackets, so we can skip over those if found to reduce noise
-              // The only difference between the original and duplicate lines is a slight difference in timestamp of when the packet was processed
-              linesToSkip = decodedLine.indexOf("SlottedMetaPacket") match {
-                case pos if pos >= 0 && nestedLinesToSkip > 0 =>
-                  writer.write(s"Skipping $nestedLinesToSkip duplicate lines")
-                  writer.newLine()
-                  nestedLinesToSkip
-                case _ => 0
-              }
-            }
-
-            writer.newLine()
+  private def decodeFilesUsing(
+                                files: Seq[File],
+                                extension: String,
+                                temporaryDirectory: File,
+                                outDirectory: String,
+                                skipExisting: Boolean,
+                                decodingFunc: (File,BufferedWriter)=>Try[List[String]]
+                              ): Unit = {
+    files.par.foreach { file =>
+      val fileName = file.getName.split(extension)(0)
+      val outFilePath = outDirectory + "/" + fileName + ".txt"
+      val outFile = new File(outFilePath)
+      if (skipExisting && outFile.exists()) {
+        println(s"file $fileName skipped due to params")
+      } else {
+        val tmpFilePath = temporaryDirectory.getAbsolutePath + "/" + fileName + ".txt"
+        val writer = new BufferedWriter(new FileWriter(new File(tmpFilePath), false))
+        try {
+          decodingFunc(file, writer).collect { lines =>
+            println(s"${lines.size} lines read from file $fileName")
+            processAndRewriteFileContents(writer, lines)
           }
+          writer.close()
+          Files.move(Paths.get(tmpFilePath), Paths.get(outFilePath), StandardCopyOption.REPLACE_EXISTING)
+        } catch {
+          case e: Throwable =>
+            println(s"File ${file.getName} threw an exception because ${e.getMessage}")
+            writer.close()
+            e.printStackTrace()
         }
-        writer.close()
-        Files.move(Paths.get(tmpFilePath), Paths.get(outFilePath), StandardCopyOption.REPLACE_EXISTING)
-      } catch {
-        case e: Throwable =>
-          println(s"File ${file.getName} threw an exception")
-          e.printStackTrace()
       }
     }
+  }
 
-    FileUtils.forceDelete(tmpFolder)
+  private def preprocessed(file: File, writer: BufferedWriter): Try[List[String]] = {
+    Using(Source.fromFile(file.getAbsolutePath)(decoder)) { source =>
+      source.getLines().toList
+    }
+  }
+
+  private def gcapy(file: File, writer: BufferedWriter): Try[List[String]] = {
+    Using(Source.fromString(s"gcapy -xa '${file.getAbsolutePath}'" !!)) { source =>
+      source.getLines().toList
+    }
+  }
+
+  @throws(classOf[IOException])
+  private def processAndRewriteFileContents(writer: BufferedWriter, lines: List[String]): Unit = {
+    var linesToSkip = 0
+    for (line <- lines.drop(1)) {
+      if (linesToSkip > 0) {
+        linesToSkip -= 1
+      } else {
+        val decodedLine = decodePacket(line.drop(line.lastIndexOf(' ')))
+        writer.write(s"${shortGcapyString(line)}")
+        writer.newLine()
+        if (!isNestedPacket(decodedLine)) {
+          // Standard line, output as is with a bit of extra whitespace for readability
+          writer.write(decodedLine.replace(",", ", "))
+          writer.newLine()
+        } else {
+          // Packet with nested packets, including possibly other nested packets within e.g. SlottedMetaPacket containing a MultiPacketEx
+          writer.write(s"${decodedLine.replace(",", ", ")}")
+          writer.newLine()
+          val nestedLinesToSkip = recursivelyHandleNestedPacket(decodedLine, writer)
+          // Gcapy output has duplicated lines for SlottedMetaPackets, so we can skip over those if found to reduce noise
+          // The only difference between the original and duplicate lines is a slight difference in timestamp of when the packet was processed
+          linesToSkip = decodedLine.indexOf("SlottedMetaPacket") match {
+            case pos if pos >= 0 && nestedLinesToSkip > 0 =>
+              writer.write(s"Skipping $nestedLinesToSkip duplicate lines")
+              writer.newLine()
+              nestedLinesToSkip
+            case _ => 0
+          }
+        }
+        writer.newLine()
+      }
+    }
   }
 
   /** Traverse down any nested packets such as SlottedMetaPacket, MultiPacket and MultiPacketEx and add indent for each layer down
     * The number of lines to skip will be returned so duplicate lines following SlottedMetaPackets in the gcapy output can be filtered out
     */
-  def recursivelyHandleNestedPacket(decodedLine: String, writer: BufferedWriter, depth: Int = 0): Int = {
+  private def recursivelyHandleNestedPacket(decodedLine: String, writer: BufferedWriter, depth: Int = 0): Int = {
     if (decodedLine.indexOf("Failed to parse") >= 0) return depth
     val regex   = "(0x[a-f0-9]+)".r
     val matches = regex.findAllIn(decodedLine)
-
     var linesToSkip = 0
     while (matches.hasNext) {
       val packet = matches.next()
-
       for (i <- depth to 0 by -1) {
         if (i == 0) writer.write("> ")
         else writer.write("-")
       }
-
       val nextDecodedLine = decodePacket(packet)
       writer.write(s"${nextDecodedLine.replace(",", ", ")}")
       writer.newLine()
-
       if (isNestedPacket(nextDecodedLine)) {
         linesToSkip += recursivelyHandleNestedPacket(nextDecodedLine, writer, depth + 1)
       }
-
       linesToSkip += 1
     }
-
     linesToSkip
   }
 
-  def shortGcapyString(line: String): String = {
+  private def shortGcapyString(line: String): String = {
     val regex = "Game record ([0-9]+) at ([0-9.]+s) is from ([S|C]).* to ([S|C]).*contents (.*)".r
     line match {
-      case regex(index, time, from, to, contents) => {
+      case regex(index, time, from, _, contents) =>
         val direction = if (from == "S") "<<<" else ">>>"
         s"#$index @ $time C $direction S ($contents)"
-      }
     }
   }
 
-  def isNestedPacket(decodedLine: String): Boolean = {
+  private def isNestedPacket(decodedLine: String): Boolean = {
     // Also matches MultiPacketEx
     decodedLine.indexOf("MultiPacket") >= 0 || decodedLine.indexOf("SlottedMetaPacket") >= 0
   }
 
-  def decodePacket(hexString: String): String = {
+  private def decodePacket(hexString: String): String = {
     PacketCoding.decodePacket(ByteVector.fromValidHex(hexString)) match {
       case Successful(value) => value.toString
-      case Failure(cause)    => s"Decoding error '${cause.toString}' for data ${hexString}"
+      case Failure(cause)    => s"Decoding error '${cause.toString}'"
     }
   }
 }

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/PacketOutput.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/PacketOutput.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2023 PSForever
+package net.psforever.tools.decodePackets
+
+trait PacketOutput {
+  def header: String
+  def text: String
+}
+
+final case class DecodedPacket(header: String, text: String) extends PacketOutput
+
+final case class DecodeError(header: String, text: String) extends PacketOutput

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/PacketOutput.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/PacketOutput.scala
@@ -2,10 +2,10 @@
 package net.psforever.tools.decodePackets
 
 trait PacketOutput {
-  def header: String
+  def header: Option[String]
   def text: String
 }
 
-final case class DecodedPacket(header: String, text: String) extends PacketOutput
+final case class DecodedPacket(header: Option[String], text: String) extends PacketOutput
 
-final case class DecodeError(header: String, text: String) extends PacketOutput
+final case class DecodeError(header: Option[String], text: String) extends PacketOutput

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
@@ -37,7 +37,13 @@ final case class DecodeErrorWriter(directoryPath: String, fileName: String)
   private val log: DecodeWriter = DecodeWriter(directoryPath, fileName)
   private val errorLog: DecodeWriter = DecodeWriter(directoryPath, fileName+".error")
 
-  def write(str: String): Unit = log.write(str)
+  def write(str: String): Unit = {
+    log.write(str)
+    if (str.contains("Decoding error")) {
+      errorLog.write(str)
+      errorLog.newLine()
+    }
+  }
 
   def write(data: PacketOutput): Unit = {
     log.write(data)
@@ -45,6 +51,9 @@ final case class DecodeErrorWriter(directoryPath: String, fileName: String)
     data match {
       case error: DecodeError =>
         errorLog.write(error)
+        errorLog.newLine()
+      case result if result.text.contains("Decoding error") =>
+        errorLog.write(data)
         errorLog.newLine()
       case _ => ()
     }

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
@@ -19,10 +19,19 @@ final case class DecodeWriter(directoryPath: String, fileName: String) extends W
   def write(str: String): Unit = log.write(str)
 
   def write(data: PacketOutput): Unit = {
-    log.write(data.header)
-    log.newLine()
-    log.write(data.text)
-    log.newLine()
+    data.header
+      .collect { str =>
+        log.write(str)
+        log.newLine()
+        log.write(data.text)
+        log.newLine()
+        Some(str)
+      }
+      .orElse {
+        log.write(data.text)
+        log.newLine()
+        None
+      }
   }
 
   def newLine(): Unit = log.newLine()
@@ -47,7 +56,6 @@ final case class DecodeErrorWriter(directoryPath: String, fileName: String)
 
   def write(data: PacketOutput): Unit = {
     log.write(data)
-    log.newLine()
     data match {
       case error: DecodeError =>
         errorLog.write(error)

--- a/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
+++ b/tools/decode-packets/src/main/scala/net/psforever/tools/decodePackets/WriterWrapper.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 PSForever
+package net.psforever.tools.decodePackets
+
+import java.io.{BufferedWriter, File, FileWriter}
+
+trait WriterWrapper {
+  def write(str: String): Unit
+  def write(str: PacketOutput): Unit
+  def newLine(): Unit
+  def close(): Unit
+  def getFileNames: Seq[String]
+}
+
+final case class DecodeWriter(directoryPath: String, fileName: String) extends WriterWrapper {
+  private val log: BufferedWriter = new BufferedWriter(
+    new FileWriter(new File(directoryPath + fileName + ".txt"), false)
+  )
+
+  def write(str: String): Unit = log.write(str)
+
+  def write(data: PacketOutput): Unit = {
+    log.write(data.header)
+    log.newLine()
+    log.write(data.text)
+    log.newLine()
+  }
+
+  def newLine(): Unit = log.newLine()
+
+  def close(): Unit = log.close()
+
+  def getFileNames: Seq[String] = Seq(fileName + ".txt")
+}
+
+final case class DecodeErrorWriter(directoryPath: String, fileName: String)
+  extends WriterWrapper {
+  private val log: DecodeWriter = DecodeWriter(directoryPath, fileName)
+  private val errorLog: DecodeWriter = DecodeWriter(directoryPath, fileName+".error")
+
+  def write(str: String): Unit = log.write(str)
+
+  def write(data: PacketOutput): Unit = {
+    log.write(data)
+    log.newLine()
+    data match {
+      case error: DecodeError =>
+        errorLog.write(error)
+        errorLog.newLine()
+      case _ => ()
+    }
+  }
+
+  def newLine(): Unit = log.newLine()
+
+  def close(): Unit = {
+    log.close()
+    errorLog.close()
+  }
+
+  def getFileNames: Seq[String] = log.getFileNames ++ errorLog.getFileNames
+}


### PR DESCRIPTION
- fixed critical issue where iterator failed to work correctly because the underlying data was a stream and the stream was closed once the iterator was produced
- even then, switched from the iterator of an open stream to an outputted list of static Strings because the iterator wasn't well-formed and could fail to extract data (results in a brief moment where the overhead of both the file stream and a copy of the file's data exists)
- added a command line option to include a whole input directory of the type of file indicated - normal `.gcap` data or `-p` for preprocessed ascii; all of these files will be processed
- demoted the `<files>...` command line argument into another option, though still unbound; both it and the input directory can contribute but the decode types must match; all of these files will be processed
- working with the files is a more straightforward process, only needing to evaluate the file type from params once

All of the specifications for the tool as described in the ReadMe should be be relevant.
Command line example: `psforever-decode-packets -p -o "decoded" -i "extracted -f "file1.txt" "file2.txt"`

Addenda: I haven't tested on files produced directly from Gcapy - the natural alternate mode of the tool - because my PATH variable isn't set up to accommodate it and I have not installed Python on this computer to run the application anyway.