### PR TITLE
Enemy Faction Equipment in Favorites

### DIFF
--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -448,11 +448,11 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
                   //loadout for a MAX
                   player.ResistArmMotion(PlayerControl.maxRestriction)
                   player.DrawnSlot = Player.HandsDownSlot
-                  (newHolsters.filter(_.start == 4), newInventory)
+                  (newHolsters.filter(_.start == 4), newInventory.filterNot(dropPred))
                 } else {
                   //loadout for a vanilla exo-suit
                   player.ResistArmMotion(Player.neverRestrict)
-                  (newHolsters, newInventory)
+                  (newHolsters.filterNot(dropPred), newInventory.filterNot(dropPred))
                 }
               } else {
                 //proposed loadout conforms to a different inventory layout than the projected exo-suit
@@ -460,7 +460,7 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
                 //holsters (matching holsters will be inserted, the rest will deposited into the inventory)
                 val (finalHolsters, leftoversForInventory) = Players.fillEmptyHolsters(
                   player.Holsters().iterator,
-                  (newHolsters.filterNot(_.obj.Size == EquipmentSize.Max) ++ newInventory)
+                  (newHolsters.filterNot(_.obj.Size == EquipmentSize.Max) ++ newInventory).filterNot(dropPred)
                 )
                 //inventory (items will be placed to accommodate the change, or dropped)
                 val (finalInventory, _) = GridInventory.recoverInventory(leftoversForInventory, player.Inventory)

--- a/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -678,8 +678,8 @@ object ContainableBehavior {
       val faction = GlobalDefinitions.isFactionEquipment(objDef)
       GlobalDefinitions.isCavernEquipment(objDef) ||
       objDef == GlobalDefinitions.router_telepad ||
-      entry.obj.isInstanceOf[BoomerTrigger] ||
-      (faction != tplayer.Faction && faction != PlanetSideEmpire.NEUTRAL)
+      entry.obj.isInstanceOf[BoomerTrigger] /*||
+      (faction != tplayer.Faction && faction != PlanetSideEmpire.NEUTRAL)*/
     }
 }
 


### PR DESCRIPTION
Needed to remove a filter that prevents you from being able to load other faction equipment in a favorite. This will allow favorites to be used outside of Desolation and still give you the equipment, but it will be reverted after Sunday.