### PR TITLE
Multiple Game World Ports

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,6 +20,7 @@ login {
 world {
   # UDP listening port
   port = 51001
+  ports = [51003, 51004, 51005, 51006, 51007, 51008, 51009, 51010]
 
   # The name of the server as displayed in the server browser.
   server-name = PSForever

--- a/src/main/scala/net/psforever/actors/net/LoginActor.scala
+++ b/src/main/scala/net/psforever/actors/net/LoginActor.scala
@@ -23,14 +23,13 @@ import scala.util.{Failure, Success}
 
 /*
 object LoginActor {
-  def apply(
+  /ef apply(
       middlewareActor: typed.ActorRef[MiddlewareActor.Command],
       uuid: String
   ): Behavior[Command] =
     Behaviors.setup(context => new LoginActor(context, middlewareActor, uuid).start())
 
   sealed trait Command
-
 }
 
 class LoginActor(
@@ -42,7 +41,6 @@ class LoginActor(
     Behaviors.receiveMessagePartial {}
   }
 }
-
  */
 
 class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], connectionId: String, sessionId: Long)
@@ -110,7 +108,11 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
 
       case ConnectToWorldRequestMessage(name, _, _, _, _, _, _, _) =>
         log.info(s"Connect to world request for '$name'")
-        val response = ConnectToWorldMessage(serverName, publicAddress.getAddress.getHostAddress, publicAddress.getPort)
+        val response = ConnectToWorldMessage(
+          serverName,
+          publicAddress.getAddress.getHostAddress,
+          SocketPane.Rotation.NextPort
+        )
         middlewareActor ! MiddlewareActor.Send(response)
         middlewareActor ! MiddlewareActor.Close()
 

--- a/src/main/scala/net/psforever/actors/net/LoginActor.scala
+++ b/src/main/scala/net/psforever/actors/net/LoginActor.scala
@@ -1,7 +1,10 @@
 package net.psforever.actors.net
 
+import akka.actor.typed.receptionist.Receptionist
+
 import java.net.{InetAddress, InetSocketAddress}
 import akka.actor.{Actor, ActorRef, Cancellable, MDCContextAware, typed}
+import akka.actor.typed.scaladsl.adapter._
 import com.github.t3hnar.bcrypt._
 import net.psforever.objects.{Account, Default}
 import net.psforever.packet.PlanetSideGamePacket
@@ -17,31 +20,18 @@ import net.psforever.util.Database._
 
 import java.security.MessageDigest
 import org.joda.time.LocalDateTime
+
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.matching.Regex
 import scala.util.{Failure, Success}
 
-/*
 object LoginActor {
-  /ef apply(
-      middlewareActor: typed.ActorRef[MiddlewareActor.Command],
-      uuid: String
-  ): Behavior[Command] =
-    Behaviors.setup(context => new LoginActor(context, middlewareActor, uuid).start())
-
   sealed trait Command
-}
 
-class LoginActor(
-    middlewareActor: typed.ActorRef[MiddlewareActor.Command],
-    uuid: String
-) {
-
-  def start(): Unit = {
-    Behaviors.receiveMessagePartial {}
-  }
+  final case class ReceptionistListing(listing: Receptionist.Listing) extends Command
 }
- */
 
 class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], connectionId: String, sessionId: Long)
     extends Actor
@@ -51,11 +41,12 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
 
   private case class UpdateServerList()
 
-  val usernameRegex = """[A-Za-z0-9]{3,}""".r
+  val usernameRegex: Regex = """[A-Za-z0-9]{3,}""".r
 
-  var leftRef: ActorRef             = ActorRef.noSender
-  var rightRef: ActorRef            = ActorRef.noSender
-  var accountIntermediary: ActorRef = ActorRef.noSender
+  var leftRef: ActorRef             = Default.Actor
+  var rightRef: ActorRef            = Default.Actor
+  var accountIntermediary: ActorRef = Default.Actor
+  var sockets: typed.ActorRef[SocketPane.Command] = Default.typed.Actor
 
   var updateServerListTask: Cancellable = Default.Cancellable
 
@@ -64,14 +55,15 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
   var canonicalHostName: String = ""
   var port: Int                 = 0
 
-  val serverName    = Config.app.world.serverName
+  val serverName: String = Config.app.world.serverName
   val publicAddress = new InetSocketAddress(InetAddress.getByName(Config.app.public), Config.app.world.port)
 
   private val bcryptRounds = 12
 
   ServiceManager.serviceManager ! Lookup("accountIntermediary")
+  ServiceManager.receptionist ! Receptionist.Find(SocketPane.SocketPaneKey, context.self)
 
-  override def postStop() = {
+  override def postStop(): Unit = {
     if (updateServerListTask != null)
       updateServerListTask.cancel()
   }
@@ -79,42 +71,46 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
   def receive: Receive = {
     case ServiceManager.LookupResult("accountIntermediary", endpoint) =>
       accountIntermediary = endpoint
+
+    case SocketPane.SocketPaneKey.Listing(listings) =>
+      sockets = listings.head
+
     case ReceiveIPAddress(address) =>
       ipAddress = address.Address
       hostName = address.HostName
       canonicalHostName = address.CanonicalHostName
       port = address.Port
+
     case UpdateServerList() =>
       updateServerList()
+
     case packet: PlanetSideGamePacket =>
       handleGamePkt(packet)
-    case default => failWithError(s"Invalid packet class received: $default")
+
+    case SocketPane.NextPort(_, address, portNum) =>
+      val response = ConnectToWorldMessage(serverName, address.getHostAddress, portNum)
+      middlewareActor ! MiddlewareActor.Send(response)
+      middlewareActor ! MiddlewareActor.Close()
+
+    case default =>
+      failWithError(s"Invalid packet class received: $default")
   }
 
-  def handleGamePkt(pkt: PlanetSideGamePacket) =
+  def handleGamePkt(pkt: PlanetSideGamePacket): Unit =
     pkt match {
       case LoginMessage(majorVersion, minorVersion, buildDate, username, password, token, revision) =>
         // TODO: prevent multiple LoginMessages from being processed in a row!! We need a state machine
-
         val clientVersion = s"Client Version: $majorVersion.$minorVersion.$revision, $buildDate"
-
         if (token.isDefined)
           log.debug(s"New login UN:$username Token:${token.get}. $clientVersion")
         else {
           log.debug(s"New login UN:$username. $clientVersion")
         }
-
-        getAccountLogin(username, password, token)
+        requestAccountLogin(username, password, token)
 
       case ConnectToWorldRequestMessage(name, _, _, _, _, _, _, _) =>
         log.info(s"Connect to world request for '$name'")
-        val response = ConnectToWorldMessage(
-          serverName,
-          publicAddress.getAddress.getHostAddress,
-          SocketPane.Rotation.NextPort
-        )
-        middlewareActor ! MiddlewareActor.Send(response)
-        middlewareActor ! MiddlewareActor.Close()
+        sockets ! SocketPane.GetNextPort("world", context.self)
 
       case _ =>
         log.warning(s"Unhandled GamePacket $pkt")
@@ -123,23 +119,19 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
   // generates a password from username and password combination
   // mimics the process the launcher follows and hashes the password salted by the username
   def generateNewPassword(username: String, password: String): String = {
-
     // salt password hash with username (like the launcher does) (username + password)
     val saltedPassword = username.concat(password)
-
     // https://stackoverflow.com/a/46332228
     // hash password (like the launcher sends)
     val hashedPassword = MessageDigest.getInstance("SHA-256")
       .digest(saltedPassword.getBytes("UTF-8"))
       .map("%02x".format(_)).mkString
-
     // bcrypt hash for DB storage
     val bcryptedPassword = hashedPassword.bcryptBounded(bcryptRounds)
-
     bcryptedPassword
   }
 
-  def getAccountLogin(username: String, passwordOpt: Option[String], tokenOpt: Option[String]): Unit = {
+  def requestAccountLogin(username: String, passwordOpt: Option[String], tokenOpt: Option[String]): Unit = {
     tokenOpt match {
       case Some(token) => accountLoginWithToken(token)
       case None        => accountLogin(username, passwordOpt.getOrElse(""))
@@ -147,9 +139,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
   }
 
   def accountLogin(username: String, password: String): Unit = {
-
     import ctx._
-
     val newToken = this.generateToken()
     val result = for {
       // backwards compatibility: prefer exact match first, then try lowercase
@@ -160,21 +150,16 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
         case Some(_) =>
           Future.successful(Seq())
       }
-
       accountOption <- accountsExact.headOption orElse accountsLower.headOption match {
-
         // account found
         case Some(account) =>
           Future.successful(Some(account))
-
         // create new account
         case None =>
           if (Config.app.login.createMissingAccounts) {
-
             // generate bcrypted passwords
             val bcryptedPassword = generateNewPassword(username, password)
             val passhash = password.bcryptBounded(bcryptRounds)
-
             // save bcrypted password hash to DB
             ctx.run(
               query[persistence.Account]
@@ -187,7 +172,6 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
             ) flatMap { id => ctx.run(query[persistence.Account].filter(_.id == lift(id))) } map { accounts =>
               Some(accounts.head)
             }
-
           } else {
             loginFailureResponse(username, newToken)
             Future.successful(None)
@@ -196,14 +180,11 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
 
       login <- accountOption match {
         case Some(account) =>
-
           // remember: this is the in client "StagingTest" login handling
           // the password is send in clear and needs to be checked against the "old" (only bcrypted) passhash
           // if there ever is a way to update the password in the future passhash and password need be updated
           (account.inactive, password.isBcryptedBounded(account.passhash)) match {
-
             case (false, true) =>
-
               accountIntermediary ! StoreAccountData(newToken, Account(account.id, account.username, account.gm))
               val future = ctx.run(
                 query[persistence.Login].insert(
@@ -214,14 +195,11 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
                   _.port              -> lift(port)
                 )
               )
-
               // handle new password
               if (account.password == "") {
-
                 // generate bcrypted password
                 // use username as provided by the user (db entry could be wrong), that is the way the launcher does it
                 val bcryptedPassword = generateNewPassword(username, password)
-
                 // update account, set password
                 ctx.run(
                   query[persistence.Account]
@@ -229,21 +207,21 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
                     .update(_.password -> lift(bcryptedPassword))
                 )
               }
-
               loginSuccessfulResponse(username, newToken)
               updateServerListTask =
                 context.system.scheduler.scheduleWithFixedDelay(0 seconds, 5 seconds, self, UpdateServerList())
               future
+
             case (_, false) =>
               loginPwdFailureResponse(username, newToken)
               Future.successful(None)
+
             case (true, _) =>
               loginAccountFailureResponse(username, newToken)
               Future.successful(None)
           }
         case None => Future.successful(None)
       }
-
     } yield login
 
     result.onComplete {
@@ -253,18 +231,12 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
   }
 
   def accountLoginWithToken(token: String): Unit = {
-
     import ctx._
-
     val newToken = this.generateToken()
     val result = for {
-
       accountsExact <- ctx.run(query[persistence.Account].filter(_.token.getOrNull == lift(token)))
-
       accountOption <- accountsExact.headOption match {
-
         case Some(account) =>
-
           // token expires after 2 hours
           // new connections and players leaving a world server will return to desktop
           if (LocalDateTime.now().isAfter(account.tokenCreated.get.plusHours(2))) {
@@ -282,9 +254,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
       login <- accountOption match {
         case Some(account) =>
           (account.inactive, account.token.getOrElse("") == token) match {
-
             case (false, true) =>
-
               accountIntermediary ! StoreAccountData(newToken, Account(account.id, account.username, account.gm))
               val future = ctx.run(
                 query[persistence.Login].insert(
@@ -295,7 +265,6 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
                   _.port -> lift(port)
                 )
               )
-
               loginSuccessfulResponseToken(account.username, token, newToken)
               updateServerListTask =
                 context.system.scheduler.scheduleWithFixedDelay(0 seconds, 5 seconds, self, UpdateServerList())
@@ -309,10 +278,8 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
               loginAccountFailureResponseToken(account.username, token, newToken)
               Future.successful(None)
           }
-
         case None => Future.successful(None)
       }
-
     } yield login
 
     result.onComplete {
@@ -321,7 +288,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     }
   }
 
-  def loginSuccessfulResponse(username: String, newToken: String) = {
+  def loginSuccessfulResponse(username: String, newToken: String): Unit = {
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
         newToken,
@@ -335,10 +302,8 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginSuccessfulResponseToken(username: String, token: String, newToken: String) = {
-
+  def loginSuccessfulResponseToken(username: String, token: String, newToken: String): Unit = {
     log.info(s"User $username logged in unsing token $token")
-
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
         newToken,
@@ -352,7 +317,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginPwdFailureResponse(username: String, newToken: String) = {
+  def loginPwdFailureResponse(username: String, newToken: String): Unit = {
     log.warning(s"Failed login to account $username")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -367,7 +332,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginFailureResponseToken(token: String, newToken: String) = {
+  def loginFailureResponseToken(token: String, newToken: String): Unit = {
     log.warning(s"Failed login using unknown token $token")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -382,7 +347,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginFailureResponseTokenExpired(token: String, newToken: String) = {
+  def loginFailureResponseTokenExpired(token: String, newToken: String): Unit = {
     log.warning(s"Failed login using expired token $token")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -397,7 +362,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginFailureResponse(username: String, newToken: String) = {
+  def loginFailureResponse(username: String, newToken: String): Unit = {
     log.warning(s"DB problem username: $username")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -412,7 +377,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginFailureResponseToken(username: String, token: String, newToken: String) = {
+  def loginFailureResponseToken(username: String, token: String, newToken: String): Unit = {
     log.warning(s"DB problem username $username token: $token")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -427,7 +392,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginAccountFailureResponse(username: String, newToken: String) = {
+  def loginAccountFailureResponse(username: String, newToken: String): Unit = {
     log.warning(s"Account $username inactive")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -442,7 +407,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def loginAccountFailureResponseToken(username: String, token: String, newToken: String) = {
+  def loginAccountFailureResponseToken(username: String, token: String, newToken: String): Unit = {
     log.warning(s"Account $username inactive token: $token ")
     middlewareActor ! MiddlewareActor.Send(
       LoginRespMessage(
@@ -457,16 +422,16 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     )
   }
 
-  def generateToken() = {
+  def generateToken(): String = {
     val r = new scala.util.Random
-    val sb = new StringBuilder
+    val sb = new mutable.StringBuilder
     for (_ <- 1 to 31) {
       sb.append(r.nextPrintableChar())
     }
     sb.toString
   }
 
-  def updateServerList() = {
+  def updateServerList(): Unit = {
     middlewareActor ! MiddlewareActor.Send(
       VNLWorldStatusMessage(
         "Welcome to PlanetSide! ",
@@ -475,7 +440,7 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
             serverName,
             WorldStatus.Up,
             Config.app.world.serverType,
-            Vector(WorldConnectionInfo(publicAddress)),
+            Vector(WorldConnectionInfo(publicAddress)), //todo ideally, ask for info from SocketPane
             PlanetSideEmpire.VS
           )
         )
@@ -487,5 +452,4 @@ class LoginActor(middlewareActor: typed.ActorRef[MiddlewareActor.Command], conne
     log.error(error)
     middlewareActor ! MiddlewareActor.Close()
   }
-
 }

--- a/src/main/scala/net/psforever/actors/net/NetworkSimulator.scala
+++ b/src/main/scala/net/psforever/actors/net/NetworkSimulator.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 PSForever
+package net.psforever.actors.net
+
+import akka.actor.typed.{ActorRef, Behavior}
+import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
+import akka.io.Udp
+import net.psforever.util.Config
+
+import java.util.concurrent.ThreadLocalRandom
+import scala.util.Random
+import scala.concurrent.duration._
+
+// TODO? This doesn't quite support all parameters of the old network simulator
+// Need to decide wheter they are necessary or not
+// https://github.com/psforever/PSF-LoginServer/blob/07f447c2344ab55d581317316c41571772ac2242/src/main/scala/net/psforever/login/UdpNetworkSimulator.scala
+private object NetworkSimulator {
+  def apply(socketActor: ActorRef[SocketActor.Command]): Behavior[Udp.Message] =
+    Behaviors.setup(context => new NetworkSimulator(context, socketActor))
+}
+
+private class NetworkSimulator(context: ActorContext[Udp.Message], socketActor: ActorRef[SocketActor.Command])
+  extends AbstractBehavior[Udp.Message](context) {
+
+  private[this] val log = org.log4s.getLogger
+
+  override def onMessage(message: Udp.Message): Behavior[Udp.Message] = {
+    message match {
+      case _: Udp.Received | _: Udp.Send =>
+        simulate(message)
+        Behaviors.same
+      case _ =>
+        socketActor ! toSocket(message)
+        Behaviors.same
+    }
+  }
+
+  def simulate(message: Udp.Message): Unit = {
+    if (Random.nextDouble() > Config.app.development.netSim.loss) {
+      if (Random.nextDouble() <= Config.app.development.netSim.reorderChance) {
+        context.scheduleOnce(
+          ThreadLocalRandom.current().nextDouble(0.01, 0.2).seconds,
+          socketActor,
+          toSocket(message)
+        )
+      } else {
+        socketActor ! toSocket(message)
+      }
+    } else {
+      log.trace("Network simulator dropped packet")
+    }
+  }
+
+  def toSocket(message: Udp.Message): SocketActor.Command =
+    message match {
+      case message: Udp.Command => SocketActor.UdpCommandMessage(message)
+      case message: Udp.Event   => SocketActor.UdpEventMessage(message)
+    }
+}

--- a/src/main/scala/net/psforever/actors/net/SocketPane.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketPane.scala
@@ -9,13 +9,37 @@ import akka.actor.typed.{ActorRef, Behavior, PostStop}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import net.psforever.packet.PlanetSidePacket
 
+private[net] object SocketPanePortRotation {
+  /**
+   * Overrode constructor for `SocketPanePortRotation` entities.
+   * Copy constructor, essentially, that retains the internal current rotation index.
+   * @param rotation the previous rotation entity
+   * @return a copy of the previous rotation entity
+   */
+  def apply(rotation: SocketPanePortRotation): SocketPanePortRotation = {
+    SocketPanePortRotation(rotation.portNumbers, rotation.currentIndex)
+  }
+
+  /**
+   * Overrode constructor for `SocketPanePortRotation` entities.
+   * Adda new port to the list of ports but retain the internal current rotation index.
+   * @param rotation the previous rotation entity
+   * @param newPort the new port number
+   * @return a copy of the previous rotation entity with an additional port that can be selected
+   */
+  def apply(rotation: SocketPanePortRotation, newPort: Int): SocketPanePortRotation = {
+    SocketPanePortRotation(rotation.portNumbers :+ newPort, rotation.currentIndex)
+  }
+}
+
 /**
  * For a given sequence of ports,
  * cycle through port numbers until the last port number has been produced
- * then start again from the first port number again.
+ * then start from the first port number again.
  * @param portNumbers the sequence of ports to be cycled between
  * @param index optional;
- *              the starting index in the sequence of ports
+ *              the starting index in the sequence of ports;
+ *              default is 0
  */
 private[net] case class SocketPanePortRotation(
                                                 portNumbers: Seq[Int],
@@ -32,29 +56,6 @@ private[net] case class SocketPanePortRotation(
     currentIndex += 1
     currentIndex %= portNumbers.size
     out
-  }
-}
-
-object SocketPanePortRotation {
-  /**
-   * Overwritten constructor for `SocketPanePortRotation` entities.
-   * Copy constructor, essentially, that retains the internal current rotation index.
-   * @param rotation the previous rotation entity
-   * @return a copy of the previous rotation entity
-   */
-  def apply(rotation: SocketPanePortRotation): SocketPanePortRotation = {
-    SocketPanePortRotation(rotation.portNumbers, rotation.currentIndex)
-  }
-
-  /**
-   * Overwritten constructor for `SocketPanePortRotation` entities.
-   * Adda new port to the list of ports but retain the internal current rotation index.
-   * @param rotation the previous rotation entity
-   * @param newPort the new port number
-   * @return a copy of the previous rotation entity with an additional port that can be selected
-   */
-  def apply(rotation: SocketPanePortRotation, newPort: Int): SocketPanePortRotation = {
-    SocketPanePortRotation(rotation.portNumbers :+ newPort, rotation.currentIndex)
   }
 }
 
@@ -88,7 +89,7 @@ object SocketPane {
   val SocketPaneKey: ServiceKey[Command] = ServiceKey[SocketPane.Command](id = "socketPane")
 
   /**
-   * Overwritten constructor for `SocketPane` entities.
+   * Overrode constructor for `SocketPane` entities.
    * Registers the entity with the actor receptionist.
    * @param setupInfo the details of the socket groups
    * @return a `SocketPane` entity
@@ -114,7 +115,7 @@ object SocketPane {
 /**
  * Management of sockets connecting to the network ports.
  * <br><br>
- * Connections to the networking ports are handled by the logic imposed by this class
+ * Connections to the networking ports are created by the logic imposed by this class
  * and are handled by sockets that bind to those ports and accept or pass packets to game logic.
  * This game logic is encapsulated by an anonymous function
  * that is automatically implemented into a game logic machine (consumption and production)
@@ -130,7 +131,7 @@ class SocketPane(
                   context: ActorContext[SocketPane.Command],
                   private val initialPortSetup: Seq[SocketSetup]
                  ) {
-  private[this] val log = org.log4s.getLogger("SocketPane")
+  private[this] val log = org.log4s.getLogger
 
   /** original socket group information, now properly flagged as "original" */
   private var socketConfigs: Seq[SocketSetup] = initialPortSetup.map { setup => setup.copy(initial = true) }
@@ -141,31 +142,31 @@ class SocketPane(
     }.toArray
   /** load balancing for redirecting newly discovered packet input to different sockets (ports);
    * should be referenced externally to switch sockets;
-   * see SocketActor.GGetNextPort */
+   * see SocketActor.GetNextPort */
   private var socketRotations: Array[SocketPanePortRotation] = initialPortSetup.map {
     case SocketSetup(_, SocketSetupInfo(_, ports, _), _) => SocketPanePortRotation(ports)
   }.toArray
 
-  log.info(s"configured ${socketActors.length} ports initially")
+  log.debug(s"sockets configured for ${socketActors.length} ports initially")
 
   def start(): Behavior[SocketPane.Command] = {
     Behaviors
       .receiveMessagePartial[SocketPane.Command] {
         case SocketPane.CreateNewSocket(key, _)
-          if !socketConfigs.exists { setup => setup.groupId == key } =>
-          log.warn(s"new port group $key does not exist and can not be appended to")
+          if !socketConfigs.exists { setup => setup.groupId.equals(key) } =>
+          log.warn(s"port group $key does not exist and can not be appended to")
           Behaviors.same
 
         case SocketPane.CreateNewSocket(groupId, port)
         if socketConfigs
-          .find { setup => setup.groupId == groupId }
+          .find { setup => setup.groupId.equals(groupId) }
           .exists { case SocketSetup(_, SocketSetupInfo(_, ports, _), _) => ports.contains(port) } =>
           log.info(s"new port $port for group $groupId already supported")
         Behaviors.same
 
         case SocketPane.CreateNewSocket(groupId, port) =>
           log.info(s"new socket to port $port created in $groupId")
-          val index = socketConfigs.indexWhere { setup => setup.groupId == groupId }
+          val index = socketConfigs.indexWhere { setup => setup.groupId.equals(groupId) }
           val SocketSetup(_, SocketSetupInfo(address, ports, plan), _) = socketConfigs(index)
           socketActors = socketActors :+
             context.spawn(SocketActor(new InetSocketAddress(address, port), plan), name=s"world-socket-$port")
@@ -176,7 +177,7 @@ class SocketPane(
           Behaviors.same
 
         case SocketPane.CreateNewSocketGroup(groupId, _)
-          if socketConfigs.exists { case SocketSetup(oldKey, _, _) => oldKey == groupId } =>
+          if socketConfigs.exists { case SocketSetup(oldKey, _, _) => oldKey.equals(groupId) } =>
           log.warn(s"port group $groupId already exists and can not be created twice")
           Behaviors.same
 
@@ -190,7 +191,7 @@ class SocketPane(
           Behaviors.same
 
         case SocketPane.GetNextPort(groupId, replyTo) =>
-          socketConfigs.indexWhere { setup => setup.groupId == groupId } match {
+          socketConfigs.indexWhere { setup => setup.groupId.equals(groupId) } match {
             case -1 =>
               log.warn(s"port group $groupId does not exist")
             case index =>

--- a/src/main/scala/net/psforever/actors/net/SocketPane.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketPane.scala
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 PSForever
+package net.psforever.actors.net
+
+import net.psforever.util.Config
+
+import java.net.{InetAddress, InetSocketAddress}
+//import akka.{actor => classic}
+import akka.actor.typed.{ActorRef, Behavior, PostStop}
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import net.psforever.packet.PlanetSidePacket
+
+final case class SocketPanePortRotation(
+                                           portNumbers: Seq[Int],
+                                           index: Int = 0
+                                         ) {
+  private var currentIndex: Int = index
+
+  def NextPort: Int = this.synchronized {
+    val out = portNumbers.lift(currentIndex).getOrElse(Config.app.world.port)
+    currentIndex += 1
+    currentIndex %= portNumbers.size
+    out
+  }
+}
+
+object SocketPanePortRotation {
+  def apply(rotation: SocketPanePortRotation): SocketPanePortRotation = {
+    SocketPanePortRotation(rotation.portNumbers, rotation.currentIndex)
+  }
+
+  def apply(rotation: SocketPanePortRotation, newPort: Int): SocketPanePortRotation = {
+    SocketPanePortRotation(rotation.portNumbers :+ newPort, rotation.currentIndex)
+  }
+}
+
+/** SocketActor creates a UDP socket, receives packets and forwards them to MiddlewareActor
+ * There is only one SocketActor, but each connected client gets its own MiddlewareActor
+ */
+object SocketPane {
+  def apply(
+             address: InetAddress,
+             nextPlan: (ActorRef[MiddlewareActor.Command], InetSocketAddress, String) => Behavior[PlanetSidePacket]
+           ): Behavior[Command] =
+    Behaviors.setup(context => new SocketPane(context, address, nextPlan).start())
+
+  sealed trait Command
+
+  final case class CreateNewSocket(port: Int) extends Command
+
+  private var rotation: SocketPanePortRotation = SocketPanePortRotation(Array(Config.app.world.port))
+
+  def Rotation: SocketPanePortRotation = SocketPanePortRotation(rotation)
+
+  final def getDefaultPorts: Seq[Int] = {
+    val config = Config.app.world
+    (config.port +: config.ports).distinct
+  }
+}
+
+class SocketPane(
+                  context: ActorContext[SocketPane.Command],
+                  address: InetAddress,
+                  next: (ActorRef[MiddlewareActor.Command], InetSocketAddress, String) => Behavior[PlanetSidePacket]
+                 ) {
+  private[this] val log = org.log4s.getLogger
+
+  private var socketActors: Array[ActorRef[SocketActor.Command]] = SocketPane.getDefaultPorts.map { i =>
+    context.spawn(SocketActor(new InetSocketAddress(address, i), next), name=s"world-socket-$i")
+  }.toArray
+  SocketPane.rotation = SocketPanePortRotation(SocketPane.getDefaultPorts)
+
+  log.info(s"Configured ${SocketPane.getDefaultPorts.size} game world instance ports")
+
+  def start(): Behavior[SocketPane.Command] = {
+    Behaviors
+      .receiveMessagePartial[SocketPane.Command] {
+        case SocketPane.CreateNewSocket(port)
+          if SocketPane.Rotation.portNumbers.contains(port) =>
+          Behaviors.same
+
+        case SocketPane.CreateNewSocket(port) =>
+          socketActors = socketActors :+ context.spawn(SocketActor(new InetSocketAddress(address, port), next), name=s"world-socket-$port")
+          SocketPane.rotation = SocketPanePortRotation(SocketPane.rotation, port)
+          log.info(s"Requested new socket to port $port has been created")
+          Behaviors.same
+
+        case _ =>
+          Behaviors.same
+      }
+      .receiveSignal {
+        case (_, PostStop) =>
+          socketActors.foreach(context.stop)
+          SocketPane.rotation = SocketPanePortRotation(Array(Config.app.world.port))
+          Behaviors.same
+      }
+  }
+}

--- a/src/main/scala/net/psforever/actors/net/SocketPane.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketPane.scala
@@ -1,22 +1,34 @@
 // Copyright (c) 2024 PSForever
 package net.psforever.actors.net
 
-import net.psforever.util.Config
+import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
 
 import java.net.{InetAddress, InetSocketAddress}
-//import akka.{actor => classic}
+import akka.{actor => classic}
 import akka.actor.typed.{ActorRef, Behavior, PostStop}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import net.psforever.packet.PlanetSidePacket
 
-final case class SocketPanePortRotation(
-                                           portNumbers: Seq[Int],
-                                           index: Int = 0
-                                         ) {
+/**
+ * For a given sequence of ports,
+ * cycle through port numbers until the last port number has been produced
+ * then start again from the first port number again.
+ * @param portNumbers the sequence of ports to be cycled between
+ * @param index optional;
+ *              the starting index in the sequence of ports
+ */
+private[net] case class SocketPanePortRotation(
+                                                portNumbers: Seq[Int],
+                                                index: Int = 0
+                                              ) {
   private var currentIndex: Int = index
 
-  def NextPort: Int = this.synchronized {
-    val out = portNumbers.lift(currentIndex).getOrElse(Config.app.world.port)
+  /**
+   * Retrieve the sequentially next port number.
+   * @return the next port number
+   */
+  def NextPort: Int = {
+    val out = portNumbers.lift(currentIndex).orElse(portNumbers.headOption).getOrElse(0)
     currentIndex += 1
     currentIndex %= portNumbers.size
     out
@@ -24,73 +36,171 @@ final case class SocketPanePortRotation(
 }
 
 object SocketPanePortRotation {
+  /**
+   * Overwritten constructor for `SocketPanePortRotation` entities.
+   * Copy constructor, essentially, that retains the internal current rotation index.
+   * @param rotation the previous rotation entity
+   * @return a copy of the previous rotation entity
+   */
   def apply(rotation: SocketPanePortRotation): SocketPanePortRotation = {
     SocketPanePortRotation(rotation.portNumbers, rotation.currentIndex)
   }
 
+  /**
+   * Overwritten constructor for `SocketPanePortRotation` entities.
+   * Adda new port to the list of ports but retain the internal current rotation index.
+   * @param rotation the previous rotation entity
+   * @param newPort the new port number
+   * @return a copy of the previous rotation entity with an additional port that can be selected
+   */
   def apply(rotation: SocketPanePortRotation, newPort: Int): SocketPanePortRotation = {
     SocketPanePortRotation(rotation.portNumbers :+ newPort, rotation.currentIndex)
   }
 }
 
-/** SocketActor creates a UDP socket, receives packets and forwards them to MiddlewareActor
- * There is only one SocketActor, but each connected client gets its own MiddlewareActor
+/**
+ * Information explaining how to manage a socket group.
+ * @param groupId moniker for the group
+ * @param info how the sockets in this group operate
+ * @param initial should this socket group be protected as "original";
+ *                defaults to `false`
  */
+final case class SocketSetup(groupId: String, info: SocketSetupInfo, initial: Boolean = false) {
+  assert(info.ports.nonEmpty, s"port group $groupId should define port numbers")
+  /* the same port can belong to multiple groups, but the same port may not be repeated in the same group */
+  assert(info.ports.size == info.ports.distinct.size, s"port group $groupId should not contain duplicate port numbers")
+}
+
+/**
+ * Information explaining the details of a socket group.
+ * @param address Internet protocol location of the host
+ * @param ports network ports that are used as endpoints of transmission;
+ *              corresponds to a number of sockets
+ * @param planOfAction whenever a new connection across a socket is made, the method of consuming network packets
+ */
+final case class SocketSetupInfo(
+                                  address: InetAddress,
+                                  ports: Seq[Int],
+                                  planOfAction: (ActorRef[MiddlewareActor.Command], InetSocketAddress, String) => Behavior[PlanetSidePacket]
+                                )
+
 object SocketPane {
-  def apply(
-             address: InetAddress,
-             nextPlan: (ActorRef[MiddlewareActor.Command], InetSocketAddress, String) => Behavior[PlanetSidePacket]
-           ): Behavior[Command] =
-    Behaviors.setup(context => new SocketPane(context, address, nextPlan).start())
+  val SocketPaneKey: ServiceKey[Command] = ServiceKey[SocketPane.Command](id = "socketPane")
+
+  /**
+   * Overwritten constructor for `SocketPane` entities.
+   * Registers the entity with the actor receptionist.
+   * @param setupInfo the details of the socket groups
+   * @return a `SocketPane` entity
+   */
+  def apply(setupInfo: Seq[SocketSetup]): Behavior[Command] = {
+    Behaviors.setup { context =>
+      context.system.receptionist ! Receptionist.Register(SocketPaneKey, context.self)
+      new SocketPane(context, setupInfo).start()
+    }
+  }
 
   sealed trait Command
 
-  final case class CreateNewSocket(port: Int) extends Command
+  final case class CreateNewSocket(groupId: String, port: Int) extends Command
 
-  private var rotation: SocketPanePortRotation = SocketPanePortRotation(Array(Config.app.world.port))
+  final case class CreateNewSocketGroup(groupId: String, info: SocketSetupInfo) extends Command
 
-  def Rotation: SocketPanePortRotation = SocketPanePortRotation(rotation)
+  final case class GetNextPort(groupId: String, replyTo: classic.ActorRef) extends Command
 
-  final def getDefaultPorts: Seq[Int] = {
-    val config = Config.app.world
-    (config.port +: config.ports).distinct
-  }
+  final case class NextPort(groupId: String, address: InetAddress, port: Int)
 }
 
+/**
+ * Management of sockets connecting to the network ports.
+ * <br><br>
+ * Connections to the networking ports are handled by the logic imposed by this class
+ * and are handled by sockets that bind to those ports and accept or pass packets to game logic.
+ * This game logic is encapsulated by an anonymous function
+ * that is automatically implemented into a game logic machine (consumption and production)
+ * upon unique connections detected / attempted across those sockets.
+ * Multiple sockets can connect to the same port so no compensation is required.
+ * <br><br>
+ * New sockets to ports can be added to existing groups after the initial socket groups.
+ * New socket groups can be created after the initial information.
+ * @param context hook for setting up the sockets and, eventually, their packet logic
+ * @param initialPortSetup the details of the socket groups
+ */
 class SocketPane(
                   context: ActorContext[SocketPane.Command],
-                  address: InetAddress,
-                  next: (ActorRef[MiddlewareActor.Command], InetSocketAddress, String) => Behavior[PlanetSidePacket]
+                  private val initialPortSetup: Seq[SocketSetup]
                  ) {
-  private[this] val log = org.log4s.getLogger
+  private[this] val log = org.log4s.getLogger("SocketPane")
 
-  private var socketActors: Array[ActorRef[SocketActor.Command]] = SocketPane.getDefaultPorts.map { i =>
-    context.spawn(SocketActor(new InetSocketAddress(address, i), next), name=s"world-socket-$i")
+  /** original socket group information, now properly flagged as "original" */
+  private var socketConfigs: Seq[SocketSetup] = initialPortSetup.map { setup => setup.copy(initial = true) }
+  /** all sockets produced by the socket group information and any later socket creation commands */
+  private var socketActors: Array[ActorRef[SocketActor.Command]] = initialPortSetup.flatMap {
+      case SocketSetup(_, SocketSetupInfo(address, ports, plan), _) =>
+        ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum") }
+    }.toArray
+  /** load balancing for redirecting newly discovered packet input to different sockets (ports);
+   * should be referenced externally to switch sockets;
+   * see SocketActor.GGetNextPort */
+  private var socketRotations: Array[SocketPanePortRotation] = initialPortSetup.map {
+    case SocketSetup(_, SocketSetupInfo(_, ports, _), _) => SocketPanePortRotation(ports)
   }.toArray
-  SocketPane.rotation = SocketPanePortRotation(SocketPane.getDefaultPorts)
 
-  log.info(s"Configured ${SocketPane.getDefaultPorts.size} game world instance ports")
+  log.info(s"configured ${socketActors.length} ports initially")
 
   def start(): Behavior[SocketPane.Command] = {
     Behaviors
       .receiveMessagePartial[SocketPane.Command] {
-        case SocketPane.CreateNewSocket(port)
-          if SocketPane.Rotation.portNumbers.contains(port) =>
+        case SocketPane.CreateNewSocket(key, _)
+          if !socketConfigs.exists { setup => setup.groupId == key } =>
+          log.warn(s"new port group $key does not exist and can not be appended to")
           Behaviors.same
 
-        case SocketPane.CreateNewSocket(port) =>
-          socketActors = socketActors :+ context.spawn(SocketActor(new InetSocketAddress(address, port), next), name=s"world-socket-$port")
-          SocketPane.rotation = SocketPanePortRotation(SocketPane.rotation, port)
-          log.info(s"Requested new socket to port $port has been created")
+        case SocketPane.CreateNewSocket(groupId, port)
+        if socketConfigs
+          .find { setup => setup.groupId == groupId }
+          .exists { case SocketSetup(_, SocketSetupInfo(_, ports, _), _) => ports.contains(port) } =>
+          log.info(s"new port $port for group $groupId already supported")
+        Behaviors.same
+
+        case SocketPane.CreateNewSocket(groupId, port) =>
+          log.info(s"new socket to port $port created in $groupId")
+          val index = socketConfigs.indexWhere { setup => setup.groupId == groupId }
+          val SocketSetup(_, SocketSetupInfo(address, ports, plan), _) = socketConfigs(index)
+          socketActors = socketActors :+
+            context.spawn(SocketActor(new InetSocketAddress(address, port), plan), name=s"world-socket-$port")
+          socketConfigs = (socketConfigs.take(index) :+ SocketSetup(groupId, SocketSetupInfo(address, ports :+ port, plan))) ++
+            socketConfigs.drop(index + 1)
+          socketRotations = (socketRotations.take(index) :+ SocketPanePortRotation(socketRotations(index), port)) ++
+            socketRotations.drop(index + 1)
           Behaviors.same
 
-        case _ =>
+        case SocketPane.CreateNewSocketGroup(groupId, _)
+          if socketConfigs.exists { case SocketSetup(oldKey, _, _) => oldKey == groupId } =>
+          log.warn(s"port group $groupId already exists and can not be created twice")
+          Behaviors.same
+
+        case SocketPane.CreateNewSocketGroup(groupId, info @ SocketSetupInfo(address, ports, plan)) =>
+          socketActors = socketActors ++
+            ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum") }
+          socketConfigs = socketConfigs :+
+            SocketSetup(groupId, info)
+          socketRotations = socketRotations :+
+            SocketPanePortRotation(ports)
+          Behaviors.same
+
+        case SocketPane.GetNextPort(groupId, replyTo) =>
+          socketConfigs.indexWhere { setup => setup.groupId == groupId } match {
+            case -1 =>
+              log.warn(s"port group $groupId does not exist")
+            case index =>
+              replyTo ! SocketPane.NextPort(groupId, socketConfigs(index).info.address, socketRotations(index).NextPort)
+          }
           Behaviors.same
       }
       .receiveSignal {
         case (_, PostStop) =>
           socketActors.foreach(context.stop)
-          SocketPane.rotation = SocketPanePortRotation(Array(Config.app.world.port))
           Behaviors.same
       }
   }

--- a/src/main/scala/net/psforever/services/account/AccountIntermediaryService.scala
+++ b/src/main/scala/net/psforever/services/account/AccountIntermediaryService.scala
@@ -25,7 +25,7 @@ class AccountIntermediaryService extends Actor {
   private val IPAddressBySessionID = mutable.Map[Long, IPAddress]()
   private[this] val log            = org.log4s.getLogger
 
-  def receive = {
+  def receive: Receive = {
     // Called by the LoginSessionActor
     case StoreAccountData(token, account) =>
       accountsByToken += (token -> account)

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -104,6 +104,7 @@ case class LoginConfig(
 
 case class WorldConfig(
     port: Int,
+    ports: Seq[Int],
     serverName: String,
     serverType: ServerType
 )


### PR DESCRIPTION
Standard operation of the game server seems to have always been one port handling both inbound and outbound packets per component, and one port for the login component and one port for the game component.  In short work, two ports to handle every player that would ever play the game.  The first port is an underwhelming effort that only gets used during the start of session (before the "technical session").  The second port is an overworked monster that manages at least four packets per user per second and at least four times as many packets as connected players per second.  The actual outbound is perhaps greater as the frequency is more rigorous than four times a second and some packets may arrive in between each of those standard four.

The login server is still just one socket-port that everyone congregates their account tinformation, but now the game world ports can exceed the same limitation.  The number of ports that could be used by the game world is defined in the configuration file `application.conf` and each user is assigned the next available socket for their session.  No load-balancing algorithm is currently utilized because socket functionality and middleware functionality is still tightly woven.

The main goal is to reduce UDP packet receive errors and reduce congestion in general.