### PR TITLE
Vehicle Gating, Again

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2425,13 +2425,13 @@ class ZoningOperations(
      * @param seat the mount index
      */
     def AvatarCreateInVehicle(tplayer: Player, vehicle: Vehicle, seat: Int): Unit = {
+      log.debug(s"AvatarCreateInVehicle: ${tplayer.Name}")
       val pdef  = tplayer.avatar.definition
       val pguid = tplayer.GUID
       val vguid = vehicle.GUID
       tplayer.VehicleSeated = None
-      tplayer.VehicleSeated = vguid
-      log.debug(s"AvatarCreateInVehicle: ${player.Name}")
       sendResponse(OCM.detailed(tplayer))
+      tplayer.VehicleSeated = vguid
       if (seat == 0 || vehicle.WeaponControlledFromSeat(seat).nonEmpty) {
         sendResponse(ObjectAttachMessage(vguid, pguid, seat))
         sessionLogic.general.accessContainer(vehicle)

--- a/src/main/scala/net/psforever/packet/game/objectcreate/CharacterData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/CharacterData.scala
@@ -18,13 +18,13 @@ import shapeless.{::, HNil}
 object ImplantEffects extends Enumeration {
   type Type = Value
 
-  val SurgeEffects: ImplantEffects.Value = Value(9)
+  val SurgeEffects: ImplantEffects.Value          = Value(9)
   val PersonalShieldEffects: ImplantEffects.Value = Value(5)
-  val DarklightEffects: ImplantEffects.Value = Value(3)
-  val RegenEffects: ImplantEffects.Value = Value(0)
-  val NoEffects: ImplantEffects.Value = Value(1)
+  val DarklightEffects: ImplantEffects.Value      = Value(3)
+  val RegenEffects: ImplantEffects.Value          = Value(0)
+  val NoEffects: ImplantEffects.Value             = Value(1)
 
-  implicit val codec: Codec[ImplantEffects.Value] = PacketHelpers.createEnumerationCodec(this, uint4L)
+  implicit val codec: Codec[ImplantEffects.Value] = PacketHelpers.createEnumerationCodec(this, uint4)
 }
 
 /**
@@ -159,7 +159,7 @@ object CharacterData extends Marshallable[CharacterData] {
     (
       ("uniform_upgrade" | UniformStyle.codec) >>:~ { style =>
         uint(bits = 3) :: //uniform_upgrade is actually interpreted as a 6u field, but the lower 3u seems to be discarded
-        ("command_rank" | uintL(bits = 3)) ::
+        ("command_rank" | uint(bits = 3)) ::
         ("implant_effects" | listOfN(uint2, ImplantEffects.codec)) ::
         ("cosmetics" | conditional(BattleRank.showCosmetics(style), Cosmetic.codec))
       }

--- a/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
@@ -95,7 +95,7 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
       unk: Int,
       player_guid: PlanetSideGUID
   ): CommonFieldData =
-    CommonFieldData(faction, bops = false, alternate = destroyed, v1 = unk > 1, None, jammered = false/*unk % 1 == 1*/, None, None, player_guid)
+    CommonFieldData(faction, bops = false, alternate = destroyed, v1 = unk > 1, None, jammered = unk > 0, None, None, player_guid)
 
   def apply(
       faction: PlanetSideEmpire.Value,
@@ -107,7 +107,7 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
   ): CommonFieldData = {
     val jammeredField = if (jammered) { Some(0) }
     else { None }
-    CommonFieldData(faction, bops, destroyed, unk > 1, None, jammered = false/*unk % 1 == 1*/, None, jammeredField, player_guid)
+    CommonFieldData(faction, bops, destroyed, unk > 1, None, jammered = unk > 0, None, jammeredField, player_guid)
   }
 
   def codec(extra: Boolean): Codec[CommonFieldData] =

--- a/src/main/scala/net/psforever/packet/game/objectcreate/DetailedCharacterData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/DetailedCharacterData.scala
@@ -608,7 +608,7 @@ object DetailedCharacterData extends Marshallable[DetailedCharacterData] {
                       ("unk7" | uint32L) ::
                       ("unk8" | uint32L) ::
                       (("imprinting" | optional(isFalse, imprint_progress_codec)) >>:~ { imprinting =>
-                      ("unkA" | listOfN(uint16L, uint32L)) ::
+                        ("unkA" | listOfN(uint16L, uint32L)) ::
                         ("unkB" | unkBCodec(
                           paddingCalculations(
                             displaceByOptionTest(pad_length, imprinting, value = 5),

--- a/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
@@ -157,7 +157,10 @@ object VehicleData extends Marshallable[VehicleData] {
 
   private val driveState8u = uint8.xmap[DriveState.Value](
     n => DriveState(n),
-    n => n.id
+    {
+      case n if n.id < 0 => DriveState.Mobile.id
+      case n => n.id
+    }
   )
 
   /**


### PR DESCRIPTION
Attempting to change zones in a vehicle, e.g., a drop pod, caused a client crash because the client attempted to create an unmounted player without legs.  The lack of unmounted detailed placement data is an invalid condition.  This issue is not affecting Live as it was only introduced in #1226 and that has not yet been pushed to the server.  The circumstances of this problem were a line that had been dragged and dropped.  The line was undoing an assignment that had _just_ been changed to run a command that would be different if the field was set; the drag accidentally dropped the undo right after the assignment and then ran the command.

This has actually been an issue for me since I have started using my current mouse, where attempts to click something are interpreted  as an attempt to drag and has left me scrambling, on more than one occasion, to hit a "cancel" button before half the server's files drop themselves into the wrong directory.