### PR TITLE
Continental Locks and Benefits

### DIFF
--- a/server/src/main/resources/overrides/game_objects0.adb.lst
+++ b/server/src/main/resources/overrides/game_objects0.adb.lst
@@ -60,10 +60,6 @@ add_property maelstrom equiptime 1000
 add_property maelstrom holstertime 1000
 add_property magcutter equiptime 250
 add_property magcutter holstertime 250
-add_property medicalapplicator equiptime 500
-add_property medicalapplicator holstertime 500
-add_property medicalapplicator firemode0_refiretime 500
-add_property medicalapplicator firemode1_refiretime 500
 add_property mini_chaingun equiptime 750
 add_property mini_chaingun holstertime 750
 add_property nano_dispenser equiptime 750

--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -150,6 +150,11 @@ object MiddlewareActor {
     packet.isInstanceOf[ChatMsg]
   }
 
+  /** `PropertyOverrideMessage` ptsd from other large packets causing issues when bundled */
+  private def propertyOverrideMessageGuard(packet: PlanetSidePacket): Boolean = {
+    packet.isInstanceOf[PropertyOverrideMessage]
+  }
+
   /**
     * A function for blanking tasks related to inbound packet resolution.
     * Do nothing.
@@ -259,7 +264,8 @@ class MiddlewareActor(
     MiddlewareActor.keepAliveMessageGuard,
     MiddlewareActor.characterInfoMessageGuard,
     MiddlewareActor.squadDetailDefinitionMessageGuard,
-    MiddlewareActor.chatMsgGuard
+    MiddlewareActor.chatMsgGuard,
+    MiddlewareActor.propertyOverrideMessageGuard
   )
 
   private val smpHistoryLength: Int = 100

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -2218,12 +2218,12 @@ class AvatarActor(
               .Holsters()
               .foreach(holster =>
                 holster.Equipment match {
-                  case Some(tool: Tool) if tool.Definition == GlobalDefinitions.medicalapplicator =>
+                  /*case Some(tool: Tool) if tool.Definition == GlobalDefinitions.medicalapplicator =>
                     //todo fix so player may hold medapp when loading the zone (client crash)
                     val item = SimpleItem(GlobalDefinitions.flail_targeting_laser)
                     holster.Equipment = None
                     holster.Equipment = item
-                    item.GUID = PlanetSideGUID(gen.getAndIncrement)
+                    item.GUID = PlanetSideGUID(gen.getAndIncrement)*/
                   case Some(tool: Tool) =>
                     tool.AmmoSlots.foreach(slot => {
                       slot.Box.GUID = PlanetSideGUID(gen.getAndIncrement)

--- a/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
+++ b/src/main/scala/net/psforever/actors/zone/BuildingActor.scala
@@ -8,6 +8,8 @@ import net.psforever.actors.commands.NtuCommand
 import net.psforever.actors.zone.building._
 import net.psforever.objects.serverobject.structures.{Amenity, Building, StructureType, WarpGate}
 import net.psforever.objects.zones.Zone
+import net.psforever.packet.PlanetSideGamePacket
+import net.psforever.packet.game.ContinentalLockUpdateMessage
 import net.psforever.persistence
 import net.psforever.services.galaxy.{GalaxyAction, GalaxyServiceMessage}
 import net.psforever.services.local.{LocalAction, LocalServiceMessage}
@@ -76,6 +78,9 @@ object BuildingActor {
 
   final case class DensityLevelUpdate(building: Building) extends Command
 
+  final case class ContinentalLock(zone: Zone) extends Command
+
+  final case class HomeLockBenefits(msg: PlanetSideGamePacket) extends Command
   /**
     * Set a facility affiliated to one faction to be affiliated to a different faction.
     * @param details building and event system references
@@ -251,6 +256,14 @@ class BuildingActor(
 
       case DensityLevelUpdate(building) =>
         details.galaxyService ! GalaxyServiceMessage(GalaxyAction.SendResponse(details.building.densityLevelUpdateMessage(building)))
+        Behaviors.same
+
+      case ContinentalLock(zone) =>
+        details.galaxyService ! GalaxyServiceMessage(GalaxyAction.SendResponse(ContinentalLockUpdateMessage(zone.Number, zone.lockedBy)))
+        Behaviors.same
+
+      case HomeLockBenefits(msg) =>
+        details.galaxyService ! GalaxyServiceMessage(GalaxyAction.SendResponse(msg))
         Behaviors.same
     }
   }


### PR DESCRIPTION
The global map will appear a bit different now. When an empire owns all main facilities on a continent, that continent will be painted in that empire's color. This is known as a "continental lock". `ContinentalLockUpdateMessage` reports the faction in control of that map.
<img width="190" height="132" alt="image" src="https://github.com/user-attachments/assets/08312cc2-6285-441e-9d5a-0b0b144b10f1" />

`lockedBy` and `benefitRecipient` are new values that store the empire that has captured that zone. A continent is no longer locked if a single facility is captured by another empire, but the benefits of having fully captured that zone persist until another empire completely captures it.

Along with making the global map pretty colors, there are also some perks that come with controlling different zones. The benefits of neutral continents are not yet implemented, but there will be benefits gained from locking both of an enemy's home zones. This comes in the form of gaining access so some of their vehicles. That benefit persists until one of the zones is completely captured by another empire. `PropertyOverrideMessage` is delivered to players when these locks happen. This "unlocks" the vehicles for the controlling empire.

That all sounds like good news, but here is the bad news that was already discussed in Discord:
**The custom properties applied to the medical applicator had to be removed**. For reasons unknown, that item having non-standard properties has caused issues in the past due to these custom properties. If a player tried to rejoin their session after a crash and had a medical applicator on them, they would crash on relog and be unable to log back in until allowing persistence to end. While adding this feature and using the `PropertyOverrideMessage`, if that packet was received while carrying a medical applicator, that would also cause the client to crash. Removing the custom properties has gotten rid of these problems. It no longer needs to be dropped on the ground when you rejoin and receiving this packet is also safe with a "normal" medical applicator. It feels like slow motion watching it be equipped and holstered, but it seems to be the only way forward.