### PR TITLE
[DO NOT MERGE] Personal SOI Accountability

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2974,6 +2974,7 @@ class ZoningOperations(
                                     physSpawnPoint: Option[SpawnPoint]
                                   ): Unit = {
       log.info(s"${player.Name} will load in zone $zoneId at position $pos in $respawnTime")
+      player.resetInteractions()
       respawnTimer.cancel()
       reviveTimer.cancel()
       deadState = DeadState.RespawnTime

--- a/src/main/scala/net/psforever/objects/Player.scala
+++ b/src/main/scala/net/psforever/objects/Player.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 PSForever
 package net.psforever.objects
 
-import net.psforever.objects.avatar.interaction.{TriggerOnPlayerRule, WithEntrance, WithGantry, WithLava, WithWater}
+import net.psforever.objects.avatar.interaction.{InteractWithSOI, TriggerOnPlayerRule, WithEntrance, WithGantry, WithLava, WithWater}
 import net.psforever.objects.avatar.{Avatar, LoadoutManager, SpecialCarry}
 import net.psforever.objects.ballistics.InteractWithRadiationClouds
 import net.psforever.objects.ce.{Deployable, InteractWithMines, InteractWithTurrets}
@@ -39,6 +39,7 @@ class Player(var avatar: Avatar)
     with InteriorAwareFromInteraction
     with AuraContainer
     with MountableEntity {
+  interaction(new InteractWithSOI())
   interaction(environment.interaction.InteractWithEnvironment(Seq(
     new WithEntrance(),
     new WithWater(avatar.name),

--- a/src/main/scala/net/psforever/objects/avatar/interaction/InteractWithSOI.scala
+++ b/src/main/scala/net/psforever/objects/avatar/interaction/InteractWithSOI.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 PSForever
+package net.psforever.objects.avatar.interaction
+
+import net.psforever.objects.Player
+import net.psforever.objects.serverobject.structures.Building
+import net.psforever.objects.zones.{InteractsWithZone, ZoneInteraction, ZoneInteractionType}
+import net.psforever.objects.zones.blockmap.SectorPopulation
+import net.psforever.types.Vector3
+
+case object SOIInteraction extends ZoneInteractionType
+
+/**
+ * na
+ */
+class InteractWithSOI()
+  extends ZoneInteraction {
+
+  private var skipTargetCounter: Int = 0
+  private var occupiedSOIs: List[(String, Building)] = List()
+
+  def Type: ZoneInteractionType = SOIInteraction
+
+  def range: Float = 0f
+
+  /**
+   * na
+   * @param sector the portion of the block map being tested
+   * @param target the fixed element in this test
+   */
+  def interaction(sector: SectorPopulation, target: InteractsWithZone): Unit = {
+    if (skipTargetCounter < 4) {
+      skipTargetCounter += 1
+    } else {
+      skipTargetCounter = 0
+      val buildings = sector.buildingList
+      if (occupiedSOIs.nonEmpty || buildings.nonEmpty) {
+        val targetZone = target.Zone
+        val targetPosition = target.Position
+        val targetAsPlayer = target.asInstanceOf[Player]
+        val key = targetAsPlayer.CharId
+        val (ongoingOccupancy, nowUnoccupied) = occupiedSOIs.partition { case (_, b) =>
+          targetZone == b.Zone && Vector3.DistanceSquared(targetPosition, b.Position) < math.pow(b.Definition.SOIRadius, 2).toFloat
+        }
+        val (_, targetBuildingsOnly) = ongoingOccupancy.unzip
+        val (_, newOccupancy) = buildings
+          .filter { b =>
+            Vector3.DistanceSquared(b.Position, targetPosition) < math.pow(b.Definition.SOIRadius, 2)
+          }
+          .partition { b => targetBuildingsOnly.exists(_.Name.equals(b.Name)) }
+        occupiedSOIs = ongoingOccupancy ++ newOccupancy.map { building => (building.Name, building) }
+        nowUnoccupied.map(_._2).foreach { _.RemovePlayersFromSOI(key) }
+        newOccupancy.foreach { _.AddPlayersInSOI(key, targetAsPlayer) }
+      }
+    }
+  }
+
+  def resetInteraction(target: InteractsWithZone): Unit = {
+    skipTargetCounter = 0
+    val charId = target.asInstanceOf[Player].CharId
+    occupiedSOIs.map(_._2).foreach { _.RemovePlayersFromSOI(charId) }
+    occupiedSOIs = List()
+  }
+}

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -91,7 +91,7 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
   var actor: typed.ActorRef[ZoneActor.Command] = Default.typed.Actor
 
   /** Actor that handles SOI related functionality, for example if a player is in an SOI */
-  private var soi = Default.Actor
+  //private var soi = Default.Actor
 
   /** The basic support structure for the globally unique number system used by this `Zone`. */
   private var guid: NumberPoolHub = new NumberPoolHub(new MaxNumberSource(max = 65536))
@@ -520,11 +520,11 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
   }
 
   def StartPlayerManagementSystems(): Unit = {
-    soi ! SOI.Start()
+    //soi ! SOI.Start()
   }
 
   def StopPlayerManagementSystems(): Unit = {
-    soi ! SOI.Stop()
+    //soi ! SOI.Stop()
   }
 
   def Activity: ActorRef = projector
@@ -1536,7 +1536,7 @@ object Zone {
           Props(classOf[ZoneHotSpotDisplay], zone, zone.hotspots, 15 seconds, zone.hotspotHistory, 60 seconds),
           s"$id-hotspots"
         )
-        zone.soi = context.actorOf(Props(classOf[SphereOfInfluenceActor], zone), s"$id-soi")
+        //zone.soi = context.actorOf(Props(classOf[SphereOfInfluenceActor], zone), s"$id-soi")
 
         zone.avatarEvents = context.actorOf(Props(classOf[AvatarService], zone), s"$id-avatar-events")
         zone.localEvents = context.actorOf(Props(classOf[LocalService], zone), s"$id-local-events")
@@ -1647,7 +1647,7 @@ object Zone {
           obj.Actor ! Service.Startup()
         }
       //allocate soi information
-      zone.soi ! SOI.Build()
+      //zone.soi ! SOI.Build()
     }
 
     private def MakeLattice(zone: Zone): Unit = {

--- a/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
+++ b/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
@@ -110,6 +110,7 @@ class ZonePopulationActor(zone: Zone, playerMap: TrieMap[Int, Option[Player]], c
     case Zone.Corpse.Remove(player) =>
       if (CorpseRemove(player, corpseList)) {
         PlayerLeave(player)
+        player.allowInteraction = false
         zone.actor ! ZoneActor.RemoveFromBlockMap(player)
       }
 


### PR DESCRIPTION
```Quick and simple```
I have changed the way players are assigned to individual SOI regions and would like to have this tested on a greater scale.  Relevant code is found in the file `InteractWithSOI.scala` which is implemented in `Player.scala`.

```Procedure```
This is merely a request for a stress test.  Just having many player characters join the game and exist somewhere in the game world should be enough.  Some of you do this "multi-box" testing far more efficiently than I ever could and I wish to leverage that.  The test target is a player character who is unmounted.  No player character has to do anything specific.

```Caution```
This is not merge-ready code.  Most of what I would be replacing is just commented or skipped around.  A lot of conditions are not handled.  Mounting in vehicle or turret is unhandled.  Zone transfers may probably work but are untested for proper behavior.

```Expanded```
Currently, any facility with a significant sphere of influence is assigned players who occupy that sphere of influence from a zone directive called the `SphereOfInfluenceActor`.  The name is not very inventive, but that's not an issue.  I consider the SOI an aspect of the environment and thus a demonstration of the player interacting with the zone's blockmap.  Even the process consider this a blockmap determination from the perspective of the facilities.  For this purpose, I would give each player the responsibility of reporting their own involvement in a facility's sphere of influence and remove from the zone a top-down policy of assigning it as well as a requirement to manipulate the system's active state.  To the latter point, the fully active system for all zones was determined to be a significant drag on processing and latency back when it was first released such that a shoehorned moniker "player management systems" was granted to it and a power toggle was employed.  It would only be initiated when the first player joins or ceased when the last player leaves, respectively.  Actual implementation of the system was a timed process that interupted other actions and demanded it be given treatment.

The rewritten proposed mechanic is a `ZoneInteraction` so it no longer requires the power switch; and, the activity is tagged onto the standard `PlanetsideStateUpstreamMessage` message responsibility rather than interjecting a whole new game tick operation; but, due to that it operates per player and is still given at least a shallow probe once every `PSUM` tick, __the over-all processing drag concern of the original system might become a renewed concern__.  That is why I am requesting the performance test.

I had been toying with this idea for a while.  I have some potential uses for it, if it pans out.