### PR TITLE
Scoring

### DIFF
--- a/src/main/scala/net/psforever/objects/serverobject/structures/participation/TowerHackParticipation.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/participation/TowerHackParticipation.scala
@@ -132,12 +132,12 @@ final case class TowerHackParticipation(building: Building) extends FacilityHack
           overwhelmingOddsBonus = 30L
         )
         //6. calculate overall command experience points
-        val finalCep: Long = math.ceil(
+        val finalCep: Long = 10L /*math.ceil(
           baseExperienceFromFacilityCapture *
             populationModifier *
             competitionMultiplier *
             Config.app.game.experience.cep.rate + competitionBonus
-        ).toLong
+        ).toLong*/
         //7. reward participants
         //Classically, only players in the SOI are rewarded
         //terminal hacker (always cep)

--- a/src/main/scala/net/psforever/objects/zones/exp/KillAssists.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/KillAssists.scala
@@ -190,10 +190,12 @@ object KillAssists {
           val victimUnique = victim.unique
           val lastDeath = killer.progress.prior.flatMap(_.death)
           val sameLastKiller = lastDeath.map(_.assailant.map(_.unique)).flatMap(_.headOption).contains(victimUnique)
-          if (revenge.defaultExperience != 0 && sameLastKiller) {
-            revenge.defaultExperience
-          } else if (sameLastKiller) {
-            math.min(revenge.maxExperience, (lastDeath.map(_.experienceEarned.toFloat).getOrElse(0f) * revenge.rate).toLong)
+          if (sameLastKiller) {
+            if (revenge.defaultExperience != 0) {
+              revenge.defaultExperience
+            } else {
+              math.min(revenge.maxExperience, (lastDeath.map(_.experienceEarned.toFloat).getOrElse(0f) * revenge.rate).toLong)
+            }
           } else {
             0L
           }

--- a/src/main/scala/net/psforever/objects/zones/exp/Support.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/Support.scala
@@ -242,7 +242,7 @@ object Support {
           individualThreatEstimates.filter(_._1 < 10)
         } else {
           individualThreatEstimates.filter(_._1 > 10)
-        }).maxBy(_._2)._1,
+        }).maxByOption(_._2).map(_._1).getOrElse(0),
         defaultValue
       )
     }


### PR DESCRIPTION
This resolution was decided after it was determined towers, which should never have given CEP upon capture or defense in the first place, were giving an inordinate amount of CEP under certain circumstances.  I am aware that capture CEP for major facilities is currently bugged - someone else is working on that issue.  Despite tower CEP being incorrect, as mentioned, maintaining it as is benefits healthy testing for future CEP corrections, so it will remain for the time being, but with a flat and severe reduction.

You will get 10 CEP for a tower capture event and you will like it.

Additionally, everyone's CEP will be reset to ~zero.  Most CEP in the database comes form towers anyway.  LLU CEP might be restored since it has nothing to do with towers.  Differentiating between major facilities and towers in the database entries is currently not possible.  Database entries for facilities captured and LLU carrying / hunting will not be affected.

Reminder: CEP currently does little but grant drip.