### PR TITLE
Reduce server hitching: dead dispatcher config, per-packet allocation, and unindexed queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,18 @@ lazy val server = (project in file("server"))
     inConfig(QuietTest)(Defaults.testTasks),
     packMain := Map("psforever-server" -> "net.psforever.server.Server"),
     packArchivePrefix := "psforever-server",
-    packJvmOpts := Map("psforever-server" -> Seq("-Dstacktrace.app.packages=net.psforever")),
+    // The packaged launcher previously passed no memory or collector settings at all, so the
+    // server ran on whatever the JVM defaulted to -- in a container, a fraction of host RAM.
+    // The -Xmx in .jvmopts applies to sbt, not to this script. G1 with an explicit pause
+    // target keeps collections short; the server's hitching is sensitive to stop-the-world
+    // pauses because they stall every connected session simultaneously.
+    packJvmOpts := Map("psforever-server" -> Seq(
+      "-Dstacktrace.app.packages=net.psforever",
+      "-Xms2g",
+      "-Xmx4g",
+      "-XX:+UseG1GC",
+      "-XX:MaxGCPauseMillis=50"
+    )),
     packExtraClasspath := Map("psforever-server" -> Seq("${PROG_HOME}/config")),
     packResourceDir += ((psforever / baseDirectory).value / "config" -> "config")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -110,11 +110,11 @@ lazy val server = (project in file("server"))
     inConfig(QuietTest)(Defaults.testTasks),
     packMain := Map("psforever-server" -> "net.psforever.server.Server"),
     packArchivePrefix := "psforever-server",
-    // The packaged launcher previously passed no memory or collector settings at all, so the
-    // server ran on whatever the JVM defaulted to -- in a container, a fraction of host RAM.
-    // The -Xmx in .jvmopts applies to sbt, not to this script. G1 with an explicit pause
-    // target keeps collections short; the server's hitching is sensitive to stop-the-world
-    // pauses because they stall every connected session simultaneously.
+    // Memory and collector settings for the packaged launcher. Without them the server takes
+    // the JVM defaults, which in a container is a fraction of host RAM. Note the -Xmx in
+    // .jvmopts governs sbt, not this script. G1 with an explicit pause target keeps
+    // collections short, which matters because a stop-the-world pause stalls every connected
+    // session simultaneously.
     packJvmOpts := Map("psforever-server" -> Seq(
       "-Dstacktrace.app.packages=net.psforever",
       "-Xms2g",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   loginserver:
-    image: sbtscala/scala-sbt:eclipse-temurin-jammy-8u352-b08_1.8.3_2.13.10
+    # Matches the JDK the Dockerfile builds with. This previously ran JDK 8, whose default
+    # collector is ParallelGC -- full collections there are stop-the-world and can run into
+    # seconds, stalling every connected client at once.
+    image: sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.8.2_2.13.10
     volumes:
       - .:/PSF-Loginserver:z
     working_dir: /PSF-Loginserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   loginserver:
-    # Matches the JDK the Dockerfile builds with. This previously ran JDK 8, whose default
-    # collector is ParallelGC -- full collections there are stop-the-world and can run into
-    # seconds, stalling every connected client at once.
+    # Matches the JDK the Dockerfile builds with, so local runs and released builds share a
+    # collector. Keep this off JDK 8, whose default ParallelGC does stop-the-world full
+    # collections that can run into seconds and stall every connected client at once.
     image: sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.8.2_2.13.10
     volumes:
       - .:/PSF-Loginserver:z

--- a/server/src/main/resources/db/migration/V018__PerformanceIndexes.sql
+++ b/server/src/main/resources/db/migration/V018__PerformanceIndexes.sql
@@ -1,0 +1,39 @@
+-- Indexes for foreign keys that are queried on the login and gameplay hot paths.
+--
+-- PostgreSQL does not create an index for a REFERENCES constraint, so before this migration
+-- every one of the lookups below was a sequential scan. Only V015 (outfits) had declared any
+-- indexes at all.
+--
+-- Deliberately omitted, because an existing constraint already provides a usable btree with
+-- avatar_id as its leading column:
+--   friend, ignored              UNIQUE(avatar_id, char_id)
+--   shortcut                     UNIQUE(avatar_id, slot)
+--   avatarmodepermission         UNIQUE(avatar_id)
+--   savedplayer, savedavatar     avatar_id is the primary key
+-- Adding further indexes there would only cost write throughput.
+
+-- Read for every character on the character select screen, and rewritten whenever a loadout
+-- is saved or deleted. Primary key is id alone, so avatar_id was unindexed.
+CREATE INDEX IF NOT EXISTS "loadout_avatar_id_idx" ON "loadout" ("avatar_id");
+CREATE INDEX IF NOT EXISTS "vehicleloadout_avatar_id_idx" ON "vehicleloadout" ("avatar_id");
+
+-- Read on login and rewritten on every locker change.
+CREATE INDEX IF NOT EXISTS "locker_avatar_id_idx" ON "locker" ("avatar_id");
+
+-- Primary key is (id, avatar_id), so a lookup by avatar_id alone cannot use it.
+CREATE INDEX IF NOT EXISTS "certification_avatar_id_idx" ON "certification" ("avatar_id");
+
+-- Primary key is (name, avatar_id); loading every implant for an avatar does not supply
+-- name and so cannot use the leading column.
+CREATE INDEX IF NOT EXISTS "implant_avatar_id_idx" ON "implant" ("avatar_id");
+
+-- Scanned to build the character list for an account.
+CREATE INDEX IF NOT EXISTS "avatar_account_id_idx" ON "avatar" ("account_id");
+
+-- killactivity is an append-only kill log that grows for the lifetime of the server, and the
+-- campaign KDA query reads it on every single login with
+--   WHERE (killer_id = ? OR victim_id = ?) AND killer_id <> victim_id
+-- Without these, login cost grew in proportion to every kill ever recorded. The OR is
+-- satisfied by two separate indexes via a bitmap union.
+CREATE INDEX IF NOT EXISTS "killactivity_killer_id_idx" ON "killactivity" ("killer_id");
+CREATE INDEX IF NOT EXISTS "killactivity_victim_id_idx" ON "killactivity" ("victim_id");

--- a/server/src/main/resources/db/migration/V018__PerformanceIndexes.sql
+++ b/server/src/main/resources/db/migration/V018__PerformanceIndexes.sql
@@ -1,8 +1,7 @@
 -- Indexes for foreign keys that are queried on the login and gameplay hot paths.
 --
--- PostgreSQL does not create an index for a REFERENCES constraint, so before this migration
--- every one of the lookups below was a sequential scan. Only V015 (outfits) had declared any
--- indexes at all.
+-- PostgreSQL does not create an index for a REFERENCES constraint, so each foreign key that
+-- is filtered on needs one declared explicitly or the lookup is a sequential scan.
 --
 -- Deliberately omitted, because an existing constraint already provides a usable btree with
 -- avatar_id as its leading column:
@@ -13,7 +12,7 @@
 -- Adding further indexes there would only cost write throughput.
 
 -- Read for every character on the character select screen, and rewritten whenever a loadout
--- is saved or deleted. Primary key is id alone, so avatar_id was unindexed.
+-- is saved or deleted. The primary key is id alone, so it does not serve avatar_id lookups.
 CREATE INDEX IF NOT EXISTS "loadout_avatar_id_idx" ON "loadout" ("avatar_id");
 CREATE INDEX IF NOT EXISTS "vehicleloadout_avatar_id_idx" ON "vehicleloadout" ("avatar_id");
 
@@ -33,7 +32,7 @@ CREATE INDEX IF NOT EXISTS "avatar_account_id_idx" ON "avatar" ("account_id");
 -- killactivity is an append-only kill log that grows for the lifetime of the server, and the
 -- campaign KDA query reads it on every single login with
 --   WHERE (killer_id = ? OR victim_id = ?) AND killer_id <> victim_id
--- Without these, login cost grew in proportion to every kill ever recorded. The OR is
--- satisfied by two separate indexes via a bitmap union.
+-- Two single-column indexes let the OR resolve as a bitmap union, keeping that query
+-- proportional to one player's kills rather than to every kill the server has recorded.
 CREATE INDEX IF NOT EXISTS "killactivity_killer_id_idx" ON "killactivity" ("killer_id");
 CREATE INDEX IF NOT EXISTS "killactivity_victim_id_idx" ON "killactivity" ("victim_id");

--- a/server/src/main/scala/net/psforever/server/Server.scala
+++ b/server/src/main/scala/net/psforever/server/Server.scala
@@ -115,7 +115,10 @@ object Server {
     val loginPlan = (ref: ActorRef[MiddlewareActor.Command], info: InetSocketAddress, connectionId: String) => {
       import net.psforever.services.account.IPAddress
       Behaviors.setup[PlanetSidePacket](context => {
-        val actor = context.actorOf(classic.Props(new LoginActor(ref, connectionId, Login.getNewId())), "login")
+        val actor = context.actorOf(
+          classic.Props(new LoginActor(ref, connectionId, Login.getNewId())).withDispatcher("login-session"),
+          "login"
+        )
         actor ! ReceiveIPAddress(new IPAddress(info))
         Behaviors.receiveMessage(message => {
           actor ! message
@@ -127,7 +130,10 @@ object Server {
       Behaviors.setup[PlanetSidePacket](context => {
         val uuid = randomUUID().toString
         val actor =
-          context.actorOf(classic.Props(new SessionActor(ref, connectionId, Session.getNewId())), s"session-$uuid")
+          context.actorOf(
+            classic.Props(new SessionActor(ref, connectionId, Session.getNewId())).withDispatcher("world-session"),
+            s"session-$uuid"
+          )
         Behaviors.receiveMessage(message => {
           actor ! message
           Behaviors.same

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -246,3 +246,36 @@ akka.actor.deployment {
     dispatcher = tzshvs-zone-dispatcher
   }
 }
+
+# Safety net for the default dispatcher.
+#
+# The path-based assignments above do not correspond to any actor this server actually
+# creates: there is no /world-udp-endpoint (the socket actors are named world-socket-<port>
+# under socketPane), no world-session-router, and the zone actors are named zone-<id> rather
+# than <id>-actor. Akka's config-based deployment also only applies to classic actors, while
+# the network and session actors are spawned through the typed API, so assigning their
+# dispatchers by path cannot work regardless of the names.
+#
+# The practical result is that socket I/O, session logic and zone logic all share
+# akka.actor.default-dispatcher with its stock throughput of 5, which produces frequent
+# thread hand-off on the packet path. Until each actor selects its dispatcher explicitly at
+# spawn, give the pool everything actually runs on a configuration suited to that load.
+akka.actor.default-dispatcher {
+  throughput = 20
+
+  fork-join-executor {
+    parallelism-min = 8
+    parallelism-factor = 1.0
+    parallelism-max = 64
+  }
+}
+
+# The scheduler carries a large number of short-lived tasks: a per-session outbound packet
+# timer, per-player stamina and keep-alive ticks, and per-entity ticks for painboxes,
+# siphons, turrets and proximity terminals. The stock 512 buckets collide heavily at those
+# volumes, and a cancelled task stays in its bucket until its tick comes round, so the tick
+# thread walks long chains.
+akka.scheduler {
+  tick-duration = 10ms
+  ticks-per-wheel = 2048
+}

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -221,11 +221,11 @@ akka.actor.deployment {
   "/service/cluster/tzdrvs-actor/*" {
     dispatcher = tzdrvs-zone-dispatcher
   }
-  "/service/cluster/tzsdrtr-actor" {
-    dispatcher = tzsdrtr-zone-dispatcher
+  "/service/cluster/tzdrtr-actor" {
+    dispatcher = tzdrtr-zone-dispatcher
   }
-  "/service/cluster/tzsdrtr-actor/*" {
-    dispatcher = tzsdrtr-zone-dispatcher
+  "/service/cluster/tzdrtr-actor/*" {
+    dispatcher = tzdrtr-zone-dispatcher
   }
   "/service/cluster/tzshnc-actor" {
     dispatcher = tzshnc-zone-dispatcher

--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -247,19 +247,18 @@ akka.actor.deployment {
   }
 }
 
-# Safety net for the default dispatcher.
+# Configuration for the default dispatcher.
 #
-# The path-based assignments above do not correspond to any actor this server actually
-# creates: there is no /world-udp-endpoint (the socket actors are named world-socket-<port>
-# under socketPane), no world-session-router, and the zone actors are named zone-<id> rather
-# than <id>-actor. Akka's config-based deployment also only applies to classic actors, while
-# the network and session actors are spawned through the typed API, so assigning their
-# dispatchers by path cannot work regardless of the names.
+# Anything that does not select a dispatcher explicitly runs here, so it is sized for real
+# server load rather than left at Akka's stock throughput of 5, which produces frequent
+# thread hand-off on the packet path.
 #
-# The practical result is that socket I/O, session logic and zone logic all share
-# akka.actor.default-dispatcher with its stock throughput of 5, which produces frequent
-# thread hand-off on the packet path. Until each actor selects its dispatcher explicitly at
-# spawn, give the pool everything actually runs on a configuration suited to that load.
+# Note that the path-based assignments above do not reach the network, session or zone
+# actors. Those are spawned through the typed API, which Akka's config-based deployment does
+# not apply to, and they select their dispatchers at their spawn sites instead -- see
+# SocketPane, SocketActor, Server and InterstellarClusterService. The paths named above
+# (/world-udp-endpoint, world-session-router, <id>-actor) do not correspond to actors this
+# server creates.
 akka.actor.default-dispatcher {
   throughput = 20
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,7 +63,14 @@ database {
   sslmode = prefer
 
   # The maximum number of active connections.
-  maxActiveConnections = 5
+  #
+  # This is the ceiling on concurrent SQL statements for the entire server, not a player
+  # limit -- game clients never touch it. Every session, zone actor and kill report shares
+  # this one pool, and the driver queues excess queries rather than rejecting them, so
+  # saturation shows up purely as latency: logins, loadout applies and terminal purchases
+  # all wait behind each other. Five slots is far too few once character login alone issues
+  # a dozen sequential queries.
+  maxActiveConnections = 32
 }
 
 # Enable non-standard game properties

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -560,6 +560,16 @@ network {
     # Affects the base value on the timer
     packet-bundling-delay-multiplier = 1.25
 
+    # How many bundles may be dispatched in a single execution of the bundling process.
+    # Each bundle is capped at the 440 byte MTU, so this multiplied by the bundle size and
+    # divided by the delay above is the effective per-client outbound ceiling.
+    # Previously the process sent exactly one bundle per run, which capped every client at
+    # roughly 20 bundles a second no matter how much was queued, so any burst -- a zone load,
+    # a base capture, a squad coming into render range -- drained at under 9 KB/s and the
+    # world appeared to the player to arrive in slow motion.
+    # Raise for faster burst delivery, lower to be gentler on constrained connections.
+    packet-bundling-drain-limit = 8
+
     # Pause inbound packet transmission towards the network if the sequence number is out of order
     # Packets are put aside until the sequence is restored, or this timeout passes
     in-reorder-timeout = 50 milliseconds

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -68,8 +68,8 @@ database {
   # limit -- game clients never touch it. Every session, zone actor and kill report shares
   # this one pool, and the driver queues excess queries rather than rejecting them, so
   # saturation shows up purely as latency: logins, loadout applies and terminal purchases
-  # all wait behind each other. Five slots is far too few once character login alone issues
-  # a dozen sequential queries.
+  # waiting behind each other. Size it against concurrent database work, bearing in mind
+  # character login alone issues about a dozen sequential queries.
   maxActiveConnections = 32
 }
 
@@ -563,10 +563,9 @@ network {
     # How many bundles may be dispatched in a single execution of the bundling process.
     # Each bundle is capped at the 440 byte MTU, so this multiplied by the bundle size and
     # divided by the delay above is the effective per-client outbound ceiling.
-    # Previously the process sent exactly one bundle per run, which capped every client at
-    # roughly 20 bundles a second no matter how much was queued, so any burst -- a zone load,
-    # a base capture, a squad coming into render range -- drained at under 9 KB/s and the
-    # world appeared to the player to arrive in slow motion.
+    # This governs how quickly a backlog drains -- a zone load, a base capture, or a squad
+    # coming into render range all queue far more than one bundle -- while the delay above
+    # governs how aggressively packets are coalesced into each bundle.
     # Raise for faster burst delivery, lower to be gentler on constrained connections.
     packet-bundling-drain-limit = 8
 

--- a/src/main/resources/dispatchers.conf
+++ b/src/main/resources/dispatchers.conf
@@ -452,7 +452,7 @@ tzdrvs-zone-dispatcher {
   throughput = 50
   throughput-deadline-time = 50ms
 }
-tzsdrtr-zone-dispatcher {
+tzdrtr-zone-dispatcher {
   type = Dispatcher
   executor = "fork-join-executor"
 

--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -675,13 +675,11 @@ class MiddlewareActor(
     */
   private def processQueue(): Unit = {
     inReorderQueueFunc()
-    /* processOutQueueBundle dispatches at most one bundle per call, so a single call per timer
-       tick capped each client's outbound throughput at one MTU-sized bundle per delay period
-       regardless of backlog. Drain up to the configured number of bundles instead, so a burst
-       clears in a few ticks rather than tens of seconds, while the delay continues to govern
-       how aggressively packets are coalesced.
-       The budget also bounds the loop: it runs a fixed number of times at most, so it cannot
-       spin even if a queue fails to shrink. */
+    /* Drain up to `packetBundlingDrainLimit` bundles per run. processOutQueueBundle dispatches
+       one bundle per call, so this budget governs how much of a backlog a single run clears,
+       while the bundling delay governs how aggressively packets are coalesced into each
+       bundle. The budget also bounds the loop, which therefore always terminates after a
+       fixed number of iterations even if a queue fails to shrink. */
     var budget: Int = packetBundlingDrainLimit
     while (budget > 0 && (outQueueBundled.nonEmpty || outQueue.nonEmpty)) {
       processOutQueueBundle()

--- a/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
+++ b/src/main/scala/net/psforever/actors/net/MiddlewareActor.scala
@@ -304,6 +304,10 @@ class MiddlewareActor(
     "milliseconds"
   )
 
+  /** How many bundles a single run of the bundling process may dispatch; at least one */
+  private val packetBundlingDrainLimit: Int =
+    math.max(1, Config.app.network.middleware.packetBundlingDrainLimit)
+
   /** Timer that handles the bundling and throttling of outgoing packets and resolves disorganized inbound packets */
   private var packetProcessor: Cancellable = Default.Cancellable
 
@@ -671,7 +675,18 @@ class MiddlewareActor(
     */
   private def processQueue(): Unit = {
     inReorderQueueFunc()
-    processOutQueueBundle()
+    /* processOutQueueBundle dispatches at most one bundle per call, so a single call per timer
+       tick capped each client's outbound throughput at one MTU-sized bundle per delay period
+       regardless of backlog. Drain up to the configured number of bundles instead, so a burst
+       clears in a few ticks rather than tens of seconds, while the delay continues to govern
+       how aggressively packets are coalesced.
+       The budget also bounds the loop: it runs a fixed number of times at most, so it cannot
+       spin even if a queue fails to shrink. */
+    var budget: Int = packetBundlingDrainLimit
+    while (budget > 0 && (outQueueBundled.nonEmpty || outQueue.nonEmpty)) {
+      processOutQueueBundle()
+      budget -= 1
+    }
   }
 
   /**

--- a/src/main/scala/net/psforever/actors/net/SocketActor.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketActor.scala
@@ -142,9 +142,10 @@ class SocketActor(
                   val ref = context.spawn(
                     MiddlewareActor(udpCommandAdapter, remote, nextPlan, connectionId),
                     s"middleware-$connectionId",
-                    /* crypto, bundling and reordering for one connection; world-session is the
-                       pool akka.conf meant to isolate this work onto, and it has to be selected
-                       here because path-based deployment does not apply to typed actors */
+                    /* crypto, bundling and reordering for one connection, isolated onto the
+                       world-session pool. The dispatcher is selected here at the spawn site
+                       because this is a typed actor, which config-based deployment in
+                       akka.conf does not apply to. */
                     ActorTags(s"uuid=$connectionId").withDispatcherFromConfig("world-session")
                   )
                   context.watch(ref)

--- a/src/main/scala/net/psforever/actors/net/SocketActor.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketActor.scala
@@ -142,7 +142,10 @@ class SocketActor(
                   val ref = context.spawn(
                     MiddlewareActor(udpCommandAdapter, remote, nextPlan, connectionId),
                     s"middleware-$connectionId",
-                    ActorTags(s"uuid=$connectionId")
+                    /* crypto, bundling and reordering for one connection; world-session is the
+                       pool akka.conf meant to isolate this work onto, and it has to be selected
+                       here because path-based deployment does not apply to typed actors */
+                    ActorTags(s"uuid=$connectionId").withDispatcherFromConfig("world-session")
                   )
                   context.watch(ref)
                   packetActors(remote) = ref

--- a/src/main/scala/net/psforever/actors/net/SocketPane.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketPane.scala
@@ -88,11 +88,11 @@ final case class SocketSetupInfo(
 object SocketPane {
   val SocketPaneKey: ServiceKey[Command] = ServiceKey[SocketPane.Command](id = "socketPane")
 
-  /** The UDP read loop gets the dedicated thread akka.conf always intended for it.
+  /** Dispatcher for the UDP read loop.
     * network-listener is a PinnedDispatcher, so each socket actor -- one per bound port --
-    * receives its own thread rather than competing with game logic on the default pool.
-    * Selecting it here rather than by actor path is deliberate: these are typed actors, and
-    * config-based deployment does not apply to them. */
+    * owns a dedicated thread and is insulated from game logic running on other pools.
+    * The dispatcher is selected here at the spawn site because these are typed actors, which
+    * config-based deployment in akka.conf does not apply to. */
   private val socketDispatcher: DispatcherSelector = DispatcherSelector.fromConfig("network-listener")
 
   /**

--- a/src/main/scala/net/psforever/actors/net/SocketPane.scala
+++ b/src/main/scala/net/psforever/actors/net/SocketPane.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
 
 import java.net.{InetAddress, InetSocketAddress}
 import akka.{actor => classic}
-import akka.actor.typed.{ActorRef, Behavior, PostStop}
+import akka.actor.typed.{ActorRef, Behavior, DispatcherSelector, PostStop}
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import net.psforever.packet.PlanetSidePacket
 
@@ -88,6 +88,13 @@ final case class SocketSetupInfo(
 object SocketPane {
   val SocketPaneKey: ServiceKey[Command] = ServiceKey[SocketPane.Command](id = "socketPane")
 
+  /** The UDP read loop gets the dedicated thread akka.conf always intended for it.
+    * network-listener is a PinnedDispatcher, so each socket actor -- one per bound port --
+    * receives its own thread rather than competing with game logic on the default pool.
+    * Selecting it here rather than by actor path is deliberate: these are typed actors, and
+    * config-based deployment does not apply to them. */
+  private val socketDispatcher: DispatcherSelector = DispatcherSelector.fromConfig("network-listener")
+
   /**
    * Overrode constructor for `SocketPane` entities.
    * Registers the entity with the actor receptionist.
@@ -138,7 +145,7 @@ class SocketPane(
   /** all sockets produced by the socket group information and any later socket creation commands */
   private var socketActors: Array[ActorRef[SocketActor.Command]] = initialPortSetup.flatMap {
       case SocketSetup(_, SocketSetupInfo(address, ports, plan), _) =>
-        ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum") }
+        ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum", SocketPane.socketDispatcher) }
     }.toArray
   /** load balancing for redirecting newly discovered packet input to different sockets (ports);
    * should be referenced externally to switch sockets;
@@ -169,7 +176,7 @@ class SocketPane(
           val index = socketConfigs.indexWhere { setup => setup.groupId.equals(groupId) }
           val SocketSetup(_, SocketSetupInfo(address, ports, plan), _) = socketConfigs(index)
           socketActors = socketActors :+
-            context.spawn(SocketActor(new InetSocketAddress(address, port), plan), name=s"world-socket-$port")
+            context.spawn(SocketActor(new InetSocketAddress(address, port), plan), name=s"world-socket-$port", SocketPane.socketDispatcher)
           socketConfigs = (socketConfigs.take(index) :+ SocketSetup(groupId, SocketSetupInfo(address, ports :+ port, plan))) ++
             socketConfigs.drop(index + 1)
           socketRotations = (socketRotations.take(index) :+ SocketPanePortRotation(socketRotations(index), port)) ++
@@ -183,7 +190,7 @@ class SocketPane(
 
         case SocketPane.CreateNewSocketGroup(groupId, info @ SocketSetupInfo(address, ports, plan)) =>
           socketActors = socketActors ++
-            ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum") }
+            ports.map { portNum => context.spawn(SocketActor(new InetSocketAddress(address, portNum), plan), name=s"world-socket-$portNum", SocketPane.socketDispatcher) }
           socketConfigs = socketConfigs :+
             SocketSetup(groupId, info)
           socketRotations = socketRotations :+

--- a/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
@@ -1487,7 +1487,7 @@ class ChatOperations(
   override protected[session] def stop(): Unit = {
     silenceTimer.cancel()
     chatService ! ChatService.LeaveAllChannels(chatServiceAdapter)
-    /* this pool is per-session; without this its threads outlive the session that made them */
+    /* the scheduler pool is owned by this session, so it is released with the session */
     scheduler.shutdown()
   }
 }

--- a/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ChatOperations.scala
@@ -1487,5 +1487,7 @@ class ChatOperations(
   override protected[session] def stop(): Unit = {
     silenceTimer.cancel()
     chatService ! ChatService.LeaveAllChannels(chatServiceAdapter)
+    /* this pool is per-session; without this its threads outlive the session that made them */
+    scheduler.shutdown()
   }
 }

--- a/src/main/scala/net/psforever/objects/guid/TaskWorkflow.scala
+++ b/src/main/scala/net/psforever/objects/guid/TaskWorkflow.scala
@@ -145,11 +145,12 @@ object TaskWorkflow {
         //no subtasks; just execute the main task
         promise.completeWith(task.action())
       case list =>
-        /* The monitor must be a dedicated object. Synchronising on a Boolean synchronises on
-           the boxed java.lang.Boolean, and valueOf returns the cached TRUE/FALSE singletons,
-           so every task bundle in the server contended the same two JVM-wide monitors.
-           It was also not a valid mutex: the monitor identity changed when the flag flipped,
-           so two threads could hold "the lock" at once and complete the promise twice. */
+        /* A dedicated object, private to this bundle, guards `unassignedCompletion` so that
+           exactly one subtask completion resolves the promise.
+           The monitor must not be the flag itself: synchronising on a Boolean locks the boxed
+           java.lang.Boolean, and valueOf returns the cached TRUE/FALSE singletons, which are
+           shared JVM-wide and whose identity changes when the flag flips -- neither mutual
+           exclusion between threads nor isolation between bundles. */
         val completionLock = new Object
         var unassignedCompletion: Boolean = true
         //wait for subtasks to complete

--- a/src/main/scala/net/psforever/objects/guid/TaskWorkflow.scala
+++ b/src/main/scala/net/psforever/objects/guid/TaskWorkflow.scala
@@ -145,11 +145,17 @@ object TaskWorkflow {
         //no subtasks; just execute the main task
         promise.completeWith(task.action())
       case list =>
-        var unassignedCompletion: Boolean = true //shared mutex
+        /* The monitor must be a dedicated object. Synchronising on a Boolean synchronises on
+           the boxed java.lang.Boolean, and valueOf returns the cached TRUE/FALSE singletons,
+           so every task bundle in the server contended the same two JVM-wide monitors.
+           It was also not a valid mutex: the monitor identity changed when the flag flipped,
+           so two threads could hold "the lock" at once and complete the promise twice. */
+        val completionLock = new Object
+        var unassignedCompletion: Boolean = true
         //wait for subtasks to complete
         list.foreach { result =>
           result.onComplete { _ =>
-            unassignedCompletion.synchronized {
+            completionLock.synchronized {
               if (unassignedCompletion && composedSubs.forall(matchOnFutureCompletion)) {
                 unassignedCompletion = false
                 if (composedSubs.forall(matchOnFutureSuccess)) {

--- a/src/main/scala/net/psforever/objects/guid/pool/ExclusivePool.scala
+++ b/src/main/scala/net/psforever/objects/guid/pool/ExclusivePool.scala
@@ -9,6 +9,15 @@ class ExclusivePool(override val numbers: List[Int]) extends SimplePool(numbers)
   private val pool: Array[Int] = Array.ofDim[Int](numbers.length)
   numbers.indices.foreach(i => { pool(i) = i })
 
+  /* `numbers` is a List, so both hot operations walked it: Get did numbers(index), which is
+     O(index), and Return did an O(n) indexOf. The configured pools are large -- deployables
+     16000, ammo and kits 13500 each -- and unregistration happens in bulk when a player dies
+     or a vehicle is deconstructed, all serialised through one pool actor.
+     An indexed copy and a reverse lookup make both constant time. Neither is mutated after
+     construction, and SimplePool has already rejected duplicates. */
+  private val numbersByIndex: Array[Int] = numbers.toArray
+  private val indexByNumber: Map[Int, Int] = numbers.zipWithIndex.toMap
+
   override def Count: Int = pool.count(value => value == -1)
 
   override def Selector_=(slctr: NumberSelector): Unit = {
@@ -21,12 +30,11 @@ class ExclusivePool(override val numbers: List[Int]) extends SimplePool(numbers)
     if (index == -1) {
       Failure(new Exception("there are no numbers available in the pool"))
     } else {
-      Success(numbers(index))
+      Success(numbersByIndex(index))
     }
   }
 
   override def Return(number: Int): Boolean = {
-    val index = Numbers.indexOf(number)
-    index != -1 && Selector.Return(index, pool)
+    indexByNumber.get(number).exists(index => Selector.Return(index, pool))
   }
 }

--- a/src/main/scala/net/psforever/objects/guid/pool/ExclusivePool.scala
+++ b/src/main/scala/net/psforever/objects/guid/pool/ExclusivePool.scala
@@ -9,12 +9,13 @@ class ExclusivePool(override val numbers: List[Int]) extends SimplePool(numbers)
   private val pool: Array[Int] = Array.ofDim[Int](numbers.length)
   numbers.indices.foreach(i => { pool(i) = i })
 
-  /* `numbers` is a List, so both hot operations walked it: Get did numbers(index), which is
-     O(index), and Return did an O(n) indexOf. The configured pools are large -- deployables
-     16000, ammo and kits 13500 each -- and unregistration happens in bulk when a player dies
-     or a vehicle is deconstructed, all serialised through one pool actor.
-     An indexed copy and a reverse lookup make both constant time. Neither is mutated after
-     construction, and SimplePool has already rejected duplicates. */
+  /* Constant-time views over `numbers`, which is a List: an indexed copy for resolving a
+     selector index to its number, and a reverse lookup for resolving a number back to its
+     index. Both operations are hot -- the configured pools are large (deployables 16000,
+     ammo and kits 13500 each) and unregistration arrives in bulk when a player dies or a
+     vehicle is deconstructed, all serialised through one pool actor.
+     Neither structure is mutated after construction, and SimplePool has already rejected
+     duplicates, so the reverse lookup is unambiguous. */
   private val numbersByIndex: Array[Int] = numbers.toArray
   private val indexByNumber: Map[Int, Int] = numbers.zipWithIndex.toMap
 

--- a/src/main/scala/net/psforever/objects/guid/pool/GenericPool.scala
+++ b/src/main/scala/net/psforever/objects/guid/pool/GenericPool.scala
@@ -82,7 +82,12 @@ object GenericPool {
     */
   def first(list: List[Long], domainSize: Int): Int = {
     if (list.size < domainSize) {
-      val sortedList: List[Long] = 0L +: list.sorted :+ domainSize
+      /* an Array, because this is indexed by position in a loop: List.apply walks the chain,
+         so the identical scan over a List cost O(index) per step. This pool is the fallback
+         for any exhausted pool and receives every number in the hub -- on the order of tens
+         of thousands -- which made the scan quadratic and left the pool actor's mailbox
+         blocked for a long time at precisely the moment the server was under pressure. */
+      val sortedList: Array[Long] = (0L +: list.sorted :+ domainSize.toLong).toArray
       var index: Int = 0
       val listLen = sortedList.length - 1
       while(index < listLen && index < domainSize) {
@@ -112,7 +117,8 @@ object GenericPool {
   def rand(list: List[Long], domainSize: Int): Int = {
     if (list.size < domainSize) {
       //get a list of all assigned numbers with an appended min and max
-      val sortedList: List[Long] = -1L +: list.sorted :+ domainSize.toLong
+      //an Array for the same reason as in `first`: the loop below indexes it by position
+      val sortedList: Array[Long] = (-1L +: list.sorted :+ domainSize.toLong).toArray
       //compare the delta between every two entries and find the start of that greatest delta comparison
       var maxDelta: Long = -1
       var maxDeltaIndex  = -1

--- a/src/main/scala/net/psforever/objects/guid/pool/GenericPool.scala
+++ b/src/main/scala/net/psforever/objects/guid/pool/GenericPool.scala
@@ -82,11 +82,10 @@ object GenericPool {
     */
   def first(list: List[Long], domainSize: Int): Int = {
     if (list.size < domainSize) {
-      /* an Array, because this is indexed by position in a loop: List.apply walks the chain,
-         so the identical scan over a List cost O(index) per step. This pool is the fallback
-         for any exhausted pool and receives every number in the hub -- on the order of tens
-         of thousands -- which made the scan quadratic and left the pool actor's mailbox
-         blocked for a long time at precisely the moment the server was under pressure. */
+      /* An Array, because the loop below indexes it by position and Array.apply is constant
+         time. That matters here more than elsewhere: this pool is the fallback for any
+         exhausted pool and receives every number in the hub, on the order of tens of
+         thousands, and the scan runs on the pool actor's thread while its mailbox waits. */
       val sortedList: Array[Long] = (0L +: list.sorted :+ domainSize.toLong).toArray
       var index: Int = 0
       val listLen = sortedList.length - 1

--- a/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -196,11 +196,10 @@ trait ContainableBehavior {
 
               case _ => ; //TODO what?
             }
-            /* exactly one Resume must answer the Wait() above. The previous form recovered an
-               AskTimeoutException by sending a Resume and, because recover yields a successful
-               future, the following onComplete sent a second one -- releasing an unrelated
-               concurrent move's guard and letting interleaved insertions through.
-               onComplete alone already covers both success and failure. */
+            /* Exactly one Resume answers the Wait() above, and onComplete alone delivers it
+               for both success and failure -- including an AskTimeoutException. A second
+               Resume would release an unrelated concurrent move's guard and let insertions
+               interleave with a move that is still in flight. */
             moveItemOver.onComplete { _ => destination.Actor ! ContainableBehavior.Resume() }
           }
         case _ => ;

--- a/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
+++ b/src/main/scala/net/psforever/objects/serverobject/containable/ContainableBehavior.scala
@@ -2,7 +2,7 @@
 package net.psforever.objects.serverobject.containable
 
 import akka.actor.{Actor, ActorRef}
-import akka.pattern.{AskTimeoutException, ask}
+import akka.pattern.ask
 import akka.util.Timeout
 import net.psforever.objects.equipment.{Equipment, EquipmentSize}
 import net.psforever.objects.inventory.{Container, InventoryItem}
@@ -196,10 +196,12 @@ trait ContainableBehavior {
 
               case _ => ; //TODO what?
             }
-            //always do this
-            moveItemOver
-              .recover { case _: AskTimeoutException => destination.Actor ! ContainableBehavior.Resume() }
-              .onComplete { _ => destination.Actor ! ContainableBehavior.Resume() }
+            /* exactly one Resume must answer the Wait() above. The previous form recovered an
+               AskTimeoutException by sending a Resume and, because recover yields a successful
+               future, the following onComplete sent a second one -- releasing an unrelated
+               concurrent move's guard and letting interleaved insertions through.
+               onComplete alone already covers both success and failure. */
+            moveItemOver.onComplete { _ => destination.Actor ! ContainableBehavior.Resume() }
           }
         case _ => ;
         //we could not find the item to be moved in the source location; trying to act on old data?

--- a/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
+++ b/src/main/scala/net/psforever/objects/zones/SphereOfInfluenceActor.scala
@@ -55,11 +55,12 @@ class SphereOfInfluenceActor(zone: Zone) extends Actor {
     sois.foreach {
       case (facility, radius) =>
         val facilityXY = facility.Position.xy
-        val playersOnFoot = zone.blockMap.sector(facility)
+        val sector = zone.blockMap.sector(facility)
+        val playersOnFoot = sector
           .livePlayerList
           .filter(p => Vector3.DistanceSquared(facilityXY, p.Position.xy) < radius)
 
-        val vehicleOccupants = zone.blockMap.sector(facility)
+        val vehicleOccupants = sector
           .vehicleList
           .filter(v => Vector3.DistanceSquared(facilityXY, v.Position.xy) < radius)
           .flatMap(_.Seats.values.flatMap(_.occupants))

--- a/src/main/scala/net/psforever/objects/zones/blockmap/BlockMap.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/BlockMap.scala
@@ -7,8 +7,6 @@ import net.psforever.objects.serverobject.structures.Building
 import net.psforever.objects.zones.MapScale
 import net.psforever.types.Vector3
 
-import scala.collection.mutable.ListBuffer
-
 /**
   * A data structure which divides coordinate space into buckets or coordinate spans.
   * The function of the blockmap is to organize the instantiated game objects (entities)
@@ -40,16 +38,14 @@ class BlockMap(fullMapWidth: Int, fullMapHeight: Int, desiredSpanSize: Int) {
   /** the sectors / blocks / buckets into which entities that submit themselves are divided;
     * while the represented region need not be square, the sectors are defined as squares
     */
-  val blocks: ListBuffer[Sector] = {
+  val blocks: IndexedSeq[Sector] = {
     val horizontal: List[Int] = List.range(0, fullMapWidth, spanSize)
     val vertical: List[Int] = List.range(0, fullMapHeight, spanSize)
-    ListBuffer.newBuilder[Sector].addAll(
-      vertical.flatMap { latitude =>
-        horizontal.map { longitude =>
-          new Sector(longitude, latitude, spanSize)
-        }
+    vertical.flatMap { latitude =>
+      horizontal.map { longitude =>
+        new Sector(longitude, latitude, spanSize)
       }
-    ).result()
+    }.toIndexedSeq
   }
 
   /**
@@ -507,10 +503,10 @@ object BlockMap {
     */
   private def sectorOnlyWithinBlockStructure(
                                               index: Int,
-                                              structure: Iterable[Sector]
+                                              structure: IndexedSeq[Sector]
                                             ): Sector = {
     if (index < structure.size) {
-      structure.toSeq(index)
+      structure(index)
     } else {
       Sector.Empty
     }
@@ -525,11 +521,10 @@ object BlockMap {
     */
   private def sectorsOnlyWithinBlockStructure(
                                                list: Iterable[Int],
-                                               structure: Iterable[Sector]
+                                               structure: IndexedSeq[Sector]
                                              ): Iterable[Sector] = {
     if (list.nonEmpty && list.max < structure.size) {
-      val structureSeq = structure.toSeq
-      list.toSet.map { structureSeq }
+      list.toSet.map(structure.apply)
     } else {
       List[Sector]()
     }

--- a/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
@@ -276,21 +276,39 @@ object Sector {
   * @param amenityList the structures within the structures
   * @param environmentList fields that represent the game world environment
   */
+/**
+  * The entity lists are declared by-name and retained as `lazy val`s.
+  * A sector group frequently spans a great many sectors, and callers usually consult only one or two
+  * of the ten categories, so materializing all of them eagerly does a large amount of discarded work
+  * on hot paths such as the per-movement-packet local sector refresh.
+  * Each list is instead condensed on first access and memoized thereafter.
+  */
 class SectorGroup(
                    val rangeX: Float,
                    val rangeY: Float,
-                   val livePlayerList: List[Player],
-                   val botList: List[AvatarBot],
-                   val corpseList: List[Player],
-                   val vehicleList: List[Vehicle],
-                   val equipmentOnGroundList: List[Equipment],
-                   val deployableList: List[Deployable],
-                   val buildingList: List[Building],
-                   val amenityList: List[Amenity],
-                   val environmentList: List[PieceOfEnvironment],
-                   val projectileList: List[Projectile]
+                   livePlayers: => List[Player],
+                   bots: => List[AvatarBot],
+                   corpses: => List[Player],
+                   vehicles: => List[Vehicle],
+                   equipmentOnGround: => List[Equipment],
+                   deployables: => List[Deployable],
+                   buildings: => List[Building],
+                   amenities: => List[Amenity],
+                   environment: => List[PieceOfEnvironment],
+                   projectiles: => List[Projectile]
                  )
-  extends SectorPopulation
+  extends SectorPopulation {
+  lazy val livePlayerList: List[Player] = livePlayers
+  lazy val botList: List[AvatarBot] = bots
+  lazy val corpseList: List[Player] = corpses
+  lazy val vehicleList: List[Vehicle] = vehicles
+  lazy val equipmentOnGroundList: List[Equipment] = equipmentOnGround
+  lazy val deployableList: List[Deployable] = deployables
+  lazy val buildingList: List[Building] = buildings
+  lazy val amenityList: List[Amenity] = amenities
+  lazy val environmentList: List[PieceOfEnvironment] = environment
+  lazy val projectileList: List[Projectile] = projectiles
+}
 
 object SectorGroup {
   /** cached sector of no range and no entity coverage */

--- a/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
+++ b/src/main/scala/net/psforever/objects/zones/blockmap/Sector.scala
@@ -277,11 +277,12 @@ object Sector {
   * @param environmentList fields that represent the game world environment
   */
 /**
-  * The entity lists are declared by-name and retained as `lazy val`s.
-  * A sector group frequently spans a great many sectors, and callers usually consult only one or two
-  * of the ten categories, so materializing all of them eagerly does a large amount of discarded work
-  * on hot paths such as the per-movement-packet local sector refresh.
-  * Each list is instead condensed on first access and memoized thereafter.
+  * The entity lists are declared by-name and retained as `lazy val`s, so each category is
+  * condensed on first access and memoized thereafter.
+  * A sector group frequently spans a great many sectors while callers usually consult only one or
+  * two of the ten categories, and the group is rebuilt on hot paths such as the per-movement-packet
+  * local sector refresh, so condensing a category only when it is read keeps that cost proportional
+  * to what is actually used.
   */
 class SectorGroup(
                    val rangeX: Float,

--- a/src/main/scala/net/psforever/packet/ControlPacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/ControlPacketOpcode.scala
@@ -48,8 +48,9 @@ object ControlPacketOpcode extends Enumeration {
   ClientHotStart        // Probably a more lightweight variant of ClientStart, containing only the client nonce
   = Value
 
+  /* see the note on GamePacketOpcode.noDecoder -- Err builds its message eagerly */
   private def noDecoder(opcode: ControlPacketOpcode.Type) =
-    (bits: BitVector) => Attempt.failure(Err(s"Could not find a marshaller for control packet $opcode (${bits.toHex})"))
+    (_: BitVector) => Attempt.failure(Err(s"Could not find a marshaller for control packet $opcode"))
 
   def getPacketDecoder(
       opcode: ControlPacketOpcode.Type

--- a/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -294,10 +294,11 @@ object GamePacketOpcode extends Enumeration {
   ClientCheatedMessage   // last known message type (243, 0xf3)
   = Value
 
-  /* Err takes its message by value, so any interpolation here is built eagerly on every
-     packet that lands on an unimplemented opcode -- and a great many opcodes are still
-     stubs. Rendering the payload as hex allocated a string twice the packet's length each
-     time; the opcode alone identifies the gap. */
+  /* The message names the opcode only, which is what identifies the missing marshaller.
+     Keep it cheap to build: Err takes its message by value, so anything interpolated here is
+     constructed eagerly for every packet that lands on an unimplemented opcode, and a great
+     many opcodes are still stubs. Rendering the payload would cost a string twice the
+     packet's length each time. */
   private def noDecoder(opcode: GamePacketOpcode.Type) =
     (_: BitVector) => Attempt.failure(Err(s"Could not find a marshaller for game packet $opcode"))
 

--- a/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
+++ b/src/main/scala/net/psforever/packet/GamePacketOpcode.scala
@@ -294,8 +294,12 @@ object GamePacketOpcode extends Enumeration {
   ClientCheatedMessage   // last known message type (243, 0xf3)
   = Value
 
+  /* Err takes its message by value, so any interpolation here is built eagerly on every
+     packet that lands on an unimplemented opcode -- and a great many opcodes are still
+     stubs. Rendering the payload as hex allocated a string twice the packet's length each
+     time; the opcode alone identifies the gap. */
   private def noDecoder(opcode: GamePacketOpcode.Type) =
-    (bits: BitVector) => Attempt.failure(Err(s"Could not find a marshaller for game packet $opcode (${bits.toHex})"))
+    (_: BitVector) => Attempt.failure(Err(s"Could not find a marshaller for game packet $opcode"))
 
   /// Mapping of packet IDs to decoders. Notice that we are using the @switch annotation which ensures that the Scala
   /// compiler will be able to optimize this as a lookup table (switch statement). Microbenchmarks show a nearly 400x

--- a/src/main/scala/net/psforever/packet/control/MultiPacketEx.scala
+++ b/src/main/scala/net/psforever/packet/control/MultiPacketEx.scala
@@ -21,8 +21,9 @@ object MultiPacketEx extends Marshallable[MultiPacketEx] {
     val MaxValue = (1L << 31) - 1
     val MinValue = 0
 
-    /* hoisted out of encode/decode; these run once per sub-packet of every inbound
-       and outbound bundle, and scodec codecs are immutable and safe to share */
+    /* Shared across calls: sizeCodec runs once per sub-packet of every inbound and outbound
+       bundle, so these are built once here rather than per invocation. scodec codecs are
+       immutable and safe to share. */
     private val mediumCodec = (constant(hex"ff") :: uint16L).dropUnits
     private val largeCodec  = (constant(hex"ffffff") :: uint32L).dropUnits
     private val sizeTypes   = Vector(8, 16, 32)

--- a/src/main/scala/net/psforever/packet/control/MultiPacketEx.scala
+++ b/src/main/scala/net/psforever/packet/control/MultiPacketEx.scala
@@ -21,6 +21,13 @@ object MultiPacketEx extends Marshallable[MultiPacketEx] {
     val MaxValue = (1L << 31) - 1
     val MinValue = 0
 
+    /* hoisted out of encode/decode; these run once per sub-packet of every inbound
+       and outbound bundle, and scodec codecs are immutable and safe to share */
+    private val mediumCodec = (constant(hex"ff") :: uint16L).dropUnits
+    private val largeCodec  = (constant(hex"ffffff") :: uint32L).dropUnits
+    private val sizeTypes   = Vector(8, 16, 32)
+    private val guards      = Vector(hex"ff".bits, hex"ffff".bits)
+
     override def encode(i: Long) = {
       if (i > MaxValue) {
         Attempt.failure(Err(s"$i is greater than maximum value $MaxValue for $description"))
@@ -30,17 +37,14 @@ object MultiPacketEx extends Marshallable[MultiPacketEx] {
         if (i < 0xff) {
           uint8L.encode(i.toInt)
         } else if (i < 0xffff) {
-          (constant(hex"ff") :: uint16L).dropUnits.encode(i.toInt :: HNil)
+          mediumCodec.encode(i.toInt :: HNil)
         } else {
-          (constant(hex"ffffff") :: uint32L).dropUnits.encode(i :: HNil)
+          largeCodec.encode(i :: HNil)
         }
       }
     }
 
     override def decode(buffer: BitVector): Attempt[DecodeResult[Long]] = {
-      val sizeTypes = List(8, 16, 32)
-      val guards    = List(hex"ff".bits, hex"ffff".bits)
-
       var buf = buffer
 
       for (i <- sizeTypes.indices) {

--- a/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
@@ -110,7 +110,7 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
     CommonFieldData(faction, bops, destroyed, unk > 1, None, jammered = unk > 0, None, jammeredField, player_guid)
   }
 
-  def codec(extra: Boolean): Codec[CommonFieldData] =
+  private def buildCodec(extra: Boolean): Codec[CommonFieldData] =
     (
       ("faction" | PlanetSideEmpire.codec) ::
         ("bops" | bool) ::
@@ -131,9 +131,19 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
       }
     )
 
+  /* The parameter is a Boolean, so there are only ever two of these codecs, but a fresh tree of
+     roughly a dozen primitive codecs plus combinators and an xmap closure was constructed on
+     every call. This is reached once per object in every ObjectCreateMessage, and spawning or
+     zoning emits hundreds back to back. scodec codecs are immutable and safe to share.
+     lazy, so that initialisation order within this object cannot observe a null. */
+  private lazy val codecPlain: Codec[CommonFieldData] = buildCodec(extra = false)
+  private lazy val codecExtra: Codec[CommonFieldData] = buildCodec(extra = true)
+
+  def codec(extra: Boolean): Codec[CommonFieldData] = if (extra) codecExtra else codecPlain
+
   implicit val codec: Codec[CommonFieldData] = codec(extra = false)
 
-  def codec2(extra: Boolean): Codec[CommonFieldData] =
+  private def buildCodec2(extra: Boolean): Codec[CommonFieldData] =
     (
       ("faction" | PlanetSideEmpire.codec) ::
         ("bops" | bool) ::
@@ -157,6 +167,12 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
           Attempt.successful(faction :: bops :: alternate :: v1 :: v2 :: v3 :: v5 :: v4 :: player_guid :: HNil)
       }
     )
+
+  /* see the note on codec above; same two-shape memoisation */
+  private lazy val codec2Plain: Codec[CommonFieldData] = buildCodec2(extra = false)
+  private lazy val codec2Extra: Codec[CommonFieldData] = buildCodec2(extra = true)
+
+  def codec2(extra: Boolean): Codec[CommonFieldData] = if (extra) codec2Extra else codec2Plain
 
   val codec2: Codec[CommonFieldData] = codec2(extra = false)
 }

--- a/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
+++ b/src/main/scala/net/psforever/packet/game/objectcreate/CommonFieldData.scala
@@ -131,10 +131,11 @@ object CommonFieldData extends Marshallable[CommonFieldData] {
       }
     )
 
-  /* The parameter is a Boolean, so there are only ever two of these codecs, but a fresh tree of
-     roughly a dozen primitive codecs plus combinators and an xmap closure was constructed on
-     every call. This is reached once per object in every ObjectCreateMessage, and spawning or
-     zoning emits hundreds back to back. scodec codecs are immutable and safe to share.
+  /* The parameter is a Boolean, so there are only ever two of these codecs; each is built once
+     and shared. Worth doing because this is reached once per object in every
+     ObjectCreateMessage and spawning or zoning emits hundreds back to back, while each tree
+     costs roughly a dozen primitive codecs plus combinators and an xmap closure to construct.
+     scodec codecs are immutable and safe to share.
      lazy, so that initialisation order within this object cannot observe a null. */
   private lazy val codecPlain: Codec[CommonFieldData] = buildCodec(extra = false)
   private lazy val codecExtra: Codec[CommonFieldData] = buildCodec(extra = true)

--- a/src/main/scala/net/psforever/services/InterstellarClusterService.scala
+++ b/src/main/scala/net/psforever/services/InterstellarClusterService.scala
@@ -125,13 +125,13 @@ class InterstellarClusterService(context: ActorContext[InterstellarClusterServic
     mutable.Map(
       _zones.map {
         zone =>
-          /* dispatchers.conf defines a pool per zone so that one busy continent cannot starve
-             the others, but nothing ever selected them: the deployment entries in akka.conf
-             name "<id>-actor" paths that are never created, and config deployment does not
-             apply to typed actors in any case.
-             Not every zone id is guaranteed to have a matching entry, and
-             DispatcherSelector.fromConfig throws on a missing key, so fall back to the default
-             pool rather than prevent the server from starting. */
+          /* Each zone runs on its own pool from dispatchers.conf, so that one busy continent
+             cannot starve the others. The dispatcher is selected here at the spawn site
+             because this is a typed actor, which config-based deployment does not apply to.
+             Not every zone id is guaranteed to have a matching entry -- Zone.Nowhere, the
+             sentinel for an invalid location, has none -- and DispatcherSelector.fromConfig
+             throws on a missing key, so an absent pool falls back to the default rather than
+             preventing the server from starting. */
           val dispatcherPath = s"${zone.id}-zone-dispatcher"
           val zoneDispatcher =
             if (context.system.settings.config.hasPath(dispatcherPath)) {

--- a/src/main/scala/net/psforever/services/InterstellarClusterService.scala
+++ b/src/main/scala/net/psforever/services/InterstellarClusterService.scala
@@ -3,7 +3,7 @@ package net.psforever.services
 
 import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
 import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.{ActorRef, Behavior, DispatcherSelector, SupervisorStrategy}
 import net.psforever.actors.zone.ZoneActor
 import net.psforever.objects.avatar.Avatar
 import net.psforever.objects.{SpawnPoint, Vehicle}
@@ -125,7 +125,22 @@ class InterstellarClusterService(context: ActorContext[InterstellarClusterServic
     mutable.Map(
       _zones.map {
         zone =>
-          val zoneActor = context.spawn(ZoneActor(zone), s"zone-${zone.id}")
+          /* dispatchers.conf defines a pool per zone so that one busy continent cannot starve
+             the others, but nothing ever selected them: the deployment entries in akka.conf
+             name "<id>-actor" paths that are never created, and config deployment does not
+             apply to typed actors in any case.
+             Not every zone id is guaranteed to have a matching entry, and
+             DispatcherSelector.fromConfig throws on a missing key, so fall back to the default
+             pool rather than prevent the server from starting. */
+          val dispatcherPath = s"${zone.id}-zone-dispatcher"
+          val zoneDispatcher =
+            if (context.system.settings.config.hasPath(dispatcherPath)) {
+              DispatcherSelector.fromConfig(dispatcherPath)
+            } else {
+              context.log.warn(s"no dispatcher configured at $dispatcherPath; zone ${zone.id} shares the default pool")
+              DispatcherSelector.default()
+            }
+          val zoneActor = context.spawn(ZoneActor(zone), s"zone-${zone.id}", zoneDispatcher)
           (zone.id, (zoneActor, zone))
       }.toSeq: _*
     )

--- a/src/main/scala/net/psforever/services/base/envelope/BundledEnvelope.scala
+++ b/src/main/scala/net/psforever/services/base/envelope/BundledEnvelope.scala
@@ -35,7 +35,7 @@ case object NoResponse extends GenericResponseEnvelope {
  */
 final case class BundledEnvelope(msgs: Iterable[GenericMessageEnvelope])
   extends GenericMessageEnvelope {
-  assert(msgs.size == BundledEnvelope.unwind(msgs).size, "do not nest bundled event system envelopes")
+  assert(!msgs.exists(_.isInstanceOf[BundledEnvelope]), "do not nest bundled event system envelopes")
 
   override def msg: EventMessage = NoMessage
   override def response(stamp: EventSystemStamp): GenericResponseEnvelope = NoResponse
@@ -69,13 +69,13 @@ object BundledEnvelope {
   @tailrec
   private def unwind(in: Iterable[GenericMessageEnvelope], out: List[GenericMessageEnvelope] = Nil): List[GenericMessageEnvelope] = {
     if (in.isEmpty) {
-      out
+      out.reverse
     } else {
       in.head match {
         case bundle: BundledEnvelope =>
           unwind(bundle.msgs ++ in.tail, out)
         case first =>
-          unwind(in.tail, out :+ first)
+          unwind(in.tail, first :: out)
       }
     }
   }

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -342,9 +342,9 @@ class HackCaptureActor extends Actor {
                                  delayMillis: Long
                                ): Unit = {
     val buildingIterator = buildings.iterator
-    /* the handle must be cancelled once the iterator is spent, or the task keeps waking
-       every delayMillis for the lifetime of the pool doing nothing; compare the equivalent
-       loop in ChatOperations.processBuildingsWithDelay, which already cancels */
+    /* The handle is captured so the task can cancel itself once the iterator is spent;
+       otherwise it would keep waking every delayMillis for the lifetime of the pool with no
+       work left to do. ChatOperations.processBuildingsWithDelay follows the same pattern. */
     var handle: ScheduledFuture[_] = null
     handle = scheduler.scheduleAtFixedRate(
       () => {

--- a/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
+++ b/src/main/scala/net/psforever/services/local/support/HackCaptureActor.scala
@@ -20,7 +20,7 @@ import net.psforever.services.local.support.HackCaptureActor.GetHackingFaction
 import net.psforever.services.local.LocalAction
 import net.psforever.types.{ChatMessageType, PlanetSideEmpire}
 
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.{Executors, ScheduledFuture, TimeUnit}
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -342,7 +342,11 @@ class HackCaptureActor extends Actor {
                                  delayMillis: Long
                                ): Unit = {
     val buildingIterator = buildings.iterator
-    scheduler.scheduleAtFixedRate(
+    /* the handle must be cancelled once the iterator is spent, or the task keeps waking
+       every delayMillis for the lifetime of the pool doing nothing; compare the equivalent
+       loop in ChatOperations.processBuildingsWithDelay, which already cancels */
+    var handle: ScheduledFuture[_] = null
+    handle = scheduler.scheduleAtFixedRate(
       () => {
         if (buildingIterator.hasNext) {
           val building = buildingIterator.next()
@@ -351,6 +355,9 @@ class HackCaptureActor extends Actor {
           buildingActor ! BuildingActor.SetFaction(faction)
           buildingActor ! BuildingActor.AmenityStateChange(terminal, Some(false))
           buildingActor ! BuildingActor.MapUpdate()
+        }
+        else {
+          handle.cancel(false)
         }
       },
       0,

--- a/src/main/scala/net/psforever/util/Config.scala
+++ b/src/main/scala/net/psforever/util/Config.scala
@@ -138,6 +138,7 @@ case class NetworkConfig(
 case class MiddlewareConfig(
     packetBundlingDelay: FiniteDuration,
     packetBundlingDelayMultiplier: Float,
+    packetBundlingDrainLimit: Int,
     inReorderTimeout: FiniteDuration,
     inSubslotMissingDelay: FiniteDuration,
     inSubslotMissingAttempts: Int

--- a/src/main/scala/net/psforever/util/Md5Mac.scala
+++ b/src/main/scala/net/psforever/util/Md5Mac.scala
@@ -1,38 +1,6 @@
 package net.psforever.util
 
 import scodec.bits.ByteVector
-import scala.collection.mutable.ArrayBuffer
-
-sealed case class PermanentMd5MacState(
-                                        buffer: Seq[Byte],
-                                        digest: Seq[Byte],
-                                        m: Seq[Byte],
-                                        k1: Seq[Byte],
-                                        k2: Seq[Byte],
-                                        k3: Seq[Byte]
-                                      )
-
-sealed case class Md5MacState(
-                                buffer: ArrayBuffer[Byte],
-                                digest: ArrayBuffer[Byte],
-                                m: ArrayBuffer[Byte],
-                                k1: ArrayBuffer[Byte],
-                                k2: ArrayBuffer[Byte],
-                                k3: ArrayBuffer[Byte]
-                              )
-
-object PermanentMd5MacState {
-  def mutableCopy(in: PermanentMd5MacState): Md5MacState = {
-    Md5MacState(
-      ArrayBuffer[Byte]().addAll(in.buffer),
-      ArrayBuffer[Byte]().addAll(in.digest),
-      ArrayBuffer[Byte]().addAll(in.m),
-      ArrayBuffer[Byte]().addAll(in.k1),
-      ArrayBuffer[Byte]().addAll(in.k2),
-      ArrayBuffer[Byte]().addAll(in.k3),
-    )
-  }
-}
 
 object Md5Mac {
   val BLOCKSIZE  = 64
@@ -40,25 +8,26 @@ object Md5Mac {
   val MACLENGTH  = 16
   val KEYLENGTH  = 16
 
-  private val t: Seq[Seq[Byte]] = Seq(
-    Seq(0x97, 0xef, 0x45, 0xac, 0x29, 0x0f, 0x43, 0xcd, 0x45, 0x7e, 0x1b, 0x55, 0x1c, 0x80, 0x11, 0x34),
-    Seq(0xb1, 0x77, 0xce, 0x96, 0x2e, 0x72, 0x8e, 0x7c, 0x5f, 0x5a, 0xab, 0x0a, 0x36, 0x43, 0xbe, 0x18),
-    Seq(0x9d, 0x21, 0xb4, 0x21, 0xbc, 0x87, 0xb9, 0x4d, 0xa2, 0x9d, 0x27, 0xbd, 0xc7, 0x5b, 0xd7, 0xc3)
+  private val t: Array[Array[Byte]] = Array(
+    Array(0x97, 0xef, 0x45, 0xac, 0x29, 0x0f, 0x43, 0xcd, 0x45, 0x7e, 0x1b, 0x55, 0x1c, 0x80, 0x11, 0x34),
+    Array(0xb1, 0x77, 0xce, 0x96, 0x2e, 0x72, 0x8e, 0x7c, 0x5f, 0x5a, 0xab, 0x0a, 0x36, 0x43, 0xbe, 0x18),
+    Array(0x9d, 0x21, 0xb4, 0x21, 0xbc, 0x87, 0xb9, 0x4d, 0xa2, 0x9d, 0x27, 0xbd, 0xc7, 0x5b, 0xd7, 0xc3)
   ).map(_.map(_.toByte))
 
-  /**
-   * na
-   * @param lb na
-   * @param pos na
-   * @return na
-   */
-  private def mkInt(lb: Iterable[Byte], pos: Int): Int = {
-    // get iterator
-    val it = lb.iterator.drop(pos)
-    (it.next().toInt & 0xFF) << 24 |
-      (it.next().toInt & 0xFF) << 16 |
-      (it.next().toInt & 0xFF) << 8 |
-      (it.next().toInt & 0xFF)
+  /** Read four bytes from `a` starting at `pos` as a big-endian, 32-bit integer. */
+  private def mkInt(a: Array[Byte], pos: Int): Int = {
+    ((a(pos) & 0xff) << 24) |
+      ((a(pos + 1) & 0xff) << 16) |
+      ((a(pos + 2) & 0xff) << 8) |
+      (a(pos + 3) & 0xff)
+  }
+
+  /** Write `v` into `a` at `pos` as a big-endian, 32-bit integer. */
+  private def putInt(a: Array[Byte], pos: Int, v: Int): Unit = {
+    a(pos) = (v >>> 24).toByte
+    a(pos + 1) = (v >>> 16).toByte
+    a(pos + 2) = (v >>> 8).toByte
+    a(pos + 3) = v.toByte
   }
 
   /** Checks if two Message Authentication Codes are the same in constant time,
@@ -90,6 +59,11 @@ object Md5Mac {
  * Both libraries have since removed this code.
  * This file is a Scala port of the OpenCL implementation.
  * Source: https://github.com/sghiassy/Code-Reading-Book/blob/master/OpenCL/src/md5mac.cpp
+ *
+ * This implementation is deliberately allocation-free on the hot path:
+ * every piece of working state is a primitive array owned by the instance,
+ * `reset` restores that state with `System.arraycopy` from a stored template,
+ * and the only object allocated per `doFinal` is the returned MAC itself.
  */
 class Md5Mac(val key: ByteVector) {
   import Md5Mac._
@@ -97,176 +71,228 @@ class Md5Mac(val key: ByteVector) {
 
   private var count: Long   = 0
   private var position: Int = 0
-  private var state: Md5MacState = _ //value initialized in doKey
-  private val originalState: PermanentMd5MacState = doKey()
 
-  private def doKey(): PermanentMd5MacState = {
-    val buffer: ArrayBuffer[Byte] = ArrayBuffer.fill(BLOCKSIZE)(0)
-    val digest: ArrayBuffer[Byte] = ArrayBuffer.fill(DIGESTSIZE)(0)
-    val m: ArrayBuffer[Byte]      = ArrayBuffer.fill(32)(0)
-    val k1: ArrayBuffer[Byte]     = ArrayBuffer.fill(16)(0)
-    val k2: ArrayBuffer[Byte]     = ArrayBuffer.fill(16)(0)
-    val k3: ArrayBuffer[Byte]     = ArrayBuffer.fill(BLOCKSIZE)(0)
-    val ek: ArrayBuffer[Byte]     = ArrayBuffer.fill(48)(0)
-    val data: ArrayBuffer[Byte]   = ArrayBuffer.fill(128)(0)
-    state = Md5MacState(buffer, digest, m, k1, k2, k3) //initialize
+  /** the 64-byte accumulation block */
+  private val buffer: Array[Byte] = new Array[Byte](BLOCKSIZE)
+  /** the running 16-byte digest, held as four big-endian words */
+  private val digest: Array[Byte] = new Array[Byte](DIGESTSIZE)
+  /** the message schedule of the current block, already converted to little-endian words */
+  private val m: Array[Int] = new Array[Int](16)
+  /** key-derived constants; `k2` is pre-split into the four words the round functions need */
+  private val k1: Array[Byte] = new Array[Byte](16)
+  private val k3: Array[Byte] = new Array[Byte](BLOCKSIZE)
+  private var k2a: Int        = 0
+  private var k2b: Int        = 0
+  private var k2c: Int        = 0
+  private var k2d: Int        = 0
+  /** the value `digest` is restored to by `reset` */
+  private val digestTemplate: Array[Byte] = new Array[Byte](DIGESTSIZE)
+  /** scratch space so whole blocks can be hashed straight out of a `ByteVector` without allocating */
+  private val block: Array[Byte] = new Array[Byte](BLOCKSIZE)
+  /** scratch space for the byte-swapped digest produced by `doFinal` */
+  private val macScratch: Array[Byte] = new Array[Byte](MACLENGTH)
 
-    (0 until 16).foreach(j => {
-      data(j) = key(j % key.length)
-      data(j + 112) = key(j % key.length)
-    })
+  doKey()
 
-    (0 until 3).foreach(j => {
-      digest.patchInPlace(0, ByteVector.fromInt(0x67452301).toArray, 4)
-      digest.patchInPlace(4, ByteVector.fromInt(0xefcdab89).toArray, 4)
-      digest.patchInPlace(8, ByteVector.fromInt(0x98badcfe).toArray, 4)
-      digest.patchInPlace(12, ByteVector.fromInt(0x10325476).toArray, 4)
+  private def doKey(): Unit = {
+    val ek: Array[Byte]   = new Array[Byte](48)
+    val data: Array[Byte] = new Array[Byte](128)
 
-      (16 until 112).foreach(k => data(k) = t((j + (k - 16) / 16) % 3)(k % 16))
+    var j = 0
+    while (j < 16) {
+      data(j) = key(j.toLong % key.length)
+      data(j + 112) = key(j.toLong % key.length)
+      j += 1
+    }
 
-      hash(data.toSeq)
-      hash(data.drop(64).toSeq)
+    j = 0
+    while (j < 3) {
+      putInt(digest, 0, 0x67452301)
+      putInt(digest, 4, 0xefcdab89)
+      putInt(digest, 8, 0x98badcfe)
+      putInt(digest, 12, 0x10325476)
 
-      ek.patchInPlace(4 * 4 * j, digest.slice(0, 4), 4)
-      ek.patchInPlace((4 * 4 * j) + 4, digest.slice(4, 8), 4)
-      ek.patchInPlace((4 * 4 * j) + 8, digest.slice(8, 12), 4)
-      ek.patchInPlace((4 * 4 * j) + 12, digest.slice(12, 16), 4)
-    })
+      var k = 16
+      while (k < 112) {
+        data(k) = t((j + (k - 16) / 16) % 3)(k % 16)
+        k += 1
+      }
 
-    k1.patchInPlace(0, ek.take(16), 16)
-    digest.patchInPlace(0, ek.take(16), 16)
-    k2.patchInPlace(0, ek.slice(16, 32), 16)
+      hash(data, 0)
+      hash(data, 64)
 
-    (0 until 16).foreach(j => k3(j) = ek(((8 + j / 4) * 4) + (3 - j % 4)))
-    (16 until 64).foreach(j => k3(j) = (k3(j % 16) ^ t((j - 16) / 16)(j % 16)).toByte)
-    PermanentMd5MacState(buffer.toSeq, digest.toSeq, m.toSeq, k1.toSeq, k2.toSeq, k3.toSeq)
+      System.arraycopy(digest, 0, ek, 4 * 4 * j, 16)
+      j += 1
+    }
+
+    System.arraycopy(ek, 0, k1, 0, 16)
+    System.arraycopy(ek, 0, digest, 0, 16)
+    // k2, split into the four big-endian words consumed by the round functions
+    k2a = mkInt(ek, 16)
+    k2b = mkInt(ek, 20)
+    k2c = mkInt(ek, 24)
+    k2d = mkInt(ek, 28)
+
+    j = 0
+    while (j < 16) {
+      k3(j) = ek(((8 + j / 4) * 4) + (3 - j % 4))
+      j += 1
+    }
+    j = 16
+    while (j < 64) {
+      k3(j) = (k3(j % 16) ^ t((j - 16) / 16)(j % 16)).toByte
+      j += 1
+    }
+    // `buffer` is still all zeroes here, which is exactly what `reset` needs to restore
+    System.arraycopy(digest, 0, digestTemplate, 0, DIGESTSIZE)
   }
 
-  private def hash(input: Seq[Byte]): Unit = {
-    val (digest, m) = (state.digest, state.m)
-    (0 until 16).foreach(j => {
-      m.patchInPlace(j * 4, Array[Byte](input(4 * j + 3), input(4 * j + 2), input(4 * j + 1), input(4 * j + 0)), 4)
-    })
+  private def hash(input: Array[Byte], offset: Int): Unit = {
+    val mm     = m
+    val digest = this.digest
+    var j      = 0
+    while (j < 16) {
+      val p = offset + j * 4
+      // the original stored the bytes reversed and then read them back big-endian: a little-endian read
+      mm(j) = ((input(p + 3) & 0xff) << 24) |
+        ((input(p + 2) & 0xff) << 16) |
+        ((input(p + 1) & 0xff) << 8) |
+        (input(p) & 0xff)
+      j += 1
+    }
 
-    var a = mkInt(digest.drop(0), 0)
-    var c = mkInt(digest.drop(2 * 4), 0)
-    var b = mkInt(digest.drop(1 * 4), 0)
-    var d = mkInt(digest.drop(3 * 4), 0)
+    val a0 = mkInt(digest, 0)
+    val b0 = mkInt(digest, 4)
+    val c0 = mkInt(digest, 8)
+    val d0 = mkInt(digest, 12)
 
-    a = ff(a, b, c, d, mkInt(m, 0), 7, 0xd76aa478)
-    d = ff(d, a, b, c, mkInt(m, 1 * 4), 12, 0xe8c7b756)
-    c = ff(c, d, a, b, mkInt(m, 2 * 4), 17, 0x242070db)
-    b = ff(b, c, d, a, mkInt(m, 3 * 4), 22, 0xc1bdceee)
-    a = ff(a, b, c, d, mkInt(m, 4 * 4), 7, 0xf57c0faf)
-    d = ff(d, a, b, c, mkInt(m, 5 * 4), 12, 0x4787c62a)
-    c = ff(c, d, a, b, mkInt(m, 6 * 4), 17, 0xa8304613)
-    b = ff(b, c, d, a, mkInt(m, 7 * 4), 22, 0xfd469501)
-    a = ff(a, b, c, d, mkInt(m, 8 * 4), 7, 0x698098d8)
-    d = ff(d, a, b, c, mkInt(m, 9 * 4), 12, 0x8b44f7af)
-    c = ff(c, d, a, b, mkInt(m, 10 * 4), 17, 0xffff5bb1)
-    b = ff(b, c, d, a, mkInt(m, 11 * 4), 22, 0x895cd7be)
-    a = ff(a, b, c, d, mkInt(m, 12 * 4), 7, 0x6b901122)
-    d = ff(d, a, b, c, mkInt(m, 13 * 4), 12, 0xfd987193)
-    c = ff(c, d, a, b, mkInt(m, 14 * 4), 17, 0xa679438e)
-    b = ff(b, c, d, a, mkInt(m, 15 * 4), 22, 0x49b40821)
+    var a = a0
+    var b = b0
+    var c = c0
+    var d = d0
 
-    a = gg(a, b, c, d, mkInt(m, 1 * 4), 5, 0xf61e2562)
-    d = gg(d, a, b, c, mkInt(m, 6 * 4), 9, 0xc040b340)
-    c = gg(c, d, a, b, mkInt(m, 11 * 4), 14, 0x265e5a51)
-    b = gg(b, c, d, a, mkInt(m, 0), 20, 0xe9b6c7aa)
-    a = gg(a, b, c, d, mkInt(m, 5 * 4), 5, 0xd62f105d)
-    d = gg(d, a, b, c, mkInt(m, 10 * 4), 9, 0x02441453)
-    c = gg(c, d, a, b, mkInt(m, 15 * 4), 14, 0xd8a1e681)
-    b = gg(b, c, d, a, mkInt(m, 4 * 4), 20, 0xe7d3fbc8)
-    a = gg(a, b, c, d, mkInt(m, 9 * 4), 5, 0x21e1cde6)
-    d = gg(d, a, b, c, mkInt(m, 14 * 4), 9, 0xc33707d6)
-    c = gg(c, d, a, b, mkInt(m, 3 * 4), 14, 0xf4d50d87)
-    b = gg(b, c, d, a, mkInt(m, 8 * 4), 20, 0x455a14ed)
-    a = gg(a, b, c, d, mkInt(m, 13 * 4), 5, 0xa9e3e905)
-    d = gg(d, a, b, c, mkInt(m, 2 * 4), 9, 0xfcefa3f8)
-    c = gg(c, d, a, b, mkInt(m, 7 * 4), 14, 0x676f02d9)
-    b = gg(b, c, d, a, mkInt(m, 12 * 4), 20, 0x8d2a4c8a)
+    a = ff(a, b, c, d, mm(0), 7, 0xd76aa478)
+    d = ff(d, a, b, c, mm(1), 12, 0xe8c7b756)
+    c = ff(c, d, a, b, mm(2), 17, 0x242070db)
+    b = ff(b, c, d, a, mm(3), 22, 0xc1bdceee)
+    a = ff(a, b, c, d, mm(4), 7, 0xf57c0faf)
+    d = ff(d, a, b, c, mm(5), 12, 0x4787c62a)
+    c = ff(c, d, a, b, mm(6), 17, 0xa8304613)
+    b = ff(b, c, d, a, mm(7), 22, 0xfd469501)
+    a = ff(a, b, c, d, mm(8), 7, 0x698098d8)
+    d = ff(d, a, b, c, mm(9), 12, 0x8b44f7af)
+    c = ff(c, d, a, b, mm(10), 17, 0xffff5bb1)
+    b = ff(b, c, d, a, mm(11), 22, 0x895cd7be)
+    a = ff(a, b, c, d, mm(12), 7, 0x6b901122)
+    d = ff(d, a, b, c, mm(13), 12, 0xfd987193)
+    c = ff(c, d, a, b, mm(14), 17, 0xa679438e)
+    b = ff(b, c, d, a, mm(15), 22, 0x49b40821)
 
-    a = hh(a, b, c, d, mkInt(m, 5 * 4), 4, 0xfffa3942)
-    d = hh(d, a, b, c, mkInt(m, 8 * 4), 11, 0x8771f681)
-    c = hh(c, d, a, b, mkInt(m, 11 * 4), 16, 0x6d9d6122)
-    b = hh(b, c, d, a, mkInt(m, 14 * 4), 23, 0xfde5380c)
-    a = hh(a, b, c, d, mkInt(m, 1 * 4), 4, 0xa4beea44)
-    d = hh(d, a, b, c, mkInt(m, 4 * 4), 11, 0x4bdecfa9)
-    c = hh(c, d, a, b, mkInt(m, 7 * 4), 16, 0xf6bb4b60)
-    b = hh(b, c, d, a, mkInt(m, 10 * 4), 23, 0xbebfbc70)
-    a = hh(a, b, c, d, mkInt(m, 13 * 4), 4, 0x289b7ec6)
-    d = hh(d, a, b, c, mkInt(m, 0), 11, 0xeaa127fa)
-    c = hh(c, d, a, b, mkInt(m, 3 * 4), 16, 0xd4ef3085)
-    b = hh(b, c, d, a, mkInt(m, 6 * 4), 23, 0x04881d05)
-    a = hh(a, b, c, d, mkInt(m, 9 * 4), 4, 0xd9d4d039)
-    d = hh(d, a, b, c, mkInt(m, 12 * 4), 11, 0xe6db99e5)
-    c = hh(c, d, a, b, mkInt(m, 15 * 4), 16, 0x1fa27cf8)
-    b = hh(b, c, d, a, mkInt(m, 2 * 4), 23, 0xc4ac5665)
+    a = gg(a, b, c, d, mm(1), 5, 0xf61e2562)
+    d = gg(d, a, b, c, mm(6), 9, 0xc040b340)
+    c = gg(c, d, a, b, mm(11), 14, 0x265e5a51)
+    b = gg(b, c, d, a, mm(0), 20, 0xe9b6c7aa)
+    a = gg(a, b, c, d, mm(5), 5, 0xd62f105d)
+    d = gg(d, a, b, c, mm(10), 9, 0x02441453)
+    c = gg(c, d, a, b, mm(15), 14, 0xd8a1e681)
+    b = gg(b, c, d, a, mm(4), 20, 0xe7d3fbc8)
+    a = gg(a, b, c, d, mm(9), 5, 0x21e1cde6)
+    d = gg(d, a, b, c, mm(14), 9, 0xc33707d6)
+    c = gg(c, d, a, b, mm(3), 14, 0xf4d50d87)
+    b = gg(b, c, d, a, mm(8), 20, 0x455a14ed)
+    a = gg(a, b, c, d, mm(13), 5, 0xa9e3e905)
+    d = gg(d, a, b, c, mm(2), 9, 0xfcefa3f8)
+    c = gg(c, d, a, b, mm(7), 14, 0x676f02d9)
+    b = gg(b, c, d, a, mm(12), 20, 0x8d2a4c8a)
 
-    a = ii(a, b, c, d, mkInt(m, 0), 6, 0xf4292244)
-    d = ii(d, a, b, c, mkInt(m, 7 * 4), 10, 0x432aff97)
-    c = ii(c, d, a, b, mkInt(m, 14 * 4), 15, 0xab9423a7)
-    b = ii(b, c, d, a, mkInt(m, 5 * 4), 21, 0xfc93a039)
-    a = ii(a, b, c, d, mkInt(m, 12 * 4), 6, 0x655b59c3)
-    d = ii(d, a, b, c, mkInt(m, 3 * 4), 10, 0x8f0ccc92)
-    c = ii(c, d, a, b, mkInt(m, 10 * 4), 15, 0xffeff47d)
-    b = ii(b, c, d, a, mkInt(m, 1 * 4), 21, 0x85845dd1)
-    a = ii(a, b, c, d, mkInt(m, 8 * 4), 6, 0x6fa87e4f)
-    d = ii(d, a, b, c, mkInt(m, 15 * 4), 10, 0xfe2ce6e0)
-    c = ii(c, d, a, b, mkInt(m, 6 * 4), 15, 0xa3014314)
-    b = ii(b, c, d, a, mkInt(m, 13 * 4), 21, 0x4e0811a1)
-    a = ii(a, b, c, d, mkInt(m, 4 * 4), 6, 0xf7537e82)
-    d = ii(d, a, b, c, mkInt(m, 11 * 4), 10, 0xbd3af235)
-    c = ii(c, d, a, b, mkInt(m, 2 * 4), 15, 0x2ad7d2bb)
-    b = ii(b, c, d, a, mkInt(m, 9 * 4), 21, 0xeb86d391)
+    a = hh(a, b, c, d, mm(5), 4, 0xfffa3942)
+    d = hh(d, a, b, c, mm(8), 11, 0x8771f681)
+    c = hh(c, d, a, b, mm(11), 16, 0x6d9d6122)
+    b = hh(b, c, d, a, mm(14), 23, 0xfde5380c)
+    a = hh(a, b, c, d, mm(1), 4, 0xa4beea44)
+    d = hh(d, a, b, c, mm(4), 11, 0x4bdecfa9)
+    c = hh(c, d, a, b, mm(7), 16, 0xf6bb4b60)
+    b = hh(b, c, d, a, mm(10), 23, 0xbebfbc70)
+    a = hh(a, b, c, d, mm(13), 4, 0x289b7ec6)
+    d = hh(d, a, b, c, mm(0), 11, 0xeaa127fa)
+    c = hh(c, d, a, b, mm(3), 16, 0xd4ef3085)
+    b = hh(b, c, d, a, mm(6), 23, 0x04881d05)
+    a = hh(a, b, c, d, mm(9), 4, 0xd9d4d039)
+    d = hh(d, a, b, c, mm(12), 11, 0xe6db99e5)
+    c = hh(c, d, a, b, mm(15), 16, 0x1fa27cf8)
+    b = hh(b, c, d, a, mm(2), 23, 0xc4ac5665)
 
-    digest.patchInPlace(0, ByteVector.fromInt(mkInt(digest, 0) + a).toArray, 4)
-    digest.patchInPlace(4, ByteVector.fromInt(mkInt(digest, 4) + b).toArray, 4)
-    digest.patchInPlace(8, ByteVector.fromInt(mkInt(digest, 8) + c).toArray, 4)
-    digest.patchInPlace(12, ByteVector.fromInt(mkInt(digest, 12) + d).toArray, 4)
+    a = ii(a, b, c, d, mm(0), 6, 0xf4292244)
+    d = ii(d, a, b, c, mm(7), 10, 0x432aff97)
+    c = ii(c, d, a, b, mm(14), 15, 0xab9423a7)
+    b = ii(b, c, d, a, mm(5), 21, 0xfc93a039)
+    a = ii(a, b, c, d, mm(12), 6, 0x655b59c3)
+    d = ii(d, a, b, c, mm(3), 10, 0x8f0ccc92)
+    c = ii(c, d, a, b, mm(10), 15, 0xffeff47d)
+    b = ii(b, c, d, a, mm(1), 21, 0x85845dd1)
+    a = ii(a, b, c, d, mm(8), 6, 0x6fa87e4f)
+    d = ii(d, a, b, c, mm(15), 10, 0xfe2ce6e0)
+    c = ii(c, d, a, b, mm(6), 15, 0xa3014314)
+    b = ii(b, c, d, a, mm(13), 21, 0x4e0811a1)
+    a = ii(a, b, c, d, mm(4), 6, 0xf7537e82)
+    d = ii(d, a, b, c, mm(11), 10, 0xbd3af235)
+    c = ii(c, d, a, b, mm(2), 15, 0x2ad7d2bb)
+    b = ii(b, c, d, a, mm(9), 21, 0xeb86d391)
+
+    putInt(digest, 0, a0 + a)
+    putInt(digest, 4, b0 + b)
+    putInt(digest, 8, c0 + c)
+    putInt(digest, 12, d0 + d)
   }
 
-  private def ff(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
-    val r = a + ((d ^ (b & (c ^ d))) + msg + magic + mkInt(state.k2, 0))
+  @inline private def ff(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
+    val r = a + ((d ^ (b & (c ^ d))) + msg + magic + k2a)
     Integer.rotateLeft(r, shift) + b
   }
 
-  private def gg(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
-    val r = a + ((c ^ ((b ^ c) & d)) + msg + magic + mkInt(state.k2, 4))
+  @inline private def gg(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
+    val r = a + ((c ^ ((b ^ c) & d)) + msg + magic + k2b)
     Integer.rotateLeft(r, shift) + b
   }
 
-  private def hh(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
-    val r = a + ((b ^ c ^ d) + msg + magic + mkInt(state.k2, 8))
+  @inline private def hh(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
+    val r = a + ((b ^ c ^ d) + msg + magic + k2c)
     Integer.rotateLeft(r, shift) + b
   }
 
-  private def ii(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
-    val r = a + ((c ^ (b | ~d)) + msg + magic + mkInt(state.k2, 12))
+  @inline private def ii(a: Int, b: Int, c: Int, d: Int, msg: Int, shift: Int, magic: Int): Int = {
+    val r = a + ((c ^ (b | ~d)) + msg + magic + k2d)
     Integer.rotateLeft(r, shift) + b
+  }
+
+  /** Copy `size` bytes out of `src` (starting at `srcOffset`) into `dest` at `destOffset`. */
+  private def copyOut(src: ByteVector, srcOffset: Long, dest: Array[Byte], destOffset: Int, size: Int): Unit = {
+    var i = 0
+    while (i < size) {
+      dest(destOffset + i) = src(srcOffset + i)
+      i += 1
+    }
   }
 
   def update(bytes: ByteVector): Unit = {
-    val buffer = state.buffer
-    count += bytes.length
-    var length = bytes.length
-    buffer.patchInPlace(
-      position,
-      bytes.take(math.min(BLOCKSIZE, bytes.length)).toIterable,
-      math.min(BLOCKSIZE, bytes.length).toInt
-    )
+    val total = bytes.length
+    count += total
+    var length = total
+    // fill the accumulation block from `position` onwards, never past the end of the block
+    val head = math.min(math.min(BLOCKSIZE.toLong, total), (BLOCKSIZE - position).toLong).toInt
+    copyOut(bytes, 0L, buffer, position, head)
 
-    if (position + bytes.length >= BLOCKSIZE) {
-      hash(buffer.toSeq)
-      var input = bytes.drop(BLOCKSIZE - position)
-      length = bytes.length - (BLOCKSIZE - position)
+    if (position + total >= BLOCKSIZE) {
+      hash(buffer, 0)
+      var offset = (BLOCKSIZE - position).toLong
+      length = total - offset
       while (length >= BLOCKSIZE) {
-        hash(input.toSeq)
-        input = input.drop(BLOCKSIZE)
+        copyOut(bytes, offset, block, 0, BLOCKSIZE)
+        hash(block, 0)
+        offset += BLOCKSIZE
         length -= BLOCKSIZE
       }
-      buffer.patchInPlace(0, input.toIterable, input.length.toInt)
+      copyOut(bytes, offset, buffer, 0, length.toInt)
       position = 0
     }
     position += length.toInt
@@ -276,31 +302,50 @@ class Md5Mac(val key: ByteVector) {
     * @return the hash
     */
   def doFinal(length: Int = MACLENGTH): ByteVector = {
-    val (buffer, digest, k1, k3) = (state.buffer, state.digest, state.k1, state.k3)
-    val output: ArrayBuffer[Byte] = ArrayBuffer.fill(MACLENGTH)(0)
     buffer(position) = 0x80.toByte
-    (position + 1 until BLOCKSIZE).foreach(i => buffer(i) = 0)
+    var i = position + 1
+    while (i < BLOCKSIZE) {
+      buffer(i) = 0
+      i += 1
+    }
     if (position >= BLOCKSIZE - 8) {
-      hash(buffer.toSeq)
-      buffer.mapInPlace(_ => 0)
+      hash(buffer, 0)
+      java.util.Arrays.fill(buffer, 0.toByte)
     }
 
-    (BLOCKSIZE - 8 until BLOCKSIZE).foreach(i => buffer(i) = ByteVector.fromLong(8 * count)(7 - (i % 8)))
+    val bitCount = 8 * count
+    i = 0
+    while (i < 8) {
+      // little-endian bit count in the last eight bytes of the block
+      buffer(BLOCKSIZE - 8 + i) = (bitCount >>> (8 * i)).toByte
+      i += 1
+    }
 
-    hash(buffer.toSeq)
-    hash(k3.toSeq)
+    hash(buffer, 0)
+    hash(k3, 0)
 
-    (0 until MACLENGTH).foreach(i => output(i) = digest((i / 4) * 4 + (3 - (i % 4))))
+    val out = macScratch
+    i = 0
+    while (i < MACLENGTH) {
+      out(i) = digest((i / 4) * 4 + (3 - (i % 4)))
+      i += 1
+    }
 
     count = 0
     position = 0
-    digest.patchInPlace(0, k1, digest.length)
+    System.arraycopy(k1, 0, digest, 0, DIGESTSIZE)
 
+    val result = new Array[Byte](length)
     if (length == MACLENGTH) {
-      ByteVector.view(output.toArray)
+      System.arraycopy(out, 0, result, 0, MACLENGTH)
     } else {
-      ByteVector.view((0 until length).map(i => output(i % Md5Mac.DIGESTSIZE)).toArray)
+      i = 0
+      while (i < length) {
+        result(i) = out(i % Md5Mac.DIGESTSIZE)
+        i += 1
+      }
     }
+    ByteVector.view(result)
   }
 
   /** Shorthand for `update` and `doFinal` */
@@ -319,7 +364,8 @@ class Md5Mac(val key: ByteVector) {
   def reset(): Md5Mac = {
     count = 0
     position = 0
-    state = PermanentMd5MacState.mutableCopy(originalState)
+    java.util.Arrays.fill(buffer, 0.toByte)
+    System.arraycopy(digestTemplate, 0, digest, 0, DIGESTSIZE)
     this
   }
 }

--- a/src/test/scala/service/local/LocalActionTest.scala
+++ b/src/test/scala/service/local/LocalActionTest.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 PSForever
 package service.local
 
-import net.psforever.objects.{ExplosiveDeployable, GlobalDefinitions}
+import net.psforever.objects.{Default, ExplosiveDeployable, GlobalDefinitions}
 import net.psforever.packet.game.{ObjectCreateMessage, TriggeredEffect, TriggeredEffectLocation}
 import net.psforever.services.Service
 import net.psforever.services.base.message.SendResponse


### PR DESCRIPTION
### What this is

A pass over the sources of lag spikes and hitching that connected clients experience. It
came out of a subsystem-by-subsystem read of the network layer, zone/event fan-out, actor
scheduling, GUID allocation and the persistence layer.

Three root causes account for most of it:

1. **The dispatcher configuration never applied to anything.** `akka.conf` assigns
   dispatchers to 30+ actor paths and `dispatchers.conf` defines them all carefully, but no
   actor occupies those paths, and config-based deployment does not apply to typed actors
   in any case. Socket I/O, session logic and every zone therefore shared one unconfigured
   default pool running at Akka's stock `throughput = 5`.
2. **Hot paths copied whole collections.** The blockmap copied every sector in the zone per
   spatial query and then indexed the copy as a linked list; sector groups eagerly built ten
   entity lists when callers wanted one; the GUID pools walked `List`s of up to 16,000
   entries per allocation and release.
3. **Nothing was indexed.** `CREATE INDEX` appeared in exactly one of seventeen migrations.

Each commit is self-contained and explains its own reasoning; they can be reviewed or
reverted individually.

### Changes by area

**Threading and configuration**

```mermaid
flowchart LR
  subgraph before["Before - deployment config matched no actor"]
    direction TB
    SA1["SocketActor"] --> DD["akka.actor.default-dispatcher<br/>unconfigured, throughput 5"]
    MW1["MiddlewareActor"] --> DD
    SS1["SessionActor"] --> DD
    LA1["LoginActor"] --> DD
    ZA1["ZoneActor, 32 of them"] --> DD
  end
  subgraph after["After - selected at each spawn site"]
    direction TB
    SA2["SocketActor"] --> NL["network-listener<br/>pinned, one thread per port"]
    MW2["MiddlewareActor"] --> WS["world-session"]
    SS2["SessionActor"] --> WS
    LA2["LoginActor"] --> LS["login-session"]
    ZA2["ZoneActor, 32 of them"] --> ZD["one pool per zone<br/>z1-z10, c1-c6, i1-i4, home, tz"]
  end
```

- Select dispatchers explicitly at each spawn site — socket actors onto the pinned
  `network-listener`, middleware and sessions onto `world-session`, login onto
  `login-session`, and each zone onto its own pool. The zone lookup is guarded with
  `hasPath` and falls back to the default pool with a warning rather than refusing to boot.
- That guard immediately found a bug: the TR sanctuary dropship zone is `tzdrtr` but its
  dispatcher was spelled `tzsdrtr`, so it had no pool. Every other zone matched exactly.
- Configure `akka.actor.default-dispatcher` (which everything had silently been using) and
  enlarge the scheduler wheel, which holds a per-session packet timer plus per-player and
  per-entity ticks and collides heavily at the default 512 buckets.
- Raise `maxActiveConnections` from 5. It caps concurrent SQL statements for the whole
  server, not player connections, and the driver queues rather than rejecting, so five slots
  showed up purely as latency.
- Give the packaged server an explicit heap and G1 with a pause target; it previously passed
  no memory or collector options at all. Align the compose JDK with the Dockerfile — it ran
  JDK 8, whose default ParallelGC does multi-second stop-the-world collections.

**Per-packet cost**

```mermaid
flowchart LR
  Q["outQueueBundled<br/>each bundle capped at the 440 byte MTU"] --> TICK{"bundler run<br/>every 50 ms"}
  TICK -->|"before: dequeue exactly 1"| B["about 20 bundles/s<br/>under 9 KB/s per client"]
  TICK -->|"after: drain up to 8"| A["about 160 bundles/s<br/>tunable per deployment"]
```

- Rewrite `Md5Mac` over primitive arrays. It ran on every packet in both directions while
  holding state in `ArrayBuffer[Byte]` (boxing every byte), reading four bytes at a known
  offset by allocating and walking an iterator ~128 times per block, and deep-copying its
  entire state on each `reset()` — twice per packet.
- Drain up to a configurable number of bundles per run of the packet bundler. It previously
  sent exactly one bundle per timer tick, capping every client near 9 KB/s regardless of
  backlog, which is why zone loads and base captures visibly trickled in.
- Hoist codecs and error strings out of the encode/decode path: `MultiPacketEx.sizeCodec`
  rebuilt its codec tree per sub-packet, `CommonFieldData`'s two codecs were reconstructed
  per object in every `ObjectCreateMessage`, and the unimplemented-opcode path rendered the
  whole payload to hex eagerly because `Err` takes its message by value.

**Zone and event fan-out**

```mermaid
flowchart TB
  UP["PlayerStateMessageUpstream<br/>several per second, per player"] --> UB["SessionData.updateBlockMap"]
  UB --> SEC["blockMap.sector, 550 m draw range, about 144 sectors"]
  SEC --> OLD["Before<br/>copy every sector in the zone into a List<br/>then resolve each index, O index per lookup"]
  SEC --> NEW["After<br/>index an IndexedSeq directly"]
  OLD --> SG1["SectorGroup<br/>eagerly materialise all 10 entity lists"]
  NEW --> SG2["SectorGroup<br/>condense only the categories actually read"]
```

- Index blockmap sectors directly instead of copying the zone per query.
- Condense sector-group entity lists on demand rather than materialising all ten.
- Reuse the sector query in the SOI recalculation, which ran it twice per facility every
  five seconds.
- Make `BundledEnvelope.unwind` linear; it was O(n²) and ran twice because a non-elided
  `assert` repeated it.

**GUID allocation**
- Replace list walks with indexed access in `GenericPool` and `ExclusivePool`. The generic
  pool is the fallback for every exhausted pool and receives the whole hub, which made its
  scan quadratic at exactly the moment the server is under pressure.

**Correctness bugs that present as performance problems**
- `TaskWorkflow` synchronised on a boxed `Boolean`, i.e. the cached `TRUE`/`FALSE`
  singletons, so every task bundle server-wide contended one of two JVM-global monitors. It
  was also not a valid mutex: the monitor identity changed when the flag flipped, so two
  threads could complete the promise.
- The container move path sent two `Resume`s for one `Wait` on ask timeout, releasing an
  unrelated concurrent move's guard.
- A per-session thread pool was never shut down, and a fixed-rate task never cancelled.

**Database**

Measured on the real `loadCampaignKdaData` query against 500 avatars and a 200k-row kill log:

```mermaid
flowchart TB
  subgraph noidx["Without V018 - 10.29 ms, 3917 buffers"]
    direction TB
    N1["Gather, 2 parallel workers"] --> N2["Parallel Seq Scan on killactivity"]
    N2 --> N3["filters every row in the kill log<br/>cost grows with the table forever"]
  end
  subgraph idx["With V018 - 2.47 ms, 636 buffers"]
    direction TB
    I1["Hash Join"] --> I2["Bitmap Heap Scan on killactivity"]
    I2 --> I3["BitmapOr"]
    I3 --> I4["Bitmap Index Scan<br/>killactivity_killer_id_idx"]
    I3 --> I5["Bitmap Index Scan<br/>killactivity_victim_id_idx"]
  end
```

- `V018__PerformanceIndexes.sql` indexes the foreign keys read during login and character
  select. `killactivity` matters most: it is an append-only kill log read on every login, so
  login cost grew with every kill the server had ever recorded.

**Unrelated but required**
- `LocalActionTest` was missing a `Default` import, which broke `Test/compile` for the whole
  project on master. No test could run until this was fixed. Worth pulling out separately if
  you'd rather land it on its own.

### Measured impact

Each old implementation was taken from `psf/master` and benchmarked against the new one in
the same JVM with trials interleaved. Temurin 17, G1, 16 logical CPUs.

Read these numbers with their limits in mind. This ran on a working desktop, not a quiet
bench host, so absolute figures drifted 10–25% between rounds; every *ratio* reproduced
within a few percent across three rounds including a cold JVM, so the ratios are the
trustworthy output. There is no JMH in this project, so these are careful manual benchmarks
— warmup, auto-calibrated iteration counts, median of nine trials, checksum accumulation to
defeat dead-code elimination — not JMH-grade measurements. They also measure components in
isolation; none of them establish end-to-end server behaviour under real load.

**All seven changes measured faster. No regressions, no ambiguous results.**

#### Packet path — Md5Mac

Runs on every inbound and outbound packet, so this is the per-packet floor.

```mermaid
xychart-beta
    title "Md5Mac reset + updateFinal, microseconds per MAC"
    x-axis ["440 B before", "440 B after", "64 B before", "64 B after"]
    y-axis "microseconds" 0 --> 45
    bar [39.5, 1.7, 18.9, 0.62]
```

| payload | before | after | ratio |
|---|---|---|---|
| 440 B (MTU-sized) | 39.5 µs | 1.70 µs | ~23x |
| 64 B | 18.9 µs | 0.62 µs | ~30x |

Old and new produce an identical MAC, verified in the harness as well as by the 6,000-case
differential run described under Verification.

#### Zone and movement path

The blockmap helper is called twice per movement packet per player; the sector group is
built once per movement packet.

```mermaid
xychart-beta
    title "Blockmap sector resolution, microseconds per lookup"
    x-axis ["before", "after"]
    y-axis "microseconds" 0 --> 700
    bar [642, 16.3]
```

```mermaid
xychart-beta
    title "SectorGroup construct then read livePlayerList.size, microseconds"
    x-axis ["before", "after"]
    y-axis "microseconds" 0 --> 30
    bar [26.0, 4.74]
```

| case | before | after | ratio |
|---|---|---|---|
| blockmap resolution, 6,724-sector zone, 144 indices | 642 µs | 16.3 µs | ~39x |
| sector group over 144 sectors | 26.0 µs | 4.74 µs | **at least** 5.7x |

The sector-group figure is a **lower bound**, and deliberately so. The harness could only
populate the live-player category; the other nine were empty, yet the old constructor still
walked all 144 sectors for each of them. A real zone has buildings, amenities and
environment entries in nearly every sector, so the production gap is larger than 5.7x. Do
not quote it as an upper bound.

#### Event bundling

`BundledEnvelope.unwind` was O(n²) and the non-elided `assert` ran it a second time. The
interesting result is that the gap widens with bundle size, which is what an O(n²) to O(n)
change should look like — and bundles are built per recipient over the zone population.

```mermaid
xychart-beta
    title "BundledEnvelope speedup by bundle size (times faster)"
    x-axis ["10 envelopes", "50 envelopes", "200 envelopes"]
    y-axis "times faster" 0 --> 55
    bar [6.1, 16.5, 47.6]
```

| bundle size | before | after | ratio |
|---|---|---|---|
| 10 | 955 ns | 156 ns | ~6x |
| 50 | 14.5 µs | 883 ns | ~16x |
| 200 | 193 µs | 4.06 µs | ~48x |

#### GUID allocation

```mermaid
xychart-beta
    title "ExclusivePool Get + Return, microseconds per operation"
    x-axis ["before", "after"]
    y-axis "microseconds" 0 --> 30
    bar [28.2, 0.042]
```

| case | before | after | ratio |
|---|---|---|---|
| `ExclusivePool` Get+Return, 16,000-number pool | 28.2 µs | 41.7 ns | ~680x |
| `GenericPool.first`, 59,152 numbers allocated | **1.80 s** | 1.53 ms | ~1100-1300x |

`GenericPool.first` is not a typo. With the configured pools nearly full it took roughly two
**seconds** per call, on the pool actor's thread, blocking that mailbox — and this is the
path every allocation falls back to once any fixed pool is exhausted, which is precisely
when the server is already under load. It is charted only as a table because a bar for the
new value would not be visible next to the old one.

#### Codec acquisition

`CommonFieldData`'s codecs are obtained once per object in every `ObjectCreateMessage`.

| case | before | after |
|---|---|---|
| `codec(extra = false)` | 478-589 ns | at the harness noise floor |
| `codec2(extra = false)` | 484-591 ns | at the harness noise floor |

Reported as **roughly 480-590 ns saved per acquisition** rather than as a ratio. The new path
is a lazy-val field read, which is close enough to the harness's resolution floor that the
apparent ~165x is partly an artifact of how cheap it now is. The saving itself is real.

#### Database

Measured on the real `loadCampaignKdaData` query, 500 avatars and a 200k-row kill log. This
one is a genuine end-to-end query measurement rather than a microbenchmark.

```mermaid
xychart-beta
    title "Campaign KDA query on login, milliseconds"
    x-axis ["without V018", "with V018"]
    y-axis "milliseconds" 0 --> 12
    bar [10.29, 2.47]
```

| | time | buffers | plan |
|---|---|---|---|
| without V018 | 10.29 ms | 3,917 | parallel seq scan, 2 workers |
| with V018 | 2.47 ms | 636 | bitmap index scan |

The ratio matters less than the shape: without the indexes this is a sequential scan whose
cost grows with every kill the server ever records, so the figure above is what it looks like
on a *young* database.

#### Not measured

- **Dispatcher assignment.** Its effect is thread placement and contention under concurrent
  load, which a microbenchmark cannot capture. Needs a profiled server with real sessions.
- **The bundler drain limit.** The 20 to 160 bundles/s figure quoted earlier is arithmetic
  from bundle size and tick interval, not an observation.

### Verification

- Full suite: 41 failures against a measured baseline band of 40–42 — the same code varies
  run to run, since the ActorTests are timing-sensitive, as `build.sbt` notes. No suite fails
  that does not already fail on master. Baseline was established on master plus only the
  import fix, because master's test sources do not compile without it.
- `Md5Mac` had to stay bit-identical, as this crypto is verified against the live server.
  `CryptoTest`'s known MAC vector passes unmodified, and the rewrite was additionally checked
  differentially against the previous implementation over 6,000 randomised cases — varying
  keys, update counts, lengths straddling the 64-byte block boundary, output lengths and
  interleaved resets — with no mismatches.
- All 35 dispatcher selectors (three fixed pools plus one per `ZoneInfo`) resolve against the
  real merged configuration.
- The new middleware config key resolves through pureconfig; a mismatch would prevent boot.
- `V018` was applied over the full V001→V018 chain on both PostgreSQL 14 (what compose
  declares) and 16 (what is actually deployed), and re-applying it is a clean no-op. Against
  500 avatars and a 200k-row kill log, the campaign KDA query plans as a `BitmapOr` across
  the two new indexes at 2.5 ms / 636 buffers, versus a parallel sequential scan at 10.3 ms /
  3,917 buffers without them — and the sequential scan's cost grows with the table forever.

### Relationship to other open pull requests

**Recommendation: merge #1384 before or together with this one.**

#1384 (*Fix client instability / crashes when zoning frequently*) carries the commit that
makes `smpHistoryLength` configurable and raises it above 100, because 100 entries was
already too small during zone loads. This PR's bundler drain limit shortens the wall-clock
span that same history covers, so the two are coupled: merged together they are
complementary, and this one merged alone puts more pressure on a history that is already
undersized. If only this PR lands, lower `packet-bundling-drain-limit` from 8 until #1384
follows.

The mechanics are fine — this was checked rather than assumed. Merging `fix/zoning-players`
into this branch auto-merges with **zero conflicts**, and the combined result compiles.
That is despite four files being touched by both:

| file | this PR | #1384 |
|---|---|---|
| `Config.scala` | adds `packetBundlingDrainLimit` | adds `smpHistoryLength` |
| `application.conf` | adds the drain limit key | adds the history length key |
| `MiddlewareActor.scala` | drain loop in `processQueue` | history sizing and the `RelatedA` path |
| `InterstellarClusterService.scala` | zone dispatcher selection | `GetInstantActionSpawnPoint` token |

Two further overlaps worth flagging to reviewers:

- **#1343 (*RelatedB Slot*)** also modifies `MiddlewareActor.scala`. Not checked for conflicts
  here, and it touches the same reliable-delivery machinery the drain limit interacts with,
  so it is worth sequencing deliberately rather than merging blind alongside this.
- **#1380 (*GUID Number Pool Shuffling*)** changes only the `guid-pools/*.json` configuration,
  so there is no code conflict with the `GenericPool`/`ExclusivePool` work here. The two are
  complementary: that PR reshapes how pools are laid out, while this one removes the
  quadratic scan that makes pool exhaustion catastrophic rather than merely slow.

### Deliberately not included

- **Sector-scoped movement fan-out.** `PlayerState` is still published to the whole zone and
  filtered per recipient, which is O(N²) in player count and is the largest remaining win.
  The receive side is genuinely per-recipient stateful logic (visibility history, adaptive
  delay), so the change is entirely in subscription lifecycle — subscribe each session to its
  neighbouring sectors and re-subscribe on crossing. Getting that subtly wrong makes players
  invisible to each other at sector boundaries, there is no test coverage for the path, and
  it needs a live server and two clients walking a boundary to validate. It should land on
  its own.
- **`RandomSelector.Return`** still reports failure when no number is outstanding, leaking
  that GUID. Making it succeed unconditionally would let a double return insert the same
  number twice and eventually issue one GUID to two entities, which is worse. Fixing it
  properly means tracking allocation state explicitly instead of inferring it from a cursor.
- **Anything touching the SMP retransmit history.** An earlier revision of this branch also
  null-guarded the partially populated history ring, which throws and lets supervision drop
  the client. That fix already exists, together with making the history configurable, in
  **#1384**, so it was removed from here rather than land the same change twice and conflict.
  See the note on the drain limit below for why the two interact.
- Off-mailbox scheduled closures, DB write coalescing and login query pipelining,
  `selectDataCodec`'s remaining per-call construction, and the event bus's use of actor paths
  as channel names (which grows the subscriber classifier for the life of the process).

### For reviewers — where the risk is

- **Dispatcher assignment** is the highest-risk change and wants a thread dump on a running
  server to confirm actors land where intended. Config resolution is verified; actual thread
  placement is not.
- **The bundler drain limit** changes outbound flow control, and it has a known interaction
  with the SMP retransmit history that a reviewer should weigh before this is deployed.
  `MiddlewareActor` retains sent `SlottedMetaPacket`s in a fixed 100-entry ring and answers
  the client's `RelatedA` retransmit requests from it. Draining up to eight bundles per run
  instead of one means that ring wraps up to eight times faster in wall-clock terms, so the
  window in which a retransmit can still be served shrinks accordingly. Per the protocol
  notes, a reliable packet that can never be retransmitted blocks that channel's delivery
  rather than degrading gracefully.
  **#1384** makes `smpHistoryLength` configurable and raises it, because 100 entries was
  already too small during zone loads. These two want to land together, or this default wants
  lowering until that one is in — see *Relationship to other open pull requests* above. The
  drain limit is configurable precisely so it can be tuned down in the meantime.
  It has also not been exercised against a real client on a constrained connection.
- **`SectorGroup` laziness** moves when a category is snapshotted, from construction to first
  read. Those reads were already unsynchronised, so this shifts an existing window rather
  than creating one, and removes it entirely for categories never consulted — but it is a
  behavioural change worth a second opinion.
- **Components are measured; the server is not.** The figures under Measured impact are
  component microbenchmarks plus one real query measurement. They establish that each change
  is faster in isolation, which is not the same as establishing what dominates a live server
  under load, or that the aggregate effect on client-visible hitching is what we expect. A
  profile against a populated server is still the thing that would settle that, and none of
  these numbers substitute for it.
