### PR TITLE
A Few Fixes and Tweaks (CCs and Outfits)

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionAvatarHandlers.scala
@@ -82,7 +82,7 @@ class SessionAvatarHandlers(
             maxCepList.lift(squadSize - 1).getOrElse(squadSize * maxCepList.head).toLong
           }
           val groupContribution: Float = squadUI
-            .map { case (id, _) => (id, squadParticipation.getOrElse(id, 0f) / 10f) }
+            .map { case (id, _) => (id, squadParticipation.getOrElse(id, 0f)) }
             .values
             .max
           val modifiedExp: Long = (cep.toFloat * groupContribution).toLong
@@ -115,7 +115,8 @@ class SessionAvatarHandlers(
             }
           }
           val modifiedExp = (cep * individualContribution).toLong
-          exp.ToDatabase.reportFacilityCapture(charId, buildingId, zoneNumber, modifiedExp, expType="bep")
+          val finalBep = math.min(modifiedExp, 2250L) // 2250 max bep for capture
+          exp.ToDatabase.reportFacilityCapture(charId, buildingId, zoneNumber, finalBep, expType="bep")
           avatarActor ! AvatarActor.AwardFacilityCaptureBep(modifiedExp)
           Some(modifiedExp)
       }

--- a/src/main/scala/net/psforever/actors/session/support/SessionOutfitHandlers.scala
+++ b/src/main/scala/net/psforever/actors/session/support/SessionOutfitHandlers.scala
@@ -13,7 +13,7 @@ import net.psforever.services.chat.OutfitChannel
 import net.psforever.types.ChatMessageType
 import net.psforever.util.Config
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId}
 import java.util.concurrent.Executors
 import scala.util.{Failure, Success}
 
@@ -61,7 +61,7 @@ object SessionOutfitHandlers {
           case _ =>
             createNewOutfit(validName, player.Faction.id, player.CharId).map { outfit =>
               val seconds: Long =
-                outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000
+                outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000
 
               PlayerControl.sendResponse(player.Zone, player.Name,
                 OutfitEvent(outfit.id, Update(
@@ -151,7 +151,7 @@ object SessionOutfitHandlers {
                 OutfitMemberEventAction.Update(invited.Name, 0, 0, 0,
                   OutfitMemberEventAction.PacketType.Padding, 0)))
 
-            val seconds: Long = outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000
+            val seconds: Long = outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000
             PlayerControl.sendResponse(invited.Zone, invited.Name,
               OutfitEvent(outfitId, Initial(OutfitInfo(
                 outfit.name, points, points, memberCount,
@@ -372,7 +372,7 @@ object SessionOutfitHandlers {
       members                              <- membersF
     } yield {
       outfitOpt.foreach { outfit =>
-        val seconds: Long = outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000
+        val seconds: Long = outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000
 
         PlayerControl.sendResponse(player.Zone, player.Name,
           OutfitEvent(outfit.id, Initial(OutfitInfo(
@@ -397,7 +397,7 @@ object SessionOutfitHandlers {
           val lastLogin = findPlayerByIdForOutfitAction(zones, avatarId, player) match {
             case Some(_) => 0L
             case None if player.Name == avatarName => 0L
-            case None =>  (System.currentTimeMillis() - login.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli) / 1000
+            case None =>  (System.currentTimeMillis() - login.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli) / 1000
           }
           PlayerControl.sendResponse(player.Zone, player.Name,
             OutfitMemberEvent(outfit.id, avatarId,
@@ -477,7 +477,7 @@ object SessionOutfitHandlers {
               unk10 = 0,
               unk11 = true,
               unk12 = 0,
-              created_timestamp = outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000,
+              created_timestamp = outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000,
               unk23 = 0,
               unk24 = 0,
               unk25 = 0
@@ -542,7 +542,7 @@ object SessionOutfitHandlers {
               unk10 = 0,
               unk11 = true,
               unk12 = 0,
-              created_timestamp = outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000,
+              created_timestamp = outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000,
               unk23 = 0,
               unk24 = 0,
               unk25 = 0
@@ -595,7 +595,7 @@ object SessionOutfitHandlers {
           } yield (outfitOpt, memberCount, points))
             .map {
               case (Some(outfit), memberCount, points) =>
-                val seconds: Long = outfit.created.atZone(java.time.ZoneOffset.UTC).toInstant.toEpochMilli / 1000
+                val seconds: Long = outfit.created.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli / 1000
 
                 PlayerControl.sendResponse(player.Zone, player.Name,
                   OutfitEvent(outfitId, Update(OutfitInfo(

--- a/src/main/scala/net/psforever/objects/serverobject/hackable/GenericHackables.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/hackable/GenericHackables.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 PSForever
 package net.psforever.objects.serverobject.hackable
 
-import net.psforever.objects.serverobject.structures.{Building, WarpGate}
+import net.psforever.objects.serverobject.structures.{Building, StructureType, WarpGate}
 import net.psforever.objects.serverobject.terminals.capture.CaptureTerminal
 import net.psforever.objects.{Player, Vehicle}
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
@@ -148,9 +148,11 @@ object GenericHackables {
    */
   def EndHackProgress(target: PlanetSideServerObject, hacker: Player): Boolean = {
     val building = target.asInstanceOf[CaptureTerminal].Owner.asInstanceOf[Building]
-    if (building.Faction == PlanetSideEmpire.NEUTRAL) {
+    if (building.Faction == PlanetSideEmpire.NEUTRAL || building.BuildingType == StructureType.Tower
+        || building.Faction == hacker.Faction) {
       false
-    } else {
+    }
+    else {
       val stopHackingCount = building.Neighbours match {
         case Some(neighbors) =>
           neighbors.count {


### PR DESCRIPTION
Should resolve a few issues:
- Hacking a tower CC
- Resecuring a base if there are no neighboring friendly bases
- Outfit member last login time. Saw some errors in the logs `Could not encode OutfitMemberEvent` because the value for seconds was negative if the last login time was very recent.
- Buffed SL CEP for a capture event.