### PR TITLE
Config Set Hack Timer

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -88,6 +88,9 @@ game {
   # Purchases timers for the battleframe robotics vehicles all update at the same time when either of them would update
   shared-bfr-cooldown = yes
 
+  # How long the countdown timer is when a facility (main overworld base) is hacked
+  facility-hack-time = 15.minutes
+
   # HART system, shuttles and facilities
   hart {
     # How long the shuttle is not boarding passengers (going through the motions)

--- a/src/main/scala/net/psforever/objects/global/GlobalDefinitionsMiscellaneous.scala
+++ b/src/main/scala/net/psforever/objects/global/GlobalDefinitionsMiscellaneous.scala
@@ -19,6 +19,7 @@ import net.psforever.objects.vital.base.DamageType
 import net.psforever.objects.vital.etc.ExplodingRadialDegrade
 import net.psforever.objects.vital.prop.DamageWithPosition
 import net.psforever.types.{ExoSuitType, Vector3}
+import net.psforever.util.Config
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -485,7 +486,7 @@ object GlobalDefinitionsMiscellaneous {
     repair_silo.TargetValidation += EffectTarget.Category.Vehicle -> EffectTarget.Validation.RepairSilo
     repair_silo.Damageable = false
     repair_silo.Repairable = false
-    
+
     recharge_terminal.Name = "recharge_terminal"
     recharge_terminal.Interval = 1000
     recharge_terminal.UseRadius = 20
@@ -707,7 +708,7 @@ object GlobalDefinitionsMiscellaneous {
     capture_terminal.Name = "capture_terminal"
     capture_terminal.Damageable = false
     capture_terminal.Repairable = false
-    capture_terminal.FacilityHackTime = 15.minutes
+    capture_terminal.FacilityHackTime = Config.app.game.facilityHackTime
 
     secondary_capture.Name = "secondary_capture"
     secondary_capture.Damageable = false

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -163,7 +163,8 @@ case class GameConfig(
     doorsCanBeOpenedByMedAppFromThisDistance: Float,
     experience: Experience,
     maxBattleRank: Int,
-    promotion: PromotionSystem
+    promotion: PromotionSystem,
+    facilityHackTime: FiniteDuration
 )
 
 case class InstantActionConfig(


### PR DESCRIPTION
Add ability to change how long the timer is when a base is hacked.

Example use case: If we were to ever do something with LLUs, like capture the flag in the past, this would allow us to set a longer timer to not require hacking the bases as frequently. Local testing it worked fine when trying 60 and 120 minutes using psforever.conf override.