### PR TITLE
Color and stupid things

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,7 +23,7 @@ world {
   ports = []
 
   # The name of the server as displayed in the server browser.
-  server-name = PSForever
+  server-name = "\\#1EACF9P\\#E87BE8S\\#F93F4E4ever"
 
   # How the server is displayed in the server browser.
   # One of: released beta development


### PR DESCRIPTION
I documented this at some point but almost lost it. So it is time to push this in order to show how this works.

While replicating the VNLWorldStatusMessage -> WorldInfo packet for the Go LoginServer I discovered, that the client can interpret colorization not only in the chat, but also for the WorldServer name.
For some additional information on the name field:

- max 32 bytes in packet
- max 18 visible characters on client

So there is some room to do stupid things.
You can for example use the build in strings for the "live" world servers (Werner/Gemini).

- @<!-- -->sdkpls-01=Markov
- @<!-- -->ablpls-01=Emerald
- @<!-- -->amspls-01=Werner
- @<!-- -->gemini=Gemini

Caveats:

- the string has to be at the beginning of the buffer for the substitution to work

But there is more fun to have! You can do some stupid hacks, too.

- you can place a CR and LF to override the previous text in the server list
> `XYZ\x0DABC\x0A`
> `XYZ\rABC\n`
\x0D -> CR
\x0A -> LF

- you can add color with this
> `\\#AABBCCABC`

- finally graduate "Internal" by using a "live" substitution name
> `amspls\x0D\\#AABBCCABC\x0A`

![image](https://github.com/user-attachments/assets/8b939d00-ebad-40ce-9905-1b065ee17cb8)

- or just go easy and color the PSForever server name how it always should have been
> `\\#1EACF9P\\#E87BE8S\\#F93F4E4ever`

![image](https://github.com/user-attachments/assets/4a786c60-5808-48c1-abe1-6d811cd12dcd)
![image](https://github.com/user-attachments/assets/68ddaa4b-3deb-449c-a612-6fd3e93f95ee)
> ignore the 4, I think it was too long :)

