### PR TITLE
Reintroduce Squads (Not Perfect)

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2805,7 +2805,7 @@ class SessionData(
   }
 
   def charSaved(): Unit = {
-    sendResponse(ChatMsg(ChatMessageType.UNK_227, wideContents=false, "", "@charsaved", None))
+    sendResponse(ChatMsg(ChatMessageType.UNK_227, wideContents=false, "", s"@charsaved ${player.Position.x} ${player.Position.y} ${player.Position.z} ", None))
   }
 
   def startDeconstructing(obj: SpawnTube): Unit = {

--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2805,7 +2805,7 @@ class SessionData(
   }
 
   def charSaved(): Unit = {
-    sendResponse(ChatMsg(ChatMessageType.UNK_227, wideContents=false, "", s"@charsaved ${player.Position.x} ${player.Position.y} ${player.Position.z} ", None))
+    sendResponse(ChatMsg(ChatMessageType.UNK_227, wideContents=false, "", "@charsaved", None))
   }
 
   def startDeconstructing(obj: SpawnTube): Unit = {

--- a/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
@@ -336,19 +336,19 @@ class SessionSquadHandlers(
           sendResponse(CharacterKnowledgeMessage(charId, Some(CharacterKnowledgeInfo(name, certs, u1, u2, zone))))
 
         case SquadResponse.SquadSearchResults(results) =>
-          //TODO positive squad search results message?
-          if(results.nonEmpty) {
-            results.foreach { guid =>
-              sendResponse(SquadDefinitionActionMessage(
-                guid,
-                0,
-                SquadAction.SquadListDecorator(SquadListDecoration.SearchResult))
-              )
-            }
-          } else {
-            sendResponse(SquadDefinitionActionMessage(player.GUID, 0, SquadAction.NoSquadSearchResults()))
-          }
-          sendResponse(SquadDefinitionActionMessage(player.GUID, 0, SquadAction.CancelSquadSearch()))
+            //TODO positive squad search results message?
+//          if(results.nonEmpty) {
+//            results.foreach { guid =>
+//              sendResponse(SquadDefinitionActionMessage(
+//                guid,
+//                0,
+//                SquadAction.SquadListDecorator(SquadListDecoration.SearchResult))
+//              )
+//            }
+//          } else {
+//            sendResponse(SquadDefinitionActionMessage(player.GUID, 0, SquadAction.NoSquadSearchResults()))
+//          }
+//          sendResponse(SquadDefinitionActionMessage(player.GUID, 0, SquadAction.CancelSquadSearch()))
 
         case SquadResponse.InitWaypoints(char_id, waypoints) =>
           waypoints.foreach {

--- a/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionSquadHandlers.scala
@@ -55,17 +55,17 @@ class SessionSquadHandlers(
   /* packet */
 
   def handleSquadDefinitionAction(pkt: SquadDefinitionActionMessage): Unit = {
-//    val SquadDefinitionActionMessage(u1, u2, action) = pkt
-//    squadService ! SquadServiceMessage(player, continent, SquadServiceAction.Definition(u1, u2, action))
+    val SquadDefinitionActionMessage(u1, u2, action) = pkt
+    squadService ! SquadServiceMessage(player, continent, SquadServiceAction.Definition(u1, u2, action))
   }
 
   def handleSquadMemberRequest(pkt: SquadMembershipRequest): Unit = {
-//    val SquadMembershipRequest(request_type, char_id, unk3, player_name, unk5) = pkt
-//    squadService ! SquadServiceMessage(
-//      player,
-//      continent,
-//      SquadServiceAction.Membership(request_type, char_id, unk3, player_name, unk5)
-//    )
+    val SquadMembershipRequest(request_type, char_id, unk3, player_name, unk5) = pkt
+    squadService ! SquadServiceMessage(
+      player,
+      continent,
+      SquadServiceAction.Membership(request_type, char_id, unk3, player_name, unk5)
+    )
   }
 
   def handleSquadWaypointRequest(pkt: SquadWaypointRequest): Unit = {

--- a/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
@@ -426,14 +426,14 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
         Refused(rejectingPlayer, invitingPlayerCharId)
         (Some(rejectingPlayer), Some(invitingPlayerCharId))
 
-      case Some(VacancyInvite(leader, _, features))
-        if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejectingPlayer) =>
+      case Some(VacancyInvite(leader, _, _))
+        /*if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejectingPlayer)*/ =>
         //rejectingPlayer is the would-be squad member; the squad leader sent the request and was rejected
         Refused(rejectingPlayer, leader)
         (Some(rejectingPlayer), Some(leader))
 
       case Some(ProximityInvite(_, features, position))
-        if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejectingPlayer) =>
+        /*if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejectingPlayer)*/ =>
         //rejectingPlayer is the would-be squad member; the squad leader sent the request and was rejected
         ReloadProximityInvite(
           tplayer.Zone.Players,
@@ -2028,7 +2028,8 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
           avatar.lookingForSquad &&
           !deniedAndExcluded.contains(charId) &&
           !refused(charId).contains(squadLeader) &&
-          requirementsToMeet.intersect(avatar.certifications) == requirementsToMeet
+          requirementsToMeet.intersect(avatar.certifications) == requirementsToMeet &&
+          charId != invitingPlayerCharId //don't send invite to yourself. can cause issues if rejected
       } match {
       case None =>
         None

--- a/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
@@ -165,7 +165,7 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
     val availableForJoiningSquad = notLimitedByEnrollmentInSquad(invitedPlayerSquadOpt, invitedPlayer)
     acceptedInvite match {
       case Some(RequestRole(petitioner, features, position))
-        if availableForJoiningSquad && canEnrollInSquad(features, petitioner.CharId) =>
+        if canEnrollInSquad(features, petitioner.CharId) =>
         //player requested to join a squad's specific position
         //invitedPlayer is actually the squad leader; petitioner is the actual "invitedPlayer"
         if (JoinSquad(petitioner, features, position)) {
@@ -174,7 +174,7 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
         }
 
       case Some(IndirectInvite(recruit, features))
-        if availableForJoiningSquad && canEnrollInSquad(features, recruit.CharId) =>
+        if canEnrollInSquad(features, recruit.CharId) =>
         //tplayer / invitedPlayer is actually the squad leader
         val recruitCharId = recruit.CharId
         HandleVacancyInvite(features, recruitCharId, invitedPlayer, recruit) match {
@@ -456,7 +456,7 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
         (Some(rejectingPlayer), Some(leaderCharId))
 
       case Some(RequestRole(rejected, features, _))
-        if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejectingPlayer) =>
+        if notLeaderOfThisSquad(squadsToLeaders, features.Squad.GUID, rejected.CharId) =>
         //rejected is the would-be squad member; rejectingPlayer is the squad leader who rejected the request
         features.DeniedPlayers(rejected.CharId)
         (Some(rejectingPlayer), None)

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -76,7 +76,7 @@ class SquadService extends Actor {
     //squads and members (users)
     squadFeatures.foreach {
       case (_, features) =>
-        CloseSquad(features.Squad)
+        DisbandSquad(features)
     }
     memberToSquad.clear()
     publishedLists.clear()
@@ -686,10 +686,10 @@ class SquadService extends Actor {
         }
         None
       case search: SearchForSquadsWithParticularRole =>
-        SquadActionDefinitionSearchForSquadsWithParticularRole(tplayer, search)
+//        SquadActionDefinitionSearchForSquadsWithParticularRole(tplayer, search)
         None
       case _: CancelSquadSearch =>
-        SquadActionDefinitionCancelSquadSearch(tplayer.CharId)
+//        SquadActionDefinitionCancelSquadSearch(tplayer.CharId)
         None
       case _: DisplaySquad =>
         GetSquad(guid) match {

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -863,6 +863,11 @@ class SquadService extends Actor {
     val sguid        = GetNextSquadId()
     val squad        = new Squad(sguid, faction)
     val leadPosition = squad.Membership(0)
+    //keep publishedLists clear of old squads. PR 1157 for details
+    val factionListings = publishedLists(faction)
+    val guidsToRemove = factionListings.filterNot(squadFeatures.contains).toList
+    guidsToRemove.foreach(factionListings -= _)
+
     leadPosition.Name = name
     leadPosition.CharId = player.CharId
     leadPosition.Health = StatConverter.Health(player.Health, player.MaxHealth, min = 1, max = 64)

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -1101,10 +1101,7 @@ class SquadService extends Actor {
           GetLeadingSquad(charId, pSquadOpt) match {
             case Some(_) =>
               //leader of a squad; the squad will be disbanded. Same logic as when a SL uses /leave and the squad is disbanded.
-              PanicDisbandSquad(
-                features,
-                squad.Membership.collect { case member if member.CharId > 0 && member.CharId != charId => member.CharId }
-              )
+              DisbandSquad(features)
             case None =>
               //not the leader of a full squad; tell other members that we are leaving
               SquadSwitchboard.PanicLeaveSquad(
@@ -1118,10 +1115,7 @@ class SquadService extends Actor {
           }
         } else {
           //with only two members before our leave, the squad will be disbanded
-          PanicDisbandSquad(
-            features,
-            squad.Membership.collect { case member if member.CharId > 0 && member.CharId != charId => member.CharId }
-          )
+          DisbandSquad(features)
         }
       case None =>
         //not a member of any squad; nothing really to do here

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -1015,12 +1015,10 @@ class SquadService extends Actor {
           subs.Publish(charId, SquadResponse.Detail(PlanetSideGUID(0), completelyBlankSquadDetail))
       }
     UpdateSquadListWhenListed(features.Stop, None)
+    //remove from list of squads
     squadFeatures -= guid
-    //really make sure it is removed
+    //really make sure it is removed from listed squads
     publishedLists(squad.Faction) -= guid
-    //testing
-    println(s"AllSquads Removed: $guid - Remaining: $squadFeatures")
-    println(s"ListedSquads: $publishedLists")
   }
 
   /**

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -1009,6 +1009,8 @@ class SquadService extends Actor {
           subs.Publish(charId, SquadResponse.Detail(PlanetSideGUID(0), completelyBlankSquadDetail))
       }
     UpdateSquadListWhenListed(features.Stop, None)
+    //I think this is right, otherwise squadFeatures will never be empty and TryResetSquadId will not reset to 1
+    squadFeatures.remove(guid)
   }
 
   /**

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -377,7 +377,7 @@ class SquadService extends Actor {
         SquadActionMembershipCancel(cancellingPlayer)
 
       case SquadAction.Membership(SquadRequestType.Promote, promotingPlayer, Some(_promotedPlayer), promotedName, _) =>
-        SquadActionMembershipPromote(promotingPlayer, _promotedPlayer, promotedName, SquadServiceMessage(tplayer, zone, action), sender())
+        //SquadActionMembershipPromote(promotingPlayer, _promotedPlayer, promotedName, SquadServiceMessage(tplayer, zone, action), sender())
 
       case SquadAction.Membership(event, _, _, _, _) =>
         debug(s"SquadAction.Membership: $event is not yet supported")

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -1095,7 +1095,7 @@ class SquadService extends Actor {
         if (size > 2) {
           GetLeadingSquad(charId, pSquadOpt) match {
             case Some(_) =>
-              //leader of a squad; the squad will be disbanded. Same logic as when a SL uses /leave and the squad is disband.
+              //leader of a squad; the squad will be disbanded. Same logic as when a SL uses /leave and the squad is disbanded.
               PanicDisbandSquad(
                 features,
                 squad.Membership.collect { case member if member.CharId > 0 && member.CharId != charId => member.CharId }

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -974,7 +974,6 @@ class SquadService extends Actor {
   def CloseSquad(squad: Squad): Unit = {
     val guid = squad.GUID
     val membership = squad.Membership.zipWithIndex
-    val factionListings = publishedLists(squad.Faction)
     val (updateMembers, updateIndices) = membership.collect {
       case (member, index) if member.CharId > 0 =>
         ((member, member.CharId, index, subs.UserEvents.get(member.CharId)), (member.CharId, index))
@@ -1011,15 +1010,12 @@ class SquadService extends Actor {
           subs.Publish(charId, SquadResponse.Detail(PlanetSideGUID(0), completelyBlankSquadDetail))
       }
     UpdateSquadListWhenListed(features.Stop, None)
-    //I think this is right, otherwise squadFeatures will never be empty and TryResetSquadId will not reset to 1
-    squadFeatures.remove(guid)
-    //for the rare case of a phantom squad that no longer exists but is still on the publishedLists
-    factionListings.find(_ == guid) match {
-      case Some(squad) =>
-        val index = factionListings.indexOf(squad)
-        factionListings.remove(index)
-      case None =>
-    }
+    squadFeatures -= guid
+    //really make sure it is removed
+    publishedLists(squad.Faction) -= guid
+    //testing
+    println(s"AllSquads Removed: $guid - Remaining: $squadFeatures")
+    println(s"ListedSquads: $publishedLists")
   }
 
   /**

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -950,6 +950,7 @@ class SquadService extends Actor {
     membership.find { case (_member, _) => _member.CharId == charId } match {
       case Some(_) if squad.Leader.CharId != charId =>
         memberToSquad.remove(charId)
+        subs.MonitorSquadDetails.subtractOne(charId)
         features.Switchboard ! SquadSwitchboard.Leave(charId)
         true
       case _ =>

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -1084,7 +1084,7 @@ class SquadService extends Actor {
     pSquadOpt match {
       //member of the squad; leave the squad
       case Some(features) =>
-        LeaveSquad(charId, features)
+        LeaveSquad(charId, features) //adding this fixed issue of rejoining the squad on login.
         val squad = features.Squad
         val size = squad.Size
         subs.UserEvents.remove(charId) match {

--- a/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
@@ -171,7 +171,7 @@ class SquadSwitchboard(
       //update for leader
       features.InitialAssociation = false
       subscriptions.Publish(leaderId, SquadResponse.IdentifyAsSquadLeader(squad.GUID))
-      subscriptions.Publish(leaderId, SquadResponse.CharacterKnowledge(charId, role.Name, role.Certifications, 40, 5, role.ZoneId))
+      subscriptions.Publish(leaderId, SquadResponse.CharacterKnowledge(charId, role.Name, role.Certifications, player.avatar.br.value, player.avatar.cr.value, role.ZoneId))
       //everyone
       subscriptions.InitSquadDetail(features)
     } else {
@@ -200,7 +200,7 @@ class SquadSwitchboard(
       )
       subscriptions.Publish(toChannel, SquadResponse.Join(squad, List(position), "", self), Seq(charId))
       //update for leader
-      subscriptions.Publish(leaderId, SquadResponse.CharacterKnowledge(charId, role.Name, role.Certifications, 40, 5, role.ZoneId))
+      subscriptions.Publish(leaderId, SquadResponse.CharacterKnowledge(charId, role.Name, role.Certifications, player.avatar.br.value, player.avatar.cr.value, role.ZoneId))
       subscriptions.SquadEvents.subscribe(sendTo, s"/$toChannel/Squad")
       subscriptions.InitSquadDetail(squad.GUID, Seq(charId), squad)
     }
@@ -729,6 +729,7 @@ class SquadSwitchboard(
           _.CharId == promotedPlayer
         }
         .foreach { member =>
+          //todo: get member br & cr to replace 40, 5
           subscriptions.Publish(promotedPlayer, SquadResponse.CharacterKnowledge(member.CharId, member.Name, member.Certifications, 40, 5, member.ZoneId))
         }
       //to old and to new squad leader
@@ -904,18 +905,18 @@ class SquadSwitchboard(
           if (leaderCharId != charId) {
             subscriptions.Publish(
               leaderCharId,
-              SquadResponse.CharacterKnowledge(charId, member.Name, certifications, 40, 5, zoneNumber)
+              SquadResponse.CharacterKnowledge(charId, member.Name, certifications, player.avatar.br.value, player.avatar.cr.value, zoneNumber)
             )
           }
           context.parent ! SquadServiceMessage(player, player.Zone, SquadAction.ReloadDecoration())
         } else if (zoneBefore != zoneNumber && leaderCharId != charId) {
           subscriptions.Publish(
             leaderCharId,
-            SquadResponse.CharacterKnowledge(charId, member.Name, certifications, 40, 5, 0)
+            SquadResponse.CharacterKnowledge(charId, member.Name, certifications, player.avatar.br.value, player.avatar.cr.value, 0)
           )
           subscriptions.Publish(
             leaderCharId,
-            SquadResponse.CharacterKnowledge(charId, member.Name, certifications, 40, 5, zoneNumber)
+            SquadResponse.CharacterKnowledge(charId, member.Name, certifications, player.avatar.br.value, player.avatar.cr.value, zoneNumber)
           )
         }
         if (features.LocationFollowsSquadLead) {

--- a/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
@@ -177,7 +177,6 @@ class SquadSwitchboard(
     } else {
       //joining an active squad; different people update differently
       //new member gets full squad UI updates
-      subscriptions.InitSquadDetail(squad.GUID, Seq(charId), squad)
       subscriptions.Publish(
         charId,
         SquadResponse.Join(
@@ -203,6 +202,7 @@ class SquadSwitchboard(
       //update for leader
       subscriptions.Publish(leaderId, SquadResponse.CharacterKnowledge(charId, role.Name, role.Certifications, 40, 5, role.ZoneId))
       subscriptions.SquadEvents.subscribe(sendTo, s"/$toChannel/Squad")
+      subscriptions.InitSquadDetail(squad.GUID, Seq(charId), squad)
     }
     context.parent ! SquadService.UpdateSquadListWhenListed(
       features,

--- a/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
@@ -653,7 +653,7 @@ class SquadSwitchboard(
     if (squad.Leader.CharId == char_id) {
       membership.lift(position) match {
         case Some(toMember) =>
-          SquadActionMembershipPromote(char_id, toMember.CharId)
+          //SquadActionMembershipPromote(char_id, toMember.CharId)
         case _ => ;
       }
     } else {
@@ -684,7 +684,7 @@ class SquadSwitchboard(
   def SquadActionMembership(action: Any): Unit = {
     action match {
       case SquadAction.Membership(SquadRequestType.Promote, promotingPlayer, Some(promotedPlayer), _, _) =>
-        SquadActionMembershipPromote(promotingPlayer, promotedPlayer)
+        //SquadActionMembershipPromote(promotingPlayer, promotedPlayer)
 
       case SquadAction.Membership(event, _, _, _, _) =>
         log.debug(s"SquadAction.Membership: $event is not supported here")


### PR DESCRIPTION
Turned squads back on for those so inclined to test them to see what actions cause issues with them.

**Running list of known "issues" (will add things that others discover here):**
-Squad cards remains on screen after a squad disbands or when you log back in if you were in a squad when the client closed. Pressing Alt makes it go away. You are not actually still in the squad; it is just a UI thing that doesn't happen.

-If you join a squad while you are dead and respawning or in the middle of zoning, some things do not appear. Squad cards, numbers on map, and squad tab do not show other squad members. Squad chat is visible. This applies to both a to-be SL or a player joining an already formed squad. Leaving and rejoining fixes. As long as you are alive or just simply deconstructing UI elements appear properly.

-There is an issue with a squad Id being reused after the count is reset. See below comment. For now, the Id is not being reset anymore if no squads exist.

-Rejoining a squad can cause your client to go to the character select screen. It seems to only happen above a certain squad size (6-7+), but it doesn't happen every time.

-Squad searching has been disabled. Error detailed below.

-If the same player is invited to multiple squads and they join the first, the 2nd inviting player will see the chat message that they invited the player, but no indication that they already joined another squad. If the player then leaves the squad, the 2nd person cannot invite them again. The receiving player never receives the new invite.

-Promoting a new SL has been disabled. SL changing could sometimes cause issues that were hard to reproduce. You want to be SL? Make a new squad.