### PR TITLE
Lukewarm Potato

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -469,7 +469,7 @@ game {
       # If a player died while carrying an lattice logic unit,
       # and satisfies the carrying duration,
       # award the player who is accredited with the kill command experience.
-      llu-slayer-credit = 200
+      llu-slayer-credit = 0
       # The maximum command experience that can be earned in a facility capture based on squad size
       maximum-per-squad-size = [990, 1980, 3466, 4950, 6436, 7920, 9406, 10890, 12376, 13860]
       # When the cep has to be capped for squad size, add a small value to the capped value

--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -450,7 +450,7 @@ class GeneralOperations(
                     continent.Number,
                     llu.Owner.GUID.guid,
                     Config.app.game.experience.cep.lluSlayerCredit,
-                    expType = "llu-slayer"
+                    expType = "lsc" //three characters - "llu slayer credit"
                   )
               }
           }

--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -15,6 +15,7 @@ import net.psforever.objects.serverobject.turret.FacilityTurret
 import net.psforever.objects.sourcing.{DeployableSource, PlayerSource, VehicleSource}
 import net.psforever.objects.vehicles.Utility.InternalTelepad
 import net.psforever.objects.zones.blockmap.BlockMapEntity
+import net.psforever.objects.zones.exp.ToDatabase
 import net.psforever.services.RemoverActor
 import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 
@@ -443,6 +444,13 @@ class GeneralOperations(
                   continent.AvatarEvents ! AvatarServiceMessage(
                     attacker.Name,
                     AvatarAction.AwardCep(attacker.CharId, Config.app.game.experience.cep.lluSlayerCredit)
+                  )
+                  ToDatabase.reportFacilityCapture(
+                    attacker.CharId,
+                    continent.Number,
+                    llu.Owner.GUID.guid,
+                    Config.app.game.experience.cep.lluSlayerCredit,
+                    expType = "llu-slayer"
                   )
               }
           }


### PR DESCRIPTION
Zero'd out the kill reward for an LLU carrier as per vanilla requirements.  This was always a placeholder.  The event should still be added to the database but the player who kills the transporter will no longer be rewarded CEP for it.

All that said, other factions, please continue to kill the enemy person making off with your LLU's.