### PR TITLE
Router Demonstration (ShiftPosition)

### DIFF
--- a/src/main/scala/net/psforever/actors/session/normal/AvatarHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/AvatarHandlerLogic.scala
@@ -574,7 +574,7 @@ class AvatarHandlerLogic(val ops: SessionAvatarHandlers, implicit val context: A
         sessionLogic.actionsToCancel()
         sessionLogic.terminals.CancelAllProximityUnits()
         AvatarActor.savePlayerLocation(player)
-        sessionLogic.zoning.spawn.shiftPosition = Some(player.Position)
+        sessionLogic.zoning.spawn.ShiftPosition = Some(player.Position)
 
         //respawn
         val respawnTimer = 300000 //milliseconds

--- a/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/GeneralLogic.scala
@@ -169,7 +169,16 @@ class GeneralLogic(val ops: GeneralOperations, implicit val context: ActorContex
     //
     val eagleEye: Boolean = ops.canSeeReallyFar
     val isNotVisible: Boolean = sessionLogic.zoning.zoningStatus == Zoning.Status.Deconstructing ||
-      (player.isAlive && sessionLogic.zoning.spawn.deadState == DeadState.RespawnTime)
+      (player.isAlive && sessionLogic.zoning.spawn.deadState == DeadState.RespawnTime) ||
+      (sessionLogic.zoning.spawn.ShiftPosition match {
+        case Some(position) if Vector3.DistanceSquared(position, pos) < 25f =>
+          sessionLogic.zoning.spawn.ShiftPosition = None
+          false
+        case Some(_) =>
+          true
+        case _ =>
+          false
+      })
     continent.AvatarEvents ! AvatarServiceMessage(
       continent.id,
       AvatarAction.PlayerState(

--- a/src/main/scala/net/psforever/actors/session/spectator/AvatarHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/spectator/AvatarHandlerLogic.scala
@@ -467,7 +467,7 @@ class AvatarHandlerLogic(val ops: SessionAvatarHandlers, implicit val context: A
         sessionLogic.actionsToCancel()
         sessionLogic.terminals.CancelAllProximityUnits()
         AvatarActor.savePlayerLocation(player)
-        sessionLogic.zoning.spawn.shiftPosition = Some(player.Position)
+        sessionLogic.zoning.spawn.ShiftPosition = Some(player.Position)
 
         //respawn
         sessionLogic.zoning.spawn.reviveTimer.cancel()

--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -182,7 +182,7 @@ class GeneralOperations(
                        ) extends CommonSessionInterfacingFunctionality {
   private[session] var progressBarValue: Option[Float] = None
   private[session] var accessedContainer: Option[PlanetSideGameObject with Container] = None
-  private[session] var recentTeleportAttempt: Long = 0
+  private[session] var recentTeleportAttemptTime: Long = 0
   private[session] var kitToBeUsed: Option[PlanetSideGUID] = None
   // If a special item (e.g. LLU) has been attached to the player the GUID should be stored here, or cleared when dropped, since the drop hotkey doesn't send the GUID of the object to be dropped.
   private[session] var specialItemSlotGuid: Option[PlanetSideGUID] = None
@@ -1210,8 +1210,8 @@ class GeneralOperations(
     sessionLogic.zoning.CancelZoningProcessWithDescriptiveReason("cancel_use")
     if (msg.unk3) {
       msg.object_id match {
-        case ObjectClass.avatar | ObjectClass.avatar_bot | ObjectClass.avatar_bot_agile | ObjectClass.avatar_bot_agile_no_weapon | 
-        ObjectClass.avatar_bot_max | ObjectClass.avatar_bot_max_no_weapon | ObjectClass.avatar_bot_reinforced | 
+        case ObjectClass.avatar | ObjectClass.avatar_bot | ObjectClass.avatar_bot_agile | ObjectClass.avatar_bot_agile_no_weapon |
+        ObjectClass.avatar_bot_max | ObjectClass.avatar_bot_max_no_weapon | ObjectClass.avatar_bot_reinforced |
         ObjectClass.avatar_bot_reinforced_no_weapon | ObjectClass.avatar_bot_standard | ObjectClass.avatar_bot_standard_no_weapon =>
         equipment match {
           case Some(tool: Tool) if tool.Definition == GlobalDefinitions.bank =>
@@ -1424,38 +1424,38 @@ class GeneralOperations(
                               dest: PlanetSideGameObject with TelepadLike
                             ): Unit = {
     val time = System.currentTimeMillis()
-    if (
-      time - recentTeleportAttempt > 2000L && router.DeploymentState == DriveState.Deployed &&
-        internalTelepad.Active &&
-        remoteTelepad.Active
-    ) {
-      val pguid = player.GUID
-      val sguid = src.GUID
-      val dguid = dest.GUID
-      val events = continent.AvatarEvents
-      val zoneid = continent.id
-      events ! AvatarServiceMessage(zoneid, AvatarAction.ObjectDelete(pguid, pguid))
-      events ! AvatarServiceMessage(player.Name,
-        AvatarAction.SendResponse(PlanetSideGUID(0), PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
-      )
-      player.Position = dest.Position
-      events ! AvatarServiceMessage(zoneid, AvatarAction.LoadPlayer(
-        pguid,
-        player.Definition.ObjectId,
-        pguid,
-        player.Definition.Packet.ConstructorData(player).get,
-        None
-      ))
-      useRouterTelepadEffect(pguid, sguid, dguid)
-      continent.LocalEvents ! LocalServiceMessage(
-        zoneid,
-        LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
-      )
-      player.LogActivity(TelepadUseActivity(VehicleSource(router), DeployableSource(remoteTelepad), PlayerSource(player)))
-    } else {
-      log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")
+    if (time - recentTeleportAttemptTime > 2000L) {
+      if (router.DeploymentState == DriveState.Deployed && internalTelepad.Active && remoteTelepad.Active) {
+        val pguid = player.GUID
+        val sguid = src.GUID
+        val dguid = dest.GUID
+        val events = continent.AvatarEvents
+        val zoneid = continent.id
+        val destinationPosition = dest.Position
+        events ! AvatarServiceMessage(zoneid, AvatarAction.ObjectDelete(pguid, pguid))
+        events ! AvatarServiceMessage(player.Name,
+          AvatarAction.SendResponse(PlanetSideGUID(0), PlayerStateShiftMessage(ShiftState(0, destinationPosition, player.Orientation.z)))
+        )
+        player.Position = destinationPosition
+        events ! AvatarServiceMessage(zoneid, AvatarAction.LoadPlayer(
+          pguid,
+          player.Definition.ObjectId,
+          pguid,
+          player.Definition.Packet.ConstructorData(player).get,
+          None
+        ))
+        useRouterTelepadEffect(pguid, sguid, dguid)
+        continent.LocalEvents ! LocalServiceMessage(
+          continent.id,
+          LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
+        )
+        sessionLogic.zoning.spawn.ShiftPosition = destinationPosition
+        player.LogActivity(TelepadUseActivity(VehicleSource(router), DeployableSource(remoteTelepad), PlayerSource(player)))
+      } else {
+        log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")
+      }
     }
-    recentTeleportAttempt = time
+    recentTeleportAttemptTime = time
   }
 
   /**
@@ -1475,7 +1475,7 @@ class GeneralOperations(
                                     ): Unit = {
     val time = System.currentTimeMillis()
     if (
-      time - recentTeleportAttempt > 2000L && router.DeploymentState == DriveState.Deployed &&
+      time - recentTeleportAttemptTime > 2000L && router.DeploymentState == DriveState.Deployed &&
         internalTelepad.Active &&
         remoteTelepad.Active
     ) {
@@ -1488,7 +1488,7 @@ class GeneralOperations(
     } else {
       log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")
     }
-    recentTeleportAttempt = time
+    recentTeleportAttemptTime = time
   }
 
   def handleUseCaptureFlag(obj: CaptureFlag): Unit = {

--- a/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/GeneralOperations.scala
@@ -1432,13 +1432,25 @@ class GeneralOperations(
       val pguid = player.GUID
       val sguid = src.GUID
       val dguid = dest.GUID
-      sendResponse(PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
-      useRouterTelepadEffect(pguid, sguid, dguid)
-      continent.LocalEvents ! LocalServiceMessage(
-        continent.id,
-        LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
+      val events = continent.AvatarEvents
+      val zoneid = continent.id
+      events ! AvatarServiceMessage(zoneid, AvatarAction.ObjectDelete(pguid, pguid))
+      events ! AvatarServiceMessage(player.Name,
+        AvatarAction.SendResponse(PlanetSideGUID(0), PlayerStateShiftMessage(ShiftState(0, dest.Position, player.Orientation.z)))
       )
       player.Position = dest.Position
+      events ! AvatarServiceMessage(zoneid, AvatarAction.LoadPlayer(
+        pguid,
+        player.Definition.ObjectId,
+        pguid,
+        player.Definition.Packet.ConstructorData(player).get,
+        None
+      ))
+      useRouterTelepadEffect(pguid, sguid, dguid)
+      continent.LocalEvents ! LocalServiceMessage(
+        zoneid,
+        LocalAction.RouterTelepadTransport(pguid, pguid, sguid, dguid)
+      )
       player.LogActivity(TelepadUseActivity(VehicleSource(router), DeployableSource(remoteTelepad), PlayerSource(player)))
     } else {
       log.warn(s"UseRouterTelepadSystem: ${player.Name} can not teleport")

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -1998,7 +1998,7 @@ class ZoningOperations(
      * As they should arrive roughly every 250 milliseconds this allows for a very crude method of scheduling tasks up to four times per second
      */
     private[session] var upstreamMessageCount: Int = 0
-    private[session] var shiftPosition: Option[Vector3] = None
+    private var shiftPosition: Option[Vector3] = None
     private[session] var shiftOrientation: Option[Vector3] = None
     private[session] var drawDeloyableIcon: PlanetSideGameObject with Deployable => Unit = RedrawDeployableIcons
     private[session] var populateAvatarAwardRibbonsFunc: (Int, Long) => Unit = setupAvatarAwardMessageDelivery
@@ -4119,6 +4119,18 @@ class ZoningOperations(
 
     def clearAllQueuedActivity(): Unit = {
       queuedActivities = Seq()
+    }
+
+    def ShiftPosition: Option[Vector3] = shiftPosition
+
+    def ShiftPosition_=(toPosition: Option[Vector3]): Option[Vector3] = {
+      shiftPosition = toPosition
+      ShiftPosition
+    }
+
+    def ShiftPosition_=(toPosition: Vector3): Option[Vector3] = {
+      shiftPosition = Some(toPosition)
+      ShiftPosition
     }
   }
 


### PR DESCRIPTION
As per ticket #134 submitted by @Dethdeath, yada yada, you know the drill.

The following test uses the branch from #1373 as a base and modifies the rendering priority in an attempt that the user as seen from another player's perspective does not linger at their point of origin long before being deleted from the same perspective.  Once the teleportation is confirmed, a location flag is set the the destination coordinates and, until the user arrives at that destination point, their rendering priority is turned off.  Specifically, the user should be moved far outside of the observing player's field of view.  They will stay that way until the shift state is processed and they are moved to the destination client locally, and that will also restore their rendering priority.  Once that transition has occurred, they will have their entity creation packet processed and now appear at the destination point.  In theory.  "Rendering priority," in this case, refers to whether the user identifies to other player's through the event system whether it should be rendered (check `AvatarAction.PlayerState`).  If the object delete packet and the object create packet are both processed before the shift state packet, the user should not erroneously reappear back at the teleportation point from another's perspective.

This was originally it's own test of a possible independent router teleport system fix that did not involve the event system and that is why it is in its own branch separate from #1373's branch.  After it was proven that the speed of a `PlanetsideStateShiftMessage` was faster than the speed of the next proper upstream packet in practice, it was given the #1373 branch as a base in attempts to resolve the occasional lingering user rendering echo.  I suppose this is the pirmary test to be performed.