### PR TITLE
Carousel of Caverns

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -574,12 +574,10 @@ class ZoningOperations(
       //CaptureFlagUpdateMessage()
       //VanuModuleUpdateMessage()
       //ModuleLimitsMessage()
-      val isCavern = continent.map.cavern
-      sendResponse(ZoneInfoMessage(continentNumber, empire_status=true, if (isCavern) {
-        Int.MaxValue.toLong
-      } else {
-        0L
-      }))
+      val isCavern = zone.map.cavern
+      if (!isCavern) {
+        sendResponse(ZoneInfoMessage(continentNumber, empire_status = true, 0L))
+      }
       sendResponse(ZoneLockInfoMessage(continentNumber, lock_status=false, unk=true))
       sendResponse(ZoneForcedCavernConnectionsMessage(continentNumber, 0))
       sendResponse(


### PR DESCRIPTION
Caverns have been locking and unlocking in a rotating order for some time now without a hitch. The global map, however, has not updated to always show the unlocked caverns. 1-4 have been on display even if 5-6 were the two unlocked caverns. With some slight adjustments to what is sent in the `ZoneInfoMessage` packets for the caverns on login and when a rotation happens, the active caverns should always be on display on the map.

Unlocked caverns send `true` in the packet. From old captures, there was a time sent as well, but it doesn't seem to care that it is always 0. The two locked caverns with the lowest remaining time until they unlock should also be visible on the map now. The two caverns with the longest time until they are unlocked will have 0 as the time in the packet. That seems to be what hides any two of them.

This was tested by using !zonerotate to force them to change. I also tested !zonerotate and letting the 5 minute countdown happen so the next cavern unlocks naturally. This had slightly different behavior and needed to be handled as well.