### PR TITLE
Multikill Rewards

### DIFF
--- a/src/main/scala/net/psforever/objects/zones/exp/ToDatabase.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/ToDatabase.scala
@@ -1,7 +1,6 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.objects.zones.exp
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import net.psforever.objects.avatar.scoring.EquipmentStat
 import net.psforever.objects.serverobject.hackable.Hackable.HackInfo
 import net.psforever.objects.sourcing.VehicleSource
@@ -10,7 +9,6 @@ import net.psforever.types.Vector3
 import net.psforever.util.Database.ctx
 import net.psforever.util.Database.ctx._
 
-import scala.concurrent.Future
 
 object ToDatabase {
   /**
@@ -103,27 +101,22 @@ object ToDatabase {
    * insert a new entry into the table.
    * Shots fired.
    */
-  def reportToolDischarge(avatarId: Long, stats: EquipmentStat): Future[Unit] = {
-    import ctx._
-    import scala.concurrent.ExecutionContext.Implicits.global
-    ctx.transaction { implicit ec =>
-      ctx.run(
-        query[persistence.Weaponstatsession]
-          .insert(
-            _.avatarId -> lift(avatarId),
-            _.weaponId -> lift(stats.objectId),
-            _.shotsFired -> lift(stats.shotsFired),
-            _.shotsLanded -> lift(stats.shotsLanded),
-            _.kills -> lift(0),
-            _.assists -> lift(0),
-            _.sessionId -> lift(-1L)
-          )
-          .onConflictUpdate(_.avatarId, _.weaponId, _.sessionId)(
-            (t, e) => t.shotsFired -> (t.shotsFired + e.shotsFired),
-            (t, e) => t.shotsLanded -> (t.shotsLanded + e.shotsLanded)
-          )
-      ).map(_ => ())
-    }
+  def reportToolDischarge(avatarId: Long, stats: EquipmentStat): Unit = {
+    ctx.run(query[persistence.Weaponstatsession]
+      .insert(
+        _.avatarId -> lift(avatarId),
+        _.weaponId -> lift(stats.objectId),
+        _.shotsFired -> lift(stats.shotsFired),
+        _.shotsLanded -> lift(stats.shotsLanded),
+        _.kills -> lift(0),
+        _.assists -> lift(0),
+        _.sessionId -> lift(-1L)
+      )
+      .onConflictUpdate(_.avatarId, _.weaponId, _.sessionId)(
+        (t, e) => t.shotsFired -> (t.shotsFired + e.shotsFired),
+        (t, e) => t.shotsLanded -> (t.shotsLanded + e.shotsLanded)
+      )
+    )
   }
 
   /**

--- a/src/main/scala/net/psforever/objects/zones/exp/ToDatabase.scala
+++ b/src/main/scala/net/psforever/objects/zones/exp/ToDatabase.scala
@@ -1,6 +1,7 @@
 // Copyright (c) 2022 PSForever
 package net.psforever.objects.zones.exp
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import net.psforever.objects.avatar.scoring.EquipmentStat
 import net.psforever.objects.serverobject.hackable.Hackable.HackInfo
 import net.psforever.objects.sourcing.VehicleSource
@@ -8,7 +9,6 @@ import net.psforever.persistence
 import net.psforever.types.Vector3
 import net.psforever.util.Database.ctx
 import net.psforever.util.Database.ctx._
-
 
 object ToDatabase {
   /**

--- a/src/main/scala/net/psforever/services/local/support/CaptureFlagManager.scala
+++ b/src/main/scala/net/psforever/services/local/support/CaptureFlagManager.scala
@@ -92,7 +92,7 @@ class CaptureFlagManager(zone: Zone) extends Actor {
         case CaptureFlagLostReasonEnum.Resecured =>
           CaptureFlagManager.ChatBroadcast(
             zone,
-            CaptureFlagChatMessageStrings.CTF_Failed_SourceResecured(flag.Owner.asInstanceOf[Building].Name, flag.Faction)
+            CaptureFlagChatMessageStrings.CTF_Failed_SourceResecured(flag.Owner.asInstanceOf[Building].Name, flag.Owner.asInstanceOf[Building].Faction)
           )
         case CaptureFlagLostReasonEnum.TimedOut  =>
           val building = flag.Owner.asInstanceOf[Building]


### PR DESCRIPTION
This is to resolve #860.

When a kill is rewarded, the current behavior has it send the player's current bep + the kill exp amount to the next step. When a player kills multiple enemies at the same time via a boomer or any other explosion/etc. this runs the updateKills for each kill. What I found is the same `avatar.bep` value is used for each kill where `setBep(avatar.bep + exp, msg)` is being used. It must be due to the asynchronous nature and `avatar.bep` not being current between the kill rewards. Example:

Kill 1:
Sends the values (5000 + 100, msg), resulting in the database setting the new bep to 5100
Kill 2:
Sends the values (5000 + 50, msg), resulting in the database setting the new bep to 5050

Kill 1's exp reward is essentially being overwritten instead of added to. This change seems to step through each multikill reward properly and use the actual current bep + reward exp in each update. I tested up to 4 killed via a boomer and 2 in a vehicle and 2 out of the vehicle dying to it exploding, each showing a separate award. Visually it looks funny in the chat window because all the kills are shown, then under it shows all the exp messages. That isn't something I am trying to change/"fix" here. Same goes for vehicle kills where on retail it would give a single exp drop that factored in all the mounted players.

I also fixed a confusing message when an LLU facility is resecured. It would say the building owner's faction resecured, but also the empire that hacked the base resecured.
![image](https://github.com/user-attachments/assets/b1608905-7e1c-4f79-86fe-b7a31ee5e3b4)
