### PR TITLE
Facility Capture Experience

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -59,7 +59,7 @@ class SessionAvatarHandlers(
     //TODO squad services deactivated, participation trophy rewards for now - 11-20-2023
     //must be in a squad to earn experience
     val charId = player.CharId
-    val squadUI = sessionLogic.squad.squadUI
+    /*val squadUI = sessionLogic.squad.squadUI
     val participation = continent
       .Building(buildingId)
       .map { building =>
@@ -117,7 +117,10 @@ class SessionAvatarHandlers(
           exp.ToDatabase.reportFacilityCapture(charId, buildingId, zoneNumber, modifiedExp, expType="bep")
           avatarActor ! AvatarActor.AwardFacilityCaptureBep(modifiedExp)
           Some(modifiedExp)
-      }
+      }*/
+    //if not in squad (temporary)
+    exp.ToDatabase.reportFacilityCapture(charId, buildingId, zoneNumber, cep, expType="bep")
+    avatarActor ! AvatarActor.AwardFacilityCaptureBep(cep)
   }
 
   /**

--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -119,7 +119,7 @@ class SessionAvatarHandlers(
           Some(modifiedExp)
       }*/
     //if not in squad (temporary)
-    exp.ToDatabase.reportFacilityCapture(charId, buildingId, zoneNumber, cep, expType="bep")
+    exp.ToDatabase.reportFacilityCapture(charId, zoneNumber, buildingId, cep, expType="bep")
     avatarActor ! AvatarActor.AwardFacilityCaptureBep(cep)
   }
 

--- a/src/main/scala/net/psforever/objects/serverobject/structures/participation/FacilityHackParticipation.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/participation/FacilityHackParticipation.scala
@@ -41,13 +41,13 @@ trait FacilityHackParticipation extends ParticipationLogic {
           .filterNot { case (_, (_, _, t)) => curr - t > hackTime }
           .partition { case (p, _) => uniqueList2.contains(p) }
       }
-      val newParticipaants = list
+      val newParticipants = list
         .filterNot { p =>
           playerContribution.exists { case (u, _) => p.CharId == u }
         }
       playerContribution =
         vanguardParticipants.map { case (u, (p, d, _)) => (u, (p, d + 1, curr)) } ++
-          newParticipaants.map { p => (p.CharId, (p, 1, curr)) } ++
+          newParticipants.map { p => (p.CharId, (p, 1, curr)) } ++
           missingParticipants
     }
   }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/participation/MajorFacilityHackParticipation.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/participation/MajorFacilityHackParticipation.scala
@@ -251,11 +251,14 @@ final case class MajorFacilityHackParticipation(building: Building) extends Faci
               overallTimeMultiplier *
               Config.app.game.experience.cep.rate + competitionBonus
           ).toLong
-          //8. reward participants
-          //Classically, only players in the SOI are rewarded, and the llu runner too
+          //8. reward participants that are still in the zone
           val hackerId = hacker.CharId
+          val contributingPlayers = contributionVictor
+            .filter { case (player, _, _) => player.Zone.id == building.Zone.id }
+            .map { case (player, _, _) => player }
+            .toList
           //terminal hacker (always cep)
-          if (playersInSoi.exists(_.CharId == hackerId) && flagCarrier.map(_.CharId).getOrElse(0L) != hackerId) {
+          if (contributingPlayers.exists(_.CharId == hackerId) && flagCarrier.map(_.CharId).getOrElse(0L) != hackerId) {
             ToDatabase.reportFacilityCapture(
               hackerId,
               zoneNumber,
@@ -266,7 +269,7 @@ final case class MajorFacilityHackParticipation(building: Building) extends Faci
             events ! AvatarServiceMessage(hacker.Name, AvatarAction.AwardCep(hackerId, finalCep))
           }
           //bystanders (cep if squad leader, bep otherwise)
-          playersInSoi
+          contributingPlayers
             .filterNot { _.CharId == hackerId }
             .foreach { player =>
               val charId = player.CharId

--- a/src/main/scala/net/psforever/objects/serverobject/structures/participation/MajorFacilityHackParticipation.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/participation/MajorFacilityHackParticipation.scala
@@ -28,7 +28,9 @@ final case class MajorFacilityHackParticipation(building: Building) extends Faci
 
   def TryUpdate(): Unit = {
     val list = building.PlayersInSOI
-    updatePlayers(list)
+    if (list.nonEmpty) {
+      updatePlayers(list)
+    }
     val now = System.currentTimeMillis()
     if (now - lastInfoRequest > 60000L) {
       updatePopulationOverTime(list, now, before = 900000L)
@@ -123,7 +125,7 @@ final case class MajorFacilityHackParticipation(building: Building) extends Faci
             hackStart,
             completionTime,
             opposingFaction,
-            contributionOpposing
+            contributionVictor
           )
         )
         //1) experience from killing opposingFaction across duration of hack
@@ -336,7 +338,7 @@ final case class MajorFacilityHackParticipation(building: Building) extends Faci
         val towerRadius = math.pow(tower.Definition.SOIRadius.toDouble * 0.7d, 2d).toFloat
         list
           .map { case (p, f, kills) =>
-            val filteredKills = kills.filter { kill => Vector3.DistanceSquared(kill.victim.Position.xy, towerPosition) <= towerRadius }
+            val filteredKills = kills.filter { kill => Vector3.DistanceSquared(kill.victim.Position.xy, towerPosition) >= towerRadius }
             (p, f, filteredKills)
           }
           .filter { case (_, _, kills) => kills.nonEmpty }

--- a/src/main/scala/net/psforever/objects/serverobject/structures/participation/TowerHackParticipation.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/structures/participation/TowerHackParticipation.scala
@@ -11,11 +11,14 @@ import net.psforever.util.Config
 final case class TowerHackParticipation(building: Building) extends FacilityHackParticipation {
   def TryUpdate(): Unit = {
     val list = building.PlayersInSOI
-    updatePlayers(building.PlayersInSOI)
+    if (list.nonEmpty) {
+      updatePlayers(list)
+    }
     val now = System.currentTimeMillis()
     if (now - lastInfoRequest > 60000L) {
       updatePopulationOverTime(list, now, before = 300000L)
     }
+    lastInfoRequest = now
   }
 
   def RewardFacilityCapture(


### PR DESCRIPTION
Made a few changes after testing and println'ing basically everything to figure out the cause of 0 experience being granted upon capturing a base that was contested. I locally tested both 1v1, 1v2, and 2v2 scenarios. A few things of note to clarify how experience awards are calculated for anyone testing:

- The player that hacks the CC will receive CEP. Other players in the SOI will receive BEP. Once squads are no longer buggy, this will change and CEP will be rewarded to squad leaders and BEP to squad members (and solo players?)
- Every player does not need to get kills to receive capture experience. I had players just stand there and do nothing and receive experience because they were in the SOI. Collectively as an attacking faction, kill experience is summed up and rewards are calculated based on that, among other things.
- ~~You must be in the SOI at time of capture to receive a reward (with one exception - LLU). I do see an issue with this as LLU carriers typically require transport, so some unlucky driver will miss out because they leave the SOI. To be addressed later by actual devs (aka Fate)~~ Players that were in the SOI at some point during the hack will receive reward as long as they are still in the same zone when the hack, or resecure, completes.

I also did one test LLU capture to ensure the LLU runner received experience.