### PR TITLE
GUID Number Pool Shuffling

### DIFF
--- a/src/main/resources/guid-pools/default.json
+++ b/src/main/resources/guid-pools/default.json
@@ -6,39 +6,39 @@
     "Selector": "specific"
   },
   {
-    "Name": "players",
+    "Name": "vehicles",
     "Start": 3001,
-    "Max": 4500,
-    "Selector": "random"
-  },
-  {
-    "Name": "lockers",
-    "Start": 4501,
     "Max": 5000,
     "Selector": "random"
   },
   {
-    "Name": "tools",
+    "Name": "lockers",
     "Start": 5001,
-    "Max": 9500,
+    "Max": 5500,
+    "Selector": "random"
+  },
+  {
+    "Name": "tools",
+    "Start": 5501,
+    "Max": 10000,
     "Selector": "random"
   },
   {
     "Name": "ammo",
-    "Start": 9501,
-    "Max": 23000,
+    "Start": 10001,
+    "Max": 23500,
     "Selector": "random"
   },
   {
     "Name": "kits",
-    "Start": 23001,
-    "Max": 36500,
+    "Start": 23501,
+    "Max": 37000,
     "Selector": "random"
   },
   {
     "Name": "items",
-    "Start": 36501,
-    "Max": 39500,
+    "Start": 37001,
+    "Max": 39700,
     "Selector": "random"
   },
   {
@@ -60,7 +60,7 @@
     "Selector": "specific"
   },
   {
-    "Name": "vehicles",
+    "Name": "players",
     "Start": 45001,
     "Max": 47000,
     "Selector": "random"

--- a/src/main/resources/guid-pools/z3.json
+++ b/src/main/resources/guid-pools/z3.json
@@ -6,14 +6,8 @@
     "Selector": "specific"
   },
   {
-    "Name": "players",
+    "Name": "vehicles",
     "Start": 4001,
-    "Max": 5500,
-    "Selector": "random"
-  },
-  {
-    "Name": "lockers",
-    "Start": 5501,
     "Max": 6000,
     "Selector": "random"
   },
@@ -45,6 +39,12 @@
     "Name": "rc-projectiles",
     "Start": 64001,
     "Max": 64300,
+    "Selector": "random"
+  },
+  {
+    "Name": "lockers",
+    "Start": 64301,
+    "Max": 64800,
     "Selector": "random"
   }
 ]

--- a/src/main/resources/guid-pools/z4.json
+++ b/src/main/resources/guid-pools/z4.json
@@ -6,14 +6,8 @@
     "Selector": "specific"
   },
   {
-    "Name": "players",
+    "Name": "vehicles",
     "Start": 3101,
-    "Max": 4600,
-    "Selector": "random"
-  },
-  {
-    "Name": "lockers",
-    "Start": 4601,
     "Max": 5100,
     "Selector": "random"
   },
@@ -45,6 +39,12 @@
     "Name": "rc-projectiles",
     "Start": 64001,
     "Max": 64300,
+    "Selector": "random"
+  },
+  {
+    "Name": "lockers",
+    "Start": 64301,
+    "Max": 64800,
     "Selector": "random"
   }
 ]


### PR DESCRIPTION
As per @ScrawnyRonnie's comment in #1349, shifting the global unique identifier number pools around thus that players are higher than vehicles corrects visibility issues regarding holstered and equipped weaponry when interacting with the AMS cloak bubble.  The GUID's for lockers, i.e., the player's internal carrying capacity reference point for their locker space, has been shifted to the end of the list where appropriate.

This solution makes me concerned the client imposes curious GUID requirements for randomly generated entities much like it does for static environment entities.  In the best case scenario, it just processed cloaked entities in an order of GUID for some specific check; and, this is really all we need to ever do to solve the only issue like this we will encounter.