### PR TITLE
Implant Terminal Hack

### DIFF
--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -13,7 +13,7 @@ import net.psforever.objects.avatar.scoring.{Assist, Death, EquipmentStat, KDASt
 import net.psforever.objects.sourcing.{TurretSource, VehicleSource}
 import net.psforever.packet.game.ImplantAction
 import net.psforever.services.avatar.AvatarServiceResponse
-import net.psforever.types.{ChatMessageType, StatisticalCategory, StatisticalElement, Vector3}
+import net.psforever.types.{ChatMessageType, StatisticalCategory, StatisticalElement}
 import net.psforever.zones.Zones
 import org.joda.time.{LocalDateTime, Seconds}
 

--- a/src/main/scala/net/psforever/actors/session/normal/LocalHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/LocalHandlerLogic.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.ce.Deployable
 import net.psforever.objects.serverobject.doors.Door
 import net.psforever.objects.vehicles.MountableWeapons
 import net.psforever.objects.{BoomerDeployable, ExplosiveDeployable, TelepadDeployable, Tool, TurretDeployable}
-import net.psforever.packet.game.{ChatMsg, DeployableObjectsInfoMessage, GenericActionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HackMessage, HackState, InventoryStateMessage, ObjectAttachMessage, ObjectCreateMessage, ObjectDeleteMessage, ObjectDetachMessage, OrbitalShuttleTimeMsg, PadAndShuttlePair, PlanetsideAttributeMessage, ProximityTerminalUseMessage, SetEmpireMessage, TriggerEffectMessage, TriggerSoundMessage, TriggeredSound, VehicleStateMessage}
+import net.psforever.packet.game.{ChatMsg, DeployableObjectsInfoMessage, GenericActionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HackMessage, HackState, HackState1, InventoryStateMessage, ObjectAttachMessage, ObjectCreateMessage, ObjectDeleteMessage, ObjectDetachMessage, OrbitalShuttleTimeMsg, PadAndShuttlePair, PlanetsideAttributeMessage, ProximityTerminalUseMessage, SetEmpireMessage, TriggerEffectMessage, TriggerSoundMessage, TriggeredSound, VehicleStateMessage}
 import net.psforever.services.Service
 import net.psforever.services.local.LocalResponse
 import net.psforever.types.{ChatMessageType, PlanetSideGUID, Vector3}
@@ -136,7 +136,7 @@ class LocalHandlerLogic(val ops: SessionLocalHandlers, implicit val context: Act
         DeconstructDeployable(obj, dguid, pos, obj.Orientation, effect)
 
       case LocalResponse.SendHackMessageHackCleared(targetGuid, unk1, unk2) =>
-        sendResponse(HackMessage(unk1=0, targetGuid, guid, progress=0, unk1, HackState.HackCleared, unk2))
+        sendResponse(HackMessage(HackState1.Unk0, targetGuid, guid, progress=0, unk1.toFloat, HackState.HackCleared, unk2))
 
       case LocalResponse.HackObject(targetGuid, unk1, unk2) =>
         sessionLogic.general.hackObject(targetGuid, unk1, unk2)

--- a/src/main/scala/net/psforever/actors/session/spectator/LocalHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/spectator/LocalHandlerLogic.scala
@@ -7,7 +7,7 @@ import net.psforever.objects.ce.Deployable
 import net.psforever.objects.guid.{GUIDTask, TaskWorkflow}
 import net.psforever.objects.vehicles.MountableWeapons
 import net.psforever.objects.{BoomerDeployable, ExplosiveDeployable, TelepadDeployable, Tool, TurretDeployable}
-import net.psforever.packet.game.{ChatMsg, DeployableObjectsInfoMessage, GenericActionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HackMessage, HackState, InventoryStateMessage, ObjectAttachMessage, ObjectCreateMessage, ObjectDeleteMessage, ObjectDetachMessage, OrbitalShuttleTimeMsg, PadAndShuttlePair, PlanetsideAttributeMessage, ProximityTerminalUseMessage, SetEmpireMessage, TriggerEffectMessage, TriggerSoundMessage, TriggeredSound, VehicleStateMessage}
+import net.psforever.packet.game.{ChatMsg, DeployableObjectsInfoMessage, GenericActionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HackMessage, HackState, HackState1, InventoryStateMessage, ObjectAttachMessage, ObjectCreateMessage, ObjectDeleteMessage, ObjectDetachMessage, OrbitalShuttleTimeMsg, PadAndShuttlePair, PlanetsideAttributeMessage, ProximityTerminalUseMessage, SetEmpireMessage, TriggerEffectMessage, TriggerSoundMessage, TriggeredSound, VehicleStateMessage}
 import net.psforever.services.Service
 import net.psforever.services.local.LocalResponse
 import net.psforever.types.{ChatMessageType, PlanetSideGUID, Vector3}
@@ -125,7 +125,7 @@ class LocalHandlerLogic(val ops: SessionLocalHandlers, implicit val context: Act
         DeconstructDeployable(obj, dguid, pos, obj.Orientation, effect)
 
       case LocalResponse.SendHackMessageHackCleared(targetGuid, unk1, unk2) =>
-        sendResponse(HackMessage(unk1=0, targetGuid, guid, progress=0, unk1, HackState.HackCleared, unk2))
+        sendResponse(HackMessage(HackState1.Unk0, targetGuid, guid, progress=0, unk1.toFloat, HackState.HackCleared, unk2))
 
       case LocalResponse.HackObject(targetGuid, unk1, unk2) =>
         sessionLogic.general.hackObject(targetGuid, unk1, unk2)

--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -562,8 +562,8 @@ class GeneralOperations(
    * @param unk1 na
    * @param unk2 na
    */
-  def hackObject(targetGuid: PlanetSideGUID, unk1: Long, unk2: Long): Unit = {
-    sendResponse(HackMessage(unk1=0, targetGuid, player_guid=Service.defaultPlayerGUID, progress=100, unk1, HackState.Hacked, unk2))
+  def hackObject(targetGuid: PlanetSideGUID, unk1: Long, unk2: HackState7): Unit = {
+    sendResponse(HackMessage(HackState1.Unk0, targetGuid, player_guid=Service.defaultPlayerGUID, progress=100, unk1, HackState.Hacked, unk2))
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/FieldTurretDeployable.scala
+++ b/src/main/scala/net/psforever/objects/FieldTurretDeployable.scala
@@ -11,6 +11,7 @@ import net.psforever.objects.serverobject.turret.{MountableTurret, WeaponTurrets
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.sourcing.SourceEntry
 import net.psforever.objects.vital.{InGameActivity, ShieldCharge}
+import net.psforever.packet.game.HackState1
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 import net.psforever.types.PlanetSideGUID
 
@@ -54,7 +55,7 @@ class FieldTurretControl(turret: TurretDeployable)
           sender() ! CommonMessages.Progress(
             GenericHackables.GetHackSpeed(player, turret),
             WeaponTurrets.FinishHackingTurretDeployable(turret, player),
-            GenericHackables.HackingTickAction(progressType = 1, player, turret, item.GUID)
+            GenericHackables.HackingTickAction(HackState1.Unk1, player, turret, item.GUID)
           )
 
         case CommonMessages.ChargeShields(amount, motivator) =>

--- a/src/main/scala/net/psforever/objects/global/GlobalDefinitionsMiscellaneous.scala
+++ b/src/main/scala/net/psforever/objects/global/GlobalDefinitionsMiscellaneous.scala
@@ -165,7 +165,7 @@ object GlobalDefinitionsMiscellaneous {
     cert_terminal.Geometry = GeometryForm.representByCylinder(radius = 0.66405f, height = 1.09374f)
 
     implant_terminal_mech.Name = "implant_terminal_mech"
-    implant_terminal_mech.MaxHealth = 1500 //TODO 1000; right now, 1000 (mech) + 500 (interface)
+    implant_terminal_mech.MaxHealth = 1000
     implant_terminal_mech.Damageable = true
     implant_terminal_mech.Repairable = true
     implant_terminal_mech.autoRepair = AutoRepairStats(1.6f, 5000, 2400, 0.05f)
@@ -176,7 +176,7 @@ object GlobalDefinitionsMiscellaneous {
     implant_terminal_interface.Name = "implant_terminal_interface"
     implant_terminal_interface.Tab += 0 -> ImplantPage(ImplantTerminalDefinition.implants)
     implant_terminal_interface.MaxHealth = 500
-    implant_terminal_interface.Damageable = false //TODO true
+    implant_terminal_interface.Damageable = false //true
     implant_terminal_interface.Repairable = true
     implant_terminal_interface.autoRepair = AutoRepairStats(1, 5000, 200, 1)
     implant_terminal_interface.RepairIfDestroyed = true

--- a/src/main/scala/net/psforever/objects/serverobject/environment/interaction/common/WithDeath.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/environment/interaction/common/WithDeath.scala
@@ -6,7 +6,7 @@ import net.psforever.objects.serverobject.environment.{EnvironmentAttribute, Env
 import net.psforever.objects.sourcing.SourceEntry
 import net.psforever.objects.vital.etc.SuicideReason
 import net.psforever.objects.vital.interaction.DamageInteraction
-import net.psforever.objects.vital.{IncarnationActivity, ReconstructionActivity, Vitality}
+import net.psforever.objects.vital.{IncarnationActivity, Vitality}
 import net.psforever.objects.zones.InteractsWithZone
 
 import scala.annotation.unused

--- a/src/main/scala/net/psforever/objects/serverobject/locks/IFFLockControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/locks/IFFLockControl.scala
@@ -4,9 +4,10 @@ package net.psforever.objects.serverobject.locks
 import akka.actor.Actor
 import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
-import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
 import net.psforever.objects.serverobject.structures.Building
+import net.psforever.packet.game.HackState1
 import net.psforever.types.{PlanetSideEmpire, Vector3}
 
 /**
@@ -18,8 +19,8 @@ class IFFLockControl(lock: IFFLock)
     extends Actor
     with FactionAffinityBehavior.Check
     with HackableBehavior.GenericHackable {
-  def FactionObject: FactionAffinity = lock
-  def HackableObject                 = lock
+  def FactionObject: IFFLock  = lock
+  def HackableObject: IFFLock = lock
 
   def receive: Receive =
     checkBehavior
@@ -28,16 +29,17 @@ class IFFLockControl(lock: IFFLock)
         case CommonMessages.Use(player, Some(item: SimpleItem))
             if item.Definition == GlobalDefinitions.remote_electronics_kit =>
           if (lock.Faction != player.Faction) {
+            // 300 / 1
             sender() ! CommonMessages.Progress(
               GenericHackables.GetHackSpeed(player, lock),
-              GenericHackables.FinishHacking(lock, player, 1114636288L),
-              GenericHackables.HackingTickAction(progressType = 1, player, lock, item.GUID)
+              GenericHackables.FinishHacking(lock, player, hackValue = 60, hackClearValue = 60),
+              GenericHackables.HackingTickAction(HackState1.Unk1, player, lock, item.GUID)
             )
           } else if (lock.Faction == player.Faction && lock.HackedBy.nonEmpty) {
             sender() ! CommonMessages.Progress(
               GenericHackables.GetHackSpeed(player, lock),
               IFFLocks.FinishResecuringIFFLock(lock),
-              GenericHackables.HackingTickAction(progressType = 1, player, lock, item.GUID)
+              GenericHackables.HackingTickAction(HackState1.Unk1, player, lock, item.GUID)
             )
           } else {
             val log = org.log4s.getLogger

--- a/src/main/scala/net/psforever/objects/serverobject/mblocker/LockerControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/mblocker/LockerControl.scala
@@ -4,8 +4,9 @@ package net.psforever.objects.serverobject.mblocker
 import akka.actor.Actor
 import net.psforever.objects.{GlobalDefinitions, SimpleItem}
 import net.psforever.objects.serverobject.CommonMessages
-import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
+import net.psforever.packet.game.HackState1
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `Locker`.
@@ -15,8 +16,8 @@ class LockerControl(locker: Locker)
     extends Actor
     with FactionAffinityBehavior.Check
     with HackableBehavior.GenericHackable {
-  def FactionObject: FactionAffinity = locker
-  def HackableObject                 = locker
+  def FactionObject: Locker  = locker
+  def HackableObject: Locker = locker
 
   def receive: Receive =
     checkBehavior
@@ -28,8 +29,8 @@ class LockerControl(locker: Locker)
           if (locker.Faction != player.Faction && locker.HackedBy.isEmpty) {
             sender() ! CommonMessages.Progress(
               GenericHackables.GetHackSpeed(player, locker),
-              GenericHackables.FinishHacking(locker, player, 3212836864L),
-              GenericHackables.HackingTickAction(progressType = 1, player, locker, item.GUID)
+              GenericHackables.FinishHacking(locker, player, hackValue = -1, hackClearValue = -1),
+              GenericHackables.HackingTickAction(HackState1.Unk1, player, locker, item.GUID)
             )
           }
         case _ => ;

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/ProximityTerminalControl.scala
@@ -3,6 +3,7 @@ package net.psforever.objects.serverobject.terminals
 
 import akka.actor.{ActorRef, Cancellable}
 import net.psforever.objects.sourcing.AmenitySource
+import net.psforever.packet.game.HackState1
 import org.log4s.Logger
 
 import scala.annotation.unused
@@ -73,8 +74,8 @@ class ProximityTerminalControl(term: Terminal with ProximityUnit)
             case b: Building if (b.Faction != player.Faction || b.CaptureTerminalIsHacked) && term.HackedBy.isEmpty =>
               sender() ! CommonMessages.Progress(
                 GenericHackables.GetHackSpeed(player, term),
-                GenericHackables.FinishHacking(term, player, 3212836864L),
-                GenericHackables.HackingTickAction(progressType = 1, player, term, item.GUID)
+                GenericHackables.FinishHacking(term, player, hackValue = -1, hackClearValue = -1),
+                GenericHackables.HackingTickAction(HackState1.Unk1, player, term, item.GUID)
               )
             case _ => ;
           }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/TerminalControl.scala
@@ -11,6 +11,7 @@ import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBe
 import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, RepairableAmenity}
 import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
 import net.psforever.objects.vital.interaction.DamageResult
+import net.psforever.packet.game.HackState1
 import net.psforever.services.Service
 import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 
@@ -48,10 +49,11 @@ class TerminalControl(term: Terminal)
           //TODO setup certifications check
           term.Owner match {
             case b: Building if (b.Faction != player.Faction || b.CaptureTerminalIsHacked) && term.HackedBy.isEmpty =>
+              //order terminals are 90 / 1, or 60 / ?
               sender() ! CommonMessages.Progress(
                 GenericHackables.GetHackSpeed(player, term),
-                GenericHackables.FinishHacking(term, player, 3212836864L),
-                GenericHackables.HackingTickAction(progressType = 1, player, term, item.GUID)
+                GenericHackables.FinishHacking(term, player, hackValue = -1, hackClearValue = -1),
+                GenericHackables.HackingTickAction(HackState1.Unk1, player, term, item.GUID)
               )
             case _ => ()
           }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminalAwareBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminalAwareBehavior.scala
@@ -1,9 +1,7 @@
 package net.psforever.objects.serverobject.terminals.capture
 
 import akka.actor.Actor.Receive
-import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.structures.Amenity
-import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.annotation.unused
 
@@ -24,28 +22,7 @@ trait CaptureTerminalAwareBehavior {
 
   protected def captureTerminalIsResecured(@unused terminal: CaptureTerminal): Unit = { /* intentionally blank */ }
 
-  protected def captureTerminalIsHacked(@unused terminal: CaptureTerminal): Unit = {
-    // Remove seated occupants for mountables
-    CaptureTerminalAwareObject match {
-      case mountable: Mountable =>
-        val guid = mountable.GUID
-        val zone = mountable.Zone
-        val zoneId = zone.id
-        val events = zone.VehicleEvents
-        mountable.Seats.values.zipWithIndex.foreach {
-          case (seat, seat_num) =>
-            seat.occupant.collect {
-              case player =>
-                seat.unmount(player)
-                player.VehicleSeated = None
-                if (player.HasGUID) {
-                  events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, seat_num, unk2=true, guid))
-                }
-            }
-        }
-      case _ => ()
-    }
-  }
+  protected def captureTerminalIsHacked(@unused terminal: CaptureTerminal): Unit = { /* intentionally blank */ }
 }
 
 object CaptureTerminalAwareBehavior {

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminalControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminalControl.scala
@@ -3,16 +3,17 @@ package net.psforever.objects.serverobject.terminals.capture
 
 import akka.actor.Actor
 import net.psforever.objects.serverobject.CommonMessages
-import net.psforever.objects.serverobject.affinity.{FactionAffinity, FactionAffinityBehavior}
+import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
 import net.psforever.objects.{GlobalDefinitions, SimpleItem}
+import net.psforever.packet.game.HackState1
 
 class CaptureTerminalControl(terminal: CaptureTerminal)
     extends Actor
     with FactionAffinityBehavior.Check
     with HackableBehavior.GenericHackable {
-  def FactionObject: FactionAffinity = terminal
-  def HackableObject                 = terminal
+  def FactionObject: CaptureTerminal  = terminal
+  def HackableObject: CaptureTerminal = terminal
 
   def receive: Receive =
     checkBehavior
@@ -27,11 +28,11 @@ class CaptureTerminalControl(terminal: CaptureTerminal)
           if (canHack) {
             sender() ! CommonMessages.Progress(
               GenericHackables.GetHackSpeed(player, terminal),
-              CaptureTerminals.FinishHackingCaptureConsole(terminal, player, 3212836864L),
-              GenericHackables.HackingTickAction(progressType = 1, player, terminal, item.GUID)
+              CaptureTerminals.FinishHackingCaptureConsole(terminal, player, unk = -1),
+              GenericHackables.HackingTickAction(HackState1.Unk1, player, terminal, item.GUID)
             )
           }
 
-        case _ => ; //no default message
+        case _ => () //no default message
       }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminals.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminals.scala
@@ -23,13 +23,13 @@ object CaptureTerminals {import scala.concurrent.duration._
   def FinishHackingCaptureConsole(target: CaptureTerminal, hackingPlayer: Player, unk: Long)(): Unit = {
     import akka.pattern.ask
 
-    log.info(s"${hackingPlayer.toString} hacked a ${target.Definition.Name}")
     // Wait for the target actor to set the HackedBy property
     import scala.concurrent.ExecutionContext.Implicits.global
     ask(target.Actor, CommonMessages.Hack(hackingPlayer, target))(timeout = 2 second)
       .mapTo[CommonMessages.EntityHackState]
       .onComplete {
         case Success(_) =>
+          log.info(s"${hackingPlayer.toString} hacked a ${target.Definition.Name}")
           val zone = target.Zone
           val zoneid = zone.id
           val events = zone.LocalEvents

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminals.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/capture/CaptureTerminals.scala
@@ -20,7 +20,7 @@ object CaptureTerminals {import scala.concurrent.duration._
    * @see `HackMessage`
    */
   //TODO add params here depending on which params in HackMessage are important
-  def FinishHackingCaptureConsole(target: CaptureTerminal, hackingPlayer: Player, unk: Long)(): Unit = {
+  def FinishHackingCaptureConsole(target: CaptureTerminal, hackingPlayer: Player, unk: Int)(): Unit = {
     import akka.pattern.ask
 
     // Wait for the target actor to set the HackedBy property

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantInterfaceControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantInterfaceControl.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 PSForever
+package net.psforever.objects.serverobject.terminals.implant
+
+import akka.actor.ActorRef
+import net.psforever.objects.Player
+import net.psforever.objects.serverobject.hackable.{GenericHackables, Hackable}
+import net.psforever.objects.serverobject.structures.Amenity
+import net.psforever.objects.serverobject.terminals.{Terminal, TerminalControl}
+import net.psforever.objects.zones.Zone
+import net.psforever.types.PlanetSideGUID
+
+object ImplantInterfaceControl {
+  private def FindPairedTerminalMech(
+                                      zone: Zone,
+                                      interfaceGuid: PlanetSideGUID
+                                    ): Option[Amenity with Hackable] = {
+    zone
+      .map
+      .terminalToInterface
+      .find { case (_, guid) => guid == interfaceGuid.guid }
+      .flatMap { case (mechGuid, _) => zone.GUID(mechGuid) }
+      .collect { case mech: ImplantTerminalMech if !mech.Destroyed && mech.HackedBy.isEmpty => mech }
+  }
+}
+
+class ImplantInterfaceControl(private val terminal: Terminal)
+  extends TerminalControl(terminal) {
+
+  override def performHack(player: Player, data: Option[Any], replyTo: ActorRef): Unit = {
+    HackableObject.HackedBy
+      .orElse {
+        super.performHack(player, data, replyTo)
+        ImplantInterfaceControl
+          .FindPairedTerminalMech(terminal.Zone, terminal.GUID)
+          .foreach(GenericHackables.FinishHacking(_, player, unk = 3212836864L)())
+        None
+      }
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantInterfaceControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantInterfaceControl.scala
@@ -32,7 +32,7 @@ class ImplantInterfaceControl(private val terminal: Terminal)
         super.performHack(player, data, replyTo)
         ImplantInterfaceControl
           .FindPairedTerminalMech(terminal.Zone, terminal.GUID)
-          .foreach(GenericHackables.FinishHacking(_, player, unk = 3212836864L)())
+          .foreach(GenericHackables.FinishHacking(_, player, hackValue = -1, hackClearValue = -1)())
         None
       }
   }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalInterface.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalInterface.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 PSForever
+package net.psforever.objects.serverobject.terminals.implant
+
+import akka.actor.ActorContext
+import net.psforever.objects.serverobject.terminals.{Terminal, TerminalDefinition}
+import net.psforever.types.Vector3
+
+object ImplantTerminalInterface {
+  /**
+   * Instantiate and configure a `Terminal` object
+   * @param pdef `ObjectDefinition` that constructs this object and maintains some of its immutable fields
+   * @param pos position
+   * @param id the unique id that will be assigned to this entity
+   * @param context a context to allow the object to properly set up `ActorSystem` functionality
+   * @return the `Terminal` object
+   */
+  def Constructor(pos: Vector3, pdef: TerminalDefinition)(id: Int, context: ActorContext): Terminal = {
+    import akka.actor.Props
+
+    val obj = Terminal(pdef)
+    obj.Position = pos
+    obj.Actor = context.actorOf(Props(classOf[ImplantInterfaceControl], obj), s"${obj.Definition.Name}_$id")
+    obj
+  }
+}

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalMechControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalMechControl.scala
@@ -1,25 +1,46 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects.serverobject.terminals.implant
 
+import akka.actor.ActorRef
 import net.psforever.objects.serverobject.affinity.FactionAffinityBehavior
 import net.psforever.objects.serverobject.damage.Damageable.Target
 import net.psforever.objects.serverobject.damage.{Damageable, DamageableEntity, DamageableMountable}
-import net.psforever.objects.serverobject.hackable.{GenericHackables, HackableBehavior}
+import net.psforever.objects.serverobject.hackable.{GenericHackables, Hackable, HackableBehavior}
 import net.psforever.objects.serverobject.mount.{Mountable, MountableBehavior}
 import net.psforever.objects.serverobject.repair.{AmenityAutoRepair, RepairableAmenity, RepairableEntity}
-import net.psforever.objects.serverobject.structures.{Building, PoweredAmenityControl}
-import net.psforever.objects.serverobject.terminals.capture.CaptureTerminalAwareBehavior
+import net.psforever.objects.serverobject.structures.{Amenity, Building, PoweredAmenityControl}
+import net.psforever.objects.serverobject.terminals.Terminal
+import net.psforever.objects.serverobject.terminals.capture.{CaptureTerminal, CaptureTerminalAwareBehavior}
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.vital.interaction.DamageResult
+import net.psforever.objects.zones.Zone
 import net.psforever.objects.{GlobalDefinitions, Player, SimpleItem}
+import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
+import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
+
+import scala.annotation.unused
+
+object ImplantTerminalMechControl {
+  private def FindPairedTerminalInterface(
+                                           zone: Zone,
+                                           mechGuid: PlanetSideGUID
+                                         ): Option[Amenity with Hackable] = {
+    zone
+      .map
+      .terminalToInterface
+      .find { case (guid, _) => guid == mechGuid.guid }
+      .flatMap { case (_, interfaceGuid) => zone.GUID(interfaceGuid) }
+      .collect { case terminal: Terminal if !terminal.Destroyed && terminal.HackedBy.isEmpty => terminal }
+  }
+}
 
 /**
-  * An `Actor` that handles messages being dispatched to a specific `ImplantTerminalMech`.
-  * @param mech the "mech" object being governed
-  */
+ * An `Actor` that handles messages being dispatched to a specific `ImplantTerminalMech`.
+ * @param mech the "mech" object being governed
+ */
 class ImplantTerminalMechControl(mech: ImplantTerminalMech)
-    extends PoweredAmenityControl
+  extends PoweredAmenityControl
     with FactionAffinityBehavior.Check
     with MountableBehavior
     with HackableBehavior.GenericHackable
@@ -41,9 +62,11 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
       .orElse(takesDamage)
       .orElse(canBeRepairedByNanoDispenser)
       .orElse(autoRepairBehavior)
+      .orElse(captureTerminalAwareBehaviour)
 
   def poweredStateLogic : Receive =
     commonBehavior
+      .orElse(hackableBehavior)
       .orElse(mountBehavior)
       .orElse {
         case CommonMessages.Use(player, Some(item: SimpleItem))
@@ -56,15 +79,16 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
                 GenericHackables.FinishHacking(mech, player, 3212836864L),
                 GenericHackables.HackingTickAction(progressType = 1, player, mech, item.GUID)
               )
-            case _ => ;
+            case _ => ()
           }
-        case _ => ;
+        case _ => ()
       }
 
   def unpoweredStateLogic: Receive =
     commonBehavior
+      .orElse(hackableBehavior)
       .orElse {
-        case _ => ;
+        case _ => ()
       }
 
   override protected def mountTest(
@@ -120,14 +144,11 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     val zoneId = zone.id
     val events = zone.VehicleEvents
     mech.Seats.values.foreach(seat =>
-      seat.occupant match {
-        case Some(player) =>
+      seat.occupant.collect {
+        case player =>
           seat.unmount(player)
           player.VehicleSeated = None
-          if (player.HasGUID) {
-            events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, 4, unk2 = false, guid))
-          }
-        case None => ;
+          events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, 4, unk2=false, guid))
       }
     )
   }
@@ -139,5 +160,124 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
   override def Restoration(obj: Target): Unit = {
     super.Restoration(obj)
     RepairableAmenity.RestorationOfHistory(obj)
+  }
+
+  override def performHack(player: Player, data: Option[Any], replyTo: ActorRef): Unit = {
+    //todo don't now how to properly hack this amenity
+    super.performHack(player, data, replyTo)
+    val zone = HackableObject.Zone
+    val guid = HackableObject.GUID
+    val localFaction = mech.Faction
+    val events = zone.LocalEvents
+    if (player.Faction == localFaction) {
+      if (mech.Owner.asInstanceOf[Building].CaptureTerminalIsHacked) {
+        //this is actually futile, as a hacked base does not grant access to the terminal
+        events ! LocalServiceMessage(localFaction.toString, LocalAction.SetEmpire(guid, localFaction))
+      }
+      kickAllOccupantsNotOfFaction(zone, guid, mech, localFaction)
+    } else {
+      opposingFactionsMayAccess(zone, guid, localFaction)
+      kickAllOccupantsOfFaction(zone, guid, mech, localFaction)
+    }
+    ImplantTerminalMechControl
+      .FindPairedTerminalInterface(zone, guid)
+      .foreach(GenericHackables.FinishHacking(_, player, unk = 3212836864L)())
+  }
+
+  override def performClearHack(data: Option[Any], replyTo: ActorRef): Unit = {
+    //todo don't now how to properly unhack this amenity
+    HackableObject.HackedBy.collect { _ =>
+      super.performClearHack(data, replyTo)
+      val toFaction = HackableObject.Faction
+      val zone = HackableObject.Zone
+      val guid = HackableObject.GUID
+      noAccessByOpposingFactions(zone, guid, toFaction)
+      kickAllOccupantsNotOfFaction(zone, guid, mech, toFaction)
+    }
+  }
+
+  override protected def captureTerminalIsHacked(@unused terminal: CaptureTerminal): Unit = {
+    //todo don't now how to properly handle a hacked mech
+    super.captureTerminalIsHacked(terminal)
+    val zone = HackableObject.Zone
+    val guid = HackableObject.GUID
+    kickAllOccupantsNotOfFactionWithTest(zone, guid, mech, (a: PlanetSideEmpire.Value) => { true })
+  }
+
+  override protected def captureTerminalIsResecured(terminal: CaptureTerminal): Unit = {
+    //todo don't now how to properly handle a hacked mech
+    super.captureTerminalIsResecured(terminal)
+    //if hacked, correct
+    val zone = HackableObject.Zone
+    val guid = HackableObject.GUID
+    val toFaction = HackableObject.Faction
+    HackableObject.HackedBy.collect {
+      case hackInfo if hackInfo.hackerFaction != toFaction =>
+        opposingFactionsMayAccess(zone, guid, toFaction)
+    }
+  }
+
+  private def opposingFactionsMayAccess(
+                                         zone: Zone,
+                                         guid: PlanetSideGUID,
+                                         setToFaction: PlanetSideEmpire.Value
+                                       ): Unit = {
+    val events = zone.LocalEvents
+    opposingFactionsAre(setToFaction).foreach { faction =>
+      events ! LocalServiceMessage(faction.toString, LocalAction.SetEmpire(guid, faction))
+    }
+  }
+
+  private def noAccessByOpposingFactions(
+                                          zone: Zone,
+                                          guid: PlanetSideGUID,
+                                          setToFaction: PlanetSideEmpire.Value
+                                        ): Unit = {
+    val events = zone.LocalEvents
+    opposingFactionsAre(setToFaction).foreach { faction =>
+      events ! LocalServiceMessage(faction.toString, LocalAction.SetEmpire(guid, setToFaction))
+    }
+  }
+
+  private def opposingFactionsAre(faction: PlanetSideEmpire.Value): PlanetSideEmpire.ValueSet = {
+    PlanetSideEmpire
+      .values
+      .filterNot { f => f == PlanetSideEmpire.NEUTRAL && f == faction }
+  }
+
+  private def kickAllOccupantsOfFaction(
+                                         zone: Zone,
+                                         guid: PlanetSideGUID,
+                                         obj: Mountable,
+                                         isFaction: PlanetSideEmpire.Value
+                                       ): Unit = {
+    kickAllOccupantsNotOfFactionWithTest(zone, guid, obj, (a: PlanetSideEmpire.Value) => { a == isFaction })
+  }
+
+  private def kickAllOccupantsNotOfFaction(
+                                            zone: Zone,
+                                            guid: PlanetSideGUID,
+                                            obj: Mountable,
+                                            isFaction: PlanetSideEmpire.Value
+                                          ): Unit = {
+    kickAllOccupantsNotOfFactionWithTest(zone, guid, obj, (a: PlanetSideEmpire.Value) => { a != isFaction })
+  }
+
+  private def kickAllOccupantsNotOfFactionWithTest(
+                                                    zone: Zone,
+                                                    guid: PlanetSideGUID,
+                                                    obj: Mountable,
+                                                    test: PlanetSideEmpire.Value => Boolean
+                                                  ): Unit = {
+    val zoneId = zone.id
+    val events = zone.LocalEvents
+    obj.Seats.values.foreach(seat =>
+      seat.occupant.collect {
+        case player if test(player.Faction) =>
+          seat.unmount(player)
+          player.VehicleSeated = None
+          events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, 4, unk2 = false, guid))
+      }
+    )
   }
 }

--- a/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalMechControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/terminals/implant/ImplantTerminalMechControl.scala
@@ -15,6 +15,7 @@ import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObjec
 import net.psforever.objects.vital.interaction.DamageResult
 import net.psforever.objects.zones.Zone
 import net.psforever.objects.{GlobalDefinitions, Player, SimpleItem}
+import net.psforever.packet.game.HackState1
 import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID}
@@ -76,8 +77,8 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
             case b: Building if (b.Faction != player.Faction || b.CaptureTerminalIsHacked) && mech.HackedBy.isEmpty =>
               sender() ! CommonMessages.Progress(
                 GenericHackables.GetHackSpeed(player, mech),
-                GenericHackables.FinishHacking(mech, player, 3212836864L),
-                GenericHackables.HackingTickAction(progressType = 1, player, mech, item.GUID)
+                GenericHackables.FinishHacking(mech, player, hackValue = -1, hackClearValue = -1),
+                GenericHackables.HackingTickAction(HackState1.Unk1, player, mech, item.GUID)
               )
             case _ => ()
           }
@@ -181,7 +182,7 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     }
     ImplantTerminalMechControl
       .FindPairedTerminalInterface(zone, guid)
-      .foreach(GenericHackables.FinishHacking(_, player, unk = 3212836864L)())
+      .foreach(GenericHackables.FinishHacking(_, player, hackValue = -1, hackClearValue = -1)())
   }
 
   override def performClearHack(data: Option[Any], replyTo: ActorRef): Unit = {
@@ -201,7 +202,7 @@ class ImplantTerminalMechControl(mech: ImplantTerminalMech)
     super.captureTerminalIsHacked(terminal)
     val zone = HackableObject.Zone
     val guid = HackableObject.GUID
-    kickAllOccupantsNotOfFactionWithTest(zone, guid, mech, (a: PlanetSideEmpire.Value) => { true })
+    kickAllOccupantsNotOfFactionWithTest(zone, guid, mech, (_: PlanetSideEmpire.Value) => { true })
   }
 
   override protected def captureTerminalIsResecured(terminal: CaptureTerminal): Unit = {

--- a/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
@@ -330,6 +330,21 @@ class FacilityTurretControl(turret: FacilityTurret)
   }
 
   override protected def captureTerminalIsHacked(terminal: CaptureTerminal): Unit = {
+    super.captureTerminalIsHacked(terminal)
+    // Remove seated occupants
+    val guid = turret.GUID
+    val zone = turret.Zone
+    val zoneId = zone.id
+    val events = zone.VehicleEvents
+    turret.Seats.values.zipWithIndex.foreach {
+      case (seat, seat_num) =>
+        seat.occupant.collect {
+          case player =>
+            seat.unmount(player)
+            player.VehicleSeated = None
+            events ! VehicleServiceMessage(zoneId, VehicleAction.KickPassenger(player.GUID, seat_num, unk2=true, guid))
+        }
+    }
     captureTerminalChanges(terminal, super.captureTerminalIsHacked, actionDelays = 3000L)
   }
 

--- a/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/turret/FacilityTurretControl.scala
@@ -13,7 +13,7 @@ import net.psforever.objects.serverobject.terminals.capture.{CaptureTerminal, Ca
 import net.psforever.objects.serverobject.turret.auto.AutomatedTurret.Target
 import net.psforever.objects.serverobject.turret.auto.{AffectedByAutomaticTurretFire, AutomatedTurret, AutomatedTurretBehavior}
 import net.psforever.objects.vital.interaction.DamageResult
-import net.psforever.packet.game.ChangeFireModeMessage
+import net.psforever.packet.game.{ChangeFireModeMessage, HackState1}
 import net.psforever.services.Service
 import net.psforever.services.vehicle.support.TurretUpgrader
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
@@ -67,7 +67,7 @@ class FacilityTurretControl(turret: FacilityTurret)
           sender() ! CommonMessages.Progress(
             1.25f,
             WeaponTurrets.FinishUpgradingMannedTurret(TurretObject, player, item, upgrade),
-            WeaponTurrets.TurretUpgradingTickAction(progressType = 2, player, TurretObject, item.GUID)
+            WeaponTurrets.TurretUpgradingTickAction(HackState1.Unk2, player, TurretObject, item.GUID)
           )
       }
     case TurretUpgrader.UpgradeCompleted(_) =>

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -179,8 +179,8 @@ class VehicleControl(vehicle: Vehicle)
         if (vehicle.Faction != player.Faction) {
           sender() ! CommonMessages.Progress(
             GenericHackables.GetHackSpeed(player, vehicle),
-            Vehicles.FinishHackingVehicle(vehicle, player, 3212836864L),
-            GenericHackables.HackingTickAction(progressType = 1, player, vehicle, item.GUID)
+            Vehicles.FinishHackingVehicle(vehicle, player),
+            GenericHackables.HackingTickAction(HackState1.Unk1, player, vehicle, item.GUID)
           )
         }
 

--- a/src/main/scala/net/psforever/services/local/LocalService.scala
+++ b/src/main/scala/net/psforever/services/local/LocalService.scala
@@ -96,10 +96,10 @@ class LocalService(zone: Zone) extends Actor {
               LocalResponse.SendHackMessageHackCleared(target.GUID, unk1, unk2)
             )
           )
-        case LocalAction.HackTemporarily(player_guid, _, target, unk1, duration, unk2) =>
-          hackClearer ! HackClearActor.ObjectIsHacked(target, zone, unk1, unk2, duration)
+        case LocalAction.HackTemporarily(player_guid, _, target, hackValue, hackClear, duration, unk2) =>
+          hackClearer ! HackClearActor.ObjectIsHacked(target, zone, hackClear, unk2, duration)
           LocalEvents.publish(
-            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.HackObject(target.GUID, unk1, unk2))
+            LocalServiceResponse(s"/$forChannel/Local", player_guid, LocalResponse.HackObject(target.GUID, hackValue, unk2))
           )
         case LocalAction.ClearTemporaryHack(_, target) =>
           hackClearer ! HackClearActor.ObjectIsResecured(target)

--- a/src/main/scala/net/psforever/services/local/LocalServiceMessage.scala
+++ b/src/main/scala/net/psforever/services/local/LocalServiceMessage.scala
@@ -14,7 +14,7 @@ import net.psforever.objects.{PlanetSideGameObject, TelepadDeployable, Vehicle}
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.GenericObjectActionEnum.GenericObjectActionEnum
 import net.psforever.packet.game.PlanetsideAttributeEnum.PlanetsideAttributeEnum
-import net.psforever.packet.game.{ChatMsg, DeployableInfo, DeploymentAction, GenericAction, TriggeredSound}
+import net.psforever.packet.game.{ChatMsg, DeployableInfo, DeploymentAction, GenericAction, HackState7, TriggeredSound}
 import net.psforever.services.hart.HartTimer.OrbitalShuttleEvent
 import net.psforever.types.{PlanetSideEmpire, PlanetSideGUID, Vector3}
 
@@ -43,15 +43,16 @@ object LocalAction {
                                         pos: Vector3,
                                         deletionEffect: Int
                                       )                                                extends Action
-  final case class HackClear(player_guid: PlanetSideGUID, target: PlanetSideServerObject, unk1: Long, unk2: Long = 8L)
+  final case class HackClear(player_guid: PlanetSideGUID, target: PlanetSideServerObject, unk1: Long, unk2: HackState7 = HackState7.Unk8)
       extends Action
   final case class HackTemporarily(
       player_guid: PlanetSideGUID,
       continent: Zone,
       target: PlanetSideServerObject,
-      unk1: Long,
+      hackValue: Long,
+      hackClearValue: Long,
       duration: Int,
-      unk2: Long = 8L
+      unk2: HackState7 = HackState7.Unk8
   ) extends Action
   final case class ClearTemporaryHack(player_guid: PlanetSideGUID, target: PlanetSideServerObject with Hackable)
       extends Action

--- a/src/main/scala/net/psforever/services/local/LocalServiceResponse.scala
+++ b/src/main/scala/net/psforever/services/local/LocalServiceResponse.scala
@@ -34,8 +34,8 @@ object LocalResponse {
                                         pos: Vector3,
                                         deletionEffect: Int
   )                                                                                                extends Response
-  final case class SendHackMessageHackCleared(target_guid: PlanetSideGUID, unk1: Long, unk2: Long) extends Response
-  final case class HackObject(target_guid: PlanetSideGUID, unk1: Long, unk2: Long) extends Response
+  final case class SendHackMessageHackCleared(target_guid: PlanetSideGUID, unk1: Long, unk2: HackState7) extends Response
+  final case class HackObject(target_guid: PlanetSideGUID, unk1: Long, unk2: HackState7) extends Response
 
   final case class SendPacket(packet: PlanetSideGamePacket) extends Response
   final case class PlanetsideAttribute(target_guid: PlanetSideGUID, attribute_number: PlanetsideAttributeEnum, attribute_value: Long)

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -10,7 +10,7 @@ import net.psforever.objects.serverobject.structures.Building
 import net.psforever.objects.serverobject.terminals.capture.CaptureTerminal
 import net.psforever.objects.zones.Zone
 import net.psforever.objects.Default
-import net.psforever.packet.game.{GenericAction, PlanetsideAttributeEnum}
+import net.psforever.packet.game.{GenericAction, HackState7, PlanetsideAttributeEnum}
 import net.psforever.objects.sourcing.PlayerSource
 import net.psforever.services.Service
 import net.psforever.services.local.support.HackCaptureActor.GetHackingFaction
@@ -231,7 +231,7 @@ class HackCaptureActor extends Actor {
     }
     NotifyHackStateChange(terminal, isResecured = true)
     // todo: this appears to be the way to reset the base warning lights after the hack finishes but it doesn't seem to work.
-    context.parent ! HackClearActor.SendHackMessageHackCleared(building.GUID, terminal.Zone.id, 3212836864L, 8L) //call up
+    context.parent ! HackClearActor.SendHackMessageHackCleared(building.GUID, terminal.Zone.id, 3212836864L, HackState7.Unk8) //call up
   }
 
   private def RestartTimer(): Unit = {

--- a/src/main/scala/net/psforever/services/local/support/HackClearActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackClearActor.scala
@@ -2,12 +2,12 @@
 package net.psforever.services.local.support
 
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{Actor, Cancellable}
 import net.psforever.objects.Default
 import net.psforever.objects.serverobject.hackable.Hackable
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.zones.Zone
+import net.psforever.packet.game.HackState7
 import net.psforever.types.PlanetSideGUID
 
 import scala.annotation.tailrec
@@ -156,7 +156,7 @@ object HackClearActor {
       target: PlanetSideServerObject,
       zone: Zone,
       unk1: Long,
-      unk2: Long,
+      unk2: HackState7,
       duration: Int,
       time: Long = System.currentTimeMillis()
   )
@@ -172,7 +172,7 @@ object HackClearActor {
     * @param obj the server object
     * @param zone_id the zone in which the object resides
     */
-  final case class SendHackMessageHackCleared(obj: PlanetSideGUID, zone_id: String, unk1: Long, unk2: Long)
+  final case class SendHackMessageHackCleared(obj: PlanetSideGUID, zone_id: String, unk1: Long, unk2: HackState7)
 
   /**
     * Internal message used to signal a test of the queued door information.
@@ -192,7 +192,7 @@ object HackClearActor {
       target: PlanetSideServerObject,
       zone: Zone,
       unk1: Long,
-      unk2: Long,
+      unk2: HackState7,
       time: Long,
       duration: Long
   )

--- a/src/main/scala/net/psforever/zones/Zones.scala
+++ b/src/main/scala/net/psforever/zones/Zones.scala
@@ -21,7 +21,7 @@ import net.psforever.objects.serverobject.resourcesilo.ResourceSilo
 import net.psforever.objects.serverobject.shuttle.OrbitalShuttlePad
 import net.psforever.objects.serverobject.structures.{Building, BuildingDefinition, FoundationBuilder, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.capture.{CaptureTerminal, CaptureTerminalDefinition}
-import net.psforever.objects.serverobject.terminals.implant.ImplantTerminalMech
+import net.psforever.objects.serverobject.terminals.implant.{ImplantTerminalInterface, ImplantTerminalMech}
 import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects.serverobject.turret.{FacilityTurret, FacilityTurretDefinition, VanuSentry}
 import net.psforever.objects.serverobject.zipline.ZipLinePath
@@ -637,7 +637,7 @@ object Zones {
 
           zoneMap.addLocalObject(
             closestTerminal.guid,
-            Terminal.Constructor(closestTerminal.position, GlobalDefinitions.implant_terminal_interface),
+            ImplantTerminalInterface.Constructor(closestTerminal.position, GlobalDefinitions.implant_terminal_interface),
             owningBuildingGuid = ownerGuid
           )
 

--- a/src/test/scala/game/HackMessageTest.scala
+++ b/src/test/scala/game/HackMessageTest.scala
@@ -14,20 +14,20 @@ class HackMessageTest extends Specification {
   "decode" in {
     PacketCoding.decodePacket(string).require match {
       case HackMessage(unk1, target_guid, player_guid, progress, unk5, hack_state, unk7) =>
-        unk1 mustEqual 0
+        unk1 mustEqual HackState1.Unk0
         target_guid mustEqual PlanetSideGUID(1024)
         player_guid mustEqual PlanetSideGUID(3607)
         progress mustEqual 0
-        unk5 mustEqual 3212836864L
+        unk5 mustEqual -1.0f
         hack_state mustEqual HackState.Start
-        unk7 mustEqual 8L
+        unk7 mustEqual HackState7.Unk8
       case _ =>
         ko
     }
   }
 
   "encode" in {
-    val msg = HackMessage(0, PlanetSideGUID(1024), PlanetSideGUID(3607), 0, 3212836864L, HackState.Start, 8L)
+    val msg = HackMessage(HackState1.Unk0, PlanetSideGUID(1024), PlanetSideGUID(3607), 0, -1.0f, HackState.Start, HackState7.Unk8)
     val pkt = PacketCoding.encodePacket(msg).require.toByteVector
     pkt mustEqual string
   }

--- a/src/test/scala/service/LocalServiceTest.scala
+++ b/src/test/scala/service/LocalServiceTest.scala
@@ -136,9 +136,9 @@ class HackClearTest extends ActorTest {
     "pass HackClear" in {
       val service = system.actorOf(Props(classOf[LocalService], Zone.Nowhere), "l_service")
       service ! Service.Join("test")
-      service ! LocalServiceMessage("test", LocalAction.HackClear(PlanetSideGUID(10), obj, 0L, 1000L))
+      service ! LocalServiceMessage("test", LocalAction.HackClear(PlanetSideGUID(10), obj, 0L, HackState7.Unk8))
       expectMsg(
-        LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.SendHackMessageHackCleared(PlanetSideGUID(40), 0L, 1000L))
+        LocalServiceResponse("/test/Local", PlanetSideGUID(10), LocalResponse.SendHackMessageHackCleared(PlanetSideGUID(40), 0L, HackState7.Unk8))
       )
     }
   }


### PR DESCRIPTION
Since I didn't know how to actually do it, I gave a hacky-solution my best shot.  In the process, I discovered that we don't really understand the nitty gritty of this hacking packet works even if we can manipulate it in other ways.

Anyway, this should allow an implant terminal to be accessible when hacked by the enemy.  Implant terminal should "resecure" when hacked while the facility's CC has ben hacked, but not before that.  Important things to remember: implant terminals are composed of two entities - the interface that you purchase from, and the mech that you mount and above which a hood lowers around you.  To keep things simple, only one of the two will take damage; but, both may retain functional dispenser anchor points for repairing.  Similarly, both may become hackable.  For best use, I recommend standing aside it, or in front of it, and aiming upwards at the hood.