### PR TITLE
Strapped Into the Seat

### DIFF
--- a/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
+++ b/src/main/scala/net/psforever/objects/vehicles/CargoBehavior.scala
@@ -61,8 +61,10 @@ trait CargoBehavior {
 
   def startCargoDismounting(bailed: Boolean): Unit = {
     if (!startCargoDismountingNoCleanup(bailed)) {
-      isDismounting = None
-      CargoObject.MountedIn = None
+      CargoObject.Zone.GUID(CargoObject.MountedIn).orElse {
+        isDismounting = None
+        CargoObject.MountedIn = None
+      }
     }
   }
 


### PR DESCRIPTION
You can no longer skip the countdown to HART shuttle take-off by attempting to bail the HART and then normally dismounting the HART into the droppod.

The HART counts as being a cargo vehicle to the facility component "carrier" in which it is housed - the `obbasemesh`.  What should happen normally, according to some notes, is that non-driver player should bail from the cargo vehicle, and drivers should cause the cargo vehicle itself to bail from the carrier vehicle, but that is not supported right now in normal vehicle interactions.  If the routine gets far enough to determine the target vehicle is not mounted in anything, it should ensure that internal flags are cleared.  One of these internal flags is used to determine if the HART shuttle is docked or not, thus indicating whether the player exits into the lobby or exits into lower Auraxis orbit.  In our case, ensuring that the mounting for one vehicle is a real entity when it fails to be a vehicle should be enough to short-circuit this short-circuit.

This is curious in general as the `obbasemesh` is not internally recognized as a vehicle.  For the server, this condition of non-cargo mounting is used as a flag to indicate a protected state. The vehicle spawn pad, which has a similar flagged relationship with the spawning vehicle during the spawning animation, does not respond in this manner to attempts at bailing and it is uncertain why.