### PR TITLE
QoL: Character Select Screen

### DIFF
--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -2144,10 +2144,11 @@ class AvatarActor(
                 Zones.sanctuaryZoneNumber(avatar.faction)
               }
             /*
-            After a client has connected to the server, their account is used to generate a list of characters.
-            On the character selection screen, each of these characters is made to exist temporarily when one is selected.
-            This "character select screen" is an isolated portion of the client, so it does not have any external constraints.
-            Temporary global unique identifiers are assigned to the underlying `Player` objects so that they can be turned into packets.
+            After a client has connected,
+            their account is used to generate a list of characters on the character selection screen.
+            In terms of globally unique identifiers (GUID's), this is an isolated portion of the client
+            and it does not clash with any other GUID record on the server (zones).
+            Assign incremental temporary GUID's so that the characters from the selection can be turned into packets.
             */
             player
               .Holsters()
@@ -2184,11 +2185,7 @@ class AvatarActor(
                 Seconds.secondsBetween(a.lastLogin, now).getSeconds
               )
             )
-            /*
-            After the user has selected a character to load from the "character select screen,"
-            the temporary global unique identifiers used for that screen are stripped from the underlying `Player` object that was selected.
-            Characters that were not selected may be destroyed along with their temporary GUIDs.
-            */
+            //do not keep track of GUID's beyond the packet
             player
               .Holsters()
               .foreach(holster =>
@@ -2205,9 +2202,9 @@ class AvatarActor(
               )
             player.Invalidate()
           }
-          //finalize
+          //finalize list
           sessionActor ! SessionActor.SendResponse(
-            CharacterInfoMessage(unk = 15, PlanetSideZoneID(0), 0, PlanetSideGUID(0), finished = true, 0)
+            CharacterInfoMessage(unk = 15, PlanetSideZoneID(0), 0, PlanetSideGUID(0), finished = true, secondsSinceLastLogin = 0L)
           )
       case Failure(e) =>
         log.error(e)("db failure")

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -2131,7 +2131,6 @@ class AvatarActor(
             //setup character
             val avatar                = AvatarActor.toAvatar(a)
             val player                = new Player(avatar)
-            player.Velocity = Some(Vector3(-3,-3,0))
             val zoneNum = saveOpt
               .collect {
                 case persistence.Savedplayer(_, _, _, _, _, zoneNum, _, _, exosuitNum, loadout) =>

--- a/src/main/scala/net/psforever/util/DefinitionUtil.scala
+++ b/src/main/scala/net/psforever/util/DefinitionUtil.scala
@@ -316,13 +316,19 @@ object DefinitionUtil {
     }
   }
 
+  /** Apply default loadout holsters to given player */
+  def applyDefaultHolsters(player: Player): Unit = {
+    val faction = player.Faction
+    player.Slot(0).Equipment = Tool(GlobalDefinitions.StandardPistol(faction))
+    player.Slot(2).Equipment = Tool(GlobalDefinitions.suppressor)
+    player.Slot(4).Equipment = Tool(GlobalDefinitions.StandardMelee(faction))
+  }
+
   /** Apply default loadout to given player */
   def applyDefaultLoadout(player: Player): Unit = {
     val faction = player.Faction
     player.ExoSuit = ExoSuitType.Standard
-    player.Slot(0).Equipment = Tool(GlobalDefinitions.StandardPistol(faction))
-    player.Slot(2).Equipment = Tool(GlobalDefinitions.suppressor)
-    player.Slot(4).Equipment = Tool(GlobalDefinitions.StandardMelee(faction))
+    applyDefaultHolsters(player)
     player.Slot(6).Equipment = AmmoBox(GlobalDefinitions.bullet_9mm)
     player.Slot(9).Equipment = AmmoBox(GlobalDefinitions.bullet_9mm)
     player.Slot(12).Equipment = AmmoBox(GlobalDefinitions.bullet_9mm)


### PR DESCRIPTION
Up until now, the characters the you see on the character select screen have only been decorated in the same fake equipment load and appear as if in a fake destination zone.  In reinforced exo-suit, they don faction-specific pistols, standard and medium, the faction-specific heavy rifle, the faction-specific anti-vehicular launcher, and a katana.  (No one probably ever saw the katana.)  The reality is that the game's database remembers what they wore when they logged out; and, if they had not logged in once yet, it knows what they will wear.  The reality is that the game's database remembers where they were when they logged out; and, if they had not logged in yet, it knows where they will go.  These realities are now visible on the paper dolls displayed in the character select menu.