### PR TITLE
Red Alert!

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -508,6 +508,18 @@ game {
     capture-experience-points-modifier = 1f
     # Don't forget to pay back that debt.
   }
+
+  alert {
+    # When a certain number of enemy players are within the SOI of a facility, an alert (DensityLevelUpdateMessage)
+    # will be dispatched to all players. Players of the owning faction will receive a chat warning (if in
+    # the same zone) and the map will flash the alert level over the facility until it changes
+    # Wiki says 25-30
+    yellow = 1
+    # Wiki says 30-60
+    orange = 2
+    # Wiki says 60+
+    red = 3
+  }
 }
 
 anti-cheat {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -514,11 +514,11 @@ game {
     # will be dispatched to all players. Players of the owning faction will receive a chat warning (if in
     # the same zone) and the map will flash the alert level over the facility until it changes
     # Wiki says 25-30
-    yellow = 1
+    yellow = 20
     # Wiki says 30-60
-    orange = 2
+    orange = 30
     # Wiki says 60+
-    red = 3
+    red = 60
   }
 }
 

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -972,7 +972,7 @@ class ZoningOperations(
    */
   def initFacility(continentNumber: Int, buildingNumber: Int, building: Building): Unit = {
     sendResponse(building.infoUpdateMessage())
-    sendResponse(DensityLevelUpdateMessage(continentNumber, buildingNumber, List(0, 0, 0, 0, 0, 0, 0, 0)))
+    sendResponse(building.densityLevelUpdateMessage(building))
   }
 
   /**

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -18,7 +18,7 @@ import net.psforever.objects.serverobject.turret.auto.AutomatedTurret
 import net.psforever.objects.sourcing.{PlayerSource, SourceEntry, VehicleSource}
 import net.psforever.objects.vital.{InGameHistory, IncarnationActivity, ReconstructionActivity, SpawningActivity}
 import net.psforever.objects.zones.blockmap.BlockMapEntity
-import net.psforever.packet.game.{CampaignStatistic, ChangeFireStateMessage_Start, HackState7, MailMessage, ObjectDetectedMessage, SessionStatistic, TriggeredSound}
+import net.psforever.packet.game.{CampaignStatistic, ChangeFireStateMessage_Start, HackState7, MailMessage, ObjectDetectedMessage, SessionStatistic, TriggeredSound, WeatherMessage, CloudInfo, StormInfo}
 import net.psforever.services.chat.DefaultChannel
 
 import scala.collection.mutable
@@ -2504,6 +2504,19 @@ class ZoningOperations(
             sessionLogic.general.toggleTeleportSystem(obj, TelepadLike.AppraiseTeleportationSystem(obj, continent))
           }
       }
+      //make weather happen
+      sendResponse(WeatherMessage(List(),List(
+        StormInfo(Vector3(0.1f, 0.15f, 0.0f), 240, 217),
+        StormInfo(Vector3(0.5f, 0.11f, 0.0f), 240, 215),
+        StormInfo(Vector3(0.15f, 0.4f, 0.0f), 249, 215),
+        StormInfo(Vector3(0.15f, 0.87f, 0.0f), 240, 215),
+        StormInfo(Vector3(0.3f, 0.65f, 0.0f), 240, 215),
+        StormInfo(Vector3(0.5f, 0.475f, 0.0f), 245, 215),
+        StormInfo(Vector3(0.725f, 0.38f, 0.0f), 243, 215),
+        StormInfo(Vector3(0.9f, 0.57f, 0.0f), 244, 215),
+        StormInfo(Vector3(0.9f, 0.9f, 0.0f), 243, 215),
+        StormInfo(Vector3(0.1f, 0.2f, 0.0f), 241, 215),
+        StormInfo(Vector3(0.95f, 0.2f, 0.0f), 241, 215))))
       //begin looking for conditions to set the avatar
       context.system.scheduler.scheduleOnce(delay = 250 millisecond, context.self, SessionActor.SetCurrentAvatar(player, 200))
     }
@@ -2615,6 +2628,19 @@ class ZoningOperations(
       }
       avatarActor ! AvatarActor.RefreshPurchaseTimes()
       setupAvatarFunc = AvatarCreate
+      //make weather happen
+        sendResponse(WeatherMessage(List(),List(
+          StormInfo(Vector3(0.1f, 0.15f, 0.0f), 240, 217),
+          StormInfo(Vector3(0.5f, 0.11f, 0.0f), 240, 215),
+          StormInfo(Vector3(0.15f, 0.4f, 0.0f), 249, 215),
+          StormInfo(Vector3(0.15f, 0.87f, 0.0f), 240, 215),
+          StormInfo(Vector3(0.3f, 0.65f, 0.0f), 240, 215),
+          StormInfo(Vector3(0.5f, 0.475f, 0.0f), 245, 215),
+          StormInfo(Vector3(0.725f, 0.38f, 0.0f), 243, 215),
+          StormInfo(Vector3(0.9f, 0.57f, 0.0f), 244, 215),
+          StormInfo(Vector3(0.9f, 0.9f, 0.0f), 243, 215),
+          StormInfo(Vector3(0.1f, 0.2f, 0.0f), 241, 215),
+          StormInfo(Vector3(0.95f, 0.2f, 0.0f), 241, 215))))
       //begin looking for conditions to set the avatar
       context.system.scheduler.scheduleOnce(delay = 750 millisecond, context.self, SessionActor.SetCurrentAvatar(player, 200))
     }

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -74,6 +74,8 @@ object BuildingActor {
 
   final case class PowerOff() extends Command
 
+  final case class DensityLevelUpdate(building: Building) extends Command
+
   /**
     * Set a facility affiliated to one faction to be affiliated to a different faction.
     * @param details building and event system references
@@ -226,6 +228,7 @@ class BuildingActor(
 
       case MapUpdate() =>
         details.galaxyService ! GalaxyServiceMessage(GalaxyAction.MapUpdate(details.building.infoUpdateMessage()))
+        details.galaxyService ! GalaxyServiceMessage(GalaxyAction.SendResponse(details.building.densityLevelUpdateMessage(building)))
         Behaviors.same
 
       case AmenityStateChange(amenity, data) =>
@@ -245,6 +248,10 @@ class BuildingActor(
 
       case Ntu(msg) =>
         logic.ntu(details, msg)
+
+      case DensityLevelUpdate(building) =>
+        details.galaxyService ! GalaxyServiceMessage(GalaxyAction.SendResponse(details.building.densityLevelUpdateMessage(building)))
+        Behaviors.same
     }
   }
 }

--- a/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
+++ b/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
@@ -55,9 +55,16 @@ class SphereOfInfluenceActor(zone: Zone) extends Actor {
     sois.foreach {
       case (facility, radius) =>
         val facilityXY = facility.Position.xy
-        facility.PlayersInSOI = zone.blockMap.sector(facility)
+        val playersOnFoot = zone.blockMap.sector(facility)
           .livePlayerList
           .filter(p => Vector3.DistanceSquared(facilityXY, p.Position.xy) < radius)
+
+        val vehicleOccupants = zone.blockMap.sector(facility)
+          .vehicleList
+          .filter(v => Vector3.DistanceSquared(facilityXY, v.Position.xy) < radius)
+          .flatMap(_.Seats.values.flatMap(_.occupants))
+
+        facility.PlayersInSOI = playersOnFoot ++ vehicleOccupants
     }
     populateTick.cancel()
     populateTick = context.system.scheduler.scheduleOnce(5 seconds, self, SOI.Populate())

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -164,7 +164,8 @@ case class GameConfig(
     experience: Experience,
     maxBattleRank: Int,
     promotion: PromotionSystem,
-    facilityHackTime: FiniteDuration
+    facilityHackTime: FiniteDuration,
+    alert: DensityAlert
 )
 
 case class InstantActionConfig(
@@ -325,4 +326,10 @@ case class PromotionSystem(
     battleExperiencePointsModifier: Float,
     supportExperiencePointsModifier: Float,
     captureExperiencePointsModifier: Float
+)
+
+case class DensityAlert(
+    yellow: Int,
+    orange: Int,
+    red: Int
 )


### PR DESCRIPTION
There was nothing more exciting than logging in to see a red alert at a base. This update brings those alerts back. For testing, I set the threshold of enemy players in an SOI very low:
1 - Yellow
2 - Orange
3 - Red

While testing, I found that PlayersInSOI did not include vehicle occupants so players in vehicles are now counted. This was preventing those occupants from receiving certain messages, such as generator under attack, so it serves a double purpose to include them now. 

I also ran into an issue with a player dying and respawning. While they are a backpack, they were not being counted so the alert level kept going down, then back up when they spawned. The client only gets a chat message for the higher level alert, but it was still sending quite often. To try to solve that (and prevent the DensityLevelUpdateMessage packet from constantly spamming), corpses are included in the condition before sending the update. This isn't foolproof because if a single player has two corpses on the ground, it no longer counts it. 

It will trigger the packet to send if the difference between the current enemy count and previous enemy count (last time TryUpdate happened - every 5-6 seconds) is at least 1. Some adjustments will need to be made (maybe timed delay between them as well), but I think this is a good start.

Also, these packets are sent during these events:
- When a player logs in, they get one for every base. This way if an alert is already active, they will see it straight away.
- When a base changes factions
- As population in the SOI fluctuates