### PR TITLE
The Walls (Do Not) Have Ears

### DIFF
--- a/src/main/scala/net/psforever/objects/serverobject/turret/auto/AutomatedTurret.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/auto/AutomatedTurret.scala
@@ -3,13 +3,15 @@ package net.psforever.objects.serverobject.turret.auto
 
 import net.psforever.objects.definition.ObjectDefinition
 import net.psforever.objects.serverobject.PlanetSideServerObject
+import net.psforever.objects.serverobject.interior.InteriorAware
 import net.psforever.objects.serverobject.turret.{TurretDefinition, WeaponTurret}
 import net.psforever.objects.sourcing.{SourceEntry, SourceUniqueness}
 import net.psforever.objects.vital.Vitality
 
 trait AutomatedTurret
   extends PlanetSideServerObject
-    with WeaponTurret {
+    with WeaponTurret
+    with InteriorAware {
   import AutomatedTurret.Target
   private var currentTarget: Option[Target] = None
 
@@ -66,5 +68,5 @@ trait AutomatedTurret
 }
 
 object AutomatedTurret {
-  type Target = PlanetSideServerObject with Vitality
+  type Target = PlanetSideServerObject with Vitality with InteriorAware
 }


### PR DESCRIPTION
If you're inside a facility, turrets outside the facility should ignore you during their target prowling phase.

Note that the main benefit of this change is that you will not hear turrets trying to shoot you in certain situations where they would not hit you normally, i.e., through exterior walls.  This change will not stop a turret from trying to shoot at you from in the facility courtyard while you are outside the rampart walls as those are both exterior locations.  I must reiterate that **NO OTHER PLAYER EVER HEARS TURRETS ATTEMPTING TO FIND YOU EXCEPT YOU ANYWAY** so this is more annoyance level down than anything.