### PR TITLE
Death By EMP

### DIFF
--- a/src/main/scala/net/psforever/objects/SpecialEmp.scala
+++ b/src/main/scala/net/psforever/objects/SpecialEmp.scala
@@ -118,8 +118,8 @@ object SpecialEmp {
         case _                  => OwnerGuid_=(Some(owner.GUID))
       }
       Position = position
-      def Faction = faction
-      def Definition = proxy_definition
+      def Faction: PlanetSideEmpire.Value = faction
+      def Definition: ObjectDefinition with VitalityDefinition = proxy_definition
     })
   }
 

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleCapacitance.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleCapacitance.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 PSForever
 package net.psforever.objects.vehicles.control
 
-import akka.actor.Actor
+import akka.actor.{Actor, Cancellable}
 import net.psforever.objects._
 import net.psforever.services.Service
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
@@ -16,7 +16,7 @@ trait VehicleCapacitance {
   _: Actor =>
   def CapacitanceObject: Vehicle
 
-  protected var capacitor = Default.Cancellable
+  protected var capacitor: Cancellable = Default.Cancellable
 
   startCapacitorTimer()
 

--- a/src/main/scala/net/psforever/objects/vital/etc/EmpReason.scala
+++ b/src/main/scala/net/psforever/objects/vital/etc/EmpReason.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2021 PSForever
 package net.psforever.objects.vital.etc
 
-import net.psforever.objects.PlanetSideGameObject
+import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.objects.serverobject.affinity.FactionAffinity
-import net.psforever.objects.sourcing.SourceEntry
+import net.psforever.objects.sourcing.{SourceEntry, VehicleSource}
 import net.psforever.objects.vital.Vitality
 import net.psforever.objects.vital.base.{DamageReason, DamageResolution}
 import net.psforever.objects.vital.prop.DamageWithPosition
@@ -41,6 +41,10 @@ object EmpReason {
              source: DamageWithPosition,
              target: PlanetSideGameObject with Vitality
            ): EmpReason = {
-    EmpReason(SourceEntry(owner), source, target.DamageModel, owner.Definition.ObjectId)
+    val ownerSource = owner match {
+      case v: Vehicle => VehicleSource(v).occupants.head
+      case _ => SourceEntry(owner)
+    }
+    EmpReason(ownerSource, source, target.DamageModel, owner.Definition.ObjectId)
   }
 }


### PR DESCRIPTION
No longer can drivers hide their war crimes behind their vehicles.

Funny story, I should be able to sufficiently prove that this issue was resolved by dropping an APC EMP on someone's head and then telling them to `/suicide`.  And I did do that.  But, as explosions are intended to inherit information from the source and carry it down a potential chain of detonations to reach victim, I decided to go the full nine yards in this test. I spawned a whole APC with one character and waited the whole time until it was ready to pop.  I had another character on a different faction set up an HE mine and a Spitfire outside of their facility, then dropped a teleported APC on that character's head, just to kill him with an EMP blast that destroyed the HE mine that destroyed the Spitfire that destroyed him.  The APC then teleported back to where it originally was as if nothing had happened.  Sucked to be that guy.