### PR TITLE
Router Demonstration (OCDM)

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -1432,13 +1432,14 @@ class GeneralOperations(
       val pguid = player.GUID
       val sguid = src.GUID
       val dguid = dest.GUID
-      sendResponse(PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
+      player.Position = dest.Position
+      sendResponse(ObjectCreateDetailedMessage(player.Definition.ObjectId, pguid, player.Definition.Packet.DetailedConstructorData(player).get))
+      sendResponse(SetCurrentAvatarMessage(pguid, 0, 0))
       useRouterTelepadEffect(pguid, sguid, dguid)
       continent.LocalEvents ! LocalServiceMessage(
         continent.id,
         LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
       )
-      player.Position = dest.Position
       player.LogActivity(TelepadUseActivity(VehicleSource(router), DeployableSource(remoteTelepad), PlayerSource(player)))
     } else {
       log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")


### PR DESCRIPTION
As per the attached ticket submitted by @Dethdeath, I changed the router telepad system to use `ObjectCreateDetailedMessage` and `SetCurrentAvatarMessage` to do a complete reconstruction of the teleporting player in an attempt at bypassing minimap updates and just have the player appear somewhere else.  I've not completely tested whether a second party observer sees anything wonky, either from a faction-aligned or an enemy faction perspective.

From the persepctive of the teleporter, however, this method is incomplete because I have not fully realigned the new(?) avatar and game world completely.  A good demonstration is that the person going through the router does not own any vehicle thbat they origijnally owned coming out the other end.  Other disconnects may also be present.  Once again, this is just to test the adjustment to the teleportation method.

CLOSES #1347