### PR TITLE
Lock The Door To My New Ride

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2495,9 +2495,13 @@ class ZoningOperations(
         )
       )
       //do this to make my deployed telepad appear that way
-      continent.Vehicles.filter(router => router.Definition == GlobalDefinitions.router && router.OwnerName.contains(player.Name))
-        .foreach { obj =>
-        sessionLogic.general.toggleTeleportSystem(obj, TelepadLike.AppraiseTeleportationSystem(obj, continent))
+      if (continent.DeployableList.exists(telepad => telepad.Definition == GlobalDefinitions.router_telepad_deployable
+        && telepad.OwnerName.contains(player.Name)))
+      {
+        continent.Vehicles.filter(router => router.Definition == GlobalDefinitions.router && router.Faction == player.Faction)
+          .foreach { obj =>
+            sessionLogic.general.toggleTeleportSystem(obj, TelepadLike.AppraiseTeleportationSystem(obj, continent))
+          }
       }
       //begin looking for conditions to set the avatar
       context.system.scheduler.scheduleOnce(delay = 250 millisecond, context.self, SessionActor.SetCurrentAvatar(player, 200))

--- a/src/main/scala/net/psforever/objects/Vehicles.scala
+++ b/src/main/scala/net/psforever/objects/Vehicles.scala
@@ -42,11 +42,13 @@ object Vehicles {
       case Some(tplayer) =>
         tplayer.avatar.vehicle = Some(vehicle.GUID)
         vehicle.AssignOwnership(playerOpt)
+        val locked = VehicleLockState.Locked.id
+        Array(0, 3).foreach(group => vehicle.PermissionGroup(group, locked))
+        Vehicles.ReloadAccessPermissions(vehicle, tplayer.Faction.toString)
         vehicle.Zone.VehicleEvents ! VehicleServiceMessage(
           vehicle.Zone.id,
           VehicleAction.Ownership(tplayer.GUID, vehicle.GUID)
         )
-        Vehicles.ReloadAccessPermissions(vehicle, tplayer.Faction.toString)
         Some(vehicle)
       case None =>
         None


### PR DESCRIPTION
Two things with this PR.

Fix #1264 
Tested pulling a vehicle as well as unlocking and allowing another player to take ownership of the vehicle. In both cases, when the owner dismounts, the driver seat (and trunk for good measure) were locked to other players. ~This also turned out to fix a vehicle appearing unlocked, but would say "you are not the driver" when attempting to mount and the driver door was in fact locked (this would happen prior to this new issue appearing).~

Also made a change to the fix I applied for router telepads in #1260. It now applies this for the telepad owner, not the router owner. This is because they aren't always the same player (as I experienced this past Sunday when my telepad stopped appearing "ready" to me when someone else jumped in my Router).