### PR TITLE
Updating Global Pop

### DIFF
--- a/src/main/scala/net/psforever/actors/session/normal/GalaxyHandlerLogic.scala
+++ b/src/main/scala/net/psforever/actors/session/normal/GalaxyHandlerLogic.scala
@@ -85,5 +85,11 @@ class GalaxyHandlerLogic(val ops: SessionGalaxyHandlers, implicit val context: A
     case GalaxyAction.LogStatusChange(name)
       if TestFilter(() => avatar.people.friend.exists(_.name.equals(name))) =>
       avatarActor ! AvatarActor.MemberListRequest(MemberAction.UpdateFriend, name)
+
+    case GalaxyAction.UpdatePopulation(zone) =>
+      val popTR = zone.Players.count(_.faction == PlanetSideEmpire.TR)
+      val popNC = zone.Players.count(_.faction == PlanetSideEmpire.NC)
+      val popVS = zone.Players.count(_.faction == PlanetSideEmpire.VS)
+      sendResponse(ZonePopulationUpdateMessage(zone.Number, 414, 138, popTR, 138, popNC, 138, popVS, 138, 0))
   }
 }

--- a/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
+++ b/src/main/scala/net/psforever/actors/session/support/ZoningOperations.scala
@@ -905,7 +905,7 @@ class ZoningOperations(
         context.self ! SessionActor.SetZone("tzdrnc", vrDrivingAreaSpawns.toArray.apply(rand.nextInt(vrDrivingAreaSpawns.size)))
       case 22 =>
         context.self ! SessionActor.SetZone("tzdrvs", vrDrivingAreaSpawns.toArray.apply(rand.nextInt(vrDrivingAreaSpawns.size)))
-      case _ => 
+      case _ =>
         log.warn(s"Received TrainingZoneMessage that requests unexpected zone number ${pkt.zone.guid}?")
     }
   }
@@ -1512,7 +1512,7 @@ class ZoningOperations(
         override def description() : String = s"doing ${task.description()} before transferring zones"
 
         def action(): Future[Any] = {
-          localZone.Population ! Zone.Population.Leave(localAvatar)
+          localZone.Population ! Zone.Population.Leave(localAvatar, galaxyService)
           localCluster ! zoneMessage
           Future(true)
         }
@@ -2663,7 +2663,7 @@ class ZoningOperations(
             AvatarAction.LoadPlayer(definition.ObjectId, guid, definition.Packet.ConstructorData(player).get, None)
           )
       }
-      continent.Population ! Zone.Population.Spawn(avatar, player, avatarActor)
+      continent.Population ! Zone.Population.Spawn(avatar, player, avatarActor, galaxyService)
       avatarActor ! AvatarActor.RefreshPurchaseTimes()
       drawDeployableIconsOnMap(
         depictDeployablesUponRevival(
@@ -3263,7 +3263,7 @@ class ZoningOperations(
             sendResponse(AvatarDeadStateMessage(DeadState.Release, 0, 0, pos, player.Faction, unk5=true))
             val toZoneId = continent.id
             player.Die
-            continent.Population ! Zone.Population.Leave(avatar) //does not matter if it doesn't work
+            continent.Population ! Zone.Population.Leave(avatar, galaxyService) //does not matter if it doesn't work
             zoneLoaded = None
             zoneReload = true
             LoadZonePhysicalSpawnPoint(toZoneId, pos, orient, respawnTime = 0 seconds, None)

--- a/src/main/scala/net/psforever/objects/zones/Zone.scala
+++ b/src/main/scala/net/psforever/objects/zones/Zone.scala
@@ -149,8 +149,8 @@ class Zone(val id: String, val map: ZoneMap, zoneNumber: Int) {
     */
   private var population: ActorRef = Default.Actor
 
-  /** 
-   * Actor that handles non-player controlled entities, used for VR Shooting Range targets. 
+  /**
+   * Actor that handles non-player controlled entities, used for VR Shooting Range targets.
    */
   private var npcPopulation: ActorRef = Default.Actor
 
@@ -1190,7 +1190,7 @@ object Zone {
       * @see `PlayerHasLeft`
       * @param avatar the `Avatar` object
       */
-    final case class Leave(avatar: Avatar)
+    final case class Leave(avatar: Avatar, galaxyService: ActorRef)
 
     /**
       * Message that instructs the zone to disassociate a `Player` from this `Actor`.
@@ -1200,7 +1200,7 @@ object Zone {
       * @param avatar the `Avatar` object
       * @param player the `Player` object
       */
-    final case class Spawn(avatar: Avatar, player: Player, avatarActor: typed.ActorRef[AvatarActor.Command])
+    final case class Spawn(avatar: Avatar, player: Player, avatarActor: typed.ActorRef[AvatarActor.Command], galaxyService: ActorRef)
 
     /**
       * Message that instructs the zone to disassociate a `Player` from this `Actor`.
@@ -1986,7 +1986,7 @@ object Zone {
     val allAffectedTargets = pssos.filter { target => testTargetsFromZone(source, target, radius) }
     //inform remaining targets that they have suffered damage
     allAffectedTargets
-      .foreach { target => 
+      .foreach { target =>
       if (target.IsInVRZone) {
         //disable all server-side damage in VR zones, unless the target is a bot in the VR Shooting Range
         target match {

--- a/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
+++ b/src/main/scala/net/psforever/objects/zones/ZonePopulationActor.scala
@@ -10,6 +10,7 @@ import net.psforever.objects.{Default, Player}
 import net.psforever.services.avatar.AvatarAction
 import net.psforever.services.base.envelope.MessageEnvelope
 import net.psforever.services.base.message.ObjectDelete
+import net.psforever.services.galaxy.GalaxyAction
 import net.psforever.types.Vector3
 
 import scala.collection.concurrent.TrieMap
@@ -36,7 +37,7 @@ class ZonePopulationActor(zone: Zone, playerMap: TrieMap[Int, Option[Player]], b
         zone.StartPlayerManagementSystems()
       }
 
-    case Zone.Population.Leave(avatar) =>
+    case Zone.Population.Leave(avatar, galaxyService) =>
       PopulationLeave(avatar.id, playerMap) match {
         case None => ;
         case player @ Some(tplayer) =>
@@ -51,8 +52,9 @@ class ZonePopulationActor(zone: Zone, playerMap: TrieMap[Int, Option[Player]], b
             zone.StopPlayerManagementSystems()
           }
       }
+      galaxyService ! MessageEnvelope("", GalaxyAction.UpdatePopulation(zone))
 
-    case Zone.Population.Spawn(avatar, player, avatarActor) =>
+    case Zone.Population.Spawn(avatar, player, avatarActor, galaxyService) =>
       PopulationSpawn(avatar.id, player, playerMap) match {
         case Some((tplayer, newToZone)) =>
           tplayer.Zone = zone
@@ -68,6 +70,7 @@ class ZonePopulationActor(zone: Zone, playerMap: TrieMap[Int, Option[Player]], b
             if (player.VehicleSeated.isEmpty) {
               zone.actor ! ZoneActor.AddToBlockMap(player, player.Position)
             }
+            galaxyService ! MessageEnvelope("", GalaxyAction.UpdatePopulation(zone))
           }
         case None =>
           sender() ! Zone.Population.PlayerCanNotSpawn(zone, player)

--- a/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
+++ b/src/main/scala/net/psforever/services/account/AccountPersistenceService.scala
@@ -456,7 +456,7 @@ class PersistenceMonitor(
     squadService.tell(Service.Leave(avatar.id.toString), context.parent)
     galaxyService.tell(MessageEnvelope(GalaxyAction.LogStatusChange(avatar.name)), context.parent)
     Deployables.Disown(inZone, avatar, context.parent)
-    inZone.Population.tell(Zone.Population.Leave(avatar), context.parent)
+    inZone.Population.tell(Zone.Population.Leave(avatar, galaxyService), context.parent)
     TaskWorkflow.execute(GUIDTask.unregisterObject(inZone.GUID, avatar.locker))
     //inZone.tasks.tell(GUIDTask.UnregisterObjectTask(avatar.locker)(inZone.GUID), context.parent)
     log.info(s"Logout of ${avatar.name}")

--- a/src/main/scala/net/psforever/services/galaxy/GalaxyAction.scala
+++ b/src/main/scala/net/psforever/services/galaxy/GalaxyAction.scala
@@ -35,4 +35,6 @@ object GalaxyAction {
   final case class UnlockedZoneUpdate(zone: Zone) extends SelfRespondingEvent
 
   final case class LogStatusChange(name: String) extends SelfRespondingEvent
+
+  final case class UpdatePopulation(zone: Zone) extends  SelfRespondingEvent
 }

--- a/src/test/scala/objects/ZoneTest.scala
+++ b/src/test/scala/objects/ZoneTest.scala
@@ -226,7 +226,7 @@ class ZonePopulationTest extends ActorTest {
       assert(zone.Players.isEmpty)
       assert(zone.LivePlayers.isEmpty)
       zone.Population ! Zone.Population.Join(avatar)
-      zone.Population ! Zone.Population.Spawn(avatar, player, null)
+      zone.Population ! Zone.Population.Spawn(avatar, player, null, null)
       expectNoMessage(Duration.create(200, "ms"))
       assert(zone.Players.size == 1)
       assert(zone.Players.head == avatar)
@@ -243,12 +243,12 @@ class ZonePopulationTest extends ActorTest {
       zone.actor = system.spawn(ZoneActor(zone), ZoneTest.TestName)
       receiveOne(Duration.create(200, "ms")) //consume
       zone.Population ! Zone.Population.Join(avatar)
-      zone.Population ! Zone.Population.Spawn(avatar, player, null)
+      zone.Population ! Zone.Population.Spawn(avatar, player, null, null)
       expectNoMessage(Duration.create(100, "ms"))
 
       assert(zone.Players.size == 1)
       assert(zone.Players.head == avatar)
-      zone.Population ! Zone.Population.Leave(avatar)
+      zone.Population ! Zone.Population.Leave(avatar, _)
       val reply = receiveOne(Duration.create(100, "ms"))
       assert(reply.isInstanceOf[Zone.Population.PlayerHasLeft])
       assert(zone.Players.isEmpty)
@@ -382,7 +382,7 @@ class ZonePopulationTest extends ActorTest {
       zone.actor = system.spawn(ZoneActor(zone), ZoneTest.TestName)
       expectNoMessage(200 milliseconds)
       zone.Population ! Zone.Population.Join(avatar)
-      zone.Population ! Zone.Population.Spawn(avatar, player, null)
+      zone.Population ! Zone.Population.Spawn(avatar, player, null, null)
       expectNoMessage(Duration.create(100, "ms"))
 
       assert(zone.Players.size == 1)


### PR DESCRIPTION
Should send `ZonePopulationUpdateMessage` as players enter and leave zones to keep the global population accurate. It currently only sends once on login. This updates the 'Global' windows on the map with % of players in each zone