### PR TITLE
Let's Try Squads Again

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -3853,7 +3853,8 @@ class ZoningOperations(
     }
 
     def startEnqueueSquadMessages: Boolean = {
-      sessionLogic.zoning.zoneReload && sessionLogic.zoning.spawn.setAvatar && player.isAlive
+      println(s"${sessionLogic.zoning.zoneReload} ${sessionLogic.zoning.spawn.setAvatar} ${player.isAlive}")
+      !sessionLogic.zoning.zoneReload && sessionLogic.zoning.spawn.setAvatar && player.isAlive
     }
 
     def enqueueNewActivity(newTasking: SpawnOperations.ActivityQueuedTask): Unit = {

--- a/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadInvitationManager.scala
@@ -368,6 +368,7 @@ class SquadInvitationManager(subs: SquadSubscriptionEntity, parent: ActorRef) {
               charId,
               SquadResponse.Membership(SquadResponseType.Cancel, charId, Some(0L), name, unk5 = false)
             )
+          case None => ()
         }
         None
       }

--- a/src/main/scala/net/psforever/services/teamwork/SquadService.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadService.scala
@@ -274,8 +274,8 @@ class SquadService extends Actor {
         SquadActionMembershipCancel(cancellingPlayer, tplayer)
 
       case SquadAction.Membership(SquadRequestType.Promote, _, _, _, _) => ()
-      //      case SquadAction.Membership(SquadRequestType.Promote, promotingPlayer, Some(_promotedPlayer), promotedName, _) =>
-      //        SquadActionMembershipPromote(promotingPlayer, _promotedPlayer, promotedName, SquadServiceMessage(tplayer, zone, action), sender())
+      case SquadAction.Membership(SquadRequestType.Promote, promotingPlayer, Some(_promotedPlayer), promotedName, _) =>
+        SquadActionMembershipPromote(promotingPlayer, _promotedPlayer, promotedName, SquadServiceMessage(tplayer, zone, action), sender())
 
       case SquadAction.Membership(event, _, _, _, _) =>
         info(s"SquadAction.Membership: $event is not yet supported")

--- a/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
+++ b/src/main/scala/net/psforever/services/teamwork/SquadSwitchboard.scala
@@ -653,7 +653,7 @@ class SquadSwitchboard(
     if (squad.Leader.CharId == char_id) {
       membership.lift(position) match {
         case Some(toMember) =>
-          //SquadActionMembershipPromote(char_id, toMember.CharId)
+          SquadActionMembershipPromote(char_id, toMember.CharId)
         case _ => ;
       }
     } else {
@@ -684,7 +684,7 @@ class SquadSwitchboard(
   def SquadActionMembership(action: Any): Unit = {
     action match {
       case SquadAction.Membership(SquadRequestType.Promote, promotingPlayer, Some(promotedPlayer), _, _) =>
-        //SquadActionMembershipPromote(promotingPlayer, promotedPlayer)
+        SquadActionMembershipPromote(promotingPlayer, promotedPlayer)
 
       case SquadAction.Membership(event, _, _, _, _) =>
         log.debug(s"SquadAction.Membership: $event is not supported here")


### PR DESCRIPTION
Baby steps here... and I just noticed a println snuck in there 😨 but that part was why characters weren't getting the Membership packet responses. So squads are functional and players now see the squad UI and chat messages for invite actions. I have only tested a few things so far. One of them was having your invite accepted while you are respawning and the invite did go through after I spawned, so that queued/delayed response to the player is working properly (this was mentioned in #1176 and seems resolved - maybe test zoning while invite is accepted too?). Going to just PR it now so Deth and others can test.