### PR TITLE
More Sideness Things

### DIFF
--- a/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
@@ -408,7 +408,7 @@ class GeneralLogic(val ops: GeneralOperations, implicit val context: ActorContex
         log.info(s"${player.Name} is constructing a $ammoType deployable")
         sessionLogic.zoning.CancelZoningProcessWithDescriptiveReason("cancel_use")
         if (ammoType == DeployedItem.spitfire_turret || ammoType == DeployedItem.spitfire_cloaked ||
-          ammoType == DeployedItem.spitfire_aa || ammoType == DeployedItem.he_mine || ammoType == DeployedItem.jammer_mine) {
+          ammoType == DeployedItem.spitfire_aa) {
           ops.handleDeployObject(continent, ammoType, pos, orient, OutsideOf, player.Faction, player, obj)
         }
         else {

--- a/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
@@ -407,7 +407,8 @@ class GeneralLogic(val ops: GeneralOperations, implicit val context: ActorContex
         }
         log.info(s"${player.Name} is constructing a $ammoType deployable")
         sessionLogic.zoning.CancelZoningProcessWithDescriptiveReason("cancel_use")
-        if (obj.AmmoType == DeployedItem.spitfire_turret || obj.AmmoType == DeployedItem.spitfire_cloaked) {
+        if (ammoType == DeployedItem.spitfire_turret || ammoType == DeployedItem.spitfire_cloaked ||
+          ammoType == DeployedItem.spitfire_aa || ammoType == DeployedItem.he_mine || ammoType == DeployedItem.jammer_mine) {
           ops.handleDeployObject(continent, ammoType, pos, orient, OutsideOf, player.Faction, player, obj)
         }
         else {

--- a/src/main/scala/net/psforever/actors/session/normal/VehicleHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/VehicleHandlerLogic.scala
@@ -8,6 +8,7 @@ import net.psforever.objects.avatar.SpecialCarry
 import net.psforever.objects.{GlobalDefinitions, Player, Tool, Vehicle, Vehicles}
 import net.psforever.objects.equipment.{Equipment, JammableMountedWeapons, JammableUnit}
 import net.psforever.objects.guid.{GUIDTask, TaskWorkflow}
+import net.psforever.objects.serverobject.interior.Sidedness.OutsideOf
 import net.psforever.objects.serverobject.mount.Mountable
 import net.psforever.objects.serverobject.pad.VehicleSpawnPad
 import net.psforever.packet.game.objectcreate.ObjectCreateMessageParent
@@ -187,6 +188,7 @@ class VehicleHandlerLogic(val ops: SessionVehicleHandlers, implicit val context:
             s"${player.Sex.possessive} ride"
         }
         log.info(s"${player.Name} has been kicked from $typeOfRide!")
+        player.WhichSide = OutsideOf
 
       case VehicleResponse.KickPassenger(_, wasKickedByDriver, _) =>
         //seat number (first field) seems to be correct if passenger is kicked manually by driver

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -3,6 +3,7 @@ package net.psforever.actors.session.support
 
 import akka.actor.{ActorContext, typed}
 import net.psforever.objects.serverobject.affinity.FactionAffinity
+import net.psforever.objects.serverobject.interior.Sidedness.OutsideOf
 import net.psforever.objects.{PlanetSideGameObject, Tool, Vehicle}
 import net.psforever.objects.vehicles.{CargoBehavior, MountableWeapons}
 import net.psforever.objects.vital.InGameHistory
@@ -197,6 +198,7 @@ class SessionMountHandlers(
    */
   def DismountVehicleAction(tplayer: Player, obj: PlanetSideGameObject with FactionAffinity with InGameHistory, seatNum: Int): Unit = {
     DismountAction(tplayer, obj, seatNum)
+    tplayer.WhichSide = OutsideOf
     //until vehicles maintain synchronized momentum without a driver
     obj match {
       case v: Vehicle

--- a/src/main/scala/net/psforever/objects/equipment/EffectTarget.scala
+++ b/src/main/scala/net/psforever/objects/equipment/EffectTarget.scala
@@ -324,7 +324,7 @@ object EffectTarget {
     def FacilityTurretValidateAircraftTarget(target: PlanetSideGameObject): Boolean =
       target match {
         case v: Vehicle
-          if GlobalDefinitions.isFlightVehicle(v.Definition) && v.Seats.values.exists(_.isOccupied) =>
+          if GlobalDefinitions.isFlightVehicle(v.Definition) && v.Seats.values.exists(_.isOccupied) && v.Definition != GlobalDefinitions.mosquito =>
           val now = System.currentTimeMillis()
           val pos = v.Position
           lazy val sector = v.Zone.blockMap.sector(pos, range = 51f)
@@ -332,10 +332,10 @@ object EffectTarget {
             .collect { case t: Tool => now - t.LastDischarge }
             .exists(_ < 2000L)
           // from the perspective of a mosquito, at 5th gauge, forward velocity is 59~60
-          lazy val movingFast = Vector3.MagnitudeSquared(v.Velocity.getOrElse(Vector3.Zero).xy) > 3721f //61
+          //lazy val movingFast = Vector3.MagnitudeSquared(v.Velocity.getOrElse(Vector3.Zero).xy) > 3721f //61
           lazy val isMoving = v.isMoving(test = 1d)
           if (v.Cloaked || radarCloakedAms(sector, pos) || radarCloakedAegis(sector, pos)) false
-          else if (v.Definition == GlobalDefinitions.mosquito) movingFast
+          //else if (v.Definition == GlobalDefinitions.mosquito) movingFast
           else v.isFlying && (isMoving || entityTookDamage(v, now) || usedEquipment)
         case _ =>
           false


### PR DESCRIPTION
Had some instances of CE sideness behavior not being quite right the last fight. Made a few more changes that I think should resolve them.

- Forced more CE to outside sideness since these can only be laid outside and they do damage/AI things based on sideness of the target.
- Through testing pulling vehicles, a player that gets out of the vehicle could have "inside" sideness depending on the vehicle terminal's location. When a player gets out of a vehicle, gets kicked, or vehicle is hacked, it should set that player's sideness to outside. Prior to this I could pull a vehicle from a tech plant, get out, and mines would not damage the player and spitfires not target.