### PR TITLE
Warpgate Fixes

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1269,6 +1269,7 @@ class ZoningOperations(
         ICS.FindZone(_.id == zoneId, context.self)
       ))
     } else {
+      vehicle.Velocity = None
       sessionLogic.general.unaccessContainer(vehicle)
       LoadZoneCommonTransferActivity()
       player.VehicleSeated = vehicle.GUID
@@ -2965,7 +2966,7 @@ class ZoningOperations(
     /**
      * na
      * @param target player being spawned
-     * @param position where player is being placed in the game wqrld
+     * @param position where player is being placed in the game world
      * @param orientation in what direction the player is facing in the game world
      * @param onThisSide description of the containing environment
      * @param goingToZone common designation for the zone

--- a/src/main/scala/net/psforever/objects/SpawnPoint.scala
+++ b/src/main/scala/net/psforever/objects/SpawnPoint.scala
@@ -140,8 +140,6 @@ object SpawnPoint {
   def CavernGate(innerRadius: Float)(obj: SpawnPoint, target: PlanetSideGameObject): (Vector3, Vector3) = {
     val (a, b) = metaGate(obj, target, innerRadius)
     target match {
-      case v: Vehicle if GlobalDefinitions.isFlightVehicle(v.Definition) =>
-        (a.xy + Vector3.z((target.Position.z + a.z) * 0.5f), b)
       case m: MountableEntity =>
         m.BailProtection = true
         (a + Vector3.z(obj.Definition.UseRadius * 0.5f), b)
@@ -154,7 +152,7 @@ object SpawnPoint {
     val (a, b) = metaGate(obj, target, innerRadius)
     target match {
       case v: Vehicle if GlobalDefinitions.isFlightVehicle(v.Definition) =>
-        (a.xy + Vector3.z((target.Position.z + a.z) * 0.5f), b)
+        (a, b)
       case _ =>
         (a + Vector3.z(flightlessZOffset), b)
     }

--- a/src/main/scala/net/psforever/objects/global/GlobalDefinitionsBuilding.scala
+++ b/src/main/scala/net/psforever/objects/global/GlobalDefinitionsBuilding.scala
@@ -129,8 +129,8 @@ object GlobalDefinitionsBuilding {
     hst.NoWarp += colossus_flight
     hst.NoWarp += peregrine_gunner
     hst.NoWarp += peregrine_flight
-    hst.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 6f)
-    
+    hst.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 12f)
+
     warpgate.Name = "warpgate"
     warpgate.UseRadius = 67.81070029f
     warpgate.SOIRadius = 302 //301.8713f
@@ -141,8 +141,8 @@ object GlobalDefinitionsBuilding {
     warpgate_cavern.UseRadius = 19.72639434f
     warpgate_cavern.SOIRadius = 41
     warpgate_cavern.VehicleAllowance = true
-    warpgate_cavern.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 4.5f)
-    
+    warpgate_cavern.SpecificPointFunc = SpawnPoint.CavernGate(innerRadius = 12f)
+
     warpgate_small.Name = "warpgate_small"
     warpgate_small.UseRadius = 69.03687655f
     warpgate_small.SOIRadius = 103

--- a/src/main/scala/net/psforever/zones/Zones.scala
+++ b/src/main/scala/net/psforever/zones/Zones.scala
@@ -295,7 +295,25 @@ object Zones {
                     WarpGate.Structure(Vector3(structure.absX, structure.absY, structure.absZ), GlobalDefinitions.hst)
                   )
                 )
-              case objectType if warpGateTypes.contains(objectType) =>
+              case objectType @ "warpgate_cavern" if warpGateTypes.contains(objectType) =>
+                zoneMap.addLocalBuilding(
+                  structure.objectName,
+                  structure.guid,
+                  structure.mapId.get,
+                  FoundationBuilder(
+                    WarpGate.Structure(Vector3(structure.absX, structure.absY, structure.absZ), GlobalDefinitions.warpgate_cavern)
+                  )
+                )
+              case objectType @ "warpgate_small" if warpGateTypes.contains(objectType) =>
+                zoneMap.addLocalBuilding(
+                  structure.objectName,
+                  structure.guid,
+                  structure.mapId.get,
+                  FoundationBuilder(
+                    WarpGate.Structure(Vector3(structure.absX, structure.absY, structure.absZ), GlobalDefinitions.warpgate_small)
+                  )
+                )
+              case objectType @ "warpgate" if warpGateTypes.contains(objectType) =>
                 zoneMap.addLocalBuilding(
                   structure.objectName,
                   structure.guid,


### PR DESCRIPTION
Discovered a few things with the different types of gates and made some changes to fix them:
- Cavern and small gates were using regular warpgate definitions instead of their own. Also adjusted their innerRadius a bit to prevent spawning too close to the center and immediately zoning back where you came from. This was only happening to me in caves, but I changed both to match what is was in the adb. I haven't had any instances of spawning in/under the ground in a cave after this change.
- Should fix #1237
- Vehicles have been maintaining their momentum while going through a direct gate (not a broadcast gate). A vehicle is now stationary on the other side instead of smashing into something or already being outside the gate by the time the zone finishes loading.