### PR TITLE
Global Domination Has Its Perks

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2924,9 +2924,11 @@ class ZoningOperations(
         0 seconds
       } else {
         //for other zones ...
+        //Searhus lock benefit also gives biolab faster respawn
+        val searhusBenefit = Zones.zones.find(_.Number == 9).exists(_.benefitRecipient == player.Faction)
         //biolabs have/grant benefits
         val cryoBenefit: Float = toSpawnPoint.Owner match {
-          case b: Building if b.hasLatticeBenefit(LatticeBenefit.BioLaboratory) => 0.5f
+          case b: Building if b.hasLatticeBenefit(LatticeBenefit.BioLaboratory) || (b.BuildingType == StructureType.Facility && !b.CaptureTerminalIsHacked && searhusBenefit) => 0.5f
           case _                                                                => 1f
         }
         //TODO cumulative death penalty

--- a/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
+++ b/src/main/scala/net/psforever/objects/definition/converter/VehicleConverter.scala
@@ -5,6 +5,7 @@ import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
 import net.psforever.objects.{PlanetSideGameObject, Vehicle}
 import net.psforever.packet.game.objectcreate._
 import net.psforever.types.{DriveState, PlanetSideGUID, VehicleFormat}
+import net.psforever.zones.Zones
 
 import scala.util.{Failure, Success, Try}
 
@@ -14,6 +15,8 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
 
   override def ConstructorData(obj: Vehicle): Try[VehicleData] = {
     val health = StatConverter.Health(obj.Health, obj.MaxHealth)
+    val boosted = if (Zones.zones.find(_.Number == 3).exists(_.benefitRecipient == obj.Faction)) true
+                  else false
     if (health > 0) { //active
       Success(
         VehicleData(
@@ -32,7 +35,7 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
               case None        => PlanetSideGUID(0)
             }
           ),
-          unk3 = false,
+          boostMaxHealth = boosted,
           health,
           unk4 = false,
           no_mount_points = false,
@@ -59,7 +62,7 @@ class VehicleConverter extends ObjectCreateConverter[Vehicle]() {
             v5 = None,
             guid = PlanetSideGUID(0)
           ),
-          unk3 = false,
+          boostMaxHealth = boosted,
           health = 0,
           unk4 = false,
           no_mount_points = true,

--- a/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/pad/process/VehicleSpawnControlLoadVehicle.scala
@@ -10,6 +10,7 @@ import net.psforever.objects.zones.Zone
 import net.psforever.services.Service
 import net.psforever.services.vehicle.{VehicleAction, VehicleServiceMessage}
 import net.psforever.types.Vector3
+import net.psforever.zones.Zones
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -44,6 +45,12 @@ class VehicleSpawnControlLoadVehicle(pad: VehicleSpawnPad) extends VehicleSpawnC
         ) //appear below the trench and doors
         vehicle.WhichSide = pad.WhichSide
         vehicle.Cloaked = vehicle.Definition.CanCloak && driver.Cloaked
+        // increase MaxHealth by 10% if driver has Cyssor empire armor benefit
+        if (Zones.zones.find(_.Number == 3).exists(_.benefitRecipient == driver.Faction)) {
+          val boosted = Math.round(vehicle.MaxHealth * 1.1).toInt
+          vehicle.MaxHealth = boosted
+          vehicle.Health = boosted
+        }
 
         temp = Some(order)
         val result = ask(pad.Zone.Transport, Zone.Vehicle.Spawn(vehicle))

--- a/src/main/scala/net/psforever/objects/serverobject/repair/RepairableEntity.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/repair/RepairableEntity.scala
@@ -58,7 +58,7 @@ trait RepairableEntity extends Repairable {
     */
   protected def CanPerformRepairs(target: Repairable.Target, player: Player, item: Tool): Boolean = {
     val definition = target.Definition
-    definition.Repairable && target.Health < definition.MaxHealth && (definition.RepairIfDestroyed || !target.Destroyed) &&
+    definition.Repairable && target.Health < target.MaxHealth && (definition.RepairIfDestroyed || !target.Destroyed) &&
     (target.Faction == player.Faction || target.Faction == PlanetSideEmpire.NEUTRAL) && item.Magazine > 0 &&
     player.isAlive && Vector3.Distance(target.Position, player.Position) < definition.RepairDistance
   }

--- a/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/VehicleData.scala
@@ -44,7 +44,7 @@ final case class VariantVehicleData(unk: Int) extends SpecificVehicleData(Vehicl
   *             -jammered - vehicles will not be jammered by setting this field<br>
   *             -player_guid the vehicle's (official) owner;
   *              a living player in the game world on the same continent as the vehicle who may mount the driver mount
-  * @param unk3 na
+  * @param boostMaxHealth vehicle gets 10% more armor from vehicle armor benefit given by Cyssor empire lock
   * @param health the amount of health the vehicle has, as a percentage of a filled bar (255)
   * @param unk4 na
   * @param no_mount_points do not display entry points for the seats
@@ -65,7 +65,7 @@ final case class VariantVehicleData(unk: Int) extends SpecificVehicleData(Vehicl
 final case class VehicleData(
     pos: PlacementData,
     data: CommonFieldData,
-    unk3: Boolean,
+    boostMaxHealth: Boolean,
     health: Int,
     unk4: Boolean,
     no_mount_points: Boolean,
@@ -106,7 +106,7 @@ object VehicleData extends Marshallable[VehicleData] {
       cloak: Boolean,
       inventory: Option[InventoryData]
   ): VehicleData = {
-    VehicleData(pos, basic, unk3 = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, None, inventory)(
+    VehicleData(pos, basic, boostMaxHealth = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, None, inventory)(
       VehicleFormat.Normal
     )
   }
@@ -128,7 +128,7 @@ object VehicleData extends Marshallable[VehicleData] {
       format: UtilityVehicleData,
       inventory: Option[InventoryData]
   ): VehicleData = {
-    VehicleData(pos, basic, unk3 = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, Some(format), inventory)(
+    VehicleData(pos, basic, boostMaxHealth = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, Some(format), inventory)(
       VehicleFormat.Utility
     )
   }
@@ -150,7 +150,7 @@ object VehicleData extends Marshallable[VehicleData] {
       format: VariantVehicleData,
       inventory: Option[InventoryData]
   ): VehicleData = {
-    VehicleData(pos, basic, unk3 = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, Some(format), inventory)(
+    VehicleData(pos, basic, boostMaxHealth = false, health, unk4 = false, no_mount_points = false, driveState, unk5 = false, unk6 = false, cloak = cloak, Some(format), inventory)(
       VehicleFormat.Variant
     )
   }


### PR DESCRIPTION
`EmpireBenefitsMessage` will send on login and upon a continent lock or loss of benefit. All benefits should be functioning. Reference https://www.psforever.net/terminology/Empire_Benefit/ for which gives what. Locally testing everything looked accurate 
<img width="1025" height="750" alt="image" src="https://github.com/user-attachments/assets/cc730ca7-ce7b-437e-9641-3c1093c28a4f" />

While working on the `VehicleData` to give vehicles an extra 10% to their max health upon creation, I discovered one of the unk boolean values was needed to make this work and for the health bar to account for the higher armor on the vehicles with that benefit. `unk3` renamed to `boostMaxHealth ` and set appropriately.