### PR TITLE
Router Demonstration (ODM)

### DIFF
--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -1432,13 +1432,25 @@ class GeneralOperations(
       val pguid = player.GUID
       val sguid = src.GUID
       val dguid = dest.GUID
-      sendResponse(PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
-      useRouterTelepadEffect(pguid, sguid, dguid)
-      continent.LocalEvents ! LocalServiceMessage(
-        continent.id,
-        LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
+      val events = continent.AvatarEvents
+      val zoneid = continent.id
+      events ! AvatarServiceMessage(zoneid, AvatarAction.ObjectDelete(pguid, pguid))
+      events ! AvatarServiceMessage(player.Name,
+        AvatarAction.SendResponse(PlanetSideGUID(0), PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
       )
       player.Position = dest.Position
+      events ! AvatarServiceMessage(zoneid, AvatarAction.LoadPlayer(
+        pguid,
+        player.Definition.ObjectId,
+        pguid,
+        player.Definition.Packet.ConstructorData(player).get,
+        None
+      ))
+      useRouterTelepadEffect(pguid, sguid, dguid)
+      continent.LocalEvents ! LocalServiceMessage(
+        zoneid,
+        LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
+      )
       player.LogActivity(TelepadUseActivity(VehicleSource(router), DeployableSource(remoteTelepad), PlayerSource(player)))
     } else {
       log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")


### PR DESCRIPTION
As per ticket #1347 submitted by @Dethdeath, I augmented the router telepad system to instigate object delete and object create on the client of other players.  To be brief, upon attempting a teleport: delete the user from the perspective of other players, tell the user to cause a player shift state to the destination, then reconstruct the user at the destination from the perspective of other players.   Unlike the original case, I tested what a second party faction-aligned observer sees and it works, it's mostly decent.  There's a bit of a hiccup in visibility at the point of origin from time to time, especially when running into the teleporter beam.  Since the original example was a cross-faction example, I have to leave that up to further performance tests.    Additionally, should also test with a bit of delay: the packets to other player obviously utilize the event system and, therefore, are out of sync with the player phase shift packet sent to self.

There should be no disconnects from the perspective of the person teleporting because it still utilizes player shift state but now additional, unspecified accommodations may be required for that teleporting player from the perspective of other players in the zone.  Will explore this later if we pursue this retooling.

An additional test can be performed where all packets are sent through the event system.  Importantly, the player can send their own player shift state packet to themselves in between the object delete and object create.  That may re-introduce the delay you mentioned in PR #1372 but it might also make events flow much better within the context of what other player's see.