### PR TITLE
RelatedB Slot

### DIFF
--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -932,7 +932,7 @@ class MiddlewareActor(
   private def inSubslotNotMissing(slot: Int, subslot: Int, inner: ByteVector): Unit = {
     if (subslot == inSubslot + 1) {
       in(PacketCoding.decodePacket(inner))
-      send(RelatedB(slot, subslot))
+      send(RelatedB(slot % 4, subslot))
       inSubslot = subslot
     } else if (subslot > inSubslot + 1) {
       in(PacketCoding.decodePacket(inner))
@@ -1005,7 +1005,7 @@ class MiddlewareActor(
     if (inSubslotsMissing.isEmpty) {
       subslotMissingProcessor.cancel()
       activeSubslotsFunc = inSubslotNotMissing
-      send(RelatedB(slot, inSubslot)) //send a confirmation packet after all requested packets are handled
+      send(RelatedB(slot % 4, inSubslot)) //send a confirmation packet after all requested packets are handled
       log.trace("normalcy with packet subslot order; resuming normal workflow")
     }
   }


### PR DESCRIPTION
The commentary in #432 should explain this problem thoroughly but, to summarize, the game had four `RelatedB` (`RB`) packets for reporting between client and server the last-received bundled packet by `slot` and `subslot` indexes.  The number of bundled packets are eight `SlottedMetaPacket`s (`SMP`), from 0 to 7.  The related logic mapped from `SMP0` to `RB0` to `SMP3` to `RB3`, but then remained unresolved as to how to deal with the mapping for 4 through 7.  It was hacked to wrap back around `SMP4` to `RB0` and like so, but that was never proven either.  This should restore that logic, thus restoring the original quagmire of whether that's the correct thing to do.

This becomes an issue when exploding too many Boomers and the client send some kind of information as an `SMP4` which is out of bounds for the resulting `RB`.  Why it uses `SMP4` for this information and what of anything is the difference between it and the more common `SMP0` is unknown.  That is just the connected issue in demonstration of this issue.