### PR TITLE
Deployable Fixes

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2494,6 +2494,11 @@ class ZoningOperations(
           reclaimOurDeployables(continent.DeployableList, player.Name, reassignDeployablesTo(player.GUID))
         )
       )
+      //do this to make my deployed telepad appear that way
+      continent.Vehicles.filter(router => router.Definition == GlobalDefinitions.router && router.OwnerName.contains(player.Name))
+        .foreach { obj =>
+        sessionLogic.general.toggleTeleportSystem(obj, TelepadLike.AppraiseTeleportationSystem(obj, continent))
+      }
       //begin looking for conditions to set the avatar
       context.system.scheduler.scheduleOnce(delay = 250 millisecond, context.self, SessionActor.SetCurrentAvatar(player, 200))
     }

--- a/src/main/scala/net/psforever/objects/ce/DeployableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/ce/DeployableBehavior.scala
@@ -68,7 +68,12 @@ trait DeployableBehavior {
       if DeployableObject.OwnerGuid.nonEmpty =>
       val obj = DeployableObject
       if (constructed.contains(true)) {
-        loseOwnership(obj, obj.Faction)
+        if (obj.Definition.DeployCategory == DeployableCategory.Boomers) {
+          loseOwnership(obj, PlanetSideEmpire.NEUTRAL)
+        }
+        else {
+          loseOwnership(obj, obj.Faction)
+        }
       } else {
         obj.OwnerGuid = None
       }

--- a/src/main/scala/net/psforever/objects/ce/DeployableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/ce/DeployableBehavior.scala
@@ -68,7 +68,7 @@ trait DeployableBehavior {
       if DeployableObject.OwnerGuid.nonEmpty =>
       val obj = DeployableObject
       if (constructed.contains(true)) {
-        loseOwnership(obj, PlanetSideEmpire.NEUTRAL)
+        loseOwnership(obj, obj.Faction)
       } else {
         obj.OwnerGuid = None
       }
@@ -290,11 +290,17 @@ object DeployableBehavior {
         originalFaction.toString,
         LocalAction.DeployableMapIcon(Service.defaultPlayerGUID, DeploymentAction.Dismiss, info)
       )
+      //remove deployable from original owner's toolbox and UI counter
+      zone.AllPlayers.filter(p => obj.OriginalOwnerName.contains(p.Name))
+        .foreach { originalOwner =>
+          originalOwner.avatar.deployables.Remove(obj)
+          originalOwner.Zone.LocalEvents ! LocalServiceMessage(originalOwner.Name, LocalAction.DeployableUIFor(obj.Definition.Item))
+      }
+      //display to the given faction
+      localEvents ! LocalServiceMessage(
+        toFaction.toString,
+        LocalAction.DeployableMapIcon(Service.defaultPlayerGUID, DeploymentAction.Build, info)
+      )
     }
-    //display to the given faction
-    localEvents ! LocalServiceMessage(
-      toFaction.toString,
-      LocalAction.DeployableMapIcon(Service.defaultPlayerGUID, DeploymentAction.Build, info)
-    )
   }
 }


### PR DESCRIPTION
This aims to address a number of issues with deployables. The changes are made to:
- Fix #1246 by retaining the original owner's empire so CE does not turn against its own faction. I couldn't think of a scenario where ownerless CE would need to belong to Neutral. I also have no idea why _sometimes_ a random number of CE has this happen.
- The owner of a deployed router telepad should be able to see it and use it again after dying. Current behavior: If the owner of the pad were to die and respawn, the telepad would appear to be stuck in a state of getting ready to deploy. The owner could still teleport from the router to the telepad, but not go back the other way.
- If your field turret, for example, is hacked, this change will remove that deployable from your on screen counter and "toolbox". Current behavior: If your field turret were to be hacked and you deployed another one, the first one that now belongs to another empire would deconstruct, likely confusing the player that could be mounted inside it.