### PR TITLE
More Experience Fixes

### DIFF
--- a/server/src/main/resources/db/migration/V012__ScoringPatch3.sql
+++ b/server/src/main/resources/db/migration/V012__ScoringPatch3.sql
@@ -1,0 +1,3 @@
+/* Original: V008__Scoring.sql */
+ALTER TABLE assistactivity
+RENAME COLUMN attacker_id TO killer_id;

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -332,11 +332,13 @@ game {
         # The kill event must have been the exact previous life's death after revive or respawn.
         # This only applies if experience is set to 0.
         # Set to zero and experience = 0 to ignore revenge.
-        rate = 0.15
+        rate = 0.05
         # If player A kills another player B who killed player A just previously, deposit this experience.
         # The kill event must have been the exact previous life's death after revive or respawn.
         # Set to zero to reuse the experience value from the previous kill event.
-        experience = 0
+        default-experience = 0
+        # When using the experience from the previous kill for revenge bonus, cap the reward at this value.
+        max-experience = 350
       }
     }
 

--- a/src/main/scala/net/psforever/objects/definition/converter/CaptureFlagConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/CaptureFlagConverter.scala
@@ -7,7 +7,6 @@ import net.psforever.objects.sourcing.PlayerSource
 import net.psforever.packet.game.objectcreate.{CaptureFlagData, PlacementData}
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
-import java.util.concurrent.TimeUnit
 import scala.util.{Success, Try}
 
 class CaptureFlagConverter extends ObjectCreateConverter[CaptureFlag]() {

--- a/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/Building.scala
@@ -19,8 +19,6 @@ import net.psforever.objects.serverobject.llu.{CaptureFlag, CaptureFlagSocket}
 import net.psforever.objects.serverobject.structures.participation.{MajorFacilityHackParticipation, NoParticipation, ParticipationLogic, TowerHackParticipation}
 import net.psforever.objects.serverobject.terminals.capture.CaptureTerminal
 
-import java.util.concurrent.TimeUnit
-
 class Building(
                 private val name: String,
                 private val building_guid: Int,

--- a/src/main/scala/net/psforever/objects/zones/exp/Support.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/Support.scala
@@ -44,6 +44,7 @@ object Support {
       fullLifespan
     )
     if (shortLifeBonus > TheShortestLifeIsWorth) {
+      //long life factors
       val longLifeBonus: Long = {
         val threat = baseExperienceLongLifeFactors(victim, recordOfWornTimes, defaultValue = 100f * shortLifeBonus.toFloat)
         if (withKills) {
@@ -52,7 +53,6 @@ object Support {
           (threat * 0.85f).toLong
         }
       }
-      //long life factors
       shortLifeBonus + longLifeBonus
     } else {
       //the shortest life is afforded no additional bonuses

--- a/src/main/scala/net/psforever/objects/zones/exp/rec/RecoveryExperienceContribution.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/rec/RecoveryExperienceContribution.scala
@@ -52,7 +52,7 @@ object RecoveryExperienceContribution {
               recoveryParticipants.put(
                 id,
                 entry.copy(
-                  weapons = weapons.head.copy(amount = math.max(0, weapons.head.amount - ramt), time = time) +: weapons.tail,
+                  weapons = weapons.head.copy(amount = math.max(0, weapons.head.amount - ramt), time = time) +: weapons.drop(1),
                   amount = math.max(0, entry.amount - ramt),
                   time = time
                 )
@@ -65,7 +65,7 @@ object RecoveryExperienceContribution {
               recoveryParticipants.put(
                 id,
                 entry.copy(
-                  weapons = weapons.tail :+ weapons.head.copy(amount = 0, time = time),
+                  weapons = weapons.drop(1) :+ weapons.head.copy(amount = 0, time = time),
                   amount = math.max(0, entry.amount - ramt),
                   time = time
                 )
@@ -214,7 +214,7 @@ object RecoveryExperienceContribution {
             recoveryParticipants.put(
               charId,
               entry.copy(
-                weapons = head.copy(amount = head.amount + amtToGain, shots = head.shots + 1, time = time) +: entry.weapons.tail,
+                weapons = head.copy(amount = head.amount + amtToGain, shots = head.shots + 1, time = time) +: entry.weapons.drop(1),
                 amount = entry.amount + amtToGain,
                 total = entry.total + amtToGain,
                 shots = entry.shots + 1,

--- a/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/ReplicationStreamMessage.scala
@@ -523,7 +523,7 @@ object SquadHeader {
       linkedInfo
     } else {
       val (code, data) = infoList.head
-      linkSquadInfo(infoList.tail, LinkedSquadInfo(code, data, Some(linkedInfo)))
+      linkSquadInfo(infoList.drop(1), LinkedSquadInfo(code, data, Some(linkedInfo)))
     }
   }
 

--- a/src/main/scala/net/psforever/packet/game/SquadDetailDefinitionUpdateMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/SquadDetailDefinitionUpdateMessage.scala
@@ -916,7 +916,7 @@ object SquadDetailDefinitionUpdateMessage extends Marshallable[SquadDetailDefini
         out
       } else {
         val (code, data) = list.head
-        linkFields(list.tail, LinkedFields(code, data, Some(out)))
+        linkFields(list.drop(1), LinkedFields(code, data, Some(out)))
       }
     }
 
@@ -1184,7 +1184,7 @@ object SquadDetailDefinitionUpdateMessage extends Marshallable[SquadDetailDefini
         out
       } else {
         val (code, data) = list.head
-        linkFields(list.tail, LinkedFields(code, data, Some(out)))
+        linkFields(list.drop(1), LinkedFields(code, data, Some(out)))
       }
     }
 

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -284,7 +284,8 @@ case class BattleExperiencePointsLifespan(
 
 case class BattleExperiencePointsRevenge(
     rate: Float,
-    experience: Long
+    defaultExperience: Long,
+    maxExperience: Long
 )
 
 case class SupportExperiencePoints(


### PR DESCRIPTION
1.  Fixed issue caused by calling `tail` on an empty list, which doesn't work
2.  Revenge kill experience rate down (0.15 -> 0.05) and value is capped