### PR TITLE
Animations and Turret Range

### DIFF
--- a/src/main/scala/net/psforever/actors/session/csr/GeneralLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/csr/GeneralLogic.scala
@@ -33,6 +33,7 @@ import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.{ActionCancelMessage, AvatarFirstTimeEventMessage, AvatarImplantMessage, AvatarJumpMessage, BattleplanMessage, BindPlayerMessage, BugReportMessage, ChangeFireModeMessage, ChangeShortcutBankMessage, CharacterCreateRequestMessage, CharacterRequestMessage, ChatMsg, CollisionIs, ConnectToWorldRequestMessage, CreateShortcutMessage, DeadState, DeployObjectMessage, DisplayedAwardMessage, DropItemMessage, EmoteMsg, FacilityBenefitShieldChargeRequestMessage, FriendsRequest, GenericAction, GenericActionMessage, GenericCollisionMsg, GenericObjectActionAtPositionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HitHint, InvalidTerrainMessage, LootItemMessage, MoveItemMessage, ObjectDetectedMessage, ObjectHeldMessage, PickupItemMessage, PlanetsideAttributeMessage, PlayerStateMessageUpstream, RequestDestroyMessage, TargetingImplantRequest, TerrainCondition, TradeMessage, UnuseItemMessage, UseItemMessage, VoiceHostInfo, VoiceHostRequest, ZipLineMessage}
 import net.psforever.services.RemoverActor
 import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
+import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.types.{CapacitorStateType, ChatMessageType, Cosmetic, ExoSuitType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 
 import scala.util.Success
@@ -181,7 +182,11 @@ class GeneralLogic(val ops: GeneralOperations, implicit val context: ActorContex
 
   def handleEmote(pkt: EmoteMsg): Unit = {
     val EmoteMsg(avatarGuid, emote) = pkt
+    val pZone = player.Zone
     sendResponse(EmoteMsg(avatarGuid, emote))
+    pZone.blockMap.sector(player).livePlayerList.collect { case t if t.GUID != player.GUID =>
+      pZone.LocalEvents ! LocalServiceMessage(t.Name, LocalAction.SendResponse(EmoteMsg(avatarGuid, emote)))
+    }
   }
 
   def handleDropItem(pkt: DropItemMessage): Unit = {

--- a/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
@@ -40,6 +40,7 @@ import net.psforever.packet.PlanetSideGamePacket
 import net.psforever.packet.game.{ActionCancelMessage, ActionResultMessage, AvatarFirstTimeEventMessage, AvatarImplantMessage, AvatarJumpMessage, BattleplanMessage, BindPlayerMessage, BugReportMessage, ChangeFireModeMessage, ChangeShortcutBankMessage, CharacterCreateRequestMessage, CharacterRequestAction, CharacterRequestMessage, ChatMsg, CollisionIs, ConnectToWorldRequestMessage, CreateShortcutMessage, DeadState, DeployObjectMessage, DisplayedAwardMessage, DropItemMessage, EmoteMsg, FacilityBenefitShieldChargeRequestMessage, FriendsRequest, GenericAction, GenericActionMessage, GenericCollisionMsg, GenericObjectActionAtPositionMessage, GenericObjectActionMessage, GenericObjectStateMsg, HitHint, InvalidTerrainMessage, LootItemMessage, MoveItemMessage, ObjectDetectedMessage, ObjectHeldMessage, PickupItemMessage, PlanetsideAttributeMessage, PlayerStateMessageUpstream, RequestDestroyMessage, TargetingImplantRequest, TerrainCondition, TradeMessage, UnuseItemMessage, UseItemMessage, VoiceHostInfo, VoiceHostRequest, ZipLineMessage}
 import net.psforever.services.account.{AccountPersistenceService, RetrieveAccountData}
 import net.psforever.services.avatar.{AvatarAction, AvatarServiceMessage}
+import net.psforever.services.local.{LocalAction, LocalServiceMessage}
 import net.psforever.services.local.support.CaptureFlagManager
 import net.psforever.types.{CapacitorStateType, ChatMessageType, Cosmetic, ExoSuitType, ImplantType, PlanetSideEmpire, PlanetSideGUID, Vector3}
 import net.psforever.util.Config
@@ -199,7 +200,11 @@ class GeneralLogic(val ops: GeneralOperations, implicit val context: ActorContex
 
   def handleEmote(pkt: EmoteMsg): Unit = {
     val EmoteMsg(avatarGuid, emote) = pkt
+    val pZone = player.Zone
     sendResponse(EmoteMsg(avatarGuid, emote))
+    pZone.blockMap.sector(player).livePlayerList.collect { case t if t.GUID != player.GUID =>
+      pZone.LocalEvents ! LocalServiceMessage(t.Name, LocalAction.SendResponse(EmoteMsg(avatarGuid, emote)))
+    }
   }
 
   def handleDropItem(pkt: DropItemMessage): Unit = {

--- a/src/main/scala/net/psforever/actors/session/normal/VehicleHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/VehicleHandlerLogic.scala
@@ -231,7 +231,7 @@ class VehicleHandlerLogic(val ops: SessionVehicleHandlers, implicit val context:
         sendResponse(ObjectCreateDetailedMessage(itemType, itemGuid, ObjectCreateMessageParent(vehicleGuid, slot), itemData))
 
       case VehicleResponse.UnloadVehicle(_, vehicleGuid) =>
-        sendResponse(ObjectDeleteMessage(vehicleGuid, unk1=0))
+        sendResponse(ObjectDeleteMessage(vehicleGuid, unk1=1))
         if (sessionLogic.zoning.spawn.prevSpawnPoint.map(_.Owner).exists {
           case ams: Vehicle =>
             ams.GUID == vehicleGuid &&

--- a/src/main/scala/net/psforever/actors/session/spectator/VehicleHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/spectator/VehicleHandlerLogic.scala
@@ -197,7 +197,7 @@ class VehicleHandlerLogic(val ops: SessionVehicleHandlers, implicit val context:
         sendResponse(PlanetsideAttributeMessage(vehicleGuid, seatGroup, permission))
 
       case VehicleResponse.UnloadVehicle(_, vehicleGuid) =>
-        sendResponse(ObjectDeleteMessage(vehicleGuid, unk1=0))
+        sendResponse(ObjectDeleteMessage(vehicleGuid, unk1=1))
 
       case VehicleResponse.UnstowEquipment(itemGuid) if isNotSameTarget =>
         //TODO prefer ObjectDetachMessage, but how to force ammo pools to update properly?

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -18,7 +18,8 @@ import net.psforever.objects.serverobject.turret.auto.AutomatedTurret
 import net.psforever.objects.sourcing.{PlayerSource, SourceEntry, VehicleSource}
 import net.psforever.objects.vital.{InGameHistory, IncarnationActivity, ReconstructionActivity, SpawningActivity}
 import net.psforever.objects.zones.blockmap.BlockMapEntity
-import net.psforever.packet.game.{CampaignStatistic, ChangeFireStateMessage_Start, HackState7, MailMessage, ObjectDetectedMessage, SessionStatistic, TriggeredSound, WeatherMessage, CloudInfo, StormInfo}
+import net.psforever.packet.game.GenericAction.FirstPersonViewWithEffect
+import net.psforever.packet.game.{CampaignStatistic, ChangeFireStateMessage_Start, CloudInfo, GenericActionMessage, GenericObjectActionEnum, HackState7, MailMessage, ObjectDetectedMessage, SessionStatistic, StormInfo, TriggeredSound, WeatherMessage}
 import net.psforever.services.chat.DefaultChannel
 
 import scala.collection.mutable
@@ -2972,10 +2973,10 @@ class ZoningOperations(
 
             case _ if player.HasGUID => // player is deconstructing self or instant action
               val player_guid = player.GUID
-              sendResponse(ObjectDeleteMessage(player_guid, 4))
+              sendResponse(ObjectDeleteMessage(player_guid, unk1=1))
               continent.AvatarEvents ! AvatarServiceMessage(
                 continent.id,
-                AvatarAction.ObjectDelete(player_guid, player_guid, 4)
+                AvatarAction.ObjectDelete(player_guid, player_guid, unk=1)
               )
               InGameHistory.SpawnReconstructionActivity(player, toZoneNumber, betterSpawnPoint)
               LoadZoneAsPlayerUsing(player, pos, ori, toSide, zoneId)
@@ -3776,6 +3777,11 @@ class ZoningOperations(
         player.death_by = 1
       }
       GoToDeploymentMap()
+      val pZone = player.Zone
+      sendResponse(GenericActionMessage(FirstPersonViewWithEffect))
+      pZone.blockMap.sector(player).livePlayerList.collect { case t if t.GUID != player.GUID =>
+        pZone.LocalEvents ! LocalServiceMessage(t.Name, LocalAction.SendGenericObjectActionMessage(t.GUID, player.GUID, GenericObjectActionEnum.PlayerDeconstructs))
+      }
     }
 
     def stopDeconstructing(): Unit = {

--- a/src/main/scala/net/psforever/objects/serverobject/damage/DamageableEntity.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/damage/DamageableEntity.scala
@@ -2,6 +2,7 @@
 package net.psforever.objects.serverobject.damage
 
 import net.psforever.objects.equipment.JammableUnit
+import net.psforever.objects.serverobject.tube.SpawnTube
 import net.psforever.objects.vital.interaction.DamageResult
 import net.psforever.objects.vital.resolution.ResolutionCalculations
 import net.psforever.objects.zones.Zone
@@ -199,9 +200,12 @@ object DamageableEntity {
     val tguid  = target.GUID
     val attribution = attributionTo(cause, target.Zone)
     zone.AvatarEvents ! AvatarServiceMessage(zoneId, AvatarAction.PlanetsideAttributeToAll(tguid, 0, target.Health))
-    zone.AvatarEvents ! AvatarServiceMessage(
-      zoneId,
-      AvatarAction.Destroy(tguid, attribution, Service.defaultPlayerGUID, target.Position)
-    )
+    if (target.isInstanceOf[SpawnTube]) {}//do nothing to prevent issue #1057
+    else {
+      zone.AvatarEvents ! AvatarServiceMessage(
+        zoneId,
+        AvatarAction.Destroy(tguid, attribution, Service.defaultPlayerGUID, target.Position)
+      )
+    }
   }
 }

--- a/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
+++ b/src/main/scala/net/psforever/packet/game/GenericObjectActionMessage.scala
@@ -91,4 +91,5 @@ object GenericObjectActionEnum extends Enumeration {
     * <b>Target</b>: CaptureTerminal
     */
   val FlagSpawned = Value(14)
+  val PlayerDeconstructs = Value(6)
 }

--- a/src/main/scala/net/psforever/services/avatar/support/CorpseRemovalActor.scala
+++ b/src/main/scala/net/psforever/services/avatar/support/CorpseRemovalActor.scala
@@ -25,7 +25,7 @@ class CorpseRemovalActor extends RemoverActor() {
     entry.zone.Population ! Zone.Corpse.Remove(entry.obj.asInstanceOf[Player])
     context.parent ! AvatarServiceMessage(
       entry.zone.id,
-      AvatarAction.ObjectDelete(Service.defaultPlayerGUID, entry.obj.GUID)
+      AvatarAction.ObjectDelete(Service.defaultPlayerGUID, entry.obj.GUID, unk=1)
     )
   }
 


### PR DESCRIPTION
Should close #393 and fix #1057 and added a few other things:

Animations should play when corpse loot bags and vehicles despawn/disappear, a player zones, and when a player deconstructs at a tube/AMS. The deconstruct animation is wild. I do not remember it being like that 😆

Repairing a spawn tube should now allow you to deconstruct from it. DestroyMessage only breaks that for tubes? So... don't send that.

Turrets, specifically wall turrets (manned turrets) have extreme range. Some have mentioned how far the auto fire will continue shooting. There is an escape range set, but it seems to ignore it and keeps firing up to 400m. What I did is probably a band aid, but the other things I threw at it that seemed like they should make a turret stop shooting didn't work. There is also a 3-4 second delay in it stopping shooting once you've reached 150m away from it, so it keeps shooting a little beyond the range. Still, much less distance than it was before so escaping them is more possible.

Lastly, emotes will be seen by other players now. The classic /em cabbagepatch can be enjoyed by surrounding players.