### PR TITLE
Doors Again Change Player's Sideness

### DIFF
--- a/src/main/scala/net/psforever/objects/avatar/interaction/WithEntrance.scala
+++ b/src/main/scala/net/psforever/objects/avatar/interaction/WithEntrance.scala
@@ -65,7 +65,7 @@ class WithEntrance()
                              obj: InteractsWithZone,
                              door: Door
                            ): Sidedness = {
-    debugInteriorCheck(obj, door)
+    //debugInteriorCheck(obj, door)
     strictInteriorCheck(obj, door)
   }
 

--- a/src/main/scala/net/psforever/objects/avatar/interaction/WithEntrance.scala
+++ b/src/main/scala/net/psforever/objects/avatar/interaction/WithEntrance.scala
@@ -65,7 +65,7 @@ class WithEntrance()
                              obj: InteractsWithZone,
                              door: Door
                            ): Sidedness = {
-    //debugInteriorCheck(obj, door)
+    debugInteriorCheck(obj, door)
     strictInteriorCheck(obj, door)
   }
 

--- a/src/main/scala/net/psforever/objects/serverobject/environment/EnvironmentAttribute.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/environment/EnvironmentAttribute.scala
@@ -82,7 +82,7 @@ object EnvironmentAttribute {
     /** only interact with living player characters or vehicles */
     def canInteractWith(obj: PlanetSideGameObject): Boolean = canInteractWithPlayersAndVehicles(obj)
 
-    def testingDepth(obj: _root_.net.psforever.objects.PlanetSideGameObject): Float = 0f
+    def testingDepth(obj: _root_.net.psforever.objects.PlanetSideGameObject): Float = 4f
   }
 
   /**


### PR DESCRIPTION
Should fix #1251 and fix #1249 

Enabled a debugging feature that shows a chat and on screen message when sideness is checked by a door. I played with lower values for the testingDepth, but I was able to "miss" the door check at a Tech Plant vehicle bay door due to its size. As unlikely as this scenario is, parking a vehicle right against the door and using surge with light armor (infil) I was able to jump high and far enough for the sideness to not change. 4 seemed to prevent that possibility.