### PR TITLE
The Pilot Goes Down With The Plane

### DIFF
--- a/src/main/scala/net/psforever/actors/session/csr/MountHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/csr/MountHandlerLogic.scala
@@ -298,6 +298,10 @@ class MountHandlerLogic(val ops: SessionMountHandlers, implicit val context: Act
         }
 
       case Mountable.CanNotDismount(obj: Vehicle, _, BailType.Bailed)
+        if obj.Health <= (obj.MaxHealth * .35).round && GlobalDefinitions.isFlightVehicle(obj.Definition) =>
+        sendResponse(ChatMsg(ChatMessageType.UNK_224, "@BailingMechanismFailure_Pilot"))
+
+      case Mountable.CanNotDismount(obj: Vehicle, _, BailType.Bailed)
         if {
           continent
             .blockMap

--- a/src/main/scala/net/psforever/actors/session/normal/MountHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/MountHandlerLogic.scala
@@ -313,6 +313,10 @@ class MountHandlerLogic(val ops: SessionMountHandlers, implicit val context: Act
         sendResponse(ChatMsg(ChatMessageType.UNK_224, "@SA_CannotBailAtThisTime"))
 
       case Mountable.CanNotDismount(obj: Vehicle, _, BailType.Bailed)
+        if obj.Health <= (obj.MaxHealth * .35).round && GlobalDefinitions.isFlightVehicle(obj.Definition) =>
+        sendResponse(ChatMsg(ChatMessageType.UNK_224, "@BailingMechanismFailure_Pilot"))
+
+      case Mountable.CanNotDismount(obj: Vehicle, _, BailType.Bailed)
         if {
           continent
             .blockMap

--- a/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionMountHandlers.scala
@@ -202,10 +202,10 @@ class SessionMountHandlers(
     //until vehicles maintain synchronized momentum without a driver
     obj match {
       case v: Vehicle
-        if seatNum == 0 && Vector3.MagnitudeSquared(v.Velocity.getOrElse(Vector3.Zero)) > 0f =>
-        sessionLogic.vehicles.serverVehicleControlVelocity.collect { _ =>
+        if seatNum == 0 =>
+        /*sessionLogic.vehicles.serverVehicleControlVelocity.collect { _ =>
           sessionLogic.vehicles.ServerVehicleOverrideStop(v)
-        }
+        }*/
         v.Velocity = Vector3.Zero
         continent.VehicleEvents ! VehicleServiceMessage(
           continent.id,
@@ -213,9 +213,9 @@ class SessionMountHandlers(
             tplayer.GUID,
             v.GUID,
             unk1 = 0,
-            v.Position,
+            tplayer.Position,
             v.Orientation,
-            vel = None,
+            v.Velocity,
             v.Flying,
             unk3 = 0,
             unk4 = 0,

--- a/src/main/scala/net/psforever/objects/Players.scala
+++ b/src/main/scala/net/psforever/objects/Players.scala
@@ -80,6 +80,8 @@ object Players {
       )
     )
     target.Zone.AvatarEvents ! AvatarServiceMessage(name, AvatarAction.Revive(target.GUID))
+    val reviveMessage = s"@YouHaveBeenMessage^revived~^$medicName~"
+    PlayerControl.sendResponse(target.Zone, name, ChatMsg(ChatMessageType.UNK_227, reviveMessage))
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
+++ b/src/main/scala/net/psforever/objects/avatar/PlayerControl.scala
@@ -5,6 +5,7 @@ import akka.actor.{Actor, ActorRef, Props, typed}
 import net.psforever.actors.session.AvatarActor
 import net.psforever.login.WorldSession.{DropEquipmentFromInventory, HoldNewEquipmentUp, PutNewEquipmentInInventoryOrDrop, RemoveOldEquipmentFromInventory}
 import net.psforever.objects._
+import net.psforever.objects.avatar.PlayerControl.sendResponse
 import net.psforever.objects.ce.Deployable
 import net.psforever.objects.definition.DeployAnimation
 import net.psforever.objects.definition.converter.OCM
@@ -147,6 +148,15 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
                   newHealth - originalHealth
                 )
               )
+              val amount = newHealth - originalHealth
+              val healMessageSelf = s"@SelfHitHealedMessage^healed~^$amount~^health~"
+              val healMessageOther = s"@WereHitByHealedMessage^healed~^$amount~^health~^$uname~"
+              if (player == user) {
+                sendResponse(user.Zone, user.Name, ChatMsg(ChatMessageType.UNK_227, healMessageSelf))
+              }
+              else {
+                sendResponse(player.Zone, player.Name, ChatMsg(ChatMessageType.UNK_227, healMessageOther))
+              }
             }
             if (player != user) {
               //"Someone is trying to heal you"
@@ -210,6 +220,15 @@ class PlayerControl(player: Player, avatarActor: typed.ActorRef[AvatarActor.Comm
                   newArmor - originalArmor
                 )
               )
+              val amount = newArmor - originalArmor
+              val repairMessageSelf = s"@SelfHitHealedMessage^repaired~^$amount~^armor~"
+              val repairMessageOther = s"@WereHitByHealedMessage^repaired~^$amount~^armor~^$uname~"
+              if (player == user) {
+                sendResponse(user.Zone, user.Name, ChatMsg(ChatMessageType.UNK_227, repairMessageSelf))
+              }
+              else {
+                sendResponse(player.Zone, player.Name, ChatMsg(ChatMessageType.UNK_227, repairMessageOther))
+              }
             }
             if (player != user) {
               if (player.isAlive) {

--- a/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/generator/GeneratorControl.scala
@@ -192,6 +192,10 @@ class GeneratorControl(gen: Generator)
     if(newHealth == target.Definition.MaxHealth) {
       stopAutoRepair()
     }
+    if(gen.Condition == PlanetSideGeneratorState.Critical && newHealth > (target.MaxHealth / 2)) {
+      gen.Condition = PlanetSideGeneratorState.Normal
+      GeneratorControl.UpdateOwner(gen, Some(GeneratorControl.Event.Normal))
+    }
     newHealth
   }
 

--- a/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/control/VehicleControl.scala
@@ -27,7 +27,7 @@ import net.psforever.objects.sourcing.{PlayerSource, SourceEntry, VehicleSource}
 import net.psforever.objects.vehicles._
 import net.psforever.objects.vehicles.interaction.WithWater
 import net.psforever.objects.vital.interaction.DamageResult
-import net.psforever.objects.vital.{InGameActivity, ShieldCharge, SpawningActivity, VehicleDismountActivity, VehicleMountActivity}
+import net.psforever.objects.vital.{DamagingActivity, InGameActivity, ShieldCharge, SpawningActivity, VehicleDismountActivity, VehicleMountActivity}
 import net.psforever.objects.zones._
 import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game._
@@ -39,6 +39,7 @@ import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.util.Random
 
 /**
   * An `Actor` that handles messages being dispatched to a specific `Vehicle`.<br>
@@ -138,6 +139,36 @@ class VehicleControl(vehicle: Vehicle)
           case Some(entry) if System.currentTimeMillis() - entry.time < 8500L => true
           case _ => false
         }) =>
+        sender() ! Mountable.MountMessages(user, Mountable.CanNotDismount(vehicle, seat_num, bailType))
+
+      case Mountable.TryDismount(user, seat_num, bailType)
+        if vehicle.Health <= (vehicle.Definition.MaxHealth * .1).round && bailType == BailType.Bailed
+          && GlobalDefinitions.isFlightVehicle(vehicle.Definition)
+          && (seat_num == 0 || vehicle.SeatPermissionGroup(seat_num).getOrElse(0) == AccessPermissionGroup.Gunner)
+          && (vehicle.History.findLast { entry => entry.isInstanceOf[DamagingActivity] } match {
+          case Some(entry) if System.currentTimeMillis() - entry.time < 4000L => true
+          case _ if Random.nextInt(10) == 1 => false
+          case _ => true }) =>
+        sender() ! Mountable.MountMessages(user, Mountable.CanNotDismount(vehicle, seat_num, bailType))
+
+      case Mountable.TryDismount(user, seat_num, bailType)
+        if vehicle.Health <= (vehicle.Definition.MaxHealth * .2).round && bailType == BailType.Bailed
+          && GlobalDefinitions.isFlightVehicle(vehicle.Definition)
+          && (seat_num == 0 || vehicle.SeatPermissionGroup(seat_num).getOrElse(0) == AccessPermissionGroup.Gunner)
+          && (vehicle.History.findLast { entry => entry.isInstanceOf[DamagingActivity] } match {
+          case Some(entry) if System.currentTimeMillis() - entry.time < 3500L => true
+          case _ if Random.nextInt(5) == 1 => false
+          case _ => true }) =>
+        sender() ! Mountable.MountMessages(user, Mountable.CanNotDismount(vehicle, seat_num, bailType))
+
+      case Mountable.TryDismount(user, seat_num, bailType)
+        if vehicle.Health <= (vehicle.Definition.MaxHealth * .35).round && bailType == BailType.Bailed
+          && GlobalDefinitions.isFlightVehicle(vehicle.Definition)
+          && (seat_num == 0 || vehicle.SeatPermissionGroup(seat_num).getOrElse(0) == AccessPermissionGroup.Gunner)
+          && (vehicle.History.findLast { entry => entry.isInstanceOf[DamagingActivity] } match {
+          case Some(entry) if System.currentTimeMillis() - entry.time < 3000L => true
+          case _ if Random.nextInt(4) == 1 => false
+          case _ => true }) =>
         sender() ! Mountable.MountMessages(user, Mountable.CanNotDismount(vehicle, seat_num, bailType))
 
       case Mountable.TryDismount(user, seat_num, bailType)

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -276,7 +276,7 @@ class HackCaptureActor extends Actor {
         && base._2.GUID != building.GUID)
       val zoneTowers = building.Zone.Buildings.filter(tower =>
         tower._2.BuildingType == StructureType.Tower && tower._2.Faction != hackedByFaction)
-      // All major facilities in zone are now owned by the hacking faction. Capture all towers in the zone
+      // All major facilities in zone are now owned by the hacking faction. Capture all remaining towers in the zone
       // Base that was just hacked is not counted (hence the size - 1) because it wasn't always in ownedBases (async?)
       if (zoneBases.size - 1 == ownedBases.size && zoneTowers.nonEmpty)
         {

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -276,7 +276,7 @@ class HackCaptureActor extends Actor {
         && base._2.GUID != building.GUID)
       val zoneTowers = building.Zone.Buildings.filter(tower =>
         tower._2.BuildingType == StructureType.Tower && tower._2.Faction != hackedByFaction)
-      // All major facilities in zone are now owned by the hacking faction. Capture all remaining towers in the zone
+      // All major facilities in zone are now owned by the hacking faction. Capture all towers in the zone
       // Base that was just hacked is not counted (hence the size - 1) because it wasn't always in ownedBases (async?)
       if (zoneBases.size - 1 == ownedBases.size && zoneTowers.nonEmpty)
         {

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -18,6 +18,8 @@ import net.psforever.services.local.support.HackCaptureActor.GetHackingFaction
 import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.types.{ChatMessageType, PlanetSideEmpire, PlanetSideGUID}
 
+import java.util.concurrent.{Executors, TimeUnit}
+import scala.collection.Seq
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.Random
 
@@ -30,6 +32,7 @@ class HackCaptureActor extends Actor {
   private var clearTrigger: Cancellable = Default.Cancellable
   /** list of currently hacked server objects */
   private var hackedObjects: List[HackCaptureActor.HackEntry] = Nil
+  private val scheduler = Executors.newScheduledThreadPool(2)
 
   def receive: Receive = {
     case HackCaptureActor.StartCaptureTerminalHack(target, _, _, _, _)
@@ -266,6 +269,20 @@ class HackCaptureActor extends Actor {
         .collect { case p if p.Faction == hackedByFaction =>
           events ! LocalServiceMessage(p.Name, msg)
         }
+      val zoneBases = building.Zone.Buildings.filter(base =>
+        base._2.BuildingType == StructureType.Facility)
+      val ownedBases = building.Zone.Buildings.filter(base =>
+        base._2.BuildingType == StructureType.Facility && base._2.Faction == hackedByFaction
+        && base._2.GUID != building.GUID)
+      val zoneTowers = building.Zone.Buildings.filter(tower =>
+        tower._2.BuildingType == StructureType.Tower && tower._2.Faction != hackedByFaction)
+      // All major facilities in zone are now owned by the hacking faction. Capture all towers in the zone
+      // Base that was just hacked is not counted (hence the size - 1) because it wasn't always in ownedBases (async?)
+      println(s"bases: ${zoneBases.size} owned: ${ownedBases.size} towers: ${zoneTowers.size}")
+      if (zoneBases.size - 1 == ownedBases.size && zoneTowers.nonEmpty)
+        {
+          processBuildingsWithDelay(zoneTowers.values.toSeq, hackedByFaction, 1000)
+        }
     } else {
       log.info("Base hack completed, but base was out of NTU.")
     }
@@ -283,6 +300,43 @@ class HackCaptureActor extends Actor {
       clearTrigger = context.system.scheduler.scheduleOnce(short_timeout, self, HackCaptureActor.ProcessCompleteHacks())
     }
   }
+
+  def processBuildingsWithDelay(
+                                 buildings: Seq[Building],
+                                 faction: PlanetSideEmpire.Value,
+                                 delayMillis: Long
+                               ): Unit = {
+    val buildingIterator = buildings.iterator
+    scheduler.scheduleAtFixedRate(
+      () => {
+        if (buildingIterator.hasNext) {
+          val building = buildingIterator.next()
+          val terminal = building.CaptureTerminal.get
+          val zone = building.Zone
+          val zoneActor = zone.actor
+          val buildingActor = building.Actor
+          //clear any previous hack
+          if (building.CaptureTerminalIsHacked) {
+            zone.LocalEvents ! LocalServiceMessage(
+              zone.id,
+              LocalAction.ResecureCaptureTerminal(terminal, PlayerSource.Nobody)
+            )
+          }
+          //push any updates this might cause
+          zoneActor ! ZoneActor.ZoneMapUpdate()
+          //convert faction affiliation
+          buildingActor ! BuildingActor.SetFaction(faction)
+          buildingActor ! BuildingActor.AmenityStateChange(terminal, Some(false))
+          //push for map updates again
+          zoneActor ! ZoneActor.ZoneMapUpdate()
+        }
+      },
+      0,
+      delayMillis,
+      TimeUnit.MILLISECONDS
+    )
+  }
+
 }
 
 object HackCaptureActor {

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -278,7 +278,6 @@ class HackCaptureActor extends Actor {
         tower._2.BuildingType == StructureType.Tower && tower._2.Faction != hackedByFaction)
       // All major facilities in zone are now owned by the hacking faction. Capture all towers in the zone
       // Base that was just hacked is not counted (hence the size - 1) because it wasn't always in ownedBases (async?)
-      println(s"bases: ${zoneBases.size} owned: ${ownedBases.size} towers: ${zoneTowers.size}")
       if (zoneBases.size - 1 == ownedBases.size && zoneTowers.nonEmpty)
         {
           processBuildingsWithDelay(zoneTowers.values.toSeq, hackedByFaction, 1000)


### PR DESCRIPTION
There's nothing more annoying than chasing an aircraft that has a sliver of armor remaining and seeing the pilot bail out. This introduces the bail malfunction system. The conditions are _mostly_ based on what is available in the wiki, which is:
- Only applies to aircraft pilots and gunners. Passengers can freely bail at any time
- Once the aircraft is below 35% of its maximum armor, bailing may be prevented
- As armor decreases, so do the chances of being able to bail

The additional condition is how long it has been since you have taken damage. As armor decreases, more time since the last damage taken is needed for the chance to bail to be allowed. While this favors the pursuer, it was my best effort at adding a "delay" between bail attempts as I couldn't see a way to prevent spamming the bail hotkey to roll the dice more quickly to hit the RNG needed.

Also added some fix attempts to fix #1234 and fix #1083.  Don't ask on the latter; I tried different things and that worked... The vehicle can tend to slowly inch forward to where the driver bailed. I think it has to do with how long the exit animation takes, so the vehicle will initially be slightly behind the driver to other players. While it is "moving" you can still enter/exit the vehicle, so this is better than what was happening before. 

Edit: Fix #1077 using the same process that capturebase all uses to capture any towers not owned by the faction that just captured the last base on the zone.

Edit edit: Fix #1205 added in messages sent to the player being repaired or the owner of a vehicle being repaired.