### PR TITLE
Fix up some chat commands

### DIFF
--- a/src/main/scala/net/psforever/actors/session/normal/ChatLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/ChatLogic.scala
@@ -234,7 +234,7 @@ class ChatLogic(val ops: ChatOperations, implicit val context: ActorContext) ext
           )
         )
       }
-      result
+      true // do not accidentally send mistyped commands to chat
     } else {
       false // not a handled command
     }

--- a/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
@@ -603,8 +603,9 @@ class ChatOperations(
   }
 
   def commandAddCertification(session: Session, message: ChatMsg, contents: String): Unit = {
-    val certs = cliTokenization(contents).map(name => Certification.values.find(_.name == name))
-    val result = if (certs.nonEmpty) {
+    val tokens = cliTokenization(contents)
+    val certs = tokens.map(name => Certification.values.find(_.name == name))
+    val result = if (tokens.nonEmpty) {
       if (certs.contains(None)) {
         s"@AckErrorCertifications"
       } else {
@@ -623,7 +624,7 @@ class ChatOperations(
   }
 
   def commandKick(session: Session, message: ChatMsg, contents: String): Unit = {
-    val inputs = cliTokenization(contents)
+    val inputs = cliTokenizationCaseSensitive(contents)
     inputs.headOption match {
       case Some(input) =>
         val determination: Player => Boolean = input.toLongOption match {
@@ -1269,7 +1270,11 @@ class ChatOperations(
   }
 
   def cliTokenization(str: String): List[String] = {
-    str.replaceAll("\\s+", " ").toLowerCase.trim.split("\\s").toList
+    str.replaceAll("\\s+", " ").toLowerCase.trim.split("\\s").toList.filter(!_.equals(""))
+  }
+
+  def cliTokenizationCaseSensitive(str: String): List[String] = {
+    str.replaceAll("\\s+", " ").trim.split("\\s").toList.filter(!_.equals(""))
   }
 
   def commandIncomingSend(message: ChatMsg): Unit = {


### PR DESCRIPTION
- fixed worldkick with case sensitive player names
- fixed command tokenization returning empty strings if no parameters were given
- added case sensitive tokenization needed for player name checks
- do not send custom commands to chat if no handler is found (mistyped command)