### PR TITLE
fix: Prevent phantom strafe bug by clearing player velocity in ObjectCreateDetailedMessage

### DIFF
--- a/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/AvatarConverter.scala
@@ -16,7 +16,7 @@ class AvatarConverter extends ObjectCreateConverter[Player]() {
     Success(
       if (obj.VehicleSeated.isEmpty) {
         PlayerData(
-          PlacementData(obj.Position, obj.Orientation, obj.Velocity),
+          PlacementData(obj.Position, obj.Orientation, None),
           MakeAppearanceData(obj),
           MakeCharacterData(obj),
           MakeInventoryData(obj),
@@ -38,7 +38,7 @@ class AvatarConverter extends ObjectCreateConverter[Player]() {
     Success(
       if (obj.VehicleSeated.isEmpty) {
         DetailedPlayerData.apply(
-          PlacementData(obj.Position, obj.Orientation, obj.Velocity),
+          PlacementData(obj.Position, obj.Orientation, None),
           MakeAppearanceData(obj),
           MakeDetailedCharacterData(obj),
           MakeDetailedInventoryData(obj),


### PR DESCRIPTION
## Summary
- Players would strafe without input after mode switches (`/gmtoggle`) or zone transitions when moving during the transition
- The client was receiving stale velocity data in PlacementData, causing it to restore phantom input state
- Fix: Always send `None` for velocity in player ObjectCreateDetailedMessage packets

## Changes
- `AvatarConverter.scala` lines 19 and 41: Changed `obj.Velocity` to `None` in PlacementData

## Test plan
- [x] Tested on private server - bug no longer reproducible
- [x] Tested on public server with community members - confirmed fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)