### PR TITLE
No More Kill Trades?

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2208,6 +2208,8 @@ class SessionData(
         // auto kick players damaging spectators
         if (obj.spectator && obj != player) {
           administrativeKick(player)
+        } else if (!player.isAlive) {
+
         } else {
           obj.Actor ! Vitality.Damage(func)
         }

--- a/src/main/scala/net/psforever/actors/session/support/SessionData.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionData.scala
@@ -2208,8 +2208,6 @@ class SessionData(
         // auto kick players damaging spectators
         if (obj.spectator && obj != player) {
           administrativeKick(player)
-        } else if (!player.isAlive) {
-
         } else {
           obj.Actor ! Vitality.Damage(func)
         }

--- a/src/main/scala/net/psforever/actors/session/support/WeaponAndProjectileOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/WeaponAndProjectileOperations.scala
@@ -609,11 +609,13 @@ private[support] class WeaponAndProjectileOperations(
           if (tool.Magazine <= 0) { //safety: enforce ammunition depletion
             prefire -= weaponGUID
             EmptyMagazine(weaponGUID, tool)
+            (o, Some(tool))
           } else if (!player.isAlive) { //proper internal accounting, but no projectile
             prefire += weaponGUID
             tool.Discharge()
             projectiles(projectileGUID.guid - Projectile.baseUID) = None
             shotsWhileDead += 1
+            (None, None)
           } else { //shooting
             if (
               avatar.stamina > 0 &&
@@ -628,8 +630,8 @@ private[support] class WeaponAndProjectileOperations(
             tool.Discharge()
             prefire += weaponGUID
             addShotsFired(tool.Definition.ObjectId, tool.AmmoSlot.Chamber)
+            (o, Some(tool))
           }
-          (o, Some(tool))
       }
       collectedTools.headOption.getOrElse((None, None))
     } else {


### PR DESCRIPTION
Tested for a while with WeaponAndProjectileOperations HandleWeaponFireAccountability and couldn't get the projectiles to not do damage if the player shooting was dead according to the server. I then opted to try another way of doing it and from my testing there was a 0% kill trade rate. I just told the server to do nothing (not calculate damage) if the shooting player is dead. It would still log SHOTS_WHILE_DEAD, but those shots do no damage so it looks like a win. Hope you have lower ping than your adversary.