### PR TITLE
This Side

### DIFF
--- a/server/src/main/resources/db/migration/V017__Sidedness.sql
+++ b/server/src/main/resources/db/migration/V017__Sidedness.sql
@@ -1,0 +1,3 @@
+/* New */
+ALTER TABLE savedplayer
+    ADD COLUMN sidedness BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/main/scala/net/psforever/actors/session/AvatarActor.scala
+++ b/src/main/scala/net/psforever/actors/session/AvatarActor.scala
@@ -43,6 +43,7 @@ import net.psforever.objects.equipment.{Equipment, EquipmentSlot}
 import net.psforever.objects.inventory.{Container, InventoryItem}
 import net.psforever.objects.loadouts.{InfantryLoadout, Loadout, VehicleLoadout}
 import net.psforever.objects.locker.LockerContainer
+import net.psforever.objects.serverobject.interior.Sidedness
 import net.psforever.objects.sourcing.{PlayerSource,SourceWithHealthEntry}
 import net.psforever.objects.vital.{DamagingActivity, HealFromImplant, HealingActivity, SpawningActivity}
 import net.psforever.packet.game.objectcreate.{BasicCharacterData, ObjectClass, RibbonBars}
@@ -739,6 +740,7 @@ object AvatarActor {
               _.py          -> lift(0),
               _.pz          -> lift(0),
               _.orientation -> lift(0),
+              _.sidedness   -> lift(false),
               _.zoneNum     -> lift(0),
               _.health      -> lift(0),
               _.armor       -> lift(0),
@@ -746,7 +748,7 @@ object AvatarActor {
               _.loadout     -> lift("")
             )
         )
-        out.completeWith(Future(persistence.Savedplayer(avatarId, 0, 0, 0, 0, 0, 0, 0, 0, "")))
+        out.completeWith(Future(persistence.Savedplayer(avatarId, 0, 0, 0, 0, false, 0, 0, 0, 0, "")))
     }
     out.future
   }
@@ -826,6 +828,7 @@ object AvatarActor {
               _.py          -> lift((position.y * 1000).toInt),
               _.pz          -> lift((position.z * 1000).toInt),
               _.orientation -> lift((player.Orientation.z * 1000).toInt),
+              _.sidedness   -> lift(Sidedness.equals(player.WhichSide, Sidedness.InsideOf)),
               _.zoneNum     -> lift(player.Zone.Number),
               _.health      -> lift(health),
               _.armor       -> lift(player.Armor),
@@ -865,6 +868,7 @@ object AvatarActor {
               _.py          -> lift((position.y * 1000).toInt),
               _.pz          -> lift((position.z * 1000).toInt),
               _.orientation -> lift((player.Orientation.z * 1000).toInt),
+              _.sidedness   -> lift(player.WhichSide == Sidedness.InsideOf),
               _.zoneNum     -> lift(player.Zone.Number)
             )
         )
@@ -2195,14 +2199,14 @@ class AvatarActor(
             val player                = new Player(avatar)
             val zoneNum = saveOpt
               .collect {
-                case persistence.Savedplayer(_, _, _, _, _, zoneNum, _, _, exosuitNum, loadout) =>
+                case persistence.Savedplayer(_, _, _, _, _, _, inZoneNum, _, _, exosuitNum, loadout) =>
                   val exo = ExoSuitType(exosuitNum)
                   player.ExoSuit = exo
                   AvatarActor.buildHolsterEquipmentFromClob(player, loadout, log)
                   if (exo == ExoSuitType.MAX) {
                     player.DrawnSlot = 0 //max arm up
                   }
-                  zoneNum
+                  inZoneNum
               }
               .getOrElse {
                 player.ExoSuit = ExoSuitType.Standard

--- a/src/main/scala/net/psforever/actors/session/csr/ChatLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/csr/ChatLogic.scala
@@ -11,6 +11,7 @@ import net.psforever.objects.serverobject.affinity.FactionAffinity
 import net.psforever.objects.serverobject.dome.ForceDomeControl
 import net.psforever.objects.serverobject.{CommonMessages, PlanetSideServerObject}
 import net.psforever.objects.serverobject.hackable.Hackable
+import net.psforever.objects.serverobject.interior.Sidedness
 import net.psforever.objects.serverobject.structures.Building
 import net.psforever.objects.zones.Zone
 import net.psforever.packet.game.{ChatMsg, SetChatFilterMessage}
@@ -229,6 +230,7 @@ class ChatLogic(val ops: ChatOperations, implicit val context: ActorContext) ext
         case "setempire" => customCommandSetEmpire(params)
         case "weaponlock" => customCommandZoneWeaponUnlock(session, params)
         case "forcedome" => customForceDomeCommand(session, params)
+        case "setside" => customSetSidedness(session, params)
         case _ =>
           // command was not handled
           sendResponse(
@@ -542,6 +544,34 @@ class ChatLogic(val ops: ChatOperations, implicit val context: ActorContext) ext
     } else {
       //no force domes in zone
       sendResponse(ChatMsg(ChatMessageType.UNK_227, "no capitol force dome(s) detected in zone"))
+    }
+    true
+  }
+
+  private def customSetSidedness(session: Session, contents: Seq[String]): Boolean = {
+    var postUsageMessage: Boolean = false
+    contents.headOption match {
+      case Some(side) if side.matches("i|in|inside") =>
+        session.player.WhichSide = Sidedness.InsideOf
+      case Some(side) if side.matches("o|out|outside") =>
+        session.player.WhichSide = Sidedness.OutsideOf
+      case Some("check") =>
+        val whichSide = if (session.player.WhichSide == Sidedness.OutsideOf) {
+          "outside"
+        } else {
+          "inside"
+        }
+        sendResponse(ChatMsg(ChatMessageType.UNK_227, s"You are $whichSide."))
+      case Some("help") | Some("usage") =>
+        postUsageMessage = true
+      case Some(token) =>
+        sendResponse(ChatMsg(ChatMessageType.UNK_227, s"unknown command - $token"))
+        postUsageMessage = true
+      case None =>
+        postUsageMessage = true
+    }
+    if (postUsageMessage) {
+      sendResponse(ChatMsg(ChatMessageType.UNK_227, "!setside i[n[side]]|o[ut[side]]|check"))
     }
     true
   }

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -2080,6 +2080,7 @@ class ZoningOperations(
           val position = Vector3(results.px * 0.001f, results.py * 0.001f, results.pz * 0.001f)
           player.Position = position
           player.Orientation = Vector3(0f, 0f, results.orientation * 0.001f)
+          player.WhichSide = if (results.sidedness) Sidedness.InsideOf else Sidedness.OutsideOf
           /*
           @reset_sanctuary=You have been returned to the sanctuary because you played another character.
            */

--- a/src/main/scala/net/psforever/persistence/SavedCharacter.scala
+++ b/src/main/scala/net/psforever/persistence/SavedCharacter.scala
@@ -9,6 +9,7 @@ case class Savedplayer(
                         py: Int, //Position.y * 1000
                         pz: Int, //Position.z * 1000
                         orientation: Int, //Orientation.z * 1000
+                        sidedness: Boolean,
                         zoneNum: Int,
                         health: Int,
                         armor: Int,


### PR DESCRIPTION
After discovering that people were no longer drowning on relog until they passed through a strict outside setting trigger, e.g, an external door, I attempted to concoct a variety of clever tricks to approximate whether a player might be considered inside or outside at any given time, from any given coordinates in a zone.  It didn't have to be perfect perfect, but it did have to work.

It didn't work.

So I just added it to the database for relogging purposes and called it a day.


___Commands___
Players engaged in customer service representative mode (CSR) can not set their sidedness state by interacting with a sidedness determination trigger and, instead, the last valid state is retained between calls to `gmtoggle` for the most part.  Players engaged in spectator activity have the similar issues but they are designed to respawn if they leave the observation mode.
CSR-level players can set their sidedness to `InsideOf` with the commands: `!setside i`, `!setside in` or `!setside inside`.
CSR-level players can set their sidedness to `OutsideOf` with the commands: `!setside o`, `!setside out` or `!setside outside`.
CSR-level players can check their current sidedness state with the command: `!setside check`.


___Caveats___
If you are already in an incorrect state and start in a way that does not involve respawning, the initial login will not put you into a correct state.  It's not designed to check that, only that it sets it properly moving forward.  If you check the SQL, the default value is `false` which is treated as `OutSideOf`.  Please interact with a sidedness determination trigger, e.g., an external door, or respawn, before assuming whether it works correctly or not.